### PR TITLE
Add connection pool to RequestHandler

### DIFF
--- a/src/services/rpc.rs
+++ b/src/services/rpc.rs
@@ -1,7 +1,5 @@
 //! This module contains Tycho RPC implementation
 
-use std::sync::Arc;
-
 use crate::{
     extractor::evm::{self, Account},
     models::Chain,
@@ -13,29 +11,39 @@ use crate::{
 };
 use actix_web::{post, web, HttpResponse, Responder};
 use chrono::{NaiveDateTime, Utc};
-use diesel_async::AsyncPgConnection;
+use diesel_async::{pooled_connection::bb8::Pool, AsyncPgConnection};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tokio::sync::Mutex;
 use tracing::error;
 
 struct RequestHandler {
     db_gw: PostgresGateway<evm::Block, evm::Transaction, evm::Account, evm::AccountUpdate>,
-    db_connection: Arc<Mutex<AsyncPgConnection>>,
+    pool: Pool<AsyncPgConnection>,
 }
 
 impl RequestHandler {
     pub fn new(
         db_gw: PostgresGateway<evm::Block, evm::Transaction, evm::Account, evm::AccountUpdate>,
-        db_connection: AsyncPgConnection,
+        pool: Pool<AsyncPgConnection>,
     ) -> Self {
-        Self { db_gw, db_connection: Arc::new(Mutex::new(db_connection)) }
+        Self { db_gw, pool }
     }
 
     async fn get_state(
         &self,
         request: &StateRequestBody,
         params: &QueryParameters,
+    ) -> Result<StateRequestResponse, RpcError> {
+        let mut db_conn = self.pool.get().await.unwrap();
+        self.get_state_with_conn(request, params, &mut db_conn)
+            .await
+    }
+
+    async fn get_state_with_conn(
+        &self,
+        request: &StateRequestBody,
+        params: &QueryParameters,
+        db_conn: &mut AsyncPgConnection,
     ) -> Result<StateRequestResponse, RpcError> {
         //TODO: handle when no contract is specified with filters
         let at = match &request.version.block {
@@ -44,8 +52,6 @@ impl RequestHandler {
         };
 
         let version = storage::Version(at, storage::VersionKind::Last);
-
-        let mut db_connection_lock = self.db_connection.lock().await;
 
         // Get the contract IDs from the request
         let contract_ids = request.contract_ids.clone();
@@ -60,7 +66,7 @@ impl RequestHandler {
         // TODO support additional tvl_gt and intertia_min_gt filters
         match self
             .db_gw
-            .get_contracts(params.chain, addresses, Some(&version), false, &mut db_connection_lock)
+            .get_contracts(params.chain, addresses, Some(&version), false, db_conn)
             .await
         {
             Ok(accounts) => Ok(StateRequestResponse::new(accounts)),
@@ -157,8 +163,8 @@ struct Block {
 
 #[cfg(test)]
 mod tests {
-    use crate::storage::postgres::db_fixtures;
-    use actix_web::{test, App};
+    use crate::storage::postgres::{connect, db_fixtures};
+    use actix_web::test;
     use diesel_async::AsyncConnection;
     use ethers::types::{H160, H256, U256};
     use std::{collections::HashMap, str::FromStr};
@@ -330,22 +336,17 @@ mod tests {
         acc_address.to_string()
     }
 
-    async fn setup_database() -> (AsyncPgConnection, String) {
+    #[tokio::test]
+    async fn test_get_state() {
         let db_url = std::env::var("DATABASE_URL").unwrap();
-        let mut conn = AsyncPgConnection::establish(&db_url)
-            .await
-            .unwrap();
+        let pool = connect(&db_url).await.unwrap();
+        let mut conn = pool.get().await.unwrap();
+
         conn.begin_test_transaction()
             .await
             .unwrap();
+
         let acc_address = setup_account(&mut conn).await;
-
-        (conn, acc_address)
-    }
-
-    #[tokio::test]
-    async fn test_get_state() {
-        let (mut conn, acc_address) = setup_database().await;
 
         let db_gw = PostgresGateway::<
             evm::Block,
@@ -354,7 +355,8 @@ mod tests {
             evm::AccountUpdate,
         >::from_connection(&mut conn)
         .await;
-        let req_handler = RequestHandler::new(db_gw, conn);
+        // Initiate with a new pool, but which will not be used in the test
+        let req_handler = RequestHandler::new(db_gw, connect(&db_url).await.unwrap());
 
         let code = hex::decode("1234").unwrap();
         let code_hash = H256::from_slice(&ethers::utils::keccak256(&code));
@@ -388,81 +390,11 @@ mod tests {
         };
 
         let state = req_handler
-            .get_state(&request, &QueryParameters::default())
+            .get_state_with_conn(&request, &QueryParameters::default(), &mut conn)
             .await
             .unwrap();
 
         assert_eq!(state.accounts.len(), 1);
         assert_eq!(state.accounts[0], expected);
-    }
-
-    #[actix_web::test]
-    async fn test_contract_state_route() {
-        let (mut conn, acc_address) = setup_database().await;
-
-        let db_gw = PostgresGateway::<
-            evm::Block,
-            evm::Transaction,
-            evm::Account,
-            evm::AccountUpdate,
-        >::from_connection(&mut conn)
-        .await;
-        let req_handler = RequestHandler::new(db_gw, conn);
-
-        // Set up the expected account data
-        let code = hex::decode("1234").unwrap();
-        let code_hash = H256::from_slice(&ethers::utils::keccak256(&code));
-        let expected = Account::new(
-            Chain::Ethereum,
-            H160::from_str("6B175474E89094C44Da98b954EedeAC495271d0F").unwrap(),
-            "account0".to_owned(),
-            HashMap::new(),
-            U256::from(100),
-            code,
-            code_hash,
-            "0xbb7e16d797a9e2fbc537e30f91ed3d27a254dd9578aa4c3af3e5f0d3e8130945"
-                .parse()
-                .unwrap(),
-            "0xbb7e16d797a9e2fbc537e30f91ed3d27a254dd9578aa4c3af3e5f0d3e8130945"
-                .parse()
-                .unwrap(),
-            Some(
-                "0xbb7e16d797a9e2fbc537e30f91ed3d27a254dd9578aa4c3af3e5f0d3e8130945"
-                    .parse()
-                    .unwrap(),
-            ),
-        );
-
-        // Set up the app with the RequestHandler and the contract_state service
-        let app = test::init_service(
-            App::new()
-                .app_data(web::Data::new(req_handler))
-                .service(contract_state),
-        )
-        .await;
-
-        // Create the request body
-        let request_body = StateRequestBody {
-            contract_ids: Some(vec![ContractId::new(
-                Chain::Ethereum,
-                hex::decode(acc_address).unwrap(),
-            )]),
-            version: Version { timestamp: Utc::now().naive_utc(), block: None },
-        };
-        dbg!(&request_body);
-
-        // Create a POST request to the /contract_state route
-        let req = test::TestRequest::post()
-            .uri("/contract_state")
-            .set_json(request_body)
-            .to_request();
-        dbg!(&req);
-
-        // Send the request to the app
-        let response: StateRequestResponse = test::call_and_read_body_json(&app, req).await;
-
-        // Assert that the response is as expected
-        assert_eq!(response.accounts.len(), 1);
-        assert_eq!(response.accounts[0], expected);
     }
 }


### PR DESCRIPTION
This is a draft implementation of replacing a single connection to the db in RequestHandler with a connection pool. This design is far superior, because it reuses a pool of connections instead of locking a mutex to access a single one. 

On the other hand it makes it way harder to test, because I am not aware of any way to initiate a test transaction on a connection pool. This makes it impossible to create the test data on the same pool the RequestHandler is using and undo all the commits.

So this is a 10 minute draft PR of the implementation, let me know what you think.