### PR TITLE
Database: Remove protocol_system_type and use string instead

### DIFF
--- a/tycho-indexer/migrations/2024-01-10_tycho_patch/down.sql
+++ b/tycho-indexer/migrations/2024-01-10_tycho_patch/down.sql
@@ -25,10 +25,5 @@ DROP TYPE financial_type;
 ALTER TABLE protocol_type
 DROP CONSTRAINT unique_name_constraint;
 
--- dropping tables will drop any triggers or indices along with it
-ALTER TABLE protocol_system
-ALTER COLUMN "name" TYPE varchar(255);
-
-DROP TYPE protocol_system_type;
 
 

--- a/tycho-indexer/migrations/2024-01-10_tycho_patch/up.sql
+++ b/tycho-indexer/migrations/2024-01-10_tycho_patch/up.sql
@@ -1,10 +1,3 @@
-CREATE TYPE protocol_system_type AS ENUM(
-    'ambient'
-);
-
-ALTER TABLE protocol_system
-ALTER COLUMN "name" TYPE protocol_system_type USING "name"::protocol_system_type;
-
 -- Make the "name" column of the protocol type unique
 ALTER TABLE protocol_type
     ADD CONSTRAINT unique_name_constraint UNIQUE (name);

--- a/tycho-indexer/src/storage/postgres/orm.rs
+++ b/tycho-indexer/src/storage/postgres/orm.rs
@@ -217,7 +217,7 @@ pub struct NewTransaction {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct ProtocolSystem {
     pub id: i64,
-    pub name: ProtocolSystemType,
+    pub name: String,
     pub inserted_ts: NaiveDateTime,
     pub modified_ts: NaiveDateTime,
 }
@@ -226,21 +226,7 @@ pub struct ProtocolSystem {
 #[diesel(table_name=protocol_system)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct NewProtocolSystem {
-    pub name: ProtocolSystemType,
-}
-
-#[derive(Debug, DbEnum, Clone)]
-#[ExistingTypePath = "crate::storage::postgres::schema::sql_types::ProtocolSystemType"]
-pub enum ProtocolSystemType {
-    Ambient,
-}
-
-impl From<models::ProtocolSystem> for ProtocolSystemType {
-    fn from(value: models::ProtocolSystem) -> Self {
-        match value {
-            models::ProtocolSystem::Ambient => ProtocolSystemType::Ambient,
-        }
-    }
+    pub name: String,
 }
 
 #[derive(Debug, DbEnum, Clone, PartialEq)]

--- a/tycho-indexer/src/storage/postgres/protocol.rs
+++ b/tycho-indexer/src/storage/postgres/protocol.rs
@@ -120,17 +120,16 @@ where
         conn: &mut Self::DB,
     ) -> Result<i64, StorageError> {
         use super::schema::protocol_system::dsl::*;
-        let new_system = orm::ProtocolSystemType::from(new);
 
         let existing_entry = protocol_system
-            .filter(name.eq(new_system.clone()))
+            .filter(name.eq(new.to_string().clone()))
             .first::<orm::ProtocolSystem>(conn)
             .await;
 
         if let Ok(entry) = existing_entry {
             return Ok(entry.id);
         } else {
-            let new_entry = orm::NewProtocolSystem { name: new_system };
+            let new_entry = orm::NewProtocolSystem { name: new.to_string() };
 
             let inserted_protocol_system = diesel::insert_into(protocol_system)
                 .values(&new_entry)

--- a/tycho-indexer/src/storage/postgres/schema.rs
+++ b/tycho-indexer/src/storage/postgres/schema.rs
@@ -11,10 +11,6 @@ pub mod sql_types {
     #[derive(diesel::query_builder::QueryId, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "implementation_type"))]
     pub struct ImplementationType;
-
-    #[derive(diesel::query_builder::QueryId, diesel::sql_types::SqlType)]
-    #[diesel(postgres_type(name = "protocol_system_type"))]
-    pub struct ProtocolSystemType;
 }
 
 diesel::table! {
@@ -186,12 +182,11 @@ diesel::table! {
 
 diesel::table! {
     use diesel::sql_types::*;
-    use super::sql_types::ProtocolSystemType;
 
     protocol_system (id) {
         id -> Int8,
         #[max_length = 255]
-        name -> ProtocolSystemType,
+        name -> Varchar,
         inserted_ts -> Timestamptz,
         modified_ts -> Timestamptz,
     }


### PR DESCRIPTION
[Slack](https://propellerswap.slack.com/archives/C05LQALE9L1/p1705498231068279)

Using `to_string` entry looks like:
<img width="952" alt="image" src="https://github.com/propeller-heads/tycho-indexer/assets/49242091/7efdefa9-c5c2-4f79-aa93-9ced10b1d142">
