### PR TITLE
Update native protocol structs

### DIFF
--- a/tycho-indexer/src/extractor/evm/mod.rs
+++ b/tycho-indexer/src/extractor/evm/mod.rs
@@ -862,7 +862,9 @@ pub struct BlockEntityChangesResult {
     chain: Chain,
     pub block: Block,
     pub state_updates: HashMap<String, ProtocolStateDelta>,
-    pub new_protocol_components: HashMap<String, ProtocolComponent>,
+    pub new_protocol_components: Vec<ProtocolComponent>,
+    pub deleted_protocol_components: Vec<ProtocolComponent>,
+    pub component_balances: Vec<ComponentBalance>,
 }
 
 /// A container for state updates grouped by transaction
@@ -875,7 +877,8 @@ pub struct BlockEntityChanges {
     chain: Chain,
     pub block: Block,
     pub state_updates: Vec<ProtocolStateDeltasWithTx>,
-    pub new_protocol_components: HashMap<String, ProtocolComponent>,
+    pub protocol_components: Vec<ProtocolComponent>,
+    pub component_balances: Vec<ComponentBalance>,
 }
 
 // TODO: remove dead code check skip once extractor is implemented
@@ -891,7 +894,7 @@ impl BlockEntityChanges {
         if let Some(block) = msg.block {
             let block = Block::try_from_message(block, chain)?;
             let mut state_updates = Vec::new();
-            let mut new_protocol_components = HashMap::new();
+            let mut protocol_components = Vec::new();
 
             for change in msg.changes.into_iter() {
                 if let Some(tx) = change.tx {
@@ -901,7 +904,7 @@ impl BlockEntityChanges {
 
                     state_updates.push(tx_update);
                     for component in change.component_changes {
-                        let pool = ProtocolComponent::try_from_message(
+                        let component = ProtocolComponent::try_from_message(
                             component,
                             chain,
                             &protocol_system,
@@ -909,7 +912,7 @@ impl BlockEntityChanges {
                             tx.hash,
                             block.ts,
                         )?;
-                        new_protocol_components.insert(pool.id.clone(), pool);
+                        protocol_components.push(component);
                     }
                 }
             }
@@ -920,7 +923,8 @@ impl BlockEntityChanges {
                 chain,
                 block,
                 state_updates,
-                new_protocol_components,
+                protocol_components,
+                component_balances: Vec::new(),
             });
         }
         Err(ExtractionError::Empty)
@@ -956,7 +960,9 @@ impl BlockEntityChanges {
             chain: self.chain,
             block: self.block,
             state_updates: aggregated_states.protocol_states,
-            new_protocol_components: self.new_protocol_components,
+            new_protocol_components: self.protocol_components,
+            deleted_protocol_components: Vec::new(),
+            component_balances: Vec::new(),
         })
     }
 }
@@ -1854,28 +1860,23 @@ mod test {
             vec![("key".to_owned(), Bytes::from(600_u64.to_be_bytes().to_vec()))]
                 .into_iter()
                 .collect();
-        let new_protocol_components: HashMap<String, ProtocolComponent> = vec![(
-            "Pool".to_owned(),
-            ProtocolComponent {
-                id: "Pool".to_owned(),
-                protocol_system: "ambient".to_string(),
-                protocol_type_name: "Pool".to_owned(),
-                chain: Chain::Ethereum,
-                tokens: vec![
-                    H160::from_str("0x6B175474E89094C44Da98b954EedeAC495271d0F").unwrap(),
-                    H160::from_str("0x6B175474E89094C44Da98b954EedeAC495271d0F").unwrap(),
-                ],
-                static_attributes: static_attr,
-                contract_ids: vec![
-                    H160::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap()
-                ],
-                change: ChangeType::Creation,
-                creation_tx: tx.hash,
-                created_at: NaiveDateTime::from_timestamp_opt(1000, 0).unwrap(),
-            },
-        )]
-        .into_iter()
-        .collect();
+        let protocol_components = vec![ProtocolComponent {
+            id: "Pool".to_owned(),
+            protocol_system: "ambient".to_string(),
+            protocol_type_name: "Pool".to_owned(),
+            chain: Chain::Ethereum,
+            tokens: vec![
+                H160::from_str("0x6B175474E89094C44Da98b954EedeAC495271d0F").unwrap(),
+                H160::from_str("0x6B175474E89094C44Da98b954EedeAC495271d0F").unwrap(),
+            ],
+            static_attributes: static_attr,
+            contract_ids: vec![
+                H160::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap()
+            ],
+            change: ChangeType::Creation,
+            creation_tx: tx.hash,
+            created_at: NaiveDateTime::from_timestamp_opt(1000, 0).unwrap(),
+        }];
         BlockEntityChanges {
             extractor: "test".to_string(),
             chain: Chain::Ethereum,
@@ -1894,7 +1895,8 @@ mod test {
                 protocol_state_with_tx(),
                 ProtocolStateDeltasWithTx { protocol_states: state_updates, tx },
             ],
-            new_protocol_components,
+            protocol_components,
+            component_balances: Vec::new(),
         }
     }
 
@@ -1962,28 +1964,23 @@ mod test {
             vec![("key".to_owned(), Bytes::from(600_u64.to_be_bytes().to_vec()))]
                 .into_iter()
                 .collect();
-        let new_protocol_components: HashMap<String, ProtocolComponent> = vec![(
-            "Pool".to_owned(),
-            ProtocolComponent {
-                id: "Pool".to_owned(),
-                protocol_system: "ambient".to_string(),
-                protocol_type_name: "Pool".to_owned(),
-                chain: Chain::Ethereum,
-                tokens: vec![
-                    H160::from_str("0x6B175474E89094C44Da98b954EedeAC495271d0F").unwrap(),
-                    H160::from_str("0x6B175474E89094C44Da98b954EedeAC495271d0F").unwrap(),
-                ],
-                static_attributes: static_attr,
-                contract_ids: vec![
-                    H160::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap()
-                ],
-                change: ChangeType::Creation,
-                creation_tx: tx.hash,
-                created_at: NaiveDateTime::from_timestamp_opt(1000, 0).unwrap(),
-            },
-        )]
-        .into_iter()
-        .collect();
+        let new_protocol_components = vec![ProtocolComponent {
+            id: "Pool".to_owned(),
+            protocol_system: "ambient".to_string(),
+            protocol_type_name: "Pool".to_owned(),
+            chain: Chain::Ethereum,
+            tokens: vec![
+                H160::from_str("0x6B175474E89094C44Da98b954EedeAC495271d0F").unwrap(),
+                H160::from_str("0x6B175474E89094C44Da98b954EedeAC495271d0F").unwrap(),
+            ],
+            static_attributes: static_attr,
+            contract_ids: vec![
+                H160::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap()
+            ],
+            change: ChangeType::Creation,
+            creation_tx: tx.hash,
+            created_at: NaiveDateTime::from_timestamp_opt(1000, 0).unwrap(),
+        }];
         BlockEntityChangesResult {
             extractor: "test".to_string(),
             chain: Chain::Ethereum,
@@ -1998,6 +1995,8 @@ mod test {
             },
             state_updates,
             new_protocol_components,
+            deleted_protocol_components: Vec::new(),
+            component_balances: Vec::new(),
         }
     }
 


### PR DESCRIPTION
The native protocol extractor structs were a bit behind on the latest changes - component balances, splitting the protocol components by change (new/deleted) etc. This is to get them on par with the vm struct changes.