### PR TITLE
Update rust version to 1.74

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.72-bookworm AS chef
+FROM rust:1.74-bookworm AS chef
 ARG TARGETPLATFORM
 WORKDIR /build
 RUN apt-get update && apt-get install -y libpq-dev jq
@@ -12,7 +12,7 @@ RUN ARCH=$(echo $TARGETPLATFORM | sed -e 's/\//_/g') && \
 RUN cargo install cargo-workspaces
 RUN cargo install cargo-chef 
 COPY rust-toolchain.toml .
-RUN rustup update 1.72
+RUN rustup update 1.74
 
 FROM chef AS planner
 COPY . .


### PR DESCRIPTION
Docker build was failing to install cargo-chef - the failure message suggested using rust version 1.74 (used to be 1.72)