### PR TITLE
Use custom version increment action.

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -36,8 +36,10 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Get next version
-        uses: reecetech/version-increment@2023.10.1
         id: version
+        uses: reecetech/version-increment@2023.10.1
+        with:
+          release_branch: no-branch/we-only-use-this-for-pre-releases
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
The github actions we are using will always create pre release information. We don't use the automatically generated version if directly on a tag.