### PR TITLE
Request snapshots by block number.

### DIFF
--- a/tycho-client/src/feed/synchronizer.rs
+++ b/tycho-client/src/feed/synchronizer.rs
@@ -160,7 +160,11 @@ where
     ) -> SyncResult<StateSyncMessage> {
         let version = VersionParam::new(
             None,
-            Some(BlockParam { chain: None, hash: Some(header.hash.clone()), number: None }),
+            Some(BlockParam {
+                chain: Some(self.extractor_id.chain),
+                hash: None,
+                number: Some(header.number as i64),
+            }),
         );
         // Use given ids or use all if not passed
         let ids = ids


### PR DESCRIPTION
Previously we would use block hash which is not properly supported atm if the block is within the revert buffer.