### PR TITLE
Allow to upsert contracts

### DIFF
--- a/tycho-core/src/storage.rs
+++ b/tycho-core/src/storage.rs
@@ -480,7 +480,7 @@ pub trait ContractStateGateway {
     /// - A Result with Ok if the operation was successful, and an Err containing `StorageError` if
     ///   there was an issue inserting the contract into the database. E.g. if the contract already
     ///   existed.
-    async fn insert_contract(&self, new: &models::contract::Contract) -> Result<(), StorageError>;
+    async fn upsert_contract(&self, new: &models::contract::Contract) -> Result<(), StorageError>;
 
     /// Update multiple contracts
     ///

--- a/tycho-indexer/src/extractor/evm/vm.rs
+++ b/tycho-indexer/src/extractor/evm/vm.rs
@@ -263,7 +263,7 @@ where
                     let new: evm::Account = acc_update.ref_into_account(&update.tx);
                     info!(block_number = ?changes.block.number, contract_address = ?new.address, "New contract found at {:#020x}", &new.address);
                     self.state_gateway
-                        .insert_contract(&(&new).into())
+                        .upsert_contract(&(&new).into())
                         .await?;
                 }
             }

--- a/tycho-indexer/src/testing.rs
+++ b/tycho-indexer/src/testing.rs
@@ -89,7 +89,7 @@ mock! {
             Self: 'async_trait;
 
         #[allow(clippy::type_complexity, clippy::type_repetition_in_bounds)]
-        fn insert_contract<'life0, 'life1, 'async_trait>(
+        fn upsert_contract<'life0, 'life1, 'async_trait>(
             &'life0 self,
             new: &'life1 Contract,
         ) -> ::core::pin::Pin<

--- a/tycho-storage/src/postgres/contract.rs
+++ b/tycho-storage/src/postgres/contract.rs
@@ -952,7 +952,12 @@ impl PostgresGateway {
             .collect()
     }
 
-    pub async fn insert_contract(
+    /// Upsert contract
+    ///
+    /// Inserts a contract or updates it if it already exists. It will not update
+    /// contract balance or contract code if they already exist though. Since a separate
+    /// method exists for updating these related components.
+    pub async fn upsert_contract(
         &self,
         new: &models::contract::Contract,
         db: &mut AsyncPgConnection,
@@ -1791,7 +1796,7 @@ mod test {
             ),
         );
         gateway
-            .insert_contract(&expected, &mut conn)
+            .upsert_contract(&expected, &mut conn)
             .await
             .unwrap();
 


### PR DESCRIPTION
One of the balancer pools already existed before we actually synced the substream. Most likely because the LP token is traded on another already synced protocol. In this case the same contract is used as token as well as for pools.