### PR TITLE
Fixes panic when casting gas or tax to u64.

### DIFF
--- a/tycho-indexer/src/extractor/evm/token_analysis_cron.rs
+++ b/tycho-indexer/src/extractor/evm/token_analysis_cron.rs
@@ -125,8 +125,11 @@ async fn analyze_batch(
             t.quality = 50;
         }
 
-        t.tax = tax.unwrap_or(U256::zero()).as_u64();
-        t.gas = gas.map_or_else(Vec::new, |g| vec![Some(g.as_u64())]);
+        t.tax = tax
+            .unwrap_or(U256::zero())
+            .try_into()
+            .unwrap_or(10_000);
+        t.gas = gas.map_or_else(Vec::new, |g| vec![Some(g.try_into().unwrap_or(8_000_000))]);
     }
 
     if !tokens.is_empty() {

--- a/tycho-indexer/src/extractor/evm/token_pre_processor.rs
+++ b/tycho-indexer/src/extractor/evm/token_pre_processor.rs
@@ -110,8 +110,11 @@ impl TokenPreProcessorTrait for TokenPreProcessor {
                 address,
                 symbol: symbol.replace('\0', ""),
                 decimals: decimals.into(),
-                tax: tax.unwrap_or(U256::zero()).as_u64(),
-                gas: gas.map_or_else(Vec::new, |g| vec![Some(g.as_u64())]),
+                tax: tax
+                    .unwrap_or(U256::zero())
+                    .try_into()
+                    .unwrap_or(10_000),
+                gas: gas.map_or_else(Vec::new, |g| vec![Some(g.try_into().unwrap_or(8_000_000))]),
                 chain: Chain::Ethereum,
                 quality,
             });


### PR DESCRIPTION
Some tokens set the balance of the receiver to the transfer amount or may expose a similar unexpected behaviour that causes tax to be unrealistically high. This case used to panic when casting tax to u64.

Although gas is usually capped to values that fit well into an u32 by RPCs. We apply a similar protection against overflow when casting to it to avoid panics (`8_000_000` is just an arbitrary high number).