### PR TITLE
Add a healthcheck endpoint.

### DIFF
--- a/tycho-core/src/dto.rs
+++ b/tycho-core/src/dto.rs
@@ -1056,6 +1056,15 @@ pub struct ProtocolComponentId {
     pub id: String,
 }
 
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(tag = "status", content = "message")]
+#[schema(example=json!({"status": "NotReady", "message": "No db connection"}))]
+pub enum Health {
+    Ready,
+    Starting(String),
+    NotReady(String),
+}
+
 #[cfg(test)]
 mod test {
     use maplit::hashmap;

--- a/tycho-indexer/src/services/mod.rs
+++ b/tycho-indexer/src/services/mod.rs
@@ -14,7 +14,7 @@ use crate::services::deltas_buffer::PendingDeltas;
 use tycho_core::{
     dto::{
         AccountUpdate, BlockParam, ChangeType, ContractDeltaRequestBody,
-        ContractDeltaRequestResponse, PaginationParams, ProtocolComponent,
+        ContractDeltaRequestResponse, Health, PaginationParams, ProtocolComponent,
         ProtocolComponentRequestResponse, ProtocolComponentsRequestBody, ProtocolDeltaRequestBody,
         ProtocolDeltaRequestResponse, ProtocolId, ProtocolStateDelta, ProtocolStateRequestBody,
         ProtocolStateRequestResponse, ResponseAccount, ResponseProtocolState, ResponseToken,
@@ -99,7 +99,8 @@ where
                 rpc::protocol_components,
                 rpc::contract_delta,
                 rpc::protocol_state,
-                rpc::protocol_delta
+                rpc::protocol_delta,
+                rpc::health,
             ),
             components(
                 schemas(VersionParam),
@@ -127,6 +128,7 @@ where
                 schemas(ProtocolDeltaRequestBody),
                 schemas(ProtocolDeltaRequestResponse),
                 schemas(ProtocolStateDelta),
+                schemas(Health),
             )
         )]
         struct ApiDoc;
@@ -181,6 +183,10 @@ where
                         self.prefix
                     ))
                     .route(web::post().to(rpc::protocol_components::<G>)),
+                )
+                .service(
+                    web::resource(format!("/{}/health", self.prefix))
+                        .route(web::get().to(rpc::health)),
                 )
                 .app_data(ws_data.clone())
                 .service(

--- a/tycho-indexer/src/services/rpc.rs
+++ b/tycho-indexer/src/services/rpc.rs
@@ -712,6 +712,17 @@ pub async fn protocol_delta<G: Gateway>(
     }
 }
 
+#[utoipa::path(
+    get,
+    path="/v1/health",
+    responses(
+        (status = 200, description = "OK", body=Health),
+    ),
+)]
+pub async fn health() -> HttpResponse {
+    HttpResponse::Ok().json(dto::Health::Ready)
+}
+
 #[cfg(test)]
 mod tests {
     use std::{collections::HashMap, str::FromStr};


### PR DESCRIPTION
Can help us detect and avoid potential deadlocks.