### PR TITLE
fix(tracing): Improve tracing spans

### DIFF
--- a/tycho-indexer/src/extractor/evm/token_pre_processor.rs
+++ b/tycho-indexer/src/extractor/evm/token_pre_processor.rs
@@ -62,7 +62,7 @@ pub fn map_vault(protocol_system: &str) -> Option<H160> {
 
 #[async_trait]
 impl TokenPreProcessorTrait for TokenPreProcessor {
-    #[instrument]
+    #[instrument(skip_all)]
     async fn get_tokens(
         &self,
         addresses: Vec<H160>,


### PR DESCRIPTION
Improve our logs and trace data. Especially include a debug span that records the current substreams trace_id so we can complain if things are too slow.


Example:
```
2024-05-08T13:20:43.546785Z  INFO tycho_indexer: Starting Tycho
2024-05-08T13:20:44.425007Z  INFO tycho_indexer::extractor::evm::vm: Found existing cursor! Resuming extractor.. name="vm:ambient" chain=Ethereum cursor="54366274736b382d555a6b65326a4a67705f51464b4b57774c70635f4446746f55776e6a4b524e436a3972797048715532635f7755324a38625233586c6144313245432d5377756f326465625148347170736c5275595875797574683753595f46486b71776f5f725f6257374c66727a62414d656565343344725f614d593752576a765259417a34654c494b7364477a4d714c644e5252685963346a4c474732686a7056393942554961635773535668773232706573375868502d666f6f64422d4f563352754c776b79366c426d456f4a5534504e4d6d4b4d71664f366d687a4d773d3d"
2024-05-08T13:20:44.691011Z  INFO tycho_indexer: Extractor ethereum:vm:ambient started!
2024-05-08T13:20:44.693694Z  INFO tycho_indexer::extractor::evm::vm: Found existing cursor! Resuming extractor.. name="vm:balancer" chain=Ethereum cursor="7150575065304b396d53494e4338376270436d696a6157774c70635f4446747455776a6b4c684a426a3450326f6e664e325a2d6d4147643850685455775f3330324543395477375f6939325946536f7439634a5436744f386b724533376e4939463338746b3444715f726539636654374f516b594a62383344653250594e3352576a37525951765f6562454b364e5731505f76645a5549795a4d35774a574c67327a745639394e514a504245757959306c32723663637945307133482d4e4643724f6430514f57686e432d6d424764304b305a6150735f575936664e7544306959413d3d"
2024-05-08T13:20:44.911268Z  INFO tycho_indexer: Extractor ethereum:vm:balancer started!
2024-05-08T13:20:44.913388Z  INFO tycho_indexer::extractor::evm::native: Found existing cursor! Resuming extractor.. name="uniswap_v3" chain=Ethereum cursor="59593941673068324e485452726f67506144714d454b57774c70635f44467474555133694c684e436a345f792d434f586935377a5554496b4f527655776676346a45626f513179766a4e624651585a366f38685a367469386b757073764355354679676f6c747a6d5f6266704b66503061674964634c3433574f71494d394852576a37545a41335f654c494b354e4876613647505a42646a4d5a5a334b6d4c693354634238595a636471424473487467797a327365386145326133486f346f512d2d4e30462d436b77434f6c42444d734c456b4a4e63714459716559767a707862413d3d"
2024-05-08T13:20:45.096871Z  INFO extractor{id="ethereum:vm:ambient"}:loop{trace_id="6c2563d3e61608e0d4fadf5709176140"}: tycho_indexer::substreams::stream: SubstreamSession session.resolved_start_block=17626324 session.linear_handoff_block=19825400 session.max_parallel_workers=10 session.trace_id="6c2563d3e61608e0d4fadf5709176140"
2024-05-08T13:20:45.200534Z  INFO tycho_indexer: Extractor ethereum:uniswap_v3 started!
2024-05-08T13:20:45.206410Z  INFO tycho_indexer::extractor::evm::native: Found existing cursor! Resuming extractor.. name="uniswap_v2" chain=Ethereum cursor="48326c6e6852453649574c58336a454f584351326d3657774c70635f444674765677726e49686c476a39332d2d5362476a4a377956445679504575446b5f6a326930627253516d766a4e65635143687a3870565236494f2d79377469377955775479676b776432365f75666f654b4c3762513464646539724372794e5a747652576a7a5659776a7a6372594b74743375627643495a425a6d4e734279656a5777336a6b47385956574936424473534a686c5454394a73364767712d65386f52442d2d6f73462d7a7a77582d6d56444a396655594f4f6371474d5f764b3654386b5a673d3d"
2024-05-08T13:20:45.254024Z  INFO extractor{id="ethereum:vm:balancer"}:loop{trace_id="afd6270cfae4bc3fb18ac93ec440f962"}: tycho_indexer::substreams::stream: SubstreamSession session.resolved_start_block=12631431 session.linear_handoff_block=19825400 session.max_parallel_workers=10 session.trace_id="afd6270cfae4bc3fb18ac93ec440f962"
2024-05-08T13:20:45.402554Z  INFO tycho_indexer: Extractor ethereum:uniswap_v2 started!
2024-05-08T13:20:45.403227Z DEBUG tycho_indexer::services::deltas_buffer: Creating new NativeRevertBuffer for uniswap_v3
2024-05-08T13:20:45.403240Z DEBUG tycho_indexer::services::deltas_buffer: Creating new NativeRevertBuffer for uniswap_v2
2024-05-08T13:20:45.403247Z DEBUG tycho_indexer::services::deltas_buffer: Creating new VmRevertBuffer for vm:ambient
2024-05-08T13:20:45.403265Z DEBUG tycho_indexer::services::deltas_buffer: Creating new VmRevertBuffer for vm:balancer
2024-05-08T13:20:45.403847Z  INFO extractor{id="ethereum:vm:ambient"}:loop{trace_id="6c2563d3e61608e0d4fadf5709176140"}:subscribe: tycho_indexer::extractor::runner: New subscription with id 0
2024-05-08T13:20:45.403861Z  INFO extractor{id="ethereum:uniswap_v3"}:loop:subscribe: tycho_indexer::extractor::runner: New subscription with id 0
2024-05-08T13:20:45.403921Z  INFO extractor{id="ethereum:uniswap_v2"}:loop:subscribe: tycho_indexer::extractor::runner: New subscription with id 0
2024-05-08T13:20:45.403959Z  INFO extractor{id="ethereum:vm:balancer"}:loop{trace_id="afd6270cfae4bc3fb18ac93ec440f962"}:subscribe: tycho_indexer::extractor::runner: New subscription with id 0
2024-05-08T13:20:45.404142Z  INFO tycho_indexer: Http and Ws server started server_url="http://0.0.0.0:4242"
2024-05-08T13:20:45.500176Z DEBUG extractor{id="ethereum:vm:ambient"}:loop{trace_id="6c2563d3e61608e0d4fadf5709176140"}: tycho_indexer::extractor::runner: New block data received.
2024-05-08T13:20:45.500308Z DEBUG extractor{id="ethereum:vm:ambient"}:loop{trace_id="6c2563d3e61608e0d4fadf5709176140"}:handle_tick_scoped_data{block_number=17626324}: tycho_indexer::extractor::revert_buffer: Draining new finalized blocks from RevertBuffer... New chain height 17626324
2024-05-08T13:20:45.500697Z DEBUG extractor{id="ethereum:vm:ambient"}:loop{trace_id="6c2563d3e61608e0d4fadf5709176140"}: tycho_indexer::extractor::runner: New block data received.
2024-05-08T13:20:45.500728Z DEBUG extractor{id="ethereum:vm:ambient"}:loop{trace_id="6c2563d3e61608e0d4fadf5709176140"}:handle_tick_scoped_data{block_number=17626325}: tycho_indexer::extractor::revert_buffer: Draining new finalized blocks from RevertBuffer... New chain height 17626325
2024-05-08T13:20:45.500764Z DEBUG extractor{id="ethereum:vm:ambient"}:loop{trace_id="6c2563d3e61608e0d4fadf5709176140"}:handle_tick_scoped_data{block_number=17626325}:upsert_contract: tycho_indexer::extractor::evm::vm: Upserting block
2024-05-08T13:20:45.501001Z DEBUG tycho_indexer::extractor::revert_buffer: Draining new finalized blocks from RevertBuffer... New chain height 17626324
2024-05-08T13:20:45.521325Z DEBUG extractor{id="ethereum:vm:ambient"}:loop{trace_id="6c2563d3e61608e0d4fadf5709176140"}: tycho_indexer::extractor::runner: New block data received.
2024-05-08T13:20:45.521390Z DEBUG extractor{id="ethereum:vm:ambient"}:loop{trace_id="6c2563d3e61608e0d4fadf5709176140"}:handle_tick_scoped_data{block_number=17626326}: tycho_indexer::extractor::revert_buffer: Draining new finalized blocks from RevertBuffer... New chain height 17626326
```