### PR TITLE
fix(client): Make client backwards compatible.

### DIFF
--- a/tycho-core/src/dto.rs
+++ b/tycho-core/src/dto.rs
@@ -295,7 +295,7 @@ pub struct BlockAccountChanges {
     chain: Chain,
     pub block: Block,
     pub revert: bool,
-    #[serde(with = "hex_hashmap_key")]
+    #[serde(with = "hex_hashmap_key", default)]
     pub new_tokens: HashMap<Bytes, ResponseToken>,
     #[serde(with = "hex_hashmap_key")]
     pub account_updates: HashMap<Bytes, AccountUpdate>,
@@ -501,7 +501,7 @@ pub struct BlockEntityChangesResult {
     pub chain: Chain,
     pub block: Block,
     pub revert: bool,
-    #[serde(with = "hex_hashmap_key")]
+    #[serde(with = "hex_hashmap_key", default)]
     pub new_tokens: HashMap<Bytes, ResponseToken>,
     pub state_updates: HashMap<String, ProtocolStateDelta>,
     pub new_protocol_components: HashMap<String, ProtocolComponent>,


### PR DESCRIPTION
Simply ignore if new_tokens field is missing, this way the client can be used with older tycho versions.