### PR TITLE
feat(token_analyzer): add detection for sell fee only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5878,6 +5878,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "url",
  "web3",
 ]

--- a/token-analyzer/Cargo.toml
+++ b/token-analyzer/Cargo.toml
@@ -25,3 +25,4 @@ clap = { version = "4", features = ["derive", "env"] }
 humantime = "2.1.0"
 reqwest.workspace = true
 url.workspace = true
+tracing-subscriber = "0.3.17"

--- a/token-analyzer/examples/run-analysis.rs
+++ b/token-analyzer/examples/run-analysis.rs
@@ -11,6 +11,10 @@ use web3::types::BlockNumber;
 
 #[tokio::main]
 async fn main() -> Result<(), ()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
     let transport = Web3Transport::new(HttpTransport::new(
         Client::new(),
         Url::from_str(
@@ -19,13 +23,14 @@ async fn main() -> Result<(), ()> {
         .unwrap(),
         "transport".to_owned(),
     ));
+    let token = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+    let liquidity_owner = "0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640";
+    let liquidity = "99018028084239";
+
     let w3 = Web3::new(transport);
     let tf = TokenFinder::new(HashMap::from([(
-        H160::from_str("0x3A9FfF453d50D4Ac52A6890647b823379ba36B9E").unwrap(),
-        (
-            H160::from_str("0x260E069deAd76baAC587B5141bB606Ef8b9Bab6c").unwrap(),
-            U256::from_dec_str("13042252617814040589").unwrap(),
-        ),
+        H160::from_str(token).unwrap(),
+        (H160::from_str(liquidity_owner).unwrap(), U256::from_dec_str(liquidity).unwrap()),
     )]));
 
     let trace_call = TraceCallDetector {
@@ -35,10 +40,7 @@ async fn main() -> Result<(), ()> {
     };
 
     let quality = trace_call
-        .detect(
-            H160::from_str("0x3A9FfF453d50D4Ac52A6890647b823379ba36B9E").unwrap(),
-            BlockNumber::Latest,
-        )
+        .detect(H160::from_str(token).unwrap(), BlockNumber::Latest)
         .await
         .unwrap();
 


### PR DESCRIPTION
This PR aims to allow our token analyzer to detect tokens that have only a sell tax (no buy or transfer tax). 

For example: https://etherscan.io/address/0xf94e7d0710709388bce3161c32b4eea56d3f91cc

Todo: make requests in parallel