### PR TITLE
Handle same ts blocks for Arbitrum in hybrid extractor

### DIFF
--- a/tycho-indexer/src/extractor/evm/hybrid.rs
+++ b/tycho-indexer/src/extractor/evm/hybrid.rs
@@ -600,10 +600,10 @@ where
         if self.chain == Chain::Arbitrum {
             if let Some(last_processed_block) = self.get_last_processed_block().await {
                 let mut inner = self.inner.lock().await;
-                let current_ts =
-                    msg.block.ts + Duration::microseconds(inner.same_ts_blocks_streak.into());
+                let latest_processed_block_ts = last_processed_block.ts -
+                    Duration::microseconds(inner.same_ts_blocks_streak.into());
 
-                if current_ts == last_processed_block.ts {
+                if msg.block.ts == latest_processed_block_ts {
                     inner.same_ts_blocks_streak += 1;
                     // For blockchains with subsecond block times, like Arbitrum, timestamps aren't
                     // precise enough to distinguish between two blocks accurately.

--- a/tycho-indexer/src/extractor/evm/mod.rs
+++ b/tycho-indexer/src/extractor/evm/mod.rs
@@ -628,21 +628,13 @@ impl BlockScoped for BlockContractChanges {
 impl Block {
     /// Parses block from tychos protobuf block message
     pub fn try_from_message(msg: substreams::Block, chain: Chain) -> Result<Self, ExtractionError> {
-        let ts_nano = match chain {
-            // For blockchains with subsecond block times, like Arbitrum, timestamps aren't precise
-            // enough to distinguish between two blocks accurately. To maintain accurate ordering,
-            // we adjust timestamps by appending part of the current block number as microseconds.
-            Chain::Arbitrum => (msg.number as u32 % 1000) * 1000,
-            _ => 0,
-        };
-
         Ok(Self {
             chain,
             number: msg.number,
             hash: pad_and_parse_32bytes(&msg.hash).map_err(ExtractionError::DecodeError)?,
             parent_hash: pad_and_parse_32bytes(&msg.parent_hash)
                 .map_err(ExtractionError::DecodeError)?,
-            ts: NaiveDateTime::from_timestamp_opt(msg.ts as i64, ts_nano).ok_or_else(|| {
+            ts: NaiveDateTime::from_timestamp_opt(msg.ts as i64, 0).ok_or_else(|| {
                 ExtractionError::DecodeError(format!(
                     "Failed to convert timestamp {} to datetime!",
                     msg.ts


### PR DESCRIPTION
This correctly fixes https://github.com/propeller-heads/tycho-indexer/pull/274. The previous fix wasn't working properly at the boundaries - every 1k blocks, we had the timestamp added which changed from 999 to 000, and therefore an incorrect order.