### PR TITLE
Fix RPC non-hybrid snapshots

### DIFF
--- a/tycho-client/src/rpc.rs
+++ b/tycho-client/src/rpc.rs
@@ -227,6 +227,10 @@ impl RPCClient for HttpRPCClient {
         let body = hyper::body::to_bytes(response.into_body())
             .await
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
+        if body.is_empty() {
+            // Pure native protocols will return empty contract states
+            return Ok(StateRequestResponse { accounts: vec![] });
+        }
         let accounts: StateRequestResponse =
             serde_json::from_slice(&body).map_err(|e| RPCError::ParseResponse(e.to_string()))?;
         trace!(?accounts, "Received contract_state response from Tycho server");
@@ -328,6 +332,10 @@ impl RPCClient for HttpRPCClient {
         let body = hyper::body::to_bytes(response.into_body())
             .await
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
+        if body.is_empty() {
+            // Pure VM protocols will return empty states
+            return Ok(ProtocolStateRequestResponse { states: vec![] });
+        }
         let states: ProtocolStateRequestResponse =
             serde_json::from_slice(&body).map_err(|e| RPCError::ParseResponse(e.to_string()))?;
         trace!(?states, "Received protocol_states response from Tycho server");

--- a/tycho-storage/src/postgres/versioning.rs
+++ b/tycho-storage/src/postgres/versioning.rs
@@ -333,7 +333,7 @@ pub async fn apply_partitioned_versioning<T: PartitionedVersionedRow>(
     let delete_versions = delete_versions.unwrap_or(&empty_delete_versions);
 
     if new_data.is_empty() && delete_versions.is_empty() {
-        return Ok((Vec::new(), Vec::new()))
+        return Ok((Vec::new(), Vec::new()));
     }
     let db_rows: Vec<T> = T::latest_versions_by_ids(
         new_data


### PR DESCRIPTION
Pure vm and native protocols return empty states for protocol and contract state respectively, which would error. We need to rather return an empty vec in these cases.