### PR TITLE
breaking(api): consistently use snake_case in Tycho API

### DIFF
--- a/scripts/compare-uniswap-v3-the-graph.py
+++ b/scripts/compare-uniswap-v3-the-graph.py
@@ -8,7 +8,7 @@ GRAPH_URL = 'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3'
 
 def fetch_tycho_data(block: int, component_ids: list[str]):
     payload = {
-      "protocolIds": [
+      "protocol_ids": [
         {
           "chain": "ethereum",
           "id": cid

--- a/scripts/compare-vm-protocol.py
+++ b/scripts/compare-vm-protocol.py
@@ -29,7 +29,7 @@ async def fetch_tycho_components(session, system: str) -> dict:
 
 async def fetch_tycho_accounts(session, accounts: list[str], state_block: int) -> list[dict]:
     payload = {
-        "contractIds": [{"address": addr, "chain": "ethereum"}for addr in accounts],
+        "contract_ids": [{"address": addr, "chain": "ethereum"}for addr in accounts],
         "version": {"block": {"number": state_block, "chain": "ethereum"}}
     }
     uri="http://127.0.0.1:4242/v1/ethereum/contract_state"

--- a/tycho-client-py/tests/test_tycho_rpc_client.py
+++ b/tycho-client-py/tests/test_tycho_rpc_client.py
@@ -54,7 +54,7 @@ def test_get_protocol_state_returns_expected_result(mock_post, asset_dir):
     mock_post.assert_called_once_with(
         "http://0.0.0.0:4242/v1/ethereum/protocol_state",
         headers={"accept": "application/json", "Content-Type": "application/json"},
-        data='{}',
+        data="{}",
         params='{"include_balances": true}',
     )
     assert isinstance(result, list)
@@ -80,7 +80,7 @@ def test_get_contract_state_returns_expected_result(mock_post, asset_dir):
     mock_post.assert_called_once_with(
         "http://0.0.0.0:4242/v1/ethereum/contract_state",
         headers={"accept": "application/json", "Content-Type": "application/json"},
-        data='{}',
+        data="{}",
         params='{"include_balances": true}',
     )
 

--- a/tycho-client-py/tycho_client/dto.py
+++ b/tycho-client-py/tycho_client/dto.py
@@ -21,7 +21,7 @@ class HexBytes(_HexBytes):
         # the returned value will be ignored
         field_schema.update(
             # some example postcodes
-            examples=["0xBadBad"],
+            examples=["0xBadBad"]
         )
 
     @classmethod
@@ -236,6 +236,7 @@ class FeedMessage(BaseModel):
 
 # Client Parameters
 
+
 class ProtocolId(BaseModel):
     chain: Chain
     id: str
@@ -253,9 +254,7 @@ class VersionParams(BaseModel):
 
 class ProtocolComponentsParams(BaseModel):
     protocol_system: Optional[str] = None
-    component_addresses: Optional[List[HexBytes]] = Field(
-        default=None, alias="componentAddresses"
-    )
+    component_addresses: Optional[List[HexBytes]] = Field(default=None)
     tvl_gt: Optional[int] = None
 
     class Config:
@@ -266,8 +265,8 @@ class ProtocolStateParams(BaseModel):
     tvl_gt: Optional[int] = None
     inertia_min_gt: Optional[int] = None
     include_balances: Optional[bool] = True
-    protocol_ids: Optional[List[ProtocolId]] = Field(default=None, alias="protocolIds")
-    protocol_system: Optional[str] = Field(default=None, alias="protocolSystem")
+    protocol_ids: Optional[List[ProtocolId]] = Field(default=None)
+    protocol_system: Optional[str] = Field(default=None)
     version: Optional[VersionParams] = None
 
     class Config:
@@ -279,7 +278,7 @@ class ContractStateParams(BaseModel):
     tvl_gt: Optional[int] = None
     inertia_min_gt: Optional[int] = None
     include_balances: Optional[bool] = True
-    contract_ids: Optional[List[ContractId]] = Field(default=None, alias="contractIds")
+    contract_ids: Optional[List[ContractId]] = Field(default=None)
     version: Optional[VersionParams] = None
 
     class Config:
@@ -294,9 +293,7 @@ class PaginationParams(BaseModel):
 class TokensParams(BaseModel):
     min_quality: Optional[int] = None
     pagination: Optional[PaginationParams] = None
-    token_addresses: Optional[List[HexBytes]] = Field(
-        default=None, alias="tokenAddresses"
-    )
+    token_addresses: Optional[List[HexBytes]] = Field(default=None)
     traded_n_days_ago: Optional[int] = None
 
     class Config:

--- a/tycho-client-py/tycho_client/rpc_client.py
+++ b/tycho-client-py/tycho_client/rpc_client.py
@@ -12,7 +12,15 @@ from .dto import (
     ContractStateParams,
     ResponseToken,
     TokensParams,
+    HexBytes,
 )
+
+
+class HexBytesEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, HexBytes):
+            return obj.hex()
+        return super().default(obj)
 
 
 class TychoRPCClient:
@@ -21,7 +29,7 @@ class TychoRPCClient:
     """
 
     def __init__(
-            self, rpc_url: str = "http://0.0.0.0:4242", chain: Chain = Chain.ethereum
+        self, rpc_url: str = "http://0.0.0.0:4242", chain: Chain = Chain.ethereum
     ):
         self.rpc_url = rpc_url
         self._headers = {
@@ -31,15 +39,15 @@ class TychoRPCClient:
         self._chain = chain
 
     def _post_request(
-            self, endpoint: str, params: dict = None, body: dict = None
+        self, endpoint: str, params: dict = None, body: dict = None
     ) -> dict:
         """Sends a POST request to the given endpoint and returns the response."""
 
         # Convert to JSON strings to cast booleans to strings
         if body is not None:
-            body = json.dumps(body)
+            body = json.dumps(body, cls=HexBytesEncoder)
         if params:
-            params = json.dumps(params)
+            params = json.dumps(params, cls=HexBytesEncoder)
 
         response = requests.post(
             self.rpc_url + endpoint,
@@ -50,7 +58,7 @@ class TychoRPCClient:
         return response.json()
 
     def get_protocol_components(
-            self, params: ProtocolComponentsParams
+        self, params: ProtocolComponentsParams
     ) -> list[ProtocolComponent]:
         params = params.dict(exclude_none=True)
 
@@ -60,20 +68,24 @@ class TychoRPCClient:
         query_params = {k: v for k, v in params.items() if k in query_params_fields}
         body = {k: v for k, v in params.items() if k in body_fields}
 
+        # Convert HexBytes to strings
+        if "component_addresses" in body:
+            body["component_addresses"] = [
+                address.hex() for address in body["component_addresses"]
+            ]
+
         res = self._post_request(
-            f"/v1/{self._chain}/protocol_components",
-            body=body,
-            params=query_params,
+            f"/v1/{self._chain}/protocol_components", body=body, params=query_params
         )
         return [ProtocolComponent(**c) for c in res["protocol_components"]]
 
     def get_protocol_state(
-            self, params: ProtocolStateParams
+        self, params: ProtocolStateParams
     ) -> list[ResponseProtocolState]:
         params = params.dict(exclude_none=True)
 
         query_params_fields = ["tvl_gt", "inertia_min_gt", "include_balances"]
-        body_fields = ["protocolIds", "protocolSystem", "version"]
+        body_fields = ["protocol_ids", "protocol_system", "version"]
 
         query_params = {k: v for k, v in params.items() if k in query_params_fields}
         body = {k: v for k, v in params.items() if k in body_fields}
@@ -87,31 +99,39 @@ class TychoRPCClient:
         params = params.dict(exclude_none=True)
 
         query_params_fields = ["tvl_gt", "inertia_min_gt", "include_balances"]
-        body_fields = ["contractIds", "version"]
+        body_fields = ["contract_ids", "version"]
 
         query_params = {k: v for k, v in params.items() if k in query_params_fields}
         body = {k: v for k, v in params.items() if k in body_fields}
 
         res = self._post_request(
-            f"/v1/{self._chain}/contract_state",
-            body=body,
-            params=query_params,
+            f"/v1/{self._chain}/contract_state", body=body, params=query_params
         )
         return [ResponseAccount(**a) for a in res["accounts"]]
 
     def get_tokens(self, params: TokensParams) -> list[ResponseToken]:
         params = params.dict(exclude_none=True)
 
-        body_fields = ["min_quality", "pagination", "tokenAddresses", "traded_n_days_ago"]
+        body_fields = [
+            "min_quality",
+            "pagination",
+            "token_addresses",
+            "traded_n_days_ago",
+        ]
         body = {k: v for k, v in params.items() if k in body_fields}
-
         res = self._post_request(f"/v1/{self._chain}/tokens", body=body, params={})
         return [ResponseToken(**t) for t in res["tokens"]]
 
 
 if __name__ == "__main__":
     client = TychoRPCClient("http://0.0.0.0:4242")
-    print(client.get_protocol_components(ProtocolComponentsParams(protocol_system="test_protocol")))
-    print(client.get_protocol_state(ProtocolStateParams(protocol_system="test_protocol")))
+    print(
+        client.get_protocol_components(
+            ProtocolComponentsParams(protocol_system="test_protocol")
+        )
+    )
+    print(
+        client.get_protocol_state(ProtocolStateParams(protocol_system="test_protocol"))
+    )
     print(client.get_contract_state(ContractStateParams()))
     print(client.get_tokens(TokensParams(min_quality=10, traded_n_days_ago=30)))

--- a/tycho-core/src/dto.rs
+++ b/tycho-core/src/dto.rs
@@ -503,7 +503,6 @@ impl ProtocolStateDelta {
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, ToSchema)]
 pub struct StateRequestBody {
-    #[serde(rename = "contractIds")]
     pub contract_ids: Option<Vec<ContractId>>,
     #[serde(default = "VersionParam::default")]
     pub version: VersionParam,
@@ -708,7 +707,6 @@ impl StateRequestParameters {
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, ToSchema)]
 pub struct TokensRequestBody {
-    #[serde(rename = "tokenAddresses")]
     #[schema(value_type=Option<Vec<String>>)]
     pub token_addresses: Option<Vec<Bytes>>,
     #[serde(default)]
@@ -788,7 +786,6 @@ impl From<models::token::CurrencyToken> for ResponseToken {
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, ToSchema)]
 pub struct ProtocolComponentsRequestBody {
     pub protocol_system: Option<String>,
-    #[serde(rename = "componentAddresses")]
     pub component_ids: Option<Vec<String>>,
 }
 
@@ -843,7 +840,6 @@ impl ProtocolComponentRequestResponse {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct ContractDeltaRequestBody {
-    #[serde(rename = "contractIds")]
     pub contract_ids: Option<Vec<ContractId>>,
     #[serde(default = "VersionParam::default")]
     pub start: VersionParam,
@@ -893,9 +889,7 @@ impl From<models::protocol::ProtocolComponentState> for ResponseProtocolState {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, ToSchema, Default)]
 pub struct ProtocolStateRequestBody {
-    #[serde(rename = "protocolIds")]
     pub protocol_ids: Option<Vec<ProtocolId>>,
-    #[serde(rename = "protocolSystem")]
     pub protocol_system: Option<String>,
     #[serde(default = "VersionParam::default")]
     pub version: VersionParam,
@@ -920,7 +914,6 @@ impl ProtocolStateRequestResponse {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct ProtocolDeltaRequestBody {
-    #[serde(rename = "contractIds")]
     pub component_ids: Option<Vec<String>>,
     #[serde(default = "VersionParam::default")]
     pub start: VersionParam,
@@ -965,7 +958,7 @@ mod test {
     fn test_parse_state_request() {
         let json_str = r#"
         {
-            "contractIds": [
+            "contract_ids": [
                 {
                     "address": "0xb4eccE46b8D4e4abFd03C9B806276A6735C9c092",
                     "chain": "ethereum"

--- a/tycho-indexer/src/services/rpc.rs
+++ b/tycho-indexer/src/services/rpc.rs
@@ -877,7 +877,7 @@ mod tests {
     async fn test_parse_state_request_no_version_specified() {
         let json_str = r#"
     {
-        "contractIds": [
+        "contract_ids": [
             {
                 "address": "0xb4eccE46b8D4e4abFd03C9B806276A6735C9c092",
                 "chain": "ethereum"


### PR DESCRIPTION
Make our API use snake_case only instead of a mix between snake and camel