### PR TITLE
fix: Hanging client on max connection attempts reached

### DIFF
--- a/tycho-client/src/deltas.rs
+++ b/tycho-client/src/deltas.rs
@@ -643,6 +643,7 @@ impl DeltasClient for WsDeltasClient {
             if retry_count >= this.max_reconnects {
                 error!("Max reconnection attempts reached; Exiting");
                 this.conn_notify.notify_waiters(); // Notify that the task is done
+                result = Err(DeltasError::ConnectionClosed);
             }
 
             result


### PR DESCRIPTION
Issue: Program would hang on `self.conn_notify.notified().await;` when max connection attempts were reached. This is because we only trigger this notification once a successful connection was formed.
Solution: also trigger the notification when max retries is reached.