### PR TITLE
fix(client-py): fix hexbytes encoding and remove camelCase aliases

### DIFF
--- a/tycho-client-py/tests/test_tycho_rpc_client.py
+++ b/tycho-client-py/tests/test_tycho_rpc_client.py
@@ -54,7 +54,7 @@ def test_get_protocol_state_returns_expected_result(mock_post, asset_dir):
     mock_post.assert_called_once_with(
         "http://0.0.0.0:4242/v1/ethereum/protocol_state",
         headers={"accept": "application/json", "Content-Type": "application/json"},
-        data='{}',
+        data="{}",
         params='{"include_balances": true}',
     )
     assert isinstance(result, list)
@@ -80,7 +80,7 @@ def test_get_contract_state_returns_expected_result(mock_post, asset_dir):
     mock_post.assert_called_once_with(
         "http://0.0.0.0:4242/v1/ethereum/contract_state",
         headers={"accept": "application/json", "Content-Type": "application/json"},
-        data='{}',
+        data="{}",
         params='{"include_balances": true}',
     )
 

--- a/tycho-client-py/tycho_client/dto.py
+++ b/tycho-client-py/tycho_client/dto.py
@@ -21,7 +21,7 @@ class HexBytes(_HexBytes):
         # the returned value will be ignored
         field_schema.update(
             # some example postcodes
-            examples=["0xBadBad"],
+            examples=["0xBadBad"]
         )
 
     @classmethod
@@ -235,6 +235,7 @@ class FeedMessage(BaseModel):
 
 
 # Client Parameters
+
 
 class ProtocolId(BaseModel):
     chain: Chain

--- a/tycho-client-py/tycho_client/rpc_client.py
+++ b/tycho-client-py/tycho_client/rpc_client.py
@@ -29,7 +29,7 @@ class TychoRPCClient:
     """
 
     def __init__(
-            self, rpc_url: str = "http://0.0.0.0:4242", chain: Chain = Chain.ethereum
+        self, rpc_url: str = "http://0.0.0.0:4242", chain: Chain = Chain.ethereum
     ):
         self.rpc_url = rpc_url
         self._headers = {
@@ -39,7 +39,7 @@ class TychoRPCClient:
         self._chain = chain
 
     def _post_request(
-            self, endpoint: str, params: dict = None, body: dict = None
+        self, endpoint: str, params: dict = None, body: dict = None
     ) -> dict:
         """Sends a POST request to the given endpoint and returns the response."""
 
@@ -58,7 +58,7 @@ class TychoRPCClient:
         return response.json()
 
     def get_protocol_components(
-            self, params: ProtocolComponentsParams
+        self, params: ProtocolComponentsParams
     ) -> list[ProtocolComponent]:
         params = params.dict(exclude_none=True)
 
@@ -69,14 +69,12 @@ class TychoRPCClient:
         body = {k: v for k, v in params.items() if k in body_fields}
 
         res = self._post_request(
-            f"/v1/{self._chain}/protocol_components",
-            body=body,
-            params=query_params,
+            f"/v1/{self._chain}/protocol_components", body=body, params=query_params
         )
         return [ProtocolComponent(**c) for c in res["protocol_components"]]
 
     def get_protocol_state(
-            self, params: ProtocolStateParams
+        self, params: ProtocolStateParams
     ) -> list[ResponseProtocolState]:
         params = params.dict(exclude_none=True)
 
@@ -101,16 +99,19 @@ class TychoRPCClient:
         body = {k: v for k, v in params.items() if k in body_fields}
 
         res = self._post_request(
-            f"/v1/{self._chain}/contract_state",
-            body=body,
-            params=query_params,
+            f"/v1/{self._chain}/contract_state", body=body, params=query_params
         )
         return [ResponseAccount(**a) for a in res["accounts"]]
 
     def get_tokens(self, params: TokensParams) -> list[ResponseToken]:
         params = params.dict(exclude_none=True)
 
-        body_fields = ["min_quality", "pagination", "token_addresses", "traded_n_days_ago"]
+        body_fields = [
+            "min_quality",
+            "pagination",
+            "token_addresses",
+            "traded_n_days_ago",
+        ]
         body = {k: v for k, v in params.items() if k in body_fields}
 
         res = self._post_request(f"/v1/{self._chain}/tokens", body=body, params={})


### PR DESCRIPTION
This PR fix a bug in tycho-client-py where fields were left empty even if present in the request. This bug was caused by snake_case, camelCase confusion in the body field arrays. And easy fix would have been to use `params.dict(by_alias=True,...)` but it would create even more unconsistencies. The proposed solution is to allow for snake case in Tycho RPC (this was done in https://github.com/propeller-heads/tycho-indexer/pull/321) and only use snake case in the clients.

This PR also fixes HexBytes encoding in the requests and apply black formatting in the python client.


Review commit by commit is suggested