### PR TITLE
refactor: do not error if the protocol system isn't found in `get_block_finality`

### DIFF
--- a/tycho-indexer/src/services/deltas_buffer.rs
+++ b/tycho-indexer/src/services/deltas_buffer.rs
@@ -261,6 +261,7 @@ impl PendingDeltas {
 
     /// Returns finality for any extractor, can error if lock is poisened. Returns None if buffer is
     /// empty.
+    /// Returns an error if the provided protocol system isn't found in the buffer.
     /// Note - if no protocol system is provided, we choose a random extractor to get the finality
     /// status from. This is particularly risky when there is an extractor syncing.
     pub fn get_block_finality(
@@ -276,6 +277,7 @@ impl PendingDeltas {
                         .map_err(|e| PendingDeltasError::LockError(system, e.to_string()))?;
                     Ok(guard.get_finality_status(version))
                 } else {
+                    debug!(?system, "Missing requested protocol system in pending deltas");
                     Err(PendingDeltasError::UnknownExtractor(system))
                 }
             }

--- a/tycho-indexer/src/services/rpc.rs
+++ b/tycho-indexer/src/services/rpc.rs
@@ -223,9 +223,10 @@ where
         };
         let request_version_finality = self
             .pending_deltas
-            .get_block_finality(ordered_version, protocol_system.clone())?
+            .get_block_finality(ordered_version, protocol_system.clone())
+            .unwrap_or(None)
             .unwrap_or_else(|| {
-                warn!(?ordered_version, "No finality found for version.");
+                warn!(?ordered_version, ?protocol_system, "No finality found for version.");
                 FinalityStatus::Finalized
             });
         debug!(


### PR DESCRIPTION
This PR allow to filter by protocol_system in Tycho RPC even if the corresponding extractor isn't currently running (for example if we use the `rpc` command of Tycho). In that case, we just get the state from the DB and don't apply anything on top of it