### PR TITLE
chore: remove ethers dependency from `tycho-storage`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6572,6 +6572,7 @@ dependencies = [
  "rstest",
  "serde_json",
  "test-log",
+ "tiny-keccak",
  "tokio",
  "tracing",
  "tycho-core",

--- a/tycho-storage/Cargo.toml
+++ b/tycho-storage/Cargo.toml
@@ -18,11 +18,12 @@ diesel_migrations = "2.1.0"
 lru = "0.12.1"
 itertools = "0.12.1"
 unicode-segmentation.workspace = true
-ethers.workspace = true
 lazy_static = "1.4.0"
+tiny-keccak = "2.0.2"
 
 
 [dev-dependencies]
+ethers.workspace = true
 rstest = "0.18.2"
 pretty_assertions = "1.4.0"
 test-log = { version = "0.2.14", features = ["trace"] }

--- a/tycho-storage/src/postgres/chain.rs
+++ b/tycho-storage/src/postgres/chain.rs
@@ -276,7 +276,6 @@ mod test {
         db_fixtures::{yesterday_midnight, yesterday_one_am},
     };
     use diesel_async::AsyncConnection;
-    use ethers::types::{H256, U256};
     use std::{str::FromStr, time::Duration};
     use tycho_core::models::Chain;
 
@@ -582,16 +581,14 @@ mod test {
 
         // set up contracts data
         let block1_hash =
-            H256::from_str("0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6")
-                .unwrap()
-                .0
-                .into();
+            Bytes::from_str("88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6")
+                .unwrap();
         let c0_address =
             Bytes::from_str("6B175474E89094C44Da98b954EedeAC495271d0F").expect("c0 address valid");
-        let exp_slots: HashMap<U256, U256> = vec![
-            (U256::from(0), U256::from(1)),
-            (U256::from(1), U256::from(5)),
-            (U256::from(2), U256::from(1)),
+        let exp_slots: HashMap<Bytes, Bytes> = vec![
+            (Bytes::from(0_u8).lpad(32, 0), Bytes::from(1_u8).lpad(32, 0)),
+            (Bytes::from(1_u8).lpad(32, 0), Bytes::from(5_u8).lpad(32, 0)),
+            (Bytes::from(2_u8).lpad(32, 0), Bytes::from(1_u8).lpad(32, 0)),
         ]
         .into_iter()
         .collect();
@@ -602,7 +599,7 @@ mod test {
             .await
             .unwrap();
 
-        let slots: HashMap<U256, U256> = schema::contract_storage::table
+        let slots: HashMap<Bytes, Bytes> = schema::contract_storage::table
             .inner_join(schema::account::table)
             .filter(schema::account::address.eq(c0_address))
             .select((schema::contract_storage::slot, schema::contract_storage::value))
@@ -612,10 +609,9 @@ mod test {
             .iter()
             .map(|(k, v)| {
                 (
-                    U256::from_big_endian(k),
-                    v.as_ref()
-                        .map(|rv| U256::from_big_endian(rv))
-                        .unwrap_or_else(U256::zero),
+                    k.clone(),
+                    v.clone()
+                        .unwrap_or(Bytes::from([0u8; 32])),
                 )
             })
             .collect();

--- a/tycho-storage/src/postgres/contract.rs
+++ b/tycho-storage/src/postgres/contract.rs
@@ -1,5 +1,6 @@
 use super::{
-    maybe_lookup_block_ts, maybe_lookup_version_ts, orm, schema, storage_error_from_diesel,
+    keccak256, maybe_lookup_block_ts, maybe_lookup_version_ts, orm, schema,
+    storage_error_from_diesel,
     versioning::{apply_partitioned_versioning, apply_versioning},
     PostgresError, PostgresGateway, WithOrdinal, WithTxHash, MAX_TS,
 };
@@ -9,7 +10,6 @@ use diesel::{
     upsert::{excluded, on_constraint},
 };
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
-use ethers::utils::keccak256;
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 use tracing::{debug, error, instrument};
 use tycho_core::{

--- a/tycho-storage/src/postgres/mod.rs
+++ b/tycho-storage/src/postgres/mod.rs
@@ -140,6 +140,7 @@ use diesel_async::{
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 use tracing::{debug, info};
 
+use tiny_keccak::{Hasher, Keccak};
 use tycho_core::{
     models::{Chain, TxHash},
     storage::{BlockIdentifier, BlockOrTimestamp, StorageError, Version, VersionKind},
@@ -399,6 +400,19 @@ async fn maybe_lookup_version_ts(
         return Err(StorageError::Unsupported(format!("Unsupported version kind: {:?}", version.1)));
     }
     maybe_lookup_block_ts(&version.0, conn).await
+}
+
+/// Compute the Keccak-256 hash of input bytes.
+///
+/// Note that strings are interpreted as UTF-8 bytes,
+pub fn keccak256<T: AsRef<[u8]>>(bytes: T) -> [u8; 32] {
+    let mut output = [0u8; 32];
+
+    let mut hasher = Keccak::v256();
+    hasher.update(bytes.as_ref());
+    hasher.finalize(&mut output);
+
+    output
 }
 
 #[derive(Clone)]
@@ -726,7 +740,6 @@ pub mod db_fixtures {
     use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime};
     use diesel::{prelude::*, sql_query};
     use diesel_async::{AsyncPgConnection, RunQueryDsl};
-    use ethers::types::{H160, H256, U256};
     use serde_json::Value;
 
     use tycho_core::{
@@ -777,18 +790,16 @@ pub mod db_fixtures {
         let block_records = vec![
             (
                 schema::block::hash.eq(Vec::from(
-                    H256::from_str(
-                        "0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6",
+                    Bytes::from_str(
+                        "88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6",
                     )
-                    .unwrap()
-                    .as_bytes(),
+                    .unwrap(),
                 )),
                 schema::block::parent_hash.eq(Vec::from(
-                    H256::from_str(
-                        "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
+                    Bytes::from_str(
+                        "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
                     )
-                    .unwrap()
-                    .as_bytes(),
+                    .unwrap(),
                 )),
                 schema::block::number.eq(1),
                 schema::block::ts.eq(yesterday_midnight()),
@@ -796,18 +807,16 @@ pub mod db_fixtures {
             ),
             (
                 schema::block::hash.eq(Vec::from(
-                    H256::from_str(
-                        "0xb495a1d7e6663152ae92708da4843337b958146015a2802f4193a410044698c9",
+                    Bytes::from_str(
+                        "b495a1d7e6663152ae92708da4843337b958146015a2802f4193a410044698c9",
                     )
-                    .unwrap()
-                    .as_bytes(),
+                    .unwrap(),
                 )),
                 schema::block::parent_hash.eq(Vec::from(
-                    H256::from_str(
-                        "0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6",
+                    Bytes::from_str(
+                        "88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6",
                     )
-                    .unwrap()
-                    .as_bytes(),
+                    .unwrap(),
                 )),
                 schema::block::number.eq(2),
                 schema::block::ts.eq(yesterday_one_am()),
@@ -824,8 +833,8 @@ pub mod db_fixtures {
 
     /// Insert a bunch of transactions using (block_id, index, hash)
     pub async fn insert_txns(conn: &mut AsyncPgConnection, txns: &[(i64, i64, &str)]) -> Vec<i64> {
-        let from_val = H160::from_str("0x4648451b5F87FF8F0F7D622bD40574bb97E25980").unwrap();
-        let to_val = H160::from_str("0x6B175474E89094C44Da98b954EedeAC495271d0F").unwrap();
+        let from_val = Bytes::from_str("4648451b5F87FF8F0F7D622bD40574bb97E25980").unwrap();
+        let to_val = Bytes::from_str("6B175474E89094C44Da98b954EedeAC495271d0F").unwrap();
         let data: Vec<_> = txns
             .iter()
             .map(|(b, i, h)| {
@@ -833,12 +842,9 @@ pub mod db_fixtures {
                 (
                     block_id.eq(b),
                     index.eq(i),
-                    hash.eq(H256::from_str(h)
-                        .expect("valid txhash")
-                        .as_bytes()
-                        .to_owned()),
-                    from.eq(from_val.as_bytes()),
-                    to.eq(to_val.as_bytes()),
+                    hash.eq(Bytes::from_str(h).expect("valid txhash")),
+                    from.eq(from_val.clone()),
+                    to.eq(to_val.clone()),
                 )
             })
             .collect();
@@ -897,19 +903,11 @@ pub mod db_fixtures {
             .iter()
             .enumerate()
             .map(|(idx, (k, v, pv))| {
-                let previous_value =
-                    pv.map(|pv| hex::decode(format!("{:064x}", U256::from(pv))).unwrap());
+                let previous_value = pv.map(|pv| hex::decode(format!("{:064x}", pv)).unwrap());
                 (
-                    schema::contract_storage::slot.eq(hex::decode(format!(
-                        "{:064x}",
-                        U256::from(*k)
-                    ))
-                    .unwrap()),
-                    schema::contract_storage::value.eq(hex::decode(format!(
-                        "{:064x}",
-                        U256::from(*v)
-                    ))
-                    .unwrap()),
+                    schema::contract_storage::slot.eq(hex::decode(format!("{:064x}", *k)).unwrap()),
+                    schema::contract_storage::value
+                        .eq(hex::decode(format!("{:064x}", *v)).unwrap()),
                     schema::contract_storage::previous_value.eq(previous_value),
                     schema::contract_storage::account_id.eq(contract_id),
                     schema::contract_storage::modify_tx.eq(modify_tx),
@@ -941,8 +939,11 @@ pub mod db_fixtures {
             .first::<NaiveDateTime>(conn)
             .await
             .expect("setup tx id not found");
+
         let mut b0 = [0; 32];
-        U256::from(new_balance).to_big_endian(&mut b0);
+        let new_balance_bytes = new_balance.to_be_bytes();
+        b0[24..].copy_from_slice(&new_balance_bytes);
+
         {
             use schema::account_balance::dsl::*;
             diesel::insert_into(account_balance)
@@ -973,10 +974,9 @@ pub mod db_fixtures {
             .await
             .expect("setup tx id not found");
 
-        let code_hash = H256::from_slice(&ethers::utils::keccak256(&code));
         let data = (
-            schema::contract_code::code.eq(code),
-            schema::contract_code::hash.eq(code_hash.as_bytes()),
+            schema::contract_code::code.eq(&code),
+            schema::contract_code::hash.eq(Bytes::from(&super::keccak256(&code))),
             schema::contract_code::account_id.eq(account_id),
             schema::contract_code::modify_tx.eq(modify_tx),
             schema::contract_code::valid_from.eq(ts),


### PR DESCRIPTION
This PR aims to remove the `ethers` dependency from `tycho-storage` without changing its logic.