### PR TITLE
fix(dto): Use capitalize enum values.

### DIFF
--- a/tycho-client-py/tycho_indexer_client/dto.py
+++ b/tycho-client-py/tycho_indexer_client/dto.py
@@ -208,12 +208,12 @@ class StateSyncMessage(BaseModel):
 
 
 class SynchronizerStateEnum(str, Enum):
-    started = "started"
-    ready = "ready"
-    stale = "stale"
-    delayed = "delayed"
-    advanced = "advanced"
-    ended = "ended"
+    started = "Started"
+    ready = "Ready"
+    stale = "Stale"
+    delayed = "Delayed"
+    advanced = "Advanced"
+    ended = "Ended"
 
 
 class SynchronizerState(BaseModel):


### PR DESCRIPTION
This allows for easy deserialization with Pydantic since rust enums variants are usually serialized with a capital first letter.