### PR TITLE
refactor: increase otel channel limit and batch size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5950,7 +5950,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-analyzer"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6440,7 +6440,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6470,7 +6470,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-core"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6496,7 +6496,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-indexer"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "actix",
  "actix-rt",
@@ -6556,7 +6556,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-storage"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "async-trait",
  "chrono",


### PR DESCRIPTION
Substreams send us blocks by batch during synchronization: a few thousands blocks in a few seconds. Our OTEL channel then gets filled and don't have time to process that many spans so quick. 

This PR should fix the `cannot send message to batch processor as the channel is full` that we get when syncing.