### PR TITLE
fix: add chain awareness to extraction state block migration

### DIFF
--- a/tycho-storage/migrations/2024-06-21_v0.7.1/up.sql
+++ b/tycho-storage/migrations/2024-06-21_v0.7.1/up.sql
@@ -2,15 +2,18 @@
 ALTER TABLE extraction_state
 ADD COLUMN "block_id" bigint REFERENCES "block"(id);
 
--- populate existing extraction_state with oldest block_id
-WITH oldest_block AS (
-    SELECT id
-    FROM "block"
-    ORDER BY id ASC
-    LIMIT 1
+-- Populate existing extraction_state with the oldest block_id for its chain
+WITH oldest_blocks AS (
+    SELECT b.chain_id, MIN(b.id) AS oldest_block_id
+    FROM "block" b
+    GROUP BY b.chain_id
 )
-UPDATE extraction_state
-SET block_id = (SELECT id FROM oldest_block);
+UPDATE extraction_state es
+SET block_id = (
+    SELECT ob.oldest_block_id
+    FROM oldest_blocks ob
+    WHERE es.chain_id = ob.chain_id
+);
 
 -- add NOT NULL constraint
 ALTER TABLE extraction_state ALTER COLUMN block_id SET NOT NULL;

--- a/tycho-storage/src/postgres/orm.rs
+++ b/tycho-storage/src/postgres/orm.rs
@@ -65,7 +65,7 @@ pub struct ExtractionState {
     /// Chain identifier that the extractor instance is scoped to.
     pub chain_id: i64,
 
-    /// Block identifier associated with the extraction state.
+    /// Last block processed by the extractor.
     pub block_id: i64,
 
     /// Last fully extracted cursor for the corresponding substream.
@@ -172,14 +172,6 @@ impl Block {
     pub async fn by_hash(block_hash: &[u8], conn: &mut AsyncPgConnection) -> QueryResult<Block> {
         block::table
             .filter(block::hash.eq(block_hash))
-            .select(Block::as_select())
-            .first::<Block>(conn)
-            .await
-    }
-
-    pub async fn by_db_id(id: i64, conn: &mut AsyncPgConnection) -> QueryResult<Block> {
-        block::table
-            .filter(block::id.eq(id))
             .select(Block::as_select())
             .first::<Block>(conn)
             .await


### PR DESCRIPTION
This PR addresses the post merge comments from here: https://github.com/propeller-heads/tycho-indexer/pull/287

Main change: fix the migration adding block id to extraction state - make it chain aware, setting the state to the latest block of it's chain.