### PR TITLE
refactor(tycho-indexer): remove chain state hack

### DIFF
--- a/tycho-indexer/src/extractor/evm/chain_state.rs
+++ b/tycho-indexer/src/extractor/evm/chain_state.rs
@@ -4,17 +4,18 @@ use chrono::NaiveDateTime;
 #[derive(Default, Clone, Copy)]
 pub struct ChainState {
     start: NaiveDateTime,
-    block_number: u64,
+    block_number_at_start: u64,
+    block_time: i64,
 }
 
 impl ChainState {
-    pub fn new(start: NaiveDateTime, block_number: u64) -> Self {
-        Self { start, block_number }
+    pub fn new(start: NaiveDateTime, block_number_at_start: u64, block_time: i64) -> Self {
+        Self { start, block_number_at_start, block_time }
     }
     pub async fn current_block(&self) -> u64 {
         let now = chrono::Local::now().naive_utc();
         let diff = now.signed_duration_since(self.start);
-        let blocks_passed = (diff.num_seconds() / 12) as u64;
-        self.block_number + blocks_passed
+        let blocks_passed = (diff.num_seconds() / self.block_time) as u64;
+        self.block_number_at_start + blocks_passed
     }
 }

--- a/tycho-indexer/src/extractor/runner.rs
+++ b/tycho-indexer/src/extractor/runner.rs
@@ -448,7 +448,6 @@ impl ExtractorBuilder {
                     "vm:curve" => Some(trim_curve_component_token),
                     _ => None,
                 },
-                128,
             )
             .await?,
         ));

--- a/tycho-indexer/src/main.rs
+++ b/tycho-indexer/src/main.rs
@@ -211,7 +211,7 @@ async fn create_indexing_tasks(
         .await
         .expect("Error getting block number");
 
-    let chain_state = ChainState::new(chrono::Local::now().naive_utc(), block_number);
+    let chain_state = ChainState::new(chrono::Local::now().naive_utc(), block_number, 12); //TODO: remove hardcoded blocktime
 
     let protocol_systems: Vec<String> = extractors_config
         .extractors


### PR DESCRIPTION
This PR removes the hack that we did previously with getting the syncing state using `ChainState`.

`ChainState` gives us an approximation of the current block header. It makes an assumption on the blocktime which can lead to difference with the blockchain true state. Using this for report progress led to weird logs (we were getting this report progress logs even though the extractor was synced).