### PR TITLE
fix(client): improve python client stream error logging

### DIFF
--- a/tycho-client-py/tycho_indexer_client/stream.py
+++ b/tycho-client-py/tycho_indexer_client/stream.py
@@ -30,7 +30,7 @@ class TychoStream:
         include_state=True,
         logs_directory: str = None,
         tycho_client_path: str = None,
-        use_tls: bool = True
+        use_tls: bool = True,
     ):
         """
         Initializes the TychoStream instance.
@@ -80,7 +80,7 @@ class TychoStream:
 
         if not self._include_state:
             cmd.append("--no-state")
-            
+
         if not self._use_tls:
             cmd.append("--no-tls")
 
@@ -92,7 +92,12 @@ class TychoStream:
             f"Starting tycho-client binary at {self._tycho_client_path}. CMD: {cmd}"
         )
         self.tycho_client = await asyncio.create_subprocess_exec(
-            self._tycho_client_path, *cmd, stdout=PIPE, stderr=STDOUT, limit=2**64
+            self._tycho_client_path,
+            *cmd,
+            stdout=PIPE,
+            stderr=STDOUT,
+            limit=2**64,
+            env={**os.environ, "NO_COLOR": "true"},
         )
 
     def __aiter__(self):
@@ -123,7 +128,7 @@ class TychoStream:
             with open(Path(self._logs_directory) / "dev_logs.log", "r") as f:
                 lines = f.readlines()
                 last_lines = lines[-10:]
-                error_msg += f" Tycho logs: {last_lines}"
+                error_msg += f" Tycho logs:\n{'\n'.join(last_lines)}"
             log.exception(error_msg)
             raise Exception("Tycho-client failed.")
         return self._process_message(msg)


### PR DESCRIPTION
Used to print the logs like:
```
Invalid JSON output on tycho. Original line: b"thread 'main' panicked at tycho-client/src/main.rs:225:10:\n". Tycho logs: ['\x1b[2m2024-10-01T09:25:50.532238Z\x1b[0m \x1b[34mDEBUG\x1b[0m \x1b[1mstate_sync\x1b[0m\x1b[1m{\x1b[0m\x1b[3mextractor_id\x1b[0m\x1b[2m=\x1b[0methereum:uniswap_v2\x1b[1m}\x1b[0m\x1b[2m:\x1b[0m \x1b[2mtycho_client::rpc\x1b[0m\x1b[2m:\x1b[0m Sending protocol_states request to Tycho server \x1b[3muri\x1b[0m\x1b[2m=\x1b[0mhttp://ethereum-tycho-indexer.dev-tycho.svc.cluster.local/v1/protocol_state\n', '\x1b[2m2024-10-01T09:25:50.545802Z\x1b[0m \x1b[34mDEBUG\x1b[0m \x1b[1mstate_sync\x1b[0m\x1b[1m{\x1b[0m\x1b[3mextractor_id\x1b[0m\x1b[2m=\x1b[0methereum:uniswap_v2\x1b[1m}\x1b[0m\x1b[2m:\x1b[0m \x1b[2mtycho_client::rpc\x1b[0m\x1b[2m:\x1b[0m Sending protocol_states request to Tycho server \x1b[3muri\x1b[0m\x1b[2m=\x1b[0mhttp://ethereum-tycho-indexer.dev-tycho.svc.cluster.local/v1/protocol_state\n', '\x1b[2m2024-10-01T09:25:50.564295Z\x1b[0m \x1b[34mDEBUG\x1b[0m\x1b[1mstate_sync\x1b[0m\x1b[1m{\x1b[0m\x1b[3mextractor_id\x1b[0m\x1b[2m=\x1b[0methereum:uniswap_v2\x1b[1m}\x1b[0m\x1b[2m:\x1b[0m \x1b[2mtycho_client::rpc\x1b[0m\x1b[2m:\x1b[0m Sending protocol_states request to Tycho server \x1b[3muri\x1b[0m\x1b[2m=\x1b[0mhttp://ethereum-tycho-indexer.dev-tycho.svc.cluster.local/v1/protocol_state\n', '\x1b[2m2024-10-01T09:25:50.586600Z\x1b[0m \x1b[34mDEBUG\x1b[0m \x1b[1mstate_sync\x1b[0m\x1b[1m{\x1b[0m\x1b[3mextractor_id\x1b[0m\x1b[2m=\x1b[0methereum:uniswap_v2\x1b[1m}\x1b[0m\x1b[2m:\x1b[0m \x1b[2mtycho_client::rpc\x1b[0m\x1b[2m:\x1b[0m Sending protocol_states request to Tycho server \x1b[3muri\x1b[0m\x1b[2m=\x1b[0mhttp://ethereum-tycho-indexer.dev-tycho.svc.cluster.local/v1/protocol_state\n', '\x1b[2m2024-10-01T09:25:50.665015Z\x1b[0m \x1b[32m INFO\x1b[0m \x1b[1mstate_sync\x1b[0m\x1b[1m{\x1b[0m\x1b[3mextractor_id\x1b[0m\x1b[2m=\x1b[0methereum:uniswap_v2\x1b[1m}\x1b[0m\x1b[2m:\x1b[0m \x1b[2mtycho_client::feed::synchronizer\x1b[0m\x1b[2m:\x1b[0m Initial snapshot retrieved, starting delta message feed \x1b[3mn_components\x1b[0m\x1b[2m=\x1b[0m2220 \x1b[3mn_snapshots\x1b[0m\x1b[2m=\x1b[0m2220\n', '\x1b[2m2024-10-01T09:25:50.678231Z\x1b[0m \x1b[34mDEBUG\x1b[0m \x1b[2mtycho_client::feed\x1b[0m\x1b[2m:\x1b[0m Synchronizer started successfully! \x1b[3mextractor_id\x1b[0m\x1b[2m=\x1b[0methereum:sushiswap_v2 \x1b[3mheight\x1b[0m\x1b[2m=\x1b[0m20869736\n', '\x1b[2m2024-10-01T09:25:50.678249Z\x1b[0m \x1b[34mDEBUG\x1b[0m \x1b[2mtycho_client::feed\x1b[0m\x1b[2m:\x1b[0m Synchronizer started successfully! \x1b[3mextractor_id\x1b[0m\x1b[2m=\x1b[0methereum:uniswap_v2 \x1b[3mheight\x1b[0m\x1b[2m=\x1b[0m20869737\n', '\x1b[2m2024-10-01T09:25:50.678254Z\x1b[0m \x1b[34mDEBUG\x1b[0m \x1b[2mtycho_client::feed\x1b[0m\x1b[2m:\x1b[0m Synchronizer started successfully! \x1b[3mextractor_id\x1b[0m\x1b[2m=\x1b[0methereum:uniswap_v3 \x1b[3mheight\x1b[0m\x1b[2m=\x1b[0m20869736\n', '\x1b[2m2024-10-01T09:25:50.678258Z\x1b[0m \x1b[34mDEBUG\x1b[0m \x1b[2mtycho_client::feed\x1b[0m\x1b[2m:\x1b[0m Synchronizer started successfully! \x1b[3mextractor_id\x1b[0m\x1b[2m=\x1b[0methereum:vm:ambient \x1b[3mheight\x1b[0m\x1b[2m=\x1b[0m20869736\n', '\x1b[2m2024-10-01T09:25:50.678268Z\x1b[0m \x1b[34mDEBUG\x1b[0m \x1b[2mtycho_client::feed\x1b[0m\x1b[2m:\x1b[0m Synchronizer started successfully! \x1b[3mextractor_id\x1b[0m\x1b[2m=\x1b[0methereum:vm:balancer \x1b[3mheight\x1b[0m\x1b[2m=\x1b[0m20869736\n']                
```

Which is unreadable and unhelpful. The logs should be cleaned up before logged on in python.