### PR TITLE
fix: Also cache component requests for specified components

### DIFF
--- a/tycho-indexer/src/services/rpc.rs
+++ b/tycho-indexer/src/services/rpc.rs
@@ -441,6 +441,17 @@ where
                 self.get_protocol_components_inner(r)
                     .await
                     .map(|res| {
+                        // If component ids were specified, check if we have all requested
+                        // components are in the response (should cache)
+                        if let Some(component_ids) = &request.component_ids {
+                            let all_found = component_ids.len() == res.pagination.total as usize;
+                            if all_found {
+                                return (res, true);
+                            } else {
+                                return (res, false);
+                            }
+                        }
+                        // Otherwise check if request is for the last page (shouldn't cache)
                         let last_page = res.pagination.total_pages() - 1;
                         (res, request.pagination.page < last_page)
                     })


### PR DESCRIPTION
Issue: right now we skip caching the last page. If the client queries only 1-2 components (as it does every time a component passes our tvl threshold) then the response of only those 1-2 components is considered the last page and is not cached. In this situation often all clients running will query for the same component for the same reason so each of these repeated queries are fetched from the DB while blocking cache access. 

Solution: We now cache any response for a request that is made with specified component ids if all the components requested were found.