### PR TITLE
refactor(rpc): be more efficient when updating state with buffer

### DIFF
--- a/tycho-client/src/feed/component_tracker.rs
+++ b/tycho-client/src/feed/component_tracker.rs
@@ -77,9 +77,11 @@ where
     /// Retrieve all components that belong to the system we are extracing and have sufficient tvl.
     pub async fn initialise_components(&mut self) -> Result<(), RPCError> {
         let body = match &self.filter.variant {
-            ComponentFilterVariant::Ids(ids) => {
-                ProtocolComponentsRequestBody::id_filtered(ids.clone(), self.chain)
-            }
+            ComponentFilterVariant::Ids(ids) => ProtocolComponentsRequestBody::id_filtered(
+                &self.protocol_system,
+                ids.clone(),
+                self.chain,
+            ),
             ComponentFilterVariant::MinimumTVLRange((_, upper_tvl_threshold)) => {
                 ProtocolComponentsRequestBody::system_filtered(
                     &self.protocol_system,
@@ -116,6 +118,7 @@ where
             return Ok(());
         }
         let request = ProtocolComponentsRequestBody::id_filtered(
+            &self.protocol_system,
             new_components
                 .iter()
                 .map(|pc_id| pc_id.to_string())

--- a/tycho-client/src/feed/synchronizer.rs
+++ b/tycho-client/src/feed/synchronizer.rs
@@ -216,7 +216,7 @@ where
             .get_protocol_states_paginated(
                 self.extractor_id.chain,
                 &request_ids,
-                &Some(self.extractor_id.name.clone()),
+                &self.extractor_id.name,
                 self.retrieve_balances,
                 &version,
                 50,
@@ -260,7 +260,7 @@ where
                 .get_contract_state_paginated(
                     self.extractor_id.chain,
                     ids.as_slice(),
-                    &Some(self.extractor_id.name.clone()),
+                    &self.extractor_id.name,
                     &version,
                     50,
                     4,

--- a/tycho-client/src/rpc.rs
+++ b/tycho-client/src/rpc.rs
@@ -61,7 +61,7 @@ pub trait RPCClient: Send + Sync {
         &self,
         chain: Chain,
         ids: &[Bytes],
-        protocol_system: &Option<String>,
+        protocol_system: &str,
         version: &VersionParam,
         chunk_size: usize,
         concurrency: usize,
@@ -72,7 +72,7 @@ pub trait RPCClient: Send + Sync {
             .chunks(chunk_size)
             .map(|chunk| StateRequestBody {
                 contract_ids: Some(chunk.to_vec()),
-                protocol_system: protocol_system.clone(),
+                protocol_system: protocol_system.to_string(),
                 chain,
                 version: version.clone(),
                 pagination: PaginationParams { page: 0, page_size: chunk_size as i64 },
@@ -273,7 +273,7 @@ pub trait RPCClient: Send + Sync {
         &self,
         chain: Chain,
         ids: &[ProtocolId],
-        protocol_system: &Option<String>,
+        protocol_system: &str,
         include_balances: bool,
         version: &VersionParam,
         chunk_size: usize,
@@ -284,7 +284,7 @@ pub trait RPCClient: Send + Sync {
             .chunks(chunk_size)
             .map(|c| ProtocolStateRequestBody {
                 protocol_ids: Some(c.to_vec()),
-                protocol_system: protocol_system.clone(),
+                protocol_system: protocol_system.to_string(),
                 chain,
                 include_balances,
                 version: version.clone(),

--- a/tycho-indexer/src/services/rpc.rs
+++ b/tycho-indexer/src/services/rpc.rs
@@ -162,7 +162,7 @@ where
                 Some(&paginated_addrs),
                 &mut accounts,
                 Some(at),
-                request.protocol_system.as_deref(),
+                &request.protocol_system,
             )?;
         }
 
@@ -199,7 +199,7 @@ where
     async fn calculate_versions(
         &self,
         request_version: &BlockOrTimestamp,
-        protocol_system: &Option<String>,
+        protocol_system: &str,
         chain: Chain,
     ) -> Result<(Version, Option<BlockNumberOrTimestamp>), RpcError> {
         let ordered_version = match request_version {
@@ -216,7 +216,7 @@ where
         };
         let request_version_finality = self
             .pending_deltas
-            .get_block_finality(ordered_version, protocol_system.clone())
+            .get_block_finality(ordered_version, protocol_system)
             .unwrap_or(None)
             .unwrap_or_else(|| {
                 warn!(?ordered_version, ?protocol_system, "No finality found for version.");
@@ -319,7 +319,7 @@ where
             .get_protocol_states(
                 &chain,
                 Some(db_version),
-                request.protocol_system.clone(),
+                Some(request.protocol_system.clone()),
                 Some(&paginated_ids),
                 request.include_balances,
                 Some(&pagination_params),
@@ -338,7 +338,7 @@ where
                     Some(&paginated_ids),
                     &mut states,
                     Some(at),
-                    request.protocol_system.as_deref(),
+                    &request.protocol_system,
                 )?;
         }
 
@@ -481,7 +481,7 @@ where
 
         let buffered_components = self
             .pending_deltas
-            .get_new_components(ids_slice, system.as_deref())?;
+            .get_new_components(ids_slice, &system)?;
         debug!(n_components = buffered_components.len(), "RetrievedBufferedComponents");
 
         // Check if we have all requested components in the cache
@@ -519,7 +519,7 @@ where
             .db_gateway
             .get_protocol_components(
                 &request.chain.into(),
-                system,
+                Some(system),
                 ids_slice,
                 request.tvl_gt,
                 Some(&pagination_params),
@@ -796,7 +796,7 @@ mod tests {
                 protocol_ids: Option<&'a [&'a str]>,
                 db_states: &mut Vec<ProtocolComponentState>,
                 version: Option<BlockNumberOrTimestamp>,
-                protocol_system: Option<&'a str>,
+                protocol_system: &'a str,
             ) -> Result<(), PendingDeltasError>;
 
             fn update_vm_states<'a>(
@@ -804,19 +804,19 @@ mod tests {
                 addresses: Option<&'a [Bytes]>,
                 db_states: &mut Vec<Account>,
                 version: Option<BlockNumberOrTimestamp>,
-                protocol_system: Option<&'a str>,
+                protocol_system: &'a str,
             ) -> Result<(), PendingDeltasError>;
 
             fn get_new_components<'a>(
                 &self,
                 ids: Option<&'a [&'a str]>,
-                protocol_system: Option<&'a str>,
+                protocol_system: &'a str,
             ) -> Result<Vec<ProtocolComponent>, PendingDeltasError>;
 
-            fn get_block_finality(
+            fn get_block_finality<'a>(
                 &self,
                 version: BlockNumberOrTimestamp,
-                protocol_system: Option<String>,
+                protocol_system: &'a str,
             ) -> Result<Option<FinalityStatus>, PendingDeltasError>;
         }
     }
@@ -875,6 +875,7 @@ mod tests {
     async fn test_parse_state_request_no_version_specified() {
         let json_str = r#"
     {
+        "protocol_system": "uniswap_v2",
         "contractIds": [
             "0xb4eccE46b8D4e4abFd03C9B806276A6735C9c092"
         ]
@@ -887,7 +888,7 @@ mod tests {
 
         let expected = dto::StateRequestBody {
             contract_ids: Some(vec![contract0]),
-            protocol_system: None,
+            protocol_system: "uniswap_v2".to_string(),
             version: dto::VersionParam { timestamp: Some(Utc::now().naive_utc()), block: None },
             chain: dto::Chain::Ethereum,
             pagination: dto::PaginationParams::default(),
@@ -986,7 +987,7 @@ mod tests {
                 Bytes::from_str("6B175474E89094C44Da98b954EedeAC495271d0F").unwrap(),
                 Bytes::from_str("388C818CA8B9251b393131C08a736A67ccB19297").unwrap(),
             ]),
-            protocol_system: None,
+            protocol_system: "uniswap_v2".to_string(),
             version: dto::VersionParam { timestamp: Some(Utc::now().naive_utc()), block: None },
             chain: dto::Chain::Ethereum,
             pagination: dto::PaginationParams::default(),
@@ -1012,7 +1013,7 @@ mod tests {
             contract_ids: Some(vec![
                 Bytes::from_str("b4eccE46b8D4e4abFd03C9B806276A6735C9c092").unwrap()
             ]),
-            protocol_system: None,
+            protocol_system: "uniswap_v2".to_string(),
             version: dto::VersionParam::default(),
             chain: dto::Chain::Ethereum,
             pagination: dto::PaginationParams::default(),
@@ -1116,7 +1117,7 @@ mod tests {
                 dto::ProtocolId { id: "state1".to_owned(), chain: dto::Chain::Ethereum },
                 dto::ProtocolId { id: "state_buff".to_owned(), chain: dto::Chain::Ethereum },
             ]),
-            protocol_system: None,
+            protocol_system: "uniswap_v2".to_string(),
             chain: dto::Chain::Ethereum,
             include_balances: true,
             version: dto::VersionParam { timestamp: Some(Utc::now().naive_utc()), block: None },
@@ -1187,7 +1188,7 @@ mod tests {
         let req_handler = RpcHandler::new(gw, Arc::new(mock_buffer));
 
         let request = dto::ProtocolComponentsRequestBody {
-            protocol_system: Option::from("ambient".to_string()),
+            protocol_system: "ambient".to_string(),
             component_ids: None,
             tvl_gt: None,
             chain: dto::Chain::Ethereum,
@@ -1280,7 +1281,7 @@ mod tests {
         let req_handler = RpcHandler::new(gw, Arc::new(mock_buffer));
 
         let request = dto::ProtocolComponentsRequestBody {
-            protocol_system: Option::from("ambient".to_string()),
+            protocol_system: "ambient".to_string(),
             component_ids: None,
             tvl_gt: None,
             chain: dto::Chain::Ethereum,
@@ -1298,7 +1299,7 @@ mod tests {
         assert_eq!(response1.pagination.total, 3);
 
         let request = dto::ProtocolComponentsRequestBody {
-            protocol_system: Option::from("ambient".to_string()),
+            protocol_system: "ambient".to_string(),
             component_ids: None,
             tvl_gt: None,
             chain: dto::Chain::Ethereum,


### PR DESCRIPTION
This PR allows us to be more efficient for during buffer lookups if the protocol system is given in the request.