### PR TITLE
feat(storage): update protocol state fetch query to apply all given filters

### DIFF
--- a/tycho-indexer/src/services/rpc.rs
+++ b/tycho-indexer/src/services/rpc.rs
@@ -769,13 +769,6 @@ pub async fn protocol_components<G: Gateway>(
 /// Retrieve protocol states
 ///
 /// This endpoint retrieves the state of protocols within a specific execution environment.
-/// Currently, the filters are not compounded, meaning that if multiple filters are provided, one
-/// will be prioritised. The priority from highest to lowest is as follows: 'protocol_ids',
-/// 'protocol_system', 'chain'. Note that 'protocol_system' serves as both a filter and as a way
-/// to specify the protocol system associated with the components requested. This is used to ensure
-/// that the correct extractor's block status is used when querying the database. If omitted, the
-/// block status will be determined by a random extractor, which could be risky if the extractor is
-/// out of sync.
 #[utoipa::path(
     post,
     path = "/v1/protocol_state",

--- a/tycho-storage/src/postgres/orm.rs
+++ b/tycho-storage/src/postgres/orm.rs
@@ -680,16 +680,19 @@ impl ProtocolState {
         WithTotal { entity: res, total: count }
     }
 
-    /// Used to fetch the full state of a component at a given version, filtered by protocol system.
+    /// Used to fetch the full state of a component at a given version, filtered by protocol system
+    /// and optionally component ids.
     ///
-    /// Retrieves all matching protocol states and their component id, filtered by protocol system.
+    /// Retrieves all matching protocol states and their component id, filtered by protocol system
+    /// and optionally component ids.
     /// If no version is provided, the latest state is returned. The results are grouped by
     /// component id to allow for easy state reconstruction. It can be trusted that all state
     /// updates for a given component are sequential.
     ///
-    /// Note - follows the same logic as by_ids, but filters by protocol system instead of component
-    /// ids.
-    pub async fn by_protocol_system(
+    /// Note - follows the same logic as by_ids, but filters by protocol system and optionally by
+    /// component ids.
+    pub async fn by_protocol(
+        component_ids: Option<&[&str]>,
         system: &str,
         chain_id: &i64,
         version_ts: Option<NaiveDateTime>,
@@ -706,6 +709,10 @@ impl ProtocolState {
             .filter(protocol_component::chain_id.eq(chain_id))
             .select(protocol_component::id)
             .into_boxed();
+
+        if let Some(ids) = component_ids {
+            component_query = component_query.filter(protocol_component::external_id.eq_any(ids));
+        }
 
         // Apply pagination and fetch total count
         let count: Option<i64> = if let Some(pagination) = pagination_params {


### PR DESCRIPTION
Currently protocol state filters are applied according to priority: if ids are provided, protocol_system is ignored. This is not the typical expected behaviour of such a function. 
Therefore it has been updated to apply ALL given filters, regardless of priority.