### PR TITLE
DO NOT MERGE fix(versioning): correctly retrieve old state

### DIFF
--- a/tycho-storage/src/postgres/contract.rs
+++ b/tycho-storage/src/postgres/contract.rs
@@ -1390,8 +1390,8 @@ impl PostgresGateway {
 #[cfg(test)]
 mod test {
     use crate::postgres::{
-        db_fixtures,
-        db_fixtures::{yesterday_midnight, yesterday_one_am},
+        db_fixtures::{self, yesterday_midnight, yesterday_one_am},
+        MAX_VERSION_TS,
     };
     use diesel_async::AsyncConnection;
     use rstest::rstest;
@@ -2183,7 +2183,7 @@ mod test {
         // Query the stored slots from the database
         let fetched_slot_data: ContractStore = schema::contract_storage::table
             .select((schema::contract_storage::slot, schema::contract_storage::value))
-            .filter(schema::contract_storage::valid_to.eq(MAX_TS))
+            .filter(schema::contract_storage::valid_to.gt(*MAX_VERSION_TS))
             .get_results(&mut conn)
             .await
             .unwrap()
@@ -2253,7 +2253,7 @@ mod test {
         // Query the stored slots from the database
         let fetched_slot_data: ContractStore = schema::contract_storage::table
             .select((schema::contract_storage::slot, schema::contract_storage::value))
-            .filter(schema::contract_storage::valid_to.eq(MAX_TS))
+            .filter(schema::contract_storage::valid_to.gt(*MAX_VERSION_TS))
             .get_results(&mut conn)
             .await
             .unwrap()

--- a/tycho-storage/src/postgres/orm.rs
+++ b/tycho-storage/src/postgres/orm.rs
@@ -454,7 +454,7 @@ impl PartitionedVersionedRow for NewComponentBalance {
                 component_balance::protocol_component_id
                     .eq_any(&component_ids)
                     .and(component_balance::token_id.eq_any(&token_ids))
-                    .and(component_balance::valid_to.eq(MAX_TS)),
+                    .and(component_balance::valid_to.gt(*MAX_VERSION_TS)),
             )
             .get_results(conn)
             .await
@@ -1076,7 +1076,7 @@ impl PartitionedVersionedRow for NewProtocolState {
                 protocol_state::protocol_component_id
                     .eq_any(&pc_id)
                     .and(protocol_state::attribute_name.eq_any(&attr_name))
-                    .and(protocol_state::valid_to.eq(MAX_TS)),
+                    .and(protocol_state::valid_to.gt(*MAX_VERSION_TS)),
             )
             .get_results(conn)
             .await
@@ -1585,7 +1585,7 @@ impl PartitionedVersionedRow for NewSlot {
                 contract_storage::account_id
                     .eq_any(&accounts)
                     .and(contract_storage::slot.eq_any(&slots))
-                    .and(contract_storage::valid_to.eq(MAX_TS)),
+                    .and(contract_storage::valid_to.gt(*MAX_VERSION_TS)),
             )
             .get_results(conn)
             .await

--- a/tycho-storage/src/postgres/protocol.rs
+++ b/tycho-storage/src/postgres/protocol.rs
@@ -373,16 +373,17 @@ impl PostgresGateway {
         let mut res: HashMap<Address, (String, Bytes)> = HashMap::new();
         schema::protocol_component::table
             .inner_join(schema::protocol_component_holds_token::table)
-            .inner_join(schema::component_balance::table)
+            .inner_join(schema::component_balance_default::table)
             .select((
-                schema::component_balance::token_id,
+                schema::component_balance_default::token_id,
                 schema::protocol_component::external_id,
-                schema::component_balance::new_balance,
+                schema::component_balance_default::new_balance,
             ))
             .filter(schema::protocol_component::chain_id.eq(chain_id))
-            .filter(schema::component_balance::balance_float.ge(min_balance.unwrap_or(0f64)))
-            .filter(schema::component_balance::valid_to.eq(MAX_TS))
-            .filter(schema::component_balance::token_id.eq_any(token_ids.keys()))
+            .filter(
+                schema::component_balance_default::balance_float.ge(min_balance.unwrap_or(0f64)),
+            )
+            .filter(schema::component_balance_default::token_id.eq_any(token_ids.keys()))
             .get_results::<(i64, String, Bytes)>(conn)
             .await
             .map_err(PostgresError::from)?


### PR DESCRIPTION
`latest_versions_by_ids` where wrongly filtering all state with `valid_to.eq(MAX_TS)` which is not working because of timestamp precision.

We now use the alternative `valid_to.gt(*MAX_VERSION_TS)` everywhere.

Note: for efficiency reason, when diesel allows it, we query the default table directly instead of filtering by ts.


**Edit: this was fixed on the db side, but ideally we want to query the default table instead of filtering by timestamps**