### PR TITLE
feat: make Snapshot attributes public

### DIFF
--- a/tycho-client/src/feed/synchronizer.rs
+++ b/tycho-client/src/feed/synchronizer.rs
@@ -62,8 +62,8 @@ pub struct ComponentWithState {
 
 #[derive(Clone, PartialEq, Debug, Default, Serialize)]
 pub struct Snapshot {
-    states: HashMap<String, ComponentWithState>,
-    vm_storage: HashMap<Bytes, ResponseAccount>,
+    pub states: HashMap<String, ComponentWithState>,
+    pub vm_storage: HashMap<Bytes, ResponseAccount>,
 }
 
 impl Snapshot {


### PR DESCRIPTION
Otherwise, they cannot be accessed from the token quoter.