### PR TITLE
fix: add openssl dependency to tycho-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4221,6 +4221,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.4.1+3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4228,6 +4237,7 @@ checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -6683,6 +6693,7 @@ dependencies = [
  "lru",
  "mockall",
  "mockito",
+ "openssl",
  "pretty_assertions",
  "rand",
  "reqwest 0.12.7",

--- a/tycho-client/Cargo.toml
+++ b/tycho-client/Cargo.toml
@@ -33,6 +33,8 @@ tracing-subscriber = { version = "0.3.17", default-features = false, features = 
 ] }
 clap = { workspace = true, features = ["derive", "env"] }
 tracing-appender = { workspace = true }
+# link openssl statically
+openssl = { version = "0.10", features = ["vendored"] }
 
 
 [dev-dependencies]


### PR DESCRIPTION
to avoid a user needing to install it, or libssl at runtime