### PR TITLE
feat(tycho-client): increase pagination chunksize to 100

### DIFF
--- a/tycho-client/src/feed/synchronizer.rs
+++ b/tycho-client/src/feed/synchronizer.rs
@@ -224,7 +224,7 @@ where
                 &self.extractor_id.name,
                 self.retrieve_balances,
                 &version,
-                50,
+                100,
                 4,
             )
             .await?
@@ -267,7 +267,7 @@ where
                     ids.as_slice(),
                     &self.extractor_id.name,
                     &version,
-                    50,
+                    100,
                     4,
                 )
                 .await?


### PR DESCRIPTION
With the smaller chunksize we were more likely to hit our rate limits. We still need to look into long term solutions to all the queries we need to do on start-up. For now this will be sufficient enough for the number of protocols and pools we have.