### PR TITLE
fix: decrement active subscription on ws connection close

### DIFF
--- a/tycho-indexer/src/services/ws.rs
+++ b/tycho-indexer/src/services/ws.rs
@@ -264,6 +264,7 @@ impl Actor for WsActor {
         for (subscription_id, handle) in self.subscriptions.drain() {
             debug!(subscription_id = ?subscription_id, "Closing subscription.");
             ctx.cancel_future(handle);
+            gauge!("websocket_extractor_subscriptions_active", "subscription_id" => subscription_id.to_string()).decrement(1);
         }
     }
 }


### PR DESCRIPTION
Previously we would only decrement the active subscriptions if it was explicitly unsubscribed. We want to also decrement it on suddenly closed connections