### PR TITLE
fix: fix protocol system deletion script account balances bug

### DIFF
--- a/tycho-storage/sql_scripts/remove_protocol_system.sh
+++ b/tycho-storage/sql_scripts/remove_protocol_system.sh
@@ -141,13 +141,12 @@ WHERE account_id IN (
     JOIN protocol_component pc ON pchc.protocol_component_id = pc.id
     JOIN protocol_system ps ON pc.protocol_system_id = ps.id
     WHERE ps.name = :'protocol_system_name'
-    AND EXISTS (
+    AND NOT EXISTS (
         SELECT 1
-        FROM protocol_component_holds_token pcht
-        JOIN token t ON pcht.token_id = t.id 
-        JOIN protocol_component pc2 ON pcht.protocol_component_id = pc2.id
+        FROM protocol_component_holds_contract pchc2
+        JOIN protocol_component pc2 ON pchc2.protocol_component_id = pc2.id
         JOIN protocol_system ps2 ON pc2.protocol_system_id = ps2.id
-        WHERE t.account_id = cc.account_id
+        WHERE pchc2.contract_code_id = cc.id
         AND ps2.name <> :'protocol_system_name'
     )
 );

--- a/tycho-storage/sql_scripts/remove_protocol_system.sh
+++ b/tycho-storage/sql_scripts/remove_protocol_system.sh
@@ -125,12 +125,34 @@ WITH tokens_to_delete AS (
     GROUP BY t.id, a.id
     HAVING COUNT(DISTINCT CASE WHEN ps.name <> :'protocol_system_name' THEN ps.id END) = 0
 )
---- Delete the linked accounts (tokens will be cascade deleted)
+--- Delete the linked accounts (tokens are be cascade deleted)
 DELETE FROM account
 WHERE id IN (SELECT account_id FROM tokens_to_delete);
 
---- Find and remove all linked accounts (accounts are not cascade deleted). Note, this will cascade delete the linked contract
---- code entries too.
+--- Find and remove all linked accounts (accounts are not cascade deleted on component deletions). Note, this will cascade 
+--- delete the linked contract code entries too.
+--- Delete linked balances for all accounts exclusively linked to the protocol components of the system being deleted. This
+--- is explicitly done to ensure we delete balances for accounts that are removed as components, but kept as tokens.
+DELETE FROM account_balance
+WHERE account_id IN (
+    SELECT DISTINCT cc.account_id
+    FROM contract_code cc
+    JOIN protocol_component_holds_contract pchc ON pchc.contract_code_id = cc.id
+    JOIN protocol_component pc ON pchc.protocol_component_id = pc.id
+    JOIN protocol_system ps ON pc.protocol_system_id = ps.id
+    WHERE ps.name = :'protocol_system_name'
+    AND EXISTS (
+        SELECT 1
+        FROM protocol_component_holds_token pcht
+        JOIN token t ON pcht.token_id = t.id 
+        JOIN protocol_component pc2 ON pcht.protocol_component_id = pc2.id
+        JOIN protocol_system ps2 ON pc2.protocol_system_id = ps2.id
+        WHERE t.account_id = cc.account_id
+        AND ps2.name <> :'protocol_system_name'
+    )
+);
+--- Delete accounts exclusively linked to the protocol components of the system being deleted, skipping accounts that are
+--- linked used as tokens by other protocol systems.
 DELETE FROM account
 WHERE id IN (
     SELECT DISTINCT cc.account_id


### PR DESCRIPTION
Context: in the tycho database schema, we use `accounts` for both token contracts and vm pool contracts. When we use the account as a token, we do not track balances of the account. When we use it as a pool, we do track balances (specifically eth balances) and store them in account_balance. 

Issue: In some special cases the same contract acts as both a pool and a token. Currently, when we delete a protocol where the account is used as a pool, we cascade delete the balances associated with it. However if the account is also used as a token outside of the protocol, we cannot delete the account and so the balances remain as well. This causes issues later if we resync the protocol that was deleted as the account balances already exist and cannot be re-created (only updated).

Solution: The account balances should be deleted as they're related to component accounts and not token accounts.

Identification of issue: This issue was identified when deleting vm:curve from tycho db: some curve pools are used as tokens in other systems and their account balances were left in the db. This caused errors when we tried to resync curve as you cannot create a new balance entry for an account balance that already exists (uniqueness is enforced on the account_id value... only 1 eth balance is allowed per account).