### PR TITLE
feat: add protocol system rpc

### DIFF
--- a/tycho-client/src/feed/synchronizer.rs
+++ b/tycho-client/src/feed/synchronizer.rs
@@ -535,7 +535,8 @@ mod test {
     use tycho_core::dto::{
         Block, Chain, PaginationResponse, ProtocolComponentRequestResponse,
         ProtocolComponentsRequestBody, ProtocolStateRequestBody, ProtocolStateRequestResponse,
-        StateRequestBody, StateRequestResponse, TokensRequestBody, TokensRequestResponse,
+        ProtocolSystemsRequestBody, ProtocolSystemsRequestResponse, StateRequestBody,
+        StateRequestResponse, TokensRequestBody, TokensRequestResponse,
     };
 
     use crate::{deltas::MockDeltasClient, rpc::MockRPCClient, DeltasError, RPCError};
@@ -584,6 +585,15 @@ mod test {
         ) -> Result<ProtocolStateRequestResponse, RPCError> {
             self.0
                 .get_protocol_states(request)
+                .await
+        }
+
+        async fn get_protocol_systems(
+            &self,
+            request: &ProtocolSystemsRequestBody,
+        ) -> Result<ProtocolSystemsRequestResponse, RPCError> {
+            self.0
+                .get_protocol_systems(request)
                 .await
         }
     }

--- a/tycho-client/src/rpc.rs
+++ b/tycho-client/src/rpc.rs
@@ -625,7 +625,7 @@ impl RPCClient for HttpRPCClient {
         debug!(%uri, "Sending protocol_systems request to Tycho server");
         let response = self
             .http_client
-            .post(&uri)
+            .get(&uri)
             .json(request)
             .send()
             .await
@@ -1014,7 +1014,7 @@ mod tests {
         serde_json::from_str::<ProtocolSystemsRequestResponse>(server_resp).expect("deserialize");
 
         let mocked_server = server
-            .mock("POST", "/v1/protocol_systems")
+            .mock("GET", "/v1/protocol_systems")
             .expect(1)
             .with_body(server_resp)
             .create_async()

--- a/tycho-client/src/rpc.rs
+++ b/tycho-client/src/rpc.rs
@@ -623,6 +623,7 @@ impl RPCClient for HttpRPCClient {
             TYCHO_SERVER_VERSION
         );
         debug!(%uri, "Sending protocol_systems request to Tycho server");
+        trace!(?request, "Sending request to Tycho server");
         let response = self
             .http_client
             .get(&uri)
@@ -630,7 +631,7 @@ impl RPCClient for HttpRPCClient {
             .send()
             .await
             .map_err(|e| RPCError::HttpClient(e.to_string()))?;
-
+        trace!(?response, "Received response from Tycho server");
         let body = response
             .text()
             .await
@@ -640,7 +641,7 @@ impl RPCClient for HttpRPCClient {
                 error!("Failed to parse protocol systems response {:?}", &body);
                 RPCError::ParseResponse(e.to_string())
             })?;
-
+        trace!(?protocol_systems, "Received protocol_systems response from Tycho server");
         Ok(protocol_systems)
     }
 }

--- a/tycho-core/src/dto.rs
+++ b/tycho-core/src/dto.rs
@@ -1205,6 +1205,28 @@ pub enum Health {
     NotReady(String),
 }
 
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, ToSchema, Eq, Hash, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct ProtocolSystemsRequestBody {
+    #[serde(default)]
+    pub chain: Chain,
+    /// Max page size supported is 100
+    #[serde(default)]
+    pub pagination: PaginationParams,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, ToSchema, Eq, Hash)]
+pub struct ProtocolSystemsRequestResponse {
+    pub protocol_systems: Vec<String>,
+    pub pagination: PaginationResponse,
+}
+
+impl ProtocolSystemsRequestResponse {
+    pub fn new(protocol_systems: Vec<String>, pagination: PaginationResponse) -> Self {
+        Self { protocol_systems, pagination }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::str::FromStr;

--- a/tycho-core/src/storage.rs
+++ b/tycho-core/src/storage.rs
@@ -465,6 +465,22 @@ pub trait ProtocolGateway {
         chain: &Chain,
         tvl_values: &HashMap<String, f64>,
     ) -> Result<(), StorageError>;
+
+    /// Retrieve a list of actively supported protocol systems
+    ///
+    /// Fetches the list of protocol systems supported by the Tycho indexing service.
+    ///
+    /// # Parameters
+    /// - `chain` The chain for which to retrieve supported protocol systems.
+    /// - `pagination_params` Optional pagination parameters to control the number of results.
+    ///
+    /// # Return
+    /// A paginated list of supported protocol systems, along with the total count.
+    async fn get_protocol_systems(
+        &self,
+        chain: &Chain,
+        pagination_params: Option<&PaginationParams>,
+    ) -> Result<WithTotal<Vec<String>>, StorageError>;
 }
 
 /// Manage contracts and their state in storage.

--- a/tycho-indexer/src/services/mod.rs
+++ b/tycho-indexer/src/services/mod.rs
@@ -212,7 +212,7 @@ where
                 )
                 .service(
                     web::resource(format!("/{}/protocol_systems", self.prefix))
-                        .route(web::post().to(rpc::protocol_systems::<G>)),
+                        .route(web::get().to(rpc::protocol_systems::<G>)),
                 )
                 .wrap(RequestTracing::new())
                 .service(

--- a/tycho-indexer/src/services/mod.rs
+++ b/tycho-indexer/src/services/mod.rs
@@ -16,9 +16,9 @@ use tycho_core::{
         AccountUpdate, BlockParam, Chain, ChangeType, ContractId, Health, PaginationParams,
         PaginationResponse, ProtocolComponent, ProtocolComponentRequestResponse,
         ProtocolComponentsRequestBody, ProtocolId, ProtocolStateDelta, ProtocolStateRequestBody,
-        ProtocolStateRequestResponse, ResponseAccount, ResponseProtocolState, ResponseToken,
-        StateRequestBody, StateRequestResponse, TokensRequestBody, TokensRequestResponse,
-        VersionParam,
+        ProtocolStateRequestResponse, ProtocolSystemsRequestBody, ProtocolSystemsRequestResponse,
+        ResponseAccount, ResponseProtocolState, ResponseToken, StateRequestBody,
+        StateRequestResponse, TokensRequestBody, TokensRequestResponse, VersionParam,
     },
     storage::Gateway,
 };
@@ -98,6 +98,7 @@ where
                 rpc::protocol_components,
                 rpc::protocol_state,
                 rpc::health,
+                rpc::protocol_systems
             ),
             components(
                 schemas(VersionParam),
@@ -123,6 +124,8 @@ where
                 schemas(ChangeType),
                 schemas(ProtocolStateDelta),
                 schemas(Health),
+                schemas(ProtocolSystemsRequestBody),
+                schemas(ProtocolSystemsRequestResponse),
             )
         )]
         struct ApiDoc;
@@ -206,6 +209,10 @@ where
                 .service(
                     web::resource(format!("/{}/health", self.prefix))
                         .route(web::get().to(rpc::health)),
+                )
+                .service(
+                    web::resource(format!("/{}/protocol_systems", self.prefix))
+                        .route(web::post().to(rpc::protocol_systems::<G>)),
                 )
                 .wrap(RequestTracing::new())
                 .service(

--- a/tycho-indexer/src/services/rpc.rs
+++ b/tycho-indexer/src/services/rpc.rs
@@ -898,7 +898,7 @@ pub async fn protocol_state<G: Gateway>(
 ///
 /// This endpoint retrieves the protocol systems available in the indexer.
 #[utoipa::path(
-    post,
+    get,
     path = "/v1/protocol_systems",
     responses(
         (status = 200, description = "OK", body = ProtocolSystemsRequestResponse),

--- a/tycho-indexer/src/testing.rs
+++ b/tycho-indexer/src/testing.rs
@@ -451,6 +451,24 @@ mock! {
             'life1: 'async_trait,
             'life2: 'async_trait,
             Self: 'async_trait;
+
+        #[allow(clippy::type_complexity)]
+        fn get_protocol_systems<'life0, 'life1, 'life2, 'async_trait>(
+            &'life0 self,
+            chain: &'life1 Chain,
+            pagination_params: Option<&'life2 PaginationParams>,
+        ) -> ::core::pin::Pin<
+            Box<
+                dyn ::core::future::Future<
+                    Output = Result<WithTotal<Vec<String>>, StorageError>,
+                > + ::core::marker::Send + 'async_trait,
+            >,
+        >
+        where
+            'life0: 'async_trait,
+            'life1: 'async_trait,
+            'life2: 'async_trait,
+            Self: 'async_trait;
     }
 
     impl Gateway for Gateway {}

--- a/tycho-storage/src/postgres/cache.rs
+++ b/tycho-storage/src/postgres/cache.rs
@@ -1027,6 +1027,17 @@ impl ProtocolGateway for CachedGateway {
             .upsert_component_tvl(chain, tvl_values, &mut conn)
             .await
     }
+
+    #[instrument(skip_all)]
+    async fn get_protocol_systems(
+        &self,
+        chain: &Chain,
+        pagination_params: Option<&PaginationParams>,
+    ) -> Result<WithTotal<Vec<String>>, StorageError> {
+        self.state_gateway
+            .get_protocol_systems(chain, pagination_params)
+            .await
+    }
 }
 
 impl Gateway for CachedGateway {}

--- a/tycho-storage/src/postgres/mod.rs
+++ b/tycho-storage/src/postgres/mod.rs
@@ -229,16 +229,6 @@ where
             .to_owned()
     }
 
-    /// Checks if a database ID exists in the cache. Returns `true` if the ID is found,
-    /// otherwise returns `false`.
-    ///
-    /// # Arguments
-    ///
-    /// * `id` - The database ID to check for existence.
-    fn id_exist(&self, id: &i64) -> bool {
-        self.map_enum.contains_key(id)
-    }
-
     /// Checks if an enum variant exists in the cache. Returns `true` if the variant is found,
     /// otherwise returns `false`.
     ///

--- a/tycho-storage/src/postgres/mod.rs
+++ b/tycho-storage/src/postgres/mod.rs
@@ -228,6 +228,26 @@ where
             })
             .to_owned()
     }
+
+    /// Checks if a database ID exists in the cache. Returns `true` if the ID is found,
+    /// otherwise returns `false`.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The database ID to check for existence.
+    fn id_exist(&self, id: &i64) -> bool {
+        self.map_enum.contains_key(id)
+    }
+
+    /// Checks if an enum variant exists in the cache. Returns `true` if the variant is found,
+    /// otherwise returns `false`.
+    ///
+    /// # Arguments
+    ///
+    /// * `val` - The enum variant to check for existence.
+    fn value_exist(&self, val: &E) -> bool {
+        self.map_id.contains_key(val)
+    }
 }
 
 type ChainEnumCache = ValueIdTableCache<Chain>;

--- a/tycho-storage/src/postgres/protocol.rs
+++ b/tycho-storage/src/postgres/protocol.rs
@@ -1711,9 +1711,10 @@ impl PostgresGateway {
 
     pub async fn get_protocol_systems(
         &self,
-        _chain: &Chain, // TODO: Add chain filter
+        chain: &Chain,
         pagination_params: Option<&PaginationParams>,
     ) -> Result<WithTotal<Vec<String>>, StorageError> {
+        let _ = self.get_chain_id(chain);
         let all_protocol_systems: Vec<String> = self
             .protocol_system_id_cache
             .map_enum

--- a/tycho-storage/src/postgres/protocol.rs
+++ b/tycho-storage/src/postgres/protocol.rs
@@ -1722,6 +1722,7 @@ impl PostgresGateway {
             .map_enum
             .values()
             .cloned()
+            .sorted()
             .collect();
 
         let total = all_protocol_systems.len() as i64;
@@ -3721,17 +3722,18 @@ mod test {
         let mut conn = setup_db().await;
         let _ = setup_data(&mut conn).await;
         let gw = EVMGateway::from_connection(&mut conn).await;
-        let exp = ["ambient", "zigzag"];
+        let all = ["ambient", "zigzag"];
+        let exp = vec![all[0]];
 
         let res = gw
             .get_protocol_systems(
                 &Chain::Ethereum,
-                Some(&PaginationParams { page: 0, page_size: 2 }),
+                Some(&PaginationParams { page: 0, page_size: 1 }),
             )
             .await
             .expect("retrieving protocol systems failed!");
 
-        assert_eq!(res.total, Some(exp.len() as i64));
+        assert_eq!(res.total, Some(all.len() as i64));
         assert_eq!(res.entity.iter().collect_vec(), exp);
     }
 

--- a/tycho-storage/src/postgres/protocol.rs
+++ b/tycho-storage/src/postgres/protocol.rs
@@ -3748,10 +3748,6 @@ mod test {
         let mut conn = setup_db().await;
         let _ = setup_data(&mut conn).await;
         let gw = EVMGateway::from_connection(&mut conn).await;
-        let exp = ["ambient", "zigzag"]
-            .iter()
-            .map(|s| s.to_string())
-            .collect::<HashSet<_>>();
 
         let res = gw
             .get_protocol_systems(&Chain::Arbitrum, None)

--- a/tycho-storage/src/postgres/protocol.rs
+++ b/tycho-storage/src/postgres/protocol.rs
@@ -1714,7 +1714,9 @@ impl PostgresGateway {
         chain: &Chain,
         pagination_params: Option<&PaginationParams>,
     ) -> Result<WithTotal<Vec<String>>, StorageError> {
-        let _ = self.get_chain_id(chain);
+        if !self.chain_id_cache.value_exist(chain) {
+            return Err(StorageError::NotFound("Chain".to_string(), chain.to_string()));
+        }
         let all_protocol_systems: Vec<String> = self
             .protocol_system_id_cache
             .map_enum

--- a/tycho-storage/src/postgres/protocol.rs
+++ b/tycho-storage/src/postgres/protocol.rs
@@ -3721,26 +3721,18 @@ mod test {
         let mut conn = setup_db().await;
         let _ = setup_data(&mut conn).await;
         let gw = EVMGateway::from_connection(&mut conn).await;
-        let exp = ["ambient"]
-            .iter()
-            .map(|s| s.to_string())
-            .collect::<HashSet<_>>();
+        let exp = ["ambient", "zigzag"];
 
         let res = gw
             .get_protocol_systems(
                 &Chain::Ethereum,
-                Some(&PaginationParams { page: 0, page_size: 1 }),
+                Some(&PaginationParams { page: 0, page_size: 2 }),
             )
             .await
             .expect("retrieving protocol systems failed!");
 
         assert_eq!(res.total, Some(exp.len() as i64));
-        assert_eq!(
-            res.entity
-                .into_iter()
-                .collect::<HashSet<_>>(),
-            exp
-        );
+        assert_eq!(res.entity.iter().collect_vec(), exp);
     }
 
     #[tokio::test]

--- a/tycho-storage/src/postgres/protocol.rs
+++ b/tycho-storage/src/postgres/protocol.rs
@@ -3744,6 +3744,29 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_get_protocol_systems_chain_not_exist() {
+        let mut conn = setup_db().await;
+        let _ = setup_data(&mut conn).await;
+        let gw = EVMGateway::from_connection(&mut conn).await;
+        let exp = ["ambient", "zigzag"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<HashSet<_>>();
+
+        let res = gw
+            .get_protocol_systems(&Chain::Arbitrum, None)
+            .await;
+
+        match res {
+            Err(StorageError::NotFound(entity, value)) => {
+                assert_eq!(entity, "Chain");
+                assert_eq!(value, Chain::Arbitrum.to_string());
+            }
+            _ => panic!("Expected StorageError::NotFound, but got {:?}", res),
+        }
+    }
+
+    #[tokio::test]
     async fn test_truncate_token_title() {
         let mut conn = setup_db().await;
         setup_data(&mut conn).await;


### PR DESCRIPTION
This PR adds a new `GET /v1/protocol_systems` endpoint to fetch supported protocol systems in real time, using the existing cache and supports pagination with page and page_size.

The `chain` parameter is currently unused because protocol systems are not linked to specific chains in the cache or database. The association between protocol_systems and chain can be added in a follow-up PR when needed.

Unit tests and documentation updates are included.

Close #478 