### PR TITLE
feat: update substreams client to accept compressed messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6690,6 +6690,7 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes",
+ "flate2",
  "futures-core",
  "futures-util",
  "h2 0.3.24",

--- a/tycho-indexer/Cargo.toml
+++ b/tycho-indexer/Cargo.toml
@@ -37,7 +37,7 @@ metrics-exporter-prometheus = { workspace = true }
 async-stream = "0.3"
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-retry = "0.3"
-tonic = { version = "0.9", features = ["tls-roots"] }
+tonic = { version = "0.9", features = ["tls-roots", "gzip"] }
 prost = "0.11"
 prost-types = "0.11"
 clap = { workspace = true, features = ["derive", "env"] }

--- a/tycho-indexer/src/substreams/mod.rs
+++ b/tycho-indexer/src/substreams/mod.rs
@@ -75,7 +75,8 @@ impl SubstreamsEndpoint {
 
                 Ok(r)
             },
-        );
+        )
+        .accept_compressed(tonic::codec::CompressionEncoding::Gzip);
 
         let response_stream = client.blocks(request).await?;
         let block_stream = response_stream.into_inner();


### PR DESCRIPTION
StreamingFast will be enforcing compressed gRPC streams on substreams by the end of the month.