### PR TITLE
feat: Handle blocks with same ts

### DIFF
--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -1518,6 +1518,9 @@ mod test {
         gw.expect_get_cursor()
             .times(1)
             .returning(|| Ok(("cursor".into(), 1)));
+        gw.expect_get_block()
+            .times(1)
+            .returning(|_| Ok(Block::default()));
 
         let extractor = create_extractor(gw).await;
         let res = extractor.get_cursor().await;
@@ -1537,6 +1540,9 @@ mod test {
         gw.expect_advance()
             .times(1)
             .returning(|_, _, _| Ok(()));
+        gw.expect_get_block()
+            .times(1)
+            .returning(|_| Ok(Block::default()));
 
         let extractor = create_extractor(gw).await;
 
@@ -1583,6 +1589,9 @@ mod test {
         gw.expect_advance()
             .times(1)
             .returning(|_, _, _| Ok(()));
+        gw.expect_get_block()
+            .times(1)
+            .returning(|_| Ok(Block::default()));
 
         let extractor = create_extractor(gw).await;
 
@@ -1639,6 +1648,9 @@ mod test {
         gw.expect_advance()
             .times(1)
             .returning(|_, _, _| Ok(()));
+        gw.expect_get_block()
+            .times(1)
+            .returning(|_| Ok(Block::default()));
 
         let extractor = create_extractor(gw).await;
 
@@ -1694,6 +1706,9 @@ mod test {
         gw.expect_advance()
             .times(0)
             .returning(|_, _, _| Ok(()));
+        gw.expect_get_block()
+            .times(1)
+            .returning(|_| Ok(Block::default()));
 
         let extractor = create_extractor(gw).await;
 
@@ -1870,6 +1885,12 @@ mod test {
             .expect_get_cursor()
             .times(1)
             .returning(|| Ok(("cursor".into(), 1)));
+
+        extractor_gw
+            .expect_get_block()
+            .times(1)
+            .returning(|_| Ok(Block::default()));
+
         let extractor = ProtocolExtractor::new(
             extractor_gw,
             EXTRACTOR_NAME,
@@ -1993,6 +2014,10 @@ mod test {
         extractor_gw
             .expect_get_components_balances()
             .return_once(|_| Ok(HashMap::new()));
+        extractor_gw
+            .expect_get_block()
+            .times(1)
+            .returning(|_| Ok(Block::default()));
 
         let extractor = ProtocolExtractor::new(
             extractor_gw,

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -47,7 +47,6 @@ use crate::{
     pb::sf::substreams::rpc::v2::{BlockScopedData, BlockUndoSignal, ModulesProgress},
 };
 
-#[allow(dead_code)]
 pub struct Inner {
     cursor: Vec<u8>,
     last_processed_block: Option<Block>,


### PR DESCRIPTION
Fixes and closes (https://github.com/propeller-heads/tycho-indexer/pull/283) 

Reason: EVM nodes gives us timestamps in seconds resolution. On sub-second blocks, we will have a conflict of multiple blocks with the same timestamp - causing bugs in the versioning system.
This solution appends n+1 microsecond for each block in a row (sequence size n) that is found with the same timestamp.