### PR TITLE
feat: make protocol system a POST endpoint

### DIFF
--- a/tycho-client/src/rpc.rs
+++ b/tycho-client/src/rpc.rs
@@ -626,7 +626,7 @@ impl RPCClient for HttpRPCClient {
         trace!(?request, "Sending request to Tycho server");
         let response = self
             .http_client
-            .get(&uri)
+            .post(&uri)
             .json(request)
             .send()
             .await
@@ -1015,7 +1015,7 @@ mod tests {
         serde_json::from_str::<ProtocolSystemsRequestResponse>(server_resp).expect("deserialize");
 
         let mocked_server = server
-            .mock("GET", "/v1/protocol_systems")
+            .mock("POST", "/v1/protocol_systems")
             .expect(1)
             .with_body(server_resp)
             .create_async()

--- a/tycho-indexer/src/services/rpc.rs
+++ b/tycho-indexer/src/services/rpc.rs
@@ -898,7 +898,7 @@ pub async fn protocol_state<G: Gateway>(
 ///
 /// This endpoint retrieves the protocol systems available in the indexer.
 #[utoipa::path(
-    get,
+    post,
     path = "/v1/protocol_systems",
     responses(
         (status = 200, description = "OK", body = ProtocolSystemsRequestResponse),


### PR DESCRIPTION
Tycho RPC follows the pattern of using POST endpoints with body parameters instead of GET endpoints with inline args.