### PR TITLE
fix: default RPC client and server to use HTTP/2

### DIFF
--- a/.github/workflows/v2-build-and-deploy-branch.yaml
+++ b/.github/workflows/v2-build-and-deploy-branch.yaml
@@ -12,6 +12,7 @@ on:
           - tycho-indexer
           - arbitrum-tycho-indexer
           - ethereum-tycho-indexer
+          - base-tycho-indexer
 
 permissions:
   id-token: write

--- a/tycho-client/src/rpc.rs
+++ b/tycho-client/src/rpc.rs
@@ -408,7 +408,7 @@ impl HttpRPCClient {
 
         let client = ClientBuilder::new()
             .default_headers(headers)
-            .pool_max_idle_per_host(0) // Disable connection pooling
+            .http2_prior_knowledge()
             .build()
             .map_err(|e| RPCError::HttpClient(e.to_string()))?;
         Ok(Self { http_client: client, url: uri })

--- a/tycho-client/src/rpc.rs
+++ b/tycho-client/src/rpc.rs
@@ -408,6 +408,7 @@ impl HttpRPCClient {
 
         let client = ClientBuilder::new()
             .default_headers(headers)
+            .pool_max_idle_per_host(0) // Disable connection pooling
             .build()
             .map_err(|e| RPCError::HttpClient(e.to_string()))?;
         Ok(Self { http_client: client, url: uri })

--- a/tycho-indexer/src/services/mod.rs
+++ b/tycho-indexer/src/services/mod.rs
@@ -228,7 +228,7 @@ where
 
             app
         })
-        .bind((self.bind, self.port))
+        .bind_auto_h2c((self.bind, self.port))
         .map_err(|err| ExtractionError::ServiceError(err.to_string()))?
         .run();
         let handle = server.handle();

--- a/tycho-indexer/src/services/mod.rs
+++ b/tycho-indexer/src/services/mod.rs
@@ -229,7 +229,9 @@ where
             app
         })
         .keep_alive(std::time::Duration::from_secs(60)) // prevents early connection closures
-        .client_disconnect_timeout(std::time::Duration::from_secs(30)) // prevents premature force disconnections
+        // Allows clients up to 30 seconds to reconnect before forcefully closing the connection.
+        // This prevents us from closing a connection the client is expecting to be able to reuse.
+        .client_disconnect_timeout(std::time::Duration::from_secs(30))
         .bind_auto_h2c((self.bind, self.port)) // allow HTTP2 requests over http connections
         .map_err(|err| ExtractionError::ServiceError(err.to_string()))?
         .run();

--- a/tycho-indexer/src/services/mod.rs
+++ b/tycho-indexer/src/services/mod.rs
@@ -228,7 +228,9 @@ where
 
             app
         })
-        .bind_auto_h2c((self.bind, self.port))
+        .keep_alive(std::time::Duration::from_secs(60)) // prevents early connection closures
+        .client_disconnect_timeout(std::time::Duration::from_secs(30)) // prevents premature force disconnections
+        .bind_auto_h2c((self.bind, self.port)) // allow HTTP2 requests over http connections
         .map_err(|err| ExtractionError::ServiceError(err.to_string()))?
         .run();
         let handle = server.handle();


### PR DESCRIPTION
This was causing bugs where the RPC was reusing connections that were already closed.