### PR TITLE
fix: increase Base blocktime default

### DIFF
--- a/tycho-client/src/stream.rs
+++ b/tycho-client/src/stream.rs
@@ -66,7 +66,7 @@ impl TychoStreamBuilder {
             Chain::Starknet => (30, 5),
             Chain::ZkSync => (1, 2),
             Chain::Arbitrum => (1, 0), // Typically closer to 0.25s
-            Chain::Base => (2, 2),
+            Chain::Base => (10, 2),
         }
     }
 


### PR DESCRIPTION
The client errors with 'stale synchroniser' on start up if we set this to 2s. Defaulting this to 10s for Base pending a proper investigation on the handling of this setting and why it errors.