### PR TITLE
feat: update postgres gateway get_tokens quality filter to be ranged

### DIFF
--- a/tycho-core/src/models/protocol.rs
+++ b/tycho-core/src/models/protocol.rs
@@ -199,7 +199,7 @@ impl ComponentBalance {
 /// Token quality range filter
 ///
 /// The quality range is considered inclusive and used as a filter, will be applied as such.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct QualityRange {
     pub min: Option<i32>,
     pub max: Option<i32>,
@@ -212,6 +212,11 @@ impl QualityRange {
 
     pub fn min_only(min: i32) -> Self {
         Self { min: Some(min), max: None }
+    }
+
+    #[allow(non_snake_case)]
+    pub fn None() -> Self {
+        Self { min: None, max: None }
     }
 }
 

--- a/tycho-core/src/models/protocol.rs
+++ b/tycho-core/src/models/protocol.rs
@@ -196,6 +196,25 @@ impl ComponentBalance {
     }
 }
 
+/// Token quality range filter
+///
+/// The quality range is considered inclusive and used as a filter, will be applied as such.
+#[derive(Debug, Clone, Default)]
+pub struct QualityRange {
+    pub min: Option<i32>,
+    pub max: Option<i32>,
+}
+
+impl QualityRange {
+    pub fn new(min: i32, max: i32) -> Self {
+        Self { min: Some(min), max: Some(max) }
+    }
+
+    pub fn min_only(min: i32) -> Self {
+        Self { min: Some(min), max: None }
+    }
+}
+
 /// Updates grouped by their respective transaction.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct ProtocolChangesWithTx {

--- a/tycho-core/src/storage.rs
+++ b/tycho-core/src/storage.rs
@@ -11,7 +11,7 @@ use crate::{
         contract::{Account, AccountBalance, AccountDelta},
         protocol::{
             ComponentBalance, ProtocolComponent, ProtocolComponentState,
-            ProtocolComponentStateDelta,
+            ProtocolComponentStateDelta, QualityRange,
         },
         token::CurrencyToken,
         Address, BlockHash, Chain, ComponentId, ContractId, ExtractionState, PaginationParams,
@@ -364,7 +364,7 @@ pub trait ProtocolGateway {
         &self,
         chain: Chain,
         address: Option<&[&Address]>,
-        min_quality: Option<i32>,
+        quality: QualityRange,
         traded_n_days_ago: Option<NaiveDateTime>,
         pagination_params: Option<&PaginationParams>,
     ) -> Result<WithTotal<Vec<CurrencyToken>>, StorageError>;

--- a/tycho-indexer/src/extractor/protocol_cache.rs
+++ b/tycho-indexer/src/extractor/protocol_cache.rs
@@ -5,7 +5,11 @@ use tokio::sync::RwLock;
 use tracing::{debug, info, instrument};
 
 use tycho_core::{
-    models::{protocol::ProtocolComponent, token::CurrencyToken, Address, Chain, ComponentId},
+    models::{
+        protocol::{ProtocolComponent, QualityRange},
+        token::CurrencyToken,
+        Address, Chain, ComponentId,
+    },
     storage::{ProtocolGateway, StorageError},
     Bytes,
 };
@@ -82,7 +86,7 @@ impl ProtocolMemoryCache {
         {
             let mut cached_tokens = self.tokens.write().await;
             self.gateway
-                .get_tokens(self.chain, None, None, None, None)
+                .get_tokens(self.chain, None, QualityRange::default(), None, None)
                 .await?
                 .entity
                 .into_iter()
@@ -165,7 +169,7 @@ impl ProtocolDataCache for ProtocolMemoryCache {
             let mut cached_tokens = self.tokens.write().await;
             let mut n_fetched = 0;
             self.gateway
-                .get_tokens(self.chain, Some(&missing), None, None, None)
+                .get_tokens(self.chain, Some(&missing), QualityRange::default(), None, None)
                 .await?
                 .entity
                 .into_iter()

--- a/tycho-indexer/src/extractor/protocol_cache.rs
+++ b/tycho-indexer/src/extractor/protocol_cache.rs
@@ -86,7 +86,7 @@ impl ProtocolMemoryCache {
         {
             let mut cached_tokens = self.tokens.write().await;
             self.gateway
-                .get_tokens(self.chain, None, QualityRange::default(), None, None)
+                .get_tokens(self.chain, None, QualityRange::None(), None, None)
                 .await?
                 .entity
                 .into_iter()
@@ -169,7 +169,7 @@ impl ProtocolDataCache for ProtocolMemoryCache {
             let mut cached_tokens = self.tokens.write().await;
             let mut n_fetched = 0;
             self.gateway
-                .get_tokens(self.chain, Some(&missing), QualityRange::default(), None, None)
+                .get_tokens(self.chain, Some(&missing), QualityRange::None(), None, None)
                 .await?
                 .entity
                 .into_iter()

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -2486,7 +2486,7 @@ mod test_serial_db {
             assert_eq!(res, exp);
 
             let tokens = cached_gw
-                .get_tokens(Chain::Ethereum, None, QualityRange::default(), None, None)
+                .get_tokens(Chain::Ethereum, None, QualityRange::None(), None, None)
                 .await
                 .unwrap()
                 .entity;

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -2004,7 +2004,10 @@ mod test_serial_db {
     use super::*;
 
     use tycho_core::{
-        models::{blockchain::TxWithChanges, ContractId, FinancialType, ImplementationType},
+        models::{
+            blockchain::TxWithChanges, protocol::QualityRange, ContractId, FinancialType,
+            ImplementationType,
+        },
         storage::{BlockIdentifier, BlockOrTimestamp},
         traits::TokenOwnerFinding,
     };
@@ -2483,7 +2486,7 @@ mod test_serial_db {
             assert_eq!(res, exp);
 
             let tokens = cached_gw
-                .get_tokens(Chain::Ethereum, None, None, None, None)
+                .get_tokens(Chain::Ethereum, None, QualityRange::default(), None, None)
                 .await
                 .unwrap()
                 .entity;

--- a/tycho-indexer/src/extractor/token_analysis_cron.rs
+++ b/tycho-indexer/src/extractor/token_analysis_cron.rs
@@ -162,7 +162,7 @@ async fn analyze_batch(
         }
 
         // If it's a fee token, set quality to 50
-        if tax.map_or(false, |tax_value| tax_value > 0) {
+        if tax.is_some_and(|tax_value| tax_value > 0) {
             t.quality = 50;
         }
 

--- a/tycho-indexer/src/services/rpc.rs
+++ b/tycho-indexer/src/services/rpc.rs
@@ -12,7 +12,10 @@ use tracing::{debug, error, info, instrument, trace, warn};
 
 use tycho_core::{
     dto::{self, PaginationResponse},
-    models::{blockchain::BlockAggregatedChanges, Address, Chain, PaginationParams},
+    models::{
+        blockchain::BlockAggregatedChanges, protocol::QualityRange, Address, Chain,
+        PaginationParams,
+    },
     storage::{BlockIdentifier, BlockOrTimestamp, Gateway, StorageError, Version, VersionKind},
     Bytes,
 };
@@ -520,7 +523,11 @@ where
         debug!(?addresses_slice, "Getting tokens.");
 
         let converted_params: PaginationParams = (&request.pagination).into();
-        let min_quality = request.min_quality;
+        let quality = if let Some(min_quality) = request.min_quality {
+            QualityRange::min_only(min_quality)
+        } else {
+            QualityRange::default()
+        };
 
         let traded_n_days_ago = request.traded_n_days_ago;
 
@@ -537,7 +544,7 @@ where
             .get_tokens(
                 request.chain.into(),
                 addresses_slice,
-                min_quality,
+                quality,
                 n_days_ago,
                 Some(&converted_params),
             )

--- a/tycho-indexer/src/services/rpc.rs
+++ b/tycho-indexer/src/services/rpc.rs
@@ -526,7 +526,7 @@ where
         let quality = if let Some(min_quality) = request.min_quality {
             QualityRange::min_only(min_quality)
         } else {
-            QualityRange::default()
+            QualityRange::None()
         };
 
         let traded_n_days_ago = request.traded_n_days_ago;

--- a/tycho-indexer/src/testing.rs
+++ b/tycho-indexer/src/testing.rs
@@ -12,7 +12,7 @@ use tycho_core::{
         contract::{Account, AccountBalance, AccountDelta},
         protocol::{
             ComponentBalance, ProtocolComponent, ProtocolComponentState,
-            ProtocolComponentStateDelta,
+            ProtocolComponentStateDelta, QualityRange,
         },
         token::CurrencyToken,
         Address, Chain, ComponentId, ContractId, ExtractionState, PaginationParams, ProtocolType,
@@ -328,7 +328,7 @@ mock! {
             &'life0 self,
             chain: Chain,
             address: Option<&'life1 [&'life2 Address]>,
-            min_quality: Option<i32>,
+            quality: QualityRange,
             traded_n_days_ago: Option<NaiveDateTime>,
             pagination_params: Option<&'life3 PaginationParams>,
         ) -> ::core::pin::Pin<

--- a/tycho-storage/src/postgres/cache.rs
+++ b/tycho-storage/src/postgres/cache.rs
@@ -20,7 +20,7 @@ use tycho_core::{
         contract::{Account, AccountBalance, AccountDelta},
         protocol::{
             ComponentBalance, ProtocolComponent, ProtocolComponentState,
-            ProtocolComponentStateDelta,
+            ProtocolComponentStateDelta, QualityRange,
         },
         token::CurrencyToken,
         Address, Chain, ComponentId, ContractId, ExtractionState, PaginationParams, ProtocolType,
@@ -923,7 +923,7 @@ impl ProtocolGateway for CachedGateway {
         &self,
         chain: Chain,
         address: Option<&[&Address]>,
-        min_quality: Option<i32>,
+        quality: QualityRange,
         traded_n_days_ago: Option<NaiveDateTime>,
         pagination_params: Option<&PaginationParams>,
     ) -> Result<WithTotal<Vec<CurrencyToken>>, StorageError> {
@@ -932,14 +932,7 @@ impl ProtocolGateway for CachedGateway {
                 StorageError::Unexpected(format!("Failed to retrieve connection: {e}"))
             })?;
         self.state_gateway
-            .get_tokens(
-                chain,
-                address,
-                min_quality,
-                traded_n_days_ago,
-                pagination_params,
-                &mut conn,
-            )
+            .get_tokens(chain, address, quality, traded_n_days_ago, pagination_params, &mut conn)
             .await
     }
 

--- a/tycho-storage/src/postgres/protocol.rs
+++ b/tycho-storage/src/postgres/protocol.rs
@@ -2984,10 +2984,10 @@ mod test {
             10,
             &[Some(10)],
             Chain::Ethereum,
-            100,
+            70,
         );
 
-        assert_eq!(tokens[1], expected_token);
+        assert_eq!(tokens[0], expected_token);
     }
 
     #[tokio::test]

--- a/tycho-storage/src/postgres/protocol.rs
+++ b/tycho-storage/src/postgres/protocol.rs
@@ -2802,7 +2802,7 @@ mod test {
 
         // get all eth tokens (no address filter)
         let tokens = gw
-            .get_tokens(Chain::Ethereum, None, QualityRange::default(), None, None, &mut conn)
+            .get_tokens(Chain::Ethereum, None, QualityRange::None(), None, None, &mut conn)
             .await
             .unwrap()
             .entity;
@@ -2813,7 +2813,7 @@ mod test {
             .get_tokens(
                 Chain::Ethereum,
                 Some(&[&WETH.into(), &USDC.into()]),
-                QualityRange::default(),
+                QualityRange::None(),
                 None,
                 None,
                 &mut conn,
@@ -2828,7 +2828,7 @@ mod test {
             .get_tokens(
                 Chain::Ethereum,
                 Some(&[&WETH.into()]),
-                QualityRange::default(),
+                QualityRange::None(),
                 None,
                 None,
                 &mut conn,
@@ -2852,7 +2852,7 @@ mod test {
             .get_tokens(
                 Chain::Ethereum,
                 None,
-                QualityRange::default(),
+                QualityRange::None(),
                 None,
                 Some(&PaginationParams { page: 0, page_size: 1 }),
                 &mut conn,
@@ -2869,7 +2869,7 @@ mod test {
             .get_tokens(
                 Chain::Ethereum,
                 None,
-                QualityRange::default(),
+                QualityRange::None(),
                 None,
                 Some(&PaginationParams { page: 0, page_size: 0 }),
                 &mut conn,
@@ -2884,7 +2884,7 @@ mod test {
             .get_tokens(
                 Chain::Ethereum,
                 None,
-                QualityRange::default(),
+                QualityRange::None(),
                 None,
                 Some(&PaginationParams { page: 2, page_size: 1 }),
                 &mut conn,
@@ -2903,7 +2903,7 @@ mod test {
         let gw = EVMGateway::from_connection(&mut conn).await;
 
         let tokens = gw
-            .get_tokens(Chain::ZkSync, None, QualityRange::default(), None, None, &mut conn)
+            .get_tokens(Chain::ZkSync, None, QualityRange::None(), None, None, &mut conn)
             .await
             .unwrap()
             .entity;
@@ -2999,14 +2999,7 @@ mod test {
         let days_cutoff: Option<NaiveDateTime> = Some(yesterday_half_past_midnight());
 
         let tokens = gw
-            .get_tokens(
-                Chain::Ethereum,
-                None,
-                QualityRange::default(),
-                days_cutoff,
-                None,
-                &mut conn,
-            )
+            .get_tokens(Chain::Ethereum, None, QualityRange::None(), days_cutoff, None, &mut conn)
             .await
             .unwrap()
             .entity;
@@ -3105,7 +3098,7 @@ mod test {
             .get_tokens(
                 Chain::Ethereum,
                 Some(&[&dai_address]),
-                QualityRange::default(),
+                QualityRange::None(),
                 None,
                 None,
                 &mut conn,
@@ -3123,7 +3116,7 @@ mod test {
             .get_tokens(
                 Chain::Ethereum,
                 Some(&[&dai_address]),
-                QualityRange::default(),
+                QualityRange::None(),
                 None,
                 None,
                 &mut conn,


### PR DESCRIPTION
ISSUE: Currently our postgres gateway’s get_tokens fn optionally filters tokens by a min quality. For the most part this is all we need as all client interactions are concerned about highest quality/most relevant tokens only. However, our token analysis cronjob is interested in tokens with quality 6-10 only. A min quality filter alone is not sufficient here and results in the cronjob needlessly fetching excessive numbers of tokens from the DB only to skip analysing them.