### PR TITLE
chore(docker): fix volume config

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
     ports:
       - "5431:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/bitnami/postgresql
   tycho-indexer:
     image: ${TYCHO_IMAGE}
     restart: "no"


### PR DESCRIPTION
This fix correctly map the volume to postgres, allowing it to be persistent between runs (unless the volume was deleted).