### PR TITLE
ci: use cargo publish directly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,8 +62,13 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - uses: katyo/publish-crates@v2
-        with:
-          path: "./tycho-common"
-          registry-token: ${{ secrets.CRATESIO_REGISTRY_TOKEN }}
+      - name: Push to crates.io
+        run: |
+          cargo publish --locked --verbose --package tycho-common
+          cargo publish --locked --verbose --package tycho-client
+# we can't use the action because it errors on github dependencies in any workspace crate
+#      - uses: katyo/publish-crates@v2
+#        with:
+#          path: "./tycho-common"
+#          registry-token: ${{ secrets.CRATESIO_REGISTRY_TOKEN }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7459,7 +7459,8 @@ dependencies = [
 [[package]]
 name = "tycho-substreams"
 version = "0.2.0"
-source = "git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.2.0#ae10195bca567c60423002497d1815a59d5d83ed"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbb710ae7ef1ef8bc8cb4d49b04e98b851d839c2fd157c972c4acbe13dbd028"
 dependencies = [
  "ethabi 18.0.0",
  "hex",

--- a/tycho-indexer/Cargo.toml
+++ b/tycho-indexer/Cargo.toml
@@ -72,7 +72,7 @@ mini-moka = "0.10.3"
 num-bigint = "0.4.4"
 num-traits = "0.2.19"
 num_cpus = "1.16.0"
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.2.0" }
+tycho-substreams = "0.2.0"
 
 [dev-dependencies]
 pretty_assertions.workspace = true


### PR DESCRIPTION
We can't use the action because it errors on github dependencies in any workspace crate and we still depend on some cowswap crates for the token analyzer.