### PR TITLE
fix: include workspace cargo toml in release config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7280,7 +7280,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.64.0"
+version = "0.63.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7319,7 +7319,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-common"
-version = "0.64.0"
+version = "0.63.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7347,7 +7347,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-ethereum"
-version = "0.64.0"
+version = "0.63.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7372,7 +7372,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-indexer"
-version = "0.64.0"
+version = "0.63.1"
 dependencies = [
  "actix",
  "actix-cors",
@@ -7434,7 +7434,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-storage"
-version = "0.64.0"
+version = "0.63.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/release.config.js
+++ b/release.config.js
@@ -86,12 +86,8 @@ if (
       assets: [
         "CHANGELOG.md",
         "Cargo.lock",
-        "tycho-ethereum/Cargo.toml",
-        "tycho-client/Cargo.toml",
+        "Cargo.toml",
         "tycho-client-py/pyproject.toml",
-        "tycho-common/Cargo.toml",
-        "tycho-indexer/Cargo.toml",
-        "tycho-storage/Cargo.toml",
       ],
       message:
         "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",


### PR DESCRIPTION
Fixes Cargo.toml changes not being included in the git release commit which is automatically created by CI.