### PR TITLE
feat(versioning): drop new entries where newer versions already exist in the DB

### DIFF
--- a/tycho-client/src/feed/component_tracker.rs
+++ b/tycho-client/src/feed/component_tracker.rs
@@ -79,11 +79,11 @@ pub struct ComponentTracker<R: RPCClient> {
     chain: Chain,
     protocol_system: String,
     filter: ComponentFilter,
-    // We will need to request a snapshot for components/Contracts that we did not emit as
+    // We will need to request a snapshot for components/contracts that we did not emit as
     // snapshot for yet but are relevant now, e.g. because min tvl threshold exceeded.
     pub components: HashMap<String, ProtocolComponent>,
-    /// derived from tracked components, we need this if subscribed to a vm extractor cause updates
-    /// are emitted on a contract level instead of on a component level.
+    /// Derived from tracked components. We need this if subscribed to a vm extractor because
+    /// updates are emitted on a contract level instead of a component level.
     pub contracts: HashSet<Bytes>,
     /// Client to retrieve necessary protocol components from the rpc.
     rpc_client: R,

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -1342,10 +1342,14 @@ impl ExtractorGateway for ExtractorPgGateway {
                     let new: Account = account_update.ref_into_account(&tx_update.tx);
                     info!(block_number = ?changes.block.number, contract_address = ?new.address, "NewContract");
 
-                    // Insert new accounts
+                    // Insert new account static values
                     self.state_gateway
-                        .upsert_contract(&new)
+                        .insert_contract(&new)
                         .await?;
+
+                    // Collect new account dynamic values for block-scoped batch insert (necessary
+                    // for correct versioning)
+                    account_changes.push((tx_update.tx.hash.clone(), account_update.clone()));
                 } else if account_update.is_update() {
                     account_changes.push((tx_update.tx.hash.clone(), account_update.clone()));
                 } else {
@@ -1410,6 +1414,7 @@ impl ExtractorGateway for ExtractorPgGateway {
         }
 
         // Insert component balance changes
+        dbg!(&component_balance_changes);
         if !component_balance_changes.is_empty() {
             self.state_gateway
                 .add_component_balances(component_balance_changes.as_slice())
@@ -2172,10 +2177,7 @@ mod test_serial_db {
         storage::BlockOrTimestamp,
         traits::TokenOwnerFinding,
     };
-    use tycho_storage::postgres::{
-        builder::GatewayBuilder, db_fixtures, db_fixtures::yesterday_midnight,
-        testing::run_against_db,
-    };
+    use tycho_storage::postgres::{builder::GatewayBuilder, db_fixtures, testing::run_against_db};
 
     use super::*;
     use crate::{
@@ -2340,7 +2342,7 @@ mod test_serial_db {
                     )
                     .unwrap(),
                     parent_hash: Bytes::default(),
-                    ts: db_fixtures::yesterday_one_am(),
+                    ts: db_fixtures::yesterday_half_past_midnight(),
                 }])
                 .await
                 .expect("block insertion succeeded");
@@ -2581,8 +2583,6 @@ mod test_serial_db {
     }
 
     // Tests a forward call with a native contract creation and an account update
-    // TODO: Fix this test. It was already disabled for native extractors, because of
-    // protocol_type_name mismatch
     #[ignore]
     #[tokio::test]
     async fn test_forward_native_protocol() {
@@ -2590,7 +2590,7 @@ mod test_serial_db {
             let (gw, _) = setup_gw(pool, ImplementationType::Custom).await;
             let msg = native_pool_creation();
 
-            let _exp = [ProtocolComponent {
+            let exp = [ProtocolComponent {
                 id: NATIVE_CREATED_CONTRACT.to_string(),
                 protocol_system: "test".to_string(),
                 protocol_type_name: "pool".to_string(),
@@ -2627,8 +2627,7 @@ mod test_serial_db {
                 .entity;
             println!("{res:?}");
 
-            // TODO: This is failing because protocol_type_name is wrong in the gateway - waiting
-            // assert_eq!(res, exp);
+            assert_eq!(res, exp);
         })
         .await;
     }
@@ -2681,6 +2680,7 @@ mod test_serial_db {
                 .unwrap();
 
             // TODO: improve asserts
+            dbg!(&component_balances);
             assert_eq!(component_balances.len(), 1);
             assert_eq!(component_balances[0].component_id, "ambient_USDC_ETH");
         })
@@ -3137,7 +3137,7 @@ mod test_serial_db {
             .expect("Failed to create extractor");
 
             // Send a sequence of block scoped data with the same timestamp.
-            let base_ts = yesterday_midnight().timestamp() as u64;
+            let base_ts = db_fixtures::yesterday_midnight().timestamp() as u64;
             let versions = [1, 2, 3, 4];
 
             let inp_sequence = versions

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -1414,7 +1414,6 @@ impl ExtractorGateway for ExtractorPgGateway {
         }
 
         // Insert component balance changes
-        dbg!(&component_balance_changes);
         if !component_balance_changes.is_empty() {
             self.state_gateway
                 .add_component_balances(component_balance_changes.as_slice())

--- a/tycho-indexer/src/main.rs
+++ b/tycho-indexer/src/main.rs
@@ -467,14 +467,18 @@ async fn initialize_accounts(
         .expect("Failed to insert tx");
 
     for account_update in extracted_accounts.into_values() {
-        let new_account = account_update.into_account(&tx);
+        let new_account = account_update.ref_into_account(&tx);
         info!(block_number = block.number, contract_address = ?new_account.address, "NewContract");
 
         // Insert new accounts
         cached_gw
-            .upsert_contract(&new_account)
+            .insert_contract(&new_account)
             .await
             .expect("Failed to insert contract");
+        cached_gw
+            .update_contracts(&[(tx.hash.clone(), account_update)])
+            .await
+            .expect("Failed to update contract");
     }
 
     let state = ExtractionState::new(

--- a/tycho-indexer/src/testing.rs
+++ b/tycho-indexer/src/testing.rs
@@ -81,7 +81,7 @@ mock! {
             'life4: 'async_trait,
             Self: 'async_trait;
 
-        fn upsert_contract<'life0, 'life1, 'async_trait>(
+        fn insert_contract<'life0, 'life1, 'async_trait>(
             &'life0 self,
             new: &'life1 Account,
         ) -> ::core::pin::Pin<

--- a/tycho-storage/migrations/2024-09-06_v0.16.2/down.sql
+++ b/tycho-storage/migrations/2024-09-06_v0.16.2/down.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS component_balance_old(
     inserted_ts timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
     valid_from timestamptz NOT NULL,
     valid_to timestamptz NOT NULL
-)
+);
 CREATE TABLE IF NOT EXISTS contract_storage_old(
     slot bytea NOT NULL,
     value bytea NULL,
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS contract_storage_old(
     valid_to timestamptz NOT NULL,
     inserted_ts timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
     modified_ts timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP
-)
+);
 CREATE TABLE IF NOT EXISTS protocol_state_old(
     attribute_name varchar NOT NULL,
     attribute_value bytea NOT NULL,
@@ -31,4 +31,4 @@ CREATE TABLE IF NOT EXISTS protocol_state_old(
     inserted_ts timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
     modified_ts timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
     protocol_component_id int8 NOT NULL
-)
+);

--- a/tycho-storage/migrations/2024-09-19_transaction_cleanup/down.sql
+++ b/tycho-storage/migrations/2024-09-19_transaction_cleanup/down.sql
@@ -2,12 +2,12 @@ SELECT cron.unschedule('clean_transaction_table');
 
 DROP FUNCTION IF EXISTS clean_transaction_table();
 
-DROP INDEX IF NOT EXISTS idx_contract_code_modify_tx;
-DROP INDEX IF NOT EXISTS idx_protocol_component_creation_tx;
-DROP INDEX IF NOT EXISTS idx_protocol_component_deletion_tx;
-DROP INDEX IF NOT EXISTS idx_account_creation_tx;
-DROP INDEX IF NOT EXISTS idx_account_deletion_tx;
-DROP INDEX IF NOT EXISTS idx_account_balance_modify_tx;
-DROP INDEX IF NOT EXISTS idx_component_balance_modify_tx;
-DROP INDEX IF NOT EXISTS idx_protocol_state_modify_tx;
-DROP INDEX IF NOT EXISTS idx_contract_storage_modify_tx;
+DROP INDEX IF EXISTS idx_contract_code_modify_tx;
+DROP INDEX IF EXISTS idx_protocol_component_creation_tx;
+DROP INDEX IF EXISTS idx_protocol_component_deletion_tx;
+DROP INDEX IF EXISTS idx_account_creation_tx;
+DROP INDEX IF EXISTS idx_account_deletion_tx;
+DROP INDEX IF EXISTS idx_account_balance_modify_tx;
+DROP INDEX IF EXISTS idx_component_balance_modify_tx;
+DROP INDEX IF EXISTS idx_protocol_state_modify_tx;
+DROP INDEX IF EXISTS idx_contract_storage_modify_tx;

--- a/tycho-storage/src/postgres/chain.rs
+++ b/tycho-storage/src/postgres/chain.rs
@@ -270,10 +270,7 @@ mod test {
     use tycho_common::models::Chain;
 
     use super::*;
-    use crate::postgres::{
-        db_fixtures,
-        db_fixtures::{yesterday_midnight, yesterday_one_am},
-    };
+    use crate::postgres::db_fixtures::{self, yesterday_half_past_midnight, yesterday_midnight};
 
     type EVMGateway = PostgresGateway;
 
@@ -317,7 +314,7 @@ mod test {
             Chain::Ethereum,
             Bytes::from(hash),
             Bytes::from("0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6"),
-            yesterday_one_am(),
+            yesterday_half_past_midnight(),
         )
     }
 

--- a/tycho-storage/src/postgres/contract.rs
+++ b/tycho-storage/src/postgres/contract.rs
@@ -1035,16 +1035,8 @@ impl PostgresGateway {
         };
         let hex_addr = hex::encode(&new.address);
 
-        use schema::account::dsl;
         diesel::insert_into(schema::account::table)
             .values(new_contract.new_account())
-            .on_conflict(on_constraint("account_chain_id_address_key"))
-            .do_update()
-            .set((
-                dsl::title.eq(excluded(dsl::title)),
-                dsl::creation_tx.eq(excluded(dsl::creation_tx)),
-                dsl::created_at.eq(excluded(dsl::created_at)),
-            ))
             .returning(schema::account::id)
             .get_result::<i64>(db)
             .await

--- a/tycho-storage/src/postgres/contract.rs
+++ b/tycho-storage/src/postgres/contract.rs
@@ -1656,10 +1656,7 @@ mod test {
     };
 
     use super::*;
-    use crate::postgres::{
-        db_fixtures,
-        db_fixtures::{yesterday_midnight, yesterday_one_am},
-    };
+    use crate::postgres::db_fixtures;
 
     type EVMGateway = PostgresGateway;
     type MaybeTS = Option<NaiveDateTime>;
@@ -1701,14 +1698,14 @@ mod test {
                     .unwrap(),
                 )),
                 schema::block::number.eq(3),
-                schema::block::ts.eq(yesterday_one_am()),
+                schema::block::ts.eq(db_fixtures::yesterday_one_am()),
                 schema::block::chain_id.eq(chain_id),
             ))
             .execute(conn)
             .await
             .unwrap();
         let ts = db_fixtures::yesterday_midnight();
-        let ts_p1 = db_fixtures::yesterday_one_am();
+        let ts_p1 = db_fixtures::yesterday_half_past_midnight();
         let tx_hashes = [
             "0xbb7e16d797a9e2fbc537e30f91ed3d27a254dd9578aa4c3af3e5f0d3e8130945".to_string(),
             "0x794f7df7a3fe973f1583fbb92536f9a8def3a89902439289315326c04068de54".to_string(),
@@ -2756,8 +2753,8 @@ mod test {
             .await
             .unwrap();
         exp.insert(account_id, storage);
-        let end_ts = yesterday_one_am() + Duration::from_secs(3600);
-        let start_ts = yesterday_midnight();
+        let end_ts = db_fixtures::yesterday_one_am() + Duration::from_secs(3600);
+        let start_ts = db_fixtures::yesterday_midnight();
 
         let res = gw
             .get_slots_delta(chain_id, &start_ts, &end_ts, &mut conn)
@@ -2783,8 +2780,8 @@ mod test {
             .await
             .unwrap();
         exp.insert(account_id, storage);
-        let start_ts = yesterday_one_am() + Duration::from_secs(3600);
-        let end_ts = yesterday_midnight();
+        let start_ts = db_fixtures::yesterday_one_am() + Duration::from_secs(3600);
+        let end_ts = db_fixtures::yesterday_midnight();
 
         let res = gw
             .get_slots_delta(chain_id, &start_ts, &end_ts, &mut conn)

--- a/tycho-storage/src/postgres/contract.rs
+++ b/tycho-storage/src/postgres/contract.rs
@@ -1685,6 +1685,28 @@ mod test {
     async fn setup_data(conn: &mut AsyncPgConnection) -> i64 {
         let chain_id = db_fixtures::insert_chain(conn, "ethereum").await;
         let blk = db_fixtures::insert_blocks(conn, chain_id).await;
+        // add block 3 with no linked data (to be used to test updates)
+        diesel::insert_into(schema::block::table)
+            .values((
+                schema::block::hash.eq(Vec::from(
+                    Bytes::from_str(
+                        "f2d7c8b6e3a1905f4c8d26b7e9513a0d7f8e2c9b1a6d5e4f3c2b1a0e9d8c7f61",
+                    )
+                    .unwrap(),
+                )),
+                schema::block::parent_hash.eq(Vec::from(
+                    Bytes::from_str(
+                        "b495a1d7e6663152ae92708da4843337b958146015a2802f4193a410044698c9",
+                    )
+                    .unwrap(),
+                )),
+                schema::block::number.eq(3),
+                schema::block::ts.eq(yesterday_one_am()),
+                schema::block::chain_id.eq(chain_id),
+            ))
+            .execute(conn)
+            .await
+            .unwrap();
         let ts = db_fixtures::yesterday_midnight();
         let ts_p1 = db_fixtures::yesterday_one_am();
         let tx_hashes = [
@@ -2284,7 +2306,7 @@ mod test {
         let gw = EVMGateway::from_connection(&mut conn).await;
         let modify_txhash = "62f4d4f29d10db8722cb66a2adb0049478b11988c8b43cd446b755afb8954678";
         let tx_hash_bytes = Bytes::from(modify_txhash);
-        let block = orm::Block::by_number(Chain::Ethereum, 2, &mut conn)
+        let block = orm::Block::by_number(Chain::Ethereum, 3, &mut conn)
             .await
             .expect("block found");
         db_fixtures::insert_txns(&mut conn, &[(block.id, 100, modify_txhash)]).await;

--- a/tycho-storage/src/postgres/mod.rs
+++ b/tycho-storage/src/postgres/mod.rs
@@ -926,7 +926,7 @@ pub mod db_fixtures {
                     .unwrap(),
                 )),
                 schema::block::number.eq(2),
-                schema::block::ts.eq(yesterday_one_am()),
+                schema::block::ts.eq(yesterday_half_past_midnight()),
                 schema::block::chain_id.eq(chain_id),
             ),
         ];

--- a/tycho-storage/src/postgres/orm.rs
+++ b/tycho-storage/src/postgres/orm.rs
@@ -453,6 +453,11 @@ impl PartitionedVersionedRow for NewComponentBalance {
             .zip(token_ids.iter())
             .collect::<HashSet<_>>();
 
+        // PERF: The removal of the filter 'valid_to = MAX_TS' means we now search in archived
+        // tables as well. A possible optimisation would be to add the valid_to filter back
+        // and then use a second query for balances still missing that will access the
+        // archived tables. Therefore, performance is not impacted in the common case
+        // (balances are rarely deleted).
         Ok(component_balance::table
             .select(ComponentBalance::as_select())
             .filter(
@@ -1089,6 +1094,11 @@ impl PartitionedVersionedRow for NewProtocolState {
             .iter()
             .zip(attr_name.iter())
             .collect::<HashSet<_>>();
+
+        // PERF: The removal of the filter 'valid_to = MAX_TS' means we now search in archived
+        // tables as well. A possible optimisation would be to add the valid_to filter back
+        // and then use a second query for states still missing that will access the
+        // archived tables. Therefore, performance is not impacted in the common case.
         Ok(protocol_state::table
             .select(ProtocolState::as_select())
             .filter(
@@ -1610,6 +1620,10 @@ impl PartitionedVersionedRow for NewSlot {
             .zip(slots.iter())
             .collect::<HashSet<_>>();
 
+        // PERF: The removal of the filter 'valid_to = MAX_TS' means we now search in archived
+        // tables as well. A possible optimisation would be to add the valid_to filter back
+        // and then use a second query for storage still missing that will access the
+        // archived tables. Therefore, performance is not impacted in the common case.
         Ok(contract_storage::table
             .select(ContractStorage::as_select())
             .filter(

--- a/tycho-storage/src/postgres/orm.rs
+++ b/tycho-storage/src/postgres/orm.rs
@@ -455,13 +455,17 @@ impl PartitionedVersionedRow for NewComponentBalance {
 
         Ok(component_balance::table
             .select(ComponentBalance::as_select())
-            .into_boxed()
             .filter(
                 component_balance::protocol_component_id
                     .eq_any(&component_ids)
-                    .and(component_balance::token_id.eq_any(&token_ids))
-                    .and(component_balance::valid_to.eq(MAX_TS)),
+                    .and(component_balance::token_id.eq_any(&token_ids)),
             )
+            .distinct_on((component_balance::protocol_component_id, component_balance::token_id))
+            .order_by((
+                component_balance::protocol_component_id,
+                component_balance::token_id,
+                component_balance::valid_to.desc(),
+            ))
             .get_results(conn)
             .await
             .map_err(PostgresError::from)?
@@ -1087,13 +1091,17 @@ impl PartitionedVersionedRow for NewProtocolState {
             .collect::<HashSet<_>>();
         Ok(protocol_state::table
             .select(ProtocolState::as_select())
-            .into_boxed()
             .filter(
                 protocol_state::protocol_component_id
                     .eq_any(&pc_id)
-                    .and(protocol_state::attribute_name.eq_any(&attr_name))
-                    .and(protocol_state::valid_to.eq(MAX_TS)),
+                    .and(protocol_state::attribute_name.eq_any(&attr_name)),
             )
+            .distinct_on((protocol_state::protocol_component_id, protocol_state::attribute_name))
+            .order_by((
+                protocol_state::protocol_component_id,
+                protocol_state::attribute_name,
+                protocol_state::valid_to.desc(),
+            ))
             .get_results(conn)
             .await
             .map_err(PostgresError::from)?
@@ -1640,13 +1648,17 @@ impl PartitionedVersionedRow for NewSlot {
 
         Ok(contract_storage::table
             .select(ContractStorage::as_select())
-            .into_boxed()
             .filter(
                 contract_storage::account_id
                     .eq_any(&accounts)
-                    .and(contract_storage::slot.eq_any(&slots))
-                    .and(contract_storage::valid_to.eq(MAX_TS)),
+                    .and(contract_storage::slot.eq_any(&slots)),
             )
+            .distinct_on((contract_storage::account_id, contract_storage::slot))
+            .order_by((
+                contract_storage::account_id,
+                contract_storage::slot,
+                contract_storage::valid_to.desc(),
+            ))
             .get_results(conn)
             .await
             .map_err(PostgresError::from)?

--- a/tycho-storage/src/postgres/orm.rs
+++ b/tycho-storage/src/postgres/orm.rs
@@ -1523,9 +1523,6 @@ pub struct NewContract {
     pub created_at: Option<NaiveDateTime>,
     #[allow(dead_code)]
     pub deleted_at: Option<NaiveDateTime>,
-    pub balance: Balance,
-    pub code: Code,
-    pub code_hash: CodeHash,
 }
 
 impl NewContract {
@@ -1537,39 +1534,6 @@ impl NewContract {
             creation_tx: self.creation_tx,
             created_at: self.created_at,
             deleted_at: None,
-        }
-    }
-
-    pub fn new_balance(
-        &self,
-        account_id: i64,
-        token_id: i64,
-        modify_tx: i64,
-        modify_ts: NaiveDateTime,
-    ) -> NewAccountBalance {
-        NewAccountBalance {
-            balance: self.balance.clone(),
-            account_id,
-            token_id,
-            modify_tx,
-            valid_from: modify_ts,
-            valid_to: None,
-        }
-    }
-
-    pub fn new_code(
-        &self,
-        account_id: i64,
-        modify_tx: i64,
-        modify_ts: NaiveDateTime,
-    ) -> NewContractCode {
-        NewContractCode {
-            code: &self.code,
-            hash: self.code_hash.clone(),
-            account_id,
-            modify_tx,
-            valid_from: modify_ts,
-            valid_to: None,
         }
     }
 }

--- a/tycho-storage/src/postgres/orm.rs
+++ b/tycho-storage/src/postgres/orm.rs
@@ -1369,7 +1369,7 @@ impl StoredVersionedRow for AccountBalance {
     }
 }
 
-#[derive(Insertable, Debug)]
+#[derive(Insertable, Debug, PartialEq, Clone)]
 #[diesel(table_name = account_balance)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct NewAccountBalance {

--- a/tycho-storage/src/postgres/orm.rs
+++ b/tycho-storage/src/postgres/orm.rs
@@ -426,6 +426,10 @@ impl PartitionedVersionedRow for NewComponentBalance {
         self.valid_to
     }
 
+    fn get_valid_from(&self) -> NaiveDateTime {
+        self.valid_from
+    }
+
     fn archive(&mut self, next_version: &mut Self) {
         next_version.previous_value = self.new_balance.clone();
         self.valid_to = next_version.valid_from;
@@ -1056,6 +1060,10 @@ impl PartitionedVersionedRow for NewProtocolState {
         self.valid_to
     }
 
+    fn get_valid_from(&self) -> NaiveDateTime {
+        self.valid_from
+    }
+
     fn archive(&mut self, next_version: &mut Self) {
         next_version.previous_value = Some(self.attribute_value.clone());
         self.valid_to = next_version.valid_from;
@@ -1325,6 +1333,10 @@ impl StoredVersionedRow for AccountBalance {
         (self.account_id, self.token_id)
     }
 
+    fn get_valid_from(&self) -> NaiveDateTime {
+        self.valid_from
+    }
+
     async fn latest_versions_by_ids<I: IntoIterator<Item = Self::EntityId> + Send + Sync>(
         ids: I,
         conn: &mut AsyncPgConnection,
@@ -1430,6 +1442,10 @@ impl StoredVersionedRow for ContractCode {
 
     fn get_entity_id(&self) -> Self::EntityId {
         self.account_id
+    }
+
+    fn get_valid_from(&self) -> NaiveDateTime {
+        self.valid_from
     }
 
     async fn latest_versions_by_ids<I: IntoIterator<Item = Self::EntityId> + Send + Sync>(
@@ -1591,6 +1607,10 @@ impl PartitionedVersionedRow for NewSlot {
 
     fn get_valid_to(&self) -> NaiveDateTime {
         self.valid_to
+    }
+
+    fn get_valid_from(&self) -> NaiveDateTime {
+        self.valid_from
     }
 
     fn archive(&mut self, next_version: &mut Self) {

--- a/tycho-storage/src/postgres/protocol.rs
+++ b/tycho-storage/src/postgres/protocol.rs
@@ -1753,7 +1753,7 @@ mod test {
     use tycho_common::storage::BlockIdentifier;
 
     use super::*;
-    use crate::postgres::{db_fixtures, db_fixtures::yesterday_half_past_midnight};
+    use crate::postgres::db_fixtures;
 
     type EVMGateway = PostgresGateway;
 
@@ -2996,7 +2996,7 @@ mod test {
         setup_data(&mut conn).await;
         let gw = EVMGateway::from_connection(&mut conn).await;
 
-        let days_cutoff: Option<NaiveDateTime> = Some(yesterday_half_past_midnight());
+        let days_cutoff: Option<NaiveDateTime> = Some(db_fixtures::yesterday_midnight());
 
         let tokens = gw
             .get_tokens(Chain::Ethereum, None, QualityRange::None(), days_cutoff, None, &mut conn)

--- a/tycho-storage/src/postgres/versioning.rs
+++ b/tycho-storage/src/postgres/versioning.rs
@@ -208,7 +208,9 @@ fn build_batch_update_query<'a, O: StoredVersionedRow>(
 ///
 /// ## Important note:
 /// This function requires that new_data is sorted by ascending execution order (block, transaction,
-/// index) for conflicting entity_id.
+/// index) for conflicting entity_id. It also assumes that full block-scoped data is inserted in the
+/// database, meaning that if one version of a database entry exists for a block, it is assumed that
+/// all updates for that entry on that block have been inserted.
 pub async fn apply_versioning<N, S>(
     new_data: &mut Vec<N>,
     conn: &mut AsyncPgConnection,
@@ -456,7 +458,9 @@ fn set_partitioned_versioning_attributes<N: PartitionedVersionedRow>(
 ///
 /// ## Important note:
 /// This function requires that new_data is sorted by ascending execution order (block, transaction
-/// index) for conflicting entity_id.
+/// index) for conflicting entity_id. It also assumes that full block-scoped data is inserted in the
+/// database, meaning that if one version of a database entry exists for a block, it is assumed that
+/// all updates for that entry on that block have been inserted.
 ///
 /// ## Note
 /// This method may only works for rows that have a primary key know before insert. So e.g.

--- a/tycho-storage/src/postgres/versioning.rs
+++ b/tycho-storage/src/postgres/versioning.rs
@@ -21,6 +21,12 @@
 //!
 //! # Design Decisions
 //!
+//! The versioning logic assumes data is inserted as block-scoped data. This means that if a row
+//! is inserted for a block, it is assumed that all updates for that EntityId on that block have
+//! been inserted. This is important to be aware of when inserting data to the db: you should batch
+//! insert all updates of a given type for a given block at once i.e. all account balance updates
+//! for a given block should be inserted in one call to the gateway.
+//!
 //! Initially we would support references in EntityId, to reduce the number of clones necessary for
 //! complex entity id types. This would lead to a strange situation, where these trait bounds
 //! for the `apply_versioning` method would not be expressible. Reasons for this are not 100% clear,

--- a/tycho-storage/src/postgres/versioning.rs
+++ b/tycho-storage/src/postgres/versioning.rs
@@ -100,6 +100,9 @@ pub trait StoredVersionedRow {
     /// Exposes the entity id.
     fn get_entity_id(&self) -> Self::EntityId;
 
+    /// Exposes the starting version.
+    fn get_valid_from(&self) -> Self::Version;
+
     /// Retrieves the latest versions for the passed entity ids from the database.
     async fn latest_versions_by_ids<I: IntoIterator<Item = Self::EntityId> + Send + Sync>(
         ids: I,
@@ -234,20 +237,28 @@ where
 pub trait PartitionedVersionedRow: Clone + Send + Sync + Debug {
     /// The entity identifier this version belongs to.
     type EntityId: Clone + Ord + Hash + Debug + Send + Sync;
+
     /// Getter for the entity id.
     fn get_id(&self) -> Self::EntityId;
+
     /// Getter for the end version, uses `MAX_TS` if version is currently active.
     fn get_valid_to(&self) -> NaiveDateTime;
+
+    /// Getter for the start version.
+    fn get_valid_from(&self) -> NaiveDateTime;
+
     /// Archives this struct given the next valid versions struct.
     ///
     /// Any attribute changes that need to happen to archive a row should happen in here
     /// such as setting valid_to attribute but also potentially setting `previous_*`
     /// attributes on next_version.
     fn archive(&mut self, next_version: &mut Self);
+
     /// Marks this row as deleted.
     ///
     /// Any attribute changes when deleting a struct need to happen in this method.
     fn delete(&mut self, delete_version: NaiveDateTime);
+
     /// Retrieves the currently active rows by entity ids.
     ///
     /// This method is used to provide the latest stored version of an entity id


### PR DESCRIPTION
Important decisions made:
- The versioning logic assumes data is inserted as block-scoped data. Therefore if the db has an update for a specific entity id at a given block, it is assumed all updates for that entity have been inserted at that block
- Due to the above, db data inserts/updates much be batched by block for dynamic/versioned tables. For the most part this is already how things are done on the indexer with one exception: new contracts.
- `upsert_contract` used to both insert a new contract and update the dynamic tables related to it. This makes it difficult to batch all changes done to the dynamic tables (slots, balance, code etc) into one db interaction as these same tables are also updated by `update_contracts`. Therefore `upsert_contract` was changed to `insert_contract` and only inserts the static contract values. It is expected that `update_contract` be subsequently called with the dynamic values for them to be inserted for new contracts. 

NOTE - it is expected that for a well designed substream package we will only get a single message for a given contract: either a creation with the latest state values, or an update with the latest state values. However if for any reason a substream doesn't abide by this and has both a creation and update event for the same contract on the same block, our decisions made above will allow us to predictably handle the scenario.