### PR TITLE
feat(dci): add entry point tracing functionality

### DIFF
--- a/tycho-common/src/traits.rs
+++ b/tycho-common/src/traits.rs
@@ -5,10 +5,10 @@ use async_trait::async_trait;
 
 use crate::{
     models::{
-        blockchain::{Block, BlockTag},
+        blockchain::{Block, BlockTag, EntryPoint, TracedEntryPoint},
         contract::AccountDelta,
         token::{CurrencyToken, TokenQuality, TransferCost, TransferTax},
-        Address, Balance,
+        Address, Balance, BlockHash,
     },
     Bytes,
 };
@@ -92,4 +92,29 @@ pub trait TokenPreProcessor: Send + Sync {
         token_finder: Arc<dyn TokenOwnerFinding>,
         block: BlockTag,
     ) -> Vec<CurrencyToken>;
+}
+
+/// Traces smart contract entry points to analyze their execution behavior and state changes.
+#[async_trait]
+pub trait EntryPointTracer {
+    type Error;
+
+    /// Traces the execution of a list of entry points at a specific block.
+    ///
+    /// # Parameters
+    /// * `block_hash` - The hash of the block at which to perform the trace. The trace will use the
+    ///   state of the blockchain at this block.
+    /// * `entry_points` - A list of entry points to trace.
+    ///
+    /// # Returns
+    /// Returns a vector of `TracedEntryPoint`, where each element contains:
+    /// * `retriggers` - A set of (address, storage slot) pairs representing state that could affect
+    ///   future executions. If any of these storage slots change, the set of called contract might
+    ///   be outdated.
+    /// * `called_addresses` - A set of all contract addresses that were called during the trace
+    async fn trace(
+        &self,
+        block_hash: BlockHash,
+        entry_points: Vec<EntryPoint>,
+    ) -> Result<Vec<TracedEntryPoint>, Self::Error>;
 }

--- a/tycho-ethereum/src/entrypoint_tracer/mod.rs
+++ b/tycho-ethereum/src/entrypoint_tracer/mod.rs
@@ -1,0 +1,1 @@
+pub mod tracer;

--- a/tycho-ethereum/src/entrypoint_tracer/tracer.rs
+++ b/tycho-ethereum/src/entrypoint_tracer/tracer.rs
@@ -1,0 +1,251 @@
+use std::{collections::HashSet, str::FromStr};
+
+use async_trait::async_trait;
+use ethcontract::{H160, H256};
+use ethers::{
+    prelude::Middleware,
+    providers::{Http, Provider},
+    types::{
+        Address as EthersAddress, BlockId, Bytes as EthersBytes, CallFrame,
+        GethDebugBuiltInTracerType, GethDebugTracerType, GethDebugTracingCallOptions,
+        GethDebugTracingOptions, GethTrace, GethTraceFrame, NameOrAddress, PreStateFrame,
+        PreStateMode, TransactionRequest,
+    },
+};
+use thiserror::Error;
+use tycho_common::{
+    keccak256,
+    models::{
+        blockchain::{EntryPoint, TracedEntryPoint},
+        Address, BlockHash,
+    },
+    traits::EntryPointTracer,
+    Bytes,
+};
+
+use crate::{BytesCodec, RPCError};
+
+struct EVMEntrypointService {
+    provider: Provider<Http>,
+}
+
+impl EVMEntrypointService {
+    pub fn new_from_url(rpc_url: &str) -> Self {
+        Self {
+            provider: Provider::<Http>::try_from(rpc_url).expect("Error creating HTTP provider"),
+        }
+    }
+
+    async fn trace_call(
+        &self,
+        target: &Address,
+        caller: &Address,
+        data: &Bytes,
+        block_hash: &BlockHash,
+        tracer_type: GethDebugBuiltInTracerType,
+    ) -> Result<GethTrace, RPCError> {
+        self.provider
+            .debug_trace_call(
+                TransactionRequest {
+                    to: Some(NameOrAddress::Address(H160::from_bytes(target))),
+                    from: Some(H160::from_bytes(caller)),
+                    data: Some(EthersBytes::from(data.to_vec())),
+                    ..Default::default()
+                },
+                Some(BlockId::Hash(H256::from_bytes(block_hash))),
+                GethDebugTracingCallOptions {
+                    tracing_options: GethDebugTracingOptions {
+                        tracer: Some(GethDebugTracerType::BuiltInTracer(tracer_type)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(RPCError::RequestError)
+    }
+}
+
+#[async_trait]
+impl EntryPointTracer for EVMEntrypointService {
+    type Error = RPCError;
+
+    async fn trace(
+        &self,
+        block_hash: BlockHash,
+        entry_points: Vec<EntryPoint>,
+    ) -> Result<Vec<TracedEntryPoint>, Self::Error> {
+        let mut results = Vec::new();
+        for entry_point in entry_points {
+            match entry_point {
+                EntryPoint::RPCTracer(rpc_entry_point) => {
+                    for (caller, data) in rpc_entry_point.args {
+                        let call_trace = self
+                            .trace_call(
+                                &rpc_entry_point.target,
+                                caller
+                                    .as_ref()
+                                    .unwrap_or(&EthersAddress::zero().to_bytes()),
+                                &data,
+                                &block_hash,
+                                GethDebugBuiltInTracerType::CallTracer,
+                            )
+                            .await?;
+
+                        let called_addresses =
+                            if let GethTrace::Known(GethTraceFrame::CallTracer(frame)) = call_trace
+                            {
+                                flatten_calls(&frame)
+                            } else {
+                                return Err(RPCError::UnknownError("CallTracer failed".to_string()));
+                            };
+
+                        let pre_state_trace = self
+                            .trace_call(
+                                &rpc_entry_point.target,
+                                caller
+                                    .as_ref()
+                                    .unwrap_or(&EthersAddress::zero().to_bytes()),
+                                &data,
+                                &block_hash,
+                                GethDebugBuiltInTracerType::PreStateTracer,
+                            )
+                            .await?;
+
+                        // Provides a very simplistic way of finding retriggers. A better way would
+                        // involve using the structure of callframes. So basically iterate the call
+                        // tree in a parent child manner then search the
+                        // childs address in the prestate of parent.
+                        let retriggers = if let GethTrace::Known(GethTraceFrame::PreStateTracer(
+                            PreStateFrame::Default(PreStateMode(frame)),
+                        )) = pre_state_trace
+                        {
+                            let mut retriggers = HashSet::new();
+                            for (address, account) in frame.iter() {
+                                if let Some(storage) = &account.storage {
+                                    for (slot, val) in storage.iter() {
+                                        for call_address in called_addresses.iter() {
+                                            let address_bytes = call_address.as_bytes();
+                                            let value_bytes = val.as_bytes();
+                                            if value_bytes
+                                                .windows(address_bytes.len())
+                                                .any(|window| window == address_bytes)
+                                            {
+                                                retriggers.insert((
+                                                    (*address).to_bytes(),
+                                                    (*slot).to_bytes(),
+                                                ));
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            retriggers
+                        } else {
+                            return Err(RPCError::UnknownError("PreStateTracer failed".to_string()));
+                        };
+                        results.push(TracedEntryPoint {
+                            retriggers,
+                            called_addresses: called_addresses
+                                .into_iter()
+                                .map(BytesCodec::to_bytes)
+                                .collect(),
+                        });
+                    }
+                }
+            }
+        }
+        Ok(results)
+    }
+}
+
+fn flatten_calls(call: &CallFrame) -> Vec<EthersAddress> {
+    let to = if let Some(NameOrAddress::Address(a)) = &call.to { *a } else { return vec![] };
+    let mut flat_calls = vec![to];
+    if let Some(sub_calls) = &call.calls {
+        for sub_call in sub_calls {
+            flat_calls.extend(flatten_calls(sub_call));
+        }
+    }
+    flat_calls
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+
+    use tycho_common::{models::blockchain::RPCTracerEntryPoint, Bytes};
+
+    use super::*;
+
+    #[tokio::test]
+    #[ignore = "requires a RPC connection"]
+    async fn test_trace_balancer_v3_stable_pool() {
+        let url = env::var("RPC_URL").expect("RPC_URL is not set");
+        let tracer = EVMEntrypointService::new_from_url(&url);
+        let entry_points = vec![
+            EntryPoint::RPCTracer(RPCTracerEntryPoint {
+                target: Bytes::from_str("0xEdf63cce4bA70cbE74064b7687882E71ebB0e988").unwrap(),
+                args: vec![(None, Bytes::from(keccak256("getRate()")))],
+            }),
+            EntryPoint::RPCTracer(RPCTracerEntryPoint {
+                target: Bytes::from_str("0x8f4E8439b970363648421C692dd897Fb9c0Bd1D9").unwrap(),
+                args: vec![(None, Bytes::from(keccak256("getRate()")))],
+            }),
+        ];
+        let traced_entry_points = tracer
+            .trace(
+                Bytes::from_str(
+                    "0x354c90a0a98912aff15b044bdff6ce3d4ace63a6fc5ac006ce53c8737d425ab2",
+                )
+                .unwrap(),
+                entry_points,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            traced_entry_points,
+            vec![
+                TracedEntryPoint {
+                    retriggers: HashSet::from([
+                        (
+                            Bytes::from_str("0x7bc3485026ac48b6cf9baf0a377477fff5703af8").unwrap(),
+                            Bytes::from_str("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc").unwrap(),
+                        ),
+                        (
+                            Bytes::from_str("0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2").unwrap(),
+                            Bytes::from_str("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc").unwrap(),
+                        ),
+                    ]),
+                    called_addresses: HashSet::from([
+                        Bytes::from_str("0xef434e4573b90b6ecd4a00f4888381e4d0cc5ccd").unwrap(),
+                        Bytes::from_str("0x487c2c53c0866f0a73ae317bd1a28f63adcd9ad1").unwrap(),
+                        Bytes::from_str("0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2").unwrap(),
+                        Bytes::from_str("0xedf63cce4ba70cbe74064b7687882e71ebb0e988").unwrap(),
+                        Bytes::from_str("0x7bc3485026ac48b6cf9baf0a377477fff5703af8").unwrap(),
+                    ]),
+                },
+                TracedEntryPoint {
+                    retriggers: HashSet::from([
+                        (
+                            Bytes::from_str("0xd4fa2d31b7968e448877f69a96de69f5de8cd23e").unwrap(),
+                            Bytes::from_str("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc").unwrap(),
+                        ),
+                        (
+                            Bytes::from_str("0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2").unwrap(),
+                            Bytes::from_str("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc").unwrap(),
+                        ),
+                    ]),
+                    called_addresses: HashSet::from([
+                        Bytes::from_str("0x8f4e8439b970363648421c692dd897fb9c0bd1d9").unwrap(),
+                        Bytes::from_str("0x487c2c53c0866f0a73ae317bd1a28f63adcd9ad1").unwrap(),
+                        Bytes::from_str("0xd4fa2d31b7968e448877f69a96de69f5de8cd23e").unwrap(),
+                        Bytes::from_str("0x87870bca3f3fd6335c3f4ce8392d69350b4fa4e2").unwrap(),
+                        Bytes::from_str("0xef434e4573b90b6ecd4a00f4888381e4d0cc5ccd").unwrap(),
+                    ]),
+                },
+            ]
+        );
+    }
+}

--- a/tycho-ethereum/src/lib.rs
+++ b/tycho-ethereum/src/lib.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "onchain_data")]
 pub mod account_extractor;
 #[cfg(feature = "onchain_data")]
+#[allow(unused)] //TODO: Remove when used
+pub mod entrypoint_tracer;
+#[cfg(feature = "onchain_data")]
 pub mod token_analyzer;
 #[cfg(feature = "onchain_data")]
 pub mod token_pre_processor;
@@ -19,6 +22,8 @@ pub enum RPCError {
     SetupError(String),
     #[error("RPC error: {0}")]
     RequestError(#[from] ProviderError),
+    #[error("Unknown error: {0}")]
+    UnknownError(String),
 }
 
 pub struct BlockTagWrapper(BlockTag);


### PR DESCRIPTION
This commit introduces a new `EntryPointTracer` trait for tracing smart contract entry points, along with related types such as `EntryPoint` and `TracedEntryPoint`. The `trace` method allows for analyzing execution behavior at a specific block. Additionally, the `tycho_common::blockchain` module has been updated to include necessary structures for this functionality.

This is the first version of the entry point tracing, we have plans to add more features in the next iterations, such as symbolic execution, fuzzing, ect..