### PR TITLE
fix: Make Snapshot attributes pub

### DIFF
--- a/tycho-client/src/feed/synchronizer.rs
+++ b/tycho-client/src/feed/synchronizer.rs
@@ -62,8 +62,8 @@ pub struct ComponentWithState {
 
 #[derive(Clone, PartialEq, Debug, Default, Serialize, Deserialize)]
 pub struct Snapshot {
-    states: HashMap<String, ComponentWithState>,
-    vm_storage: HashMap<Bytes, ResponseAccount>,
+    pub states: HashMap<String, ComponentWithState>,
+    pub vm_storage: HashMap<Bytes, ResponseAccount>,
 }
 
 impl Snapshot {


### PR DESCRIPTION
It is impossible to create test fixtures for FeedMessage atm because the attributes of Snapshot are not public