### PR TITLE
chore: Update PostgreSQL schema patch to avoid conflicts on `diesel print-schema`

### DIFF
--- a/tycho-storage/src/postgres/schema.patch
+++ b/tycho-storage/src/postgres/schema.patch
@@ -1,38 +1,10 @@
-diff --git a/tycho-storage/src/postgres/schema.rs b/tycho-storage/src/postgres/schema.rs
-index d71a8300..6178d82a 100644
---- a/tycho-storage/src/postgres/schema.rs
-+++ b/tycho-storage/src/postgres/schema.rs
-@@ -236,21 +236,128 @@ diesel::joinable!(token -> account (account_id));
- diesel::joinable!(token_price -> token (token_id));
- diesel::joinable!(transaction -> block (block_id));
+--- schema_old.rs	2025-04-14 18:43:16
++++ schema.rs	2025-04-14 18:43:03
+@@ -65,6 +65,34 @@
+ }
  
- diesel::allow_tables_to_appear_in_same_query!(
-     account,
-     account_balance,
-     block,
-     chain,
-     component_tvl,
-     contract_code,
-     extraction_state,
-     protocol_calls_contract,
-     protocol_component,
-     protocol_component_holds_contract,
-     protocol_component_holds_token,
-     protocol_system,
-     protocol_type,
-     token,
-     token_price,
-     transaction,
-+    component_balance,
-+    component_balance_default,
-+    contract_storage,
-+    contract_storage_default,
-+    protocol_state,
-+    protocol_state_default
- );
-+
-+diesel::table! {
-+    component_balance (protocol_component_id, token_id, modify_tx) {
+ diesel::table! {
++    component_balance (token_id, protocol_component_id, valid_to) {
 +        token_id -> Int8,
 +        new_balance -> Bytea,
 +        previous_value -> Bytea,
@@ -46,7 +18,7 @@ index d71a8300..6178d82a 100644
 +}
 +
 +diesel::table! {
-+    component_balance_default (protocol_component_id, token_id, modify_tx) {
++    component_balance_default (token_id, protocol_component_id, valid_to) {
 +        token_id -> Int8,
 +        new_balance -> Bytea,
 +        previous_value -> Bytea,
@@ -60,7 +32,20 @@ index d71a8300..6178d82a 100644
 +}
 +
 +diesel::table! {
-+    contract_storage (account_id, slot, modify_tx) {
+     component_tvl (id) {
+         id -> Int8,
+         protocol_component_id -> Int8,
+@@ -83,6 +111,36 @@
+         modify_tx -> Int8,
+         valid_from -> Timestamptz,
+         valid_to -> Nullable<Timestamptz>,
++        inserted_ts -> Timestamptz,
++        modified_ts -> Timestamptz,
++    }
++}
++
++diesel::table! {
++    contract_storage (account_id, slot, valid_to) {
 +        slot -> Bytea,
 +        value -> Nullable<Bytea>,
 +        previous_value -> Nullable<Bytea>,
@@ -75,7 +60,7 @@ index d71a8300..6178d82a 100644
 +}
 +
 +diesel::table! {
-+    contract_storage_default (account_id, slot, modify_tx) {
++    contract_storage_default (account_id, slot, valid_to) {
 +        slot -> Bytea,
 +        value -> Nullable<Bytea>,
 +        previous_value -> Nullable<Bytea>,
@@ -84,50 +69,91 @@ index d71a8300..6178d82a 100644
 +        ordinal -> Int8,
 +        valid_from -> Timestamptz,
 +        valid_to -> Timestamptz,
-+        inserted_ts -> Timestamptz,
-+        modified_ts -> Timestamptz,
-+    }
-+}
-+
-+diesel::table! {
-+    protocol_state (protocol_component_id, attribute_name, modify_tx) {
+         inserted_ts -> Timestamptz,
+         modified_ts -> Timestamptz,
+     }
+@@ -141,6 +199,34 @@
+ }
+ 
+ diesel::table! {
++    protocol_state (protocol_component_id, attribute_name, valid_to) {
++        attribute_name -> Varchar,
++        attribute_value -> Bytea,
++        previous_value -> Nullable<Bytea>,
 +        modify_tx -> Int8,
 +        valid_from -> Timestamptz,
 +        valid_to -> Timestamptz,
 +        inserted_ts -> Timestamptz,
 +        modified_ts -> Timestamptz,
 +        protocol_component_id -> Int8,
-+        attribute_name -> Varchar,
-+        attribute_value -> Bytea,
-+        previous_value -> Nullable<Bytea>,
 +    }
 +}
 +
 +diesel::table! {
-+    protocol_state_default (protocol_component_id, attribute_name, modify_tx) {
++    protocol_state_default (protocol_component_id, attribute_name, valid_to) {
++        attribute_name -> Varchar,
++        attribute_value -> Bytea,
++        previous_value -> Nullable<Bytea>,
 +        modify_tx -> Int8,
 +        valid_from -> Timestamptz,
 +        valid_to -> Timestamptz,
 +        inserted_ts -> Timestamptz,
 +        modified_ts -> Timestamptz,
 +        protocol_component_id -> Int8,
-+        attribute_name -> Varchar,
-+        attribute_value -> Bytea,
-+        previous_value -> Nullable<Bytea>,
 +    }
 +}
 +
++diesel::table! {
+     protocol_system (id) {
+         id -> Int8,
+         #[max_length = 255]
+@@ -210,9 +296,19 @@
+ diesel::joinable!(account_balance -> token (token_id));
+ diesel::joinable!(account_balance -> transaction (modify_tx));
+ diesel::joinable!(block -> chain (chain_id));
 +diesel::joinable!(component_balance -> protocol_component (protocol_component_id));
 +diesel::joinable!(component_balance -> token (token_id));
 +diesel::joinable!(component_balance -> transaction (modify_tx));
 +diesel::joinable!(component_balance_default -> protocol_component (protocol_component_id));
 +diesel::joinable!(component_balance_default -> token (token_id));
 +diesel::joinable!(component_balance_default -> transaction (modify_tx));
+ diesel::joinable!(component_tvl -> protocol_component (protocol_component_id));
+ diesel::joinable!(contract_code -> account (account_id));
+ diesel::joinable!(contract_code -> transaction (modify_tx));
 +diesel::joinable!(contract_storage -> account (account_id));
 +diesel::joinable!(contract_storage -> transaction (modify_tx));
 +diesel::joinable!(contract_storage_default -> account (account_id));
 +diesel::joinable!(contract_storage_default -> transaction (modify_tx));
+ diesel::joinable!(extraction_state -> block (block_id));
+ diesel::joinable!(extraction_state -> chain (chain_id));
+ diesel::joinable!(protocol_component -> chain (chain_id));
+@@ -222,6 +318,10 @@
+ diesel::joinable!(protocol_component_holds_contract -> protocol_component (protocol_component_id));
+ diesel::joinable!(protocol_component_holds_token -> protocol_component (protocol_component_id));
+ diesel::joinable!(protocol_component_holds_token -> token (token_id));
 +diesel::joinable!(protocol_state -> protocol_component (protocol_component_id));
 +diesel::joinable!(protocol_state -> transaction (modify_tx));
 +diesel::joinable!(protocol_state_default -> protocol_component (protocol_component_id));
 +diesel::joinable!(protocol_state_default -> transaction (modify_tx));
+ diesel::joinable!(token -> account (account_id));
+ diesel::joinable!(token_price -> token (token_id));
+ diesel::joinable!(transaction -> block (block_id));
+@@ -231,12 +331,18 @@
+     account_balance,
+     block,
+     chain,
++    component_balance,
++    component_balance_default,
+     component_tvl,
+     contract_code,
++    contract_storage,
++    contract_storage_default,
+     extraction_state,
+     protocol_component,
+     protocol_component_holds_contract,
+     protocol_component_holds_token,
++    protocol_state,
++    protocol_state_default,
+     protocol_system,
+     protocol_type,
+     token,


### PR DESCRIPTION
This PR fixes a bug that was causing diesel print-schema to fail with `error applying hunk #1`

This bug was due to an outdated patch that was leading to conflicts when it was applied on top of the current migrations.