### PR TITLE
feat(DCI): Implement batch account extractor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "0346d8c1f762b41b458ed3145eea914966bb9ad20b9be0d6d463b20d45586370"
 dependencies = [
  "actix-utils",
  "actix-web",
- "derive_more",
+ "derive_more 0.99.17",
  "futures-util",
  "log",
  "once_cell",
@@ -85,7 +85,7 @@ dependencies = [
  "brotli",
  "bytes",
  "bytestring",
- "derive_more",
+ "derive_more 0.99.17",
  "encoding_rs",
  "flate2",
  "futures-core",
@@ -99,7 +99,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "smallvec",
  "tokio",
@@ -267,7 +267,7 @@ dependencies = [
  "bytestring",
  "cfg-if",
  "cookie 0.16.2",
- "derive_more",
+ "derive_more 0.99.17",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -375,10 +375,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.12",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -410,6 +410,586 @@ name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
+name = "alloy"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f245ea9ef9be909776941c6c0ce829fb6b79cd6bfafa43762af7a702c4eb8ee4"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-network",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "alloy-transport-http",
+]
+
+[[package]]
+name = "alloy-chains"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7734aecfc58a597dde036e4c5cace2ae43e2f8bf3d406b022a1ef34da178dd49"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "strum 0.27.1",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2179ba839ac532f50279f5da2a6c5047f791f03f6f808b4dfab11327b97902f"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-trie",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 2.0.1",
+ "either",
+ "k256",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_with",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aec6f67bdc62aa277e0ec13c1b1fb396c8a62b65c8e9bd8c1d3583cc6d1a8dd3"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-contract"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5084cf42388dff75b255308194f9d3e67ae2a93ce7e24262a512cc4043ac1838"
+dependencies = [
+ "alloy-consensus",
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "alloy-transport",
+ "futures 0.3.30",
+ "futures-util",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d020a85ae8cf79b9c897a86d617357817bbc9a7d159dd7e6fedf1bc90f64d35"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884a5d4560f7e5e34ec3c5e54a60223c56352677dd049b495fbb59384cf72a90"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "const-hex",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow 0.7.6",
+]
+
+[[package]]
+name = "alloy-eip2124"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe3e16484669964c26ac48390245d84c410b1a5f968976076c17184725ef235"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804cefe429015b4244966c006d25bda5545fa9db5990e9c9079faf255052f50a"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609515c1955b33af3d78d26357540f68c5551a90ef58fd53def04f2aa074ec43"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 2.0.1",
+ "either",
+ "serde",
+ "sha2",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dfec8348d97bd624901c6a4b22bb4c24df8a3128fc3d5e42d24f7b79dfa8588"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "alloy-trie",
+ "serde",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5189fa9a8797e92396bc4b4454c5f2073a4945f7c2b366af9af60f9536558f7a"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3994ab6ff6bdeb5aebe65381a8f6a47534789817570111555e8ac413e242ce06"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-network"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be3aa020a6d3aa7601185b4c1a7d6f3a5228cb5424352db63064b29a455c891"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "derive_more 2.0.1",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498f2ee2eef38a6db0fc810c7bf7daebdf5f2fa8d04adb8bd53e54e91ddbdea3"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70b98b99c1dcfbe74d7f0b31433ff215e7d1555e367d90e62db904f3c9d4ff53"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more 2.0.1",
+ "foldhash",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.0",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.9.0",
+ "ruint",
+ "rustc-hash 2.1.1",
+ "serde",
+ "sha3",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-provider"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6ba76d476f475668925f858cc4db51781f12abdaa4e0274eb57a09f574e869"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-sol-types",
+ "alloy-transport",
+ "alloy-transport-http",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap 6.1.0",
+ "either",
+ "futures 0.3.30",
+ "futures-utils-wasm",
+ "lru 0.13.0",
+ "parking_lot",
+ "pin-project",
+ "reqwest 0.12.7",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6c1d995bff8d011f7cd6c81820d51825e6e06d6db73914c1630ecf544d83d6"
+dependencies = [
+ "alloy-rlp-derive",
+ "arrayvec",
+ "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40e1ef334153322fd878d07e86af7a529bcb86b2439525920a88eba87bcf943"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6a6985b48a536b47aa0aece56e6a0f49240ce5d33a7f0c94f1b312eda79aa1"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "alloy-transport-http",
+ "async-stream",
+ "futures 0.3.30",
+ "pin-project",
+ "reqwest 0.12.7",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf27873220877cb15125eb6eec2f86c6e9b41473aca85844bd3d9d755bfc0a0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a40595b927dfb07218459037837dbc8de8500a26024bb6ff0548dd2ccc13e0"
+dependencies = [
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2a9f64e0f69cfb6029e2a044519a1bdd44ce9fc334d5315a7b9837f7a6748e5"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-sol-types",
+ "itertools 0.14.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4dba6ff08916bc0a9cbba121ce21f67c0b554c39cf174bc7b9df6c651bd3c3b"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c580da7f00f3999e44e327223044d6732358627f93043e22d92c583f6583556"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve 0.13.8",
+ "k256",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00f0f07862bd8f6bc66c953660693c5903062c2c9d308485b2a6eee411089e7"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand 0.8.5",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60fcfa26956bcb22f66ab13407115197f26ef23abca5b48d39a1946897382d74"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a9b402f0013f1ff8c24066eeafc2207a8e52810a2b18b77776ce7fead5af41"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck 0.5.0",
+ "indexmap 2.7.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+ "syn-solidity",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d02d61741337bb6b3f4899c2e3173fe17ffa2810e143d3b28acd953197c8dd79"
+dependencies = [
+ "alloy-json-abi",
+ "const-hex",
+ "dunce",
+ "heck 0.5.0",
+ "macro-string",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.99",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b5f5f9f561c29f78ea521ebe2e5ac1633f1b1442dae582f68ecd57c6350042"
+dependencies = [
+ "serde",
+ "winnow 0.7.6",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02635bce18205ff8149fb752c753b0a91ea3f3c8ee04c58846448be4811a640"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "const-hex",
+ "serde",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1f1a55f9ff9a48aa0b4a8c616803754620010fbb266edae2f4548f4304373b"
+dependencies = [
+ "alloy-json-rpc",
+ "base64 0.22.1",
+ "derive_more 2.0.1",
+ "futures 0.3.30",
+ "futures-utils-wasm",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tower 0.5.2",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171b3d8824b6697d6c8325373ec410d230b6c59ce552edfbfabe4e7b8a26aac3"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "reqwest 0.12.7",
+ "serde_json",
+ "tower 0.5.2",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9382b4e38b126358f276b863673bc47840d3b3508dd1c9efe22f81b4e83649"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "arrayvec",
+ "derive_more 1.0.0",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "tracing",
+]
 
 [[package]]
 name = "android-tzdata"
@@ -481,10 +1061,146 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.0",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ascii-canvas"
@@ -546,7 +1262,7 @@ checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
 dependencies = [
  "futures 0.3.30",
  "pharos",
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -568,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.1.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823b8bb275161044e2ac7a25879cb3e2480cb403e3943022c7c769c599b756aa"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -599,7 +1315,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "cookie 0.16.2",
- "derive_more",
+ "derive_more 0.99.17",
  "futures-core",
  "futures-util",
  "h2 0.3.24",
@@ -609,7 +1325,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -641,7 +1357,7 @@ dependencies = [
  "ring 0.16.20",
  "time",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "zeroize",
 ]
@@ -808,7 +1524,7 @@ dependencies = [
  "http 0.2.11",
  "regex",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
@@ -837,7 +1553,7 @@ dependencies = [
  "hmac",
  "http 0.2.11",
  "http-body 0.4.6",
- "lru",
+ "lru 0.12.2",
  "once_cell",
  "percent-encoding",
  "regex-lite",
@@ -867,7 +1583,7 @@ dependencies = [
  "http 0.2.11",
  "regex",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
@@ -937,7 +1653,7 @@ dependencies = [
  "bytes",
  "http 0.2.11",
  "regex",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
@@ -1091,7 +1807,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.20.9",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
@@ -1161,7 +1877,7 @@ dependencies = [
  "http 0.2.11",
  "http-body 0.4.6",
  "pin-project-lite",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
@@ -1325,7 +2041,7 @@ dependencies = [
  "aws-smithy-http 0.55.3",
  "aws-smithy-types 0.55.3",
  "http 0.2.11",
- "rustc_version",
+ "rustc_version 0.4.0",
  "tracing",
 ]
 
@@ -1339,7 +2055,7 @@ dependencies = [
  "aws-smithy-async 1.2.4",
  "aws-smithy-runtime-api",
  "aws-smithy-types 1.2.13",
- "rustc_version",
+ "rustc_version 0.4.0",
  "tracing",
 ]
 
@@ -1366,7 +2082,7 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper 0.1.2",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
 ]
@@ -1483,7 +2199,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.99",
  "which",
@@ -1495,7 +2211,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -1503,6 +2228,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -1535,6 +2266,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
 ]
 
 [[package]]
@@ -1642,6 +2385,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "c-kzg"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7e3c397401eb76228c89561cf22f85f41c95aa799ee9d860de3ea1cbc728fc"
+dependencies = [
+ "arbitrary",
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,7 +2426,7 @@ checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver",
+ "semver 1.0.21",
  "serde",
  "serde_json",
 ]
@@ -1680,7 +2439,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver",
+ "semver 1.0.21",
  "serde",
  "serde_json",
  "thiserror 1.0.56",
@@ -1767,7 +2526,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.10.0",
 ]
 
 [[package]]
@@ -1776,7 +2535,7 @@ version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.99",
@@ -1805,7 +2564,7 @@ checksum = "3b6be4a5df2098cd811f3194f64ddb96c267606bffd9689ac7b0160097b01ad3"
 dependencies = [
  "bs58",
  "coins-core",
- "digest",
+ "digest 0.10.7",
  "hmac",
  "k256",
  "serde",
@@ -1824,7 +2583,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2 0.12.2",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "thiserror 1.0.56",
 ]
@@ -1838,7 +2597,7 @@ dependencies = [
  "base64 0.21.7",
  "bech32",
  "bs58",
- "digest",
+ "digest 0.10.7",
  "generic-array",
  "hex",
  "ripemd",
@@ -1904,9 +2663,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.10.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5104de16b218eddf8e34ffe2f86f74bfa4e61e95a1b89732fccf6325efd0557"
+checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2038,7 +2797,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -2106,7 +2865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -2118,7 +2877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -2143,12 +2902,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
@@ -2207,6 +3015,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2218,8 +3049,49 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl 2.0.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2258,7 +3130,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81c5131a2895ef64741dad1d483f358c2a229a3a2d1b256778cdc5e146db64d4"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.99",
@@ -2307,6 +3179,15 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "digest"
@@ -2393,18 +3274,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der 0.7.8",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
+ "serdect",
  "signature 2.2.0",
  "spki 0.7.3",
 ]
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -2415,12 +3300,12 @@ dependencies = [
  "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
- "digest",
+ "digest 0.10.7",
  "ff 0.12.1",
  "generic-array",
  "group 0.12.1",
  "pkcs8 0.9.0",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1 0.3.0",
  "subtle",
  "zeroize",
@@ -2434,13 +3319,14 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct 0.2.0",
  "crypto-bigint 0.5.5",
- "digest",
+ "digest 0.10.7",
  "ff 0.13.0",
  "generic-array",
  "group 0.13.0",
  "pkcs8 0.10.2",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1 0.7.3",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -2474,7 +3360,7 @@ dependencies = [
  "hex",
  "k256",
  "log",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "serde",
  "sha3",
@@ -2532,11 +3418,11 @@ checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
 dependencies = [
  "aes",
  "ctr",
- "digest",
+ "digest 0.10.7",
  "hex",
  "hmac",
  "pbkdf2 0.11.0",
- "rand",
+ "rand 0.8.5",
  "scrypt",
  "serde",
  "serde_json",
@@ -2800,11 +3686,11 @@ dependencies = [
  "num_enum",
  "once_cell",
  "open-fastrlp",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.25.0",
  "syn 2.0.99",
  "tempfile",
  "thiserror 1.0.56",
@@ -2821,7 +3707,7 @@ dependencies = [
  "chrono",
  "ethers-core",
  "reqwest 0.11.24",
- "semver",
+ "semver 1.0.21",
  "serde",
  "serde_json",
  "thiserror 1.0.56",
@@ -2905,7 +3791,7 @@ dependencies = [
  "elliptic-curve 0.13.8",
  "eth-keystore",
  "ethers-core",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "thiserror 1.0.56",
  "tracing",
@@ -2930,7 +3816,7 @@ dependencies = [
  "path-slash",
  "rayon",
  "regex",
- "semver",
+ "semver 1.0.21",
  "serde",
  "serde_json",
  "solang-parser",
@@ -3004,12 +3890,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3019,7 +3927,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3036,7 +3944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3048,7 +3956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3092,9 +4000,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -3265,6 +4173,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-utils-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3292,7 +4206,19 @@ checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3326,7 +4252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff 0.12.1",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3337,7 +4263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff 0.13.0",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3401,7 +4327,10 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -3433,6 +4362,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3452,6 +4387,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex-literal"
@@ -3471,7 +4409,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3735,6 +4673,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3831,6 +4775,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -3913,6 +4858,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3975,6 +4929,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "once_cell",
+ "serdect",
  "sha2",
  "signature 2.2.0",
 ]
@@ -3989,13 +4944,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
 dependencies = [
  "ascii-canvas",
- "bit-set",
+ "bit-set 0.5.3",
  "diff",
  "ena",
  "is-terminal",
@@ -4036,9 +5001,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libloading"
@@ -4116,6 +5081,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "macro-string"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4143,7 +5128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4242,7 +5227,7 @@ checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
- "dashmap",
+ "dashmap 5.5.3",
  "skeptic",
  "smallvec",
  "tagptr",
@@ -4272,7 +5257,7 @@ checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -4314,7 +5299,7 @@ dependencies = [
  "futures 0.3.30",
  "hyper 0.14.28",
  "log",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -4447,6 +5432,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nybbles"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
+dependencies = [
+ "alloy-rlp",
+ "const-hex",
+ "proptest",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4474,9 +5472,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "open-fastrlp"
@@ -4618,7 +5616,7 @@ dependencies = [
  "opentelemetry",
  "ordered-float",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.56",
  "tokio",
  "tokio-stream",
@@ -4699,9 +5697,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -4727,7 +5725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -4749,7 +5747,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
  "password-hash",
  "sha2",
@@ -4761,7 +5759,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -4842,7 +5840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures 0.3.30",
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -4862,7 +5860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4973,7 +5971,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "stringprep",
 ]
@@ -5156,6 +6154,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5203,17 +6223,21 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.2",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
 
@@ -5244,7 +6268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.4.1",
  "itertools 0.10.5",
  "lazy_static",
  "log",
@@ -5346,10 +6370,16 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -5359,6 +6389,12 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "radium"
@@ -5373,8 +6409,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "serde",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -5384,7 +6433,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5393,7 +6452,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.12",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
+ "serde",
 ]
 
 [[package]]
@@ -5402,7 +6471,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5449,7 +6518,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.12",
  "libredox",
  "thiserror 1.0.56",
 ]
@@ -5654,7 +6723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
  "cc",
- "getrandom",
+ "getrandom 0.2.12",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -5667,7 +6736,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5701,7 +6770,7 @@ dependencies = [
  "futures 0.3.30",
  "futures-timer",
  "rstest_macros",
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -5716,10 +6785,43 @@ dependencies = [
  "quote",
  "regex",
  "relative-path",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn 2.0.99",
  "unicode-ident",
 ]
+
+[[package]]
+name = "ruint"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78a46eb779843b2c4f21fac5773e25d6d5b7c8f0922876c91541790d2ca27eef"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types 0.12.2",
+ "proptest",
+ "rand 0.8.5",
+ "rand 0.9.0",
+ "rlp",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rust-embed"
@@ -5768,6 +6870,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5775,11 +6883,20 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.21",
 ]
 
 [[package]]
@@ -5911,6 +7028,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5941,7 +7070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7d66a1128282b7ef025a8ead62a4a9fcf017382ec53b8ffbf4d7bf77bd3c60"
 dependencies = [
  "cfg-if",
- "derive_more",
+ "derive_more 0.99.17",
  "parity-scale-codec",
  "scale-info-derive",
 ]
@@ -6029,6 +7158,7 @@ dependencies = [
  "der 0.7.8",
  "generic-array",
  "pkcs8 0.10.2",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -6089,11 +7219,29 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
 ]
 
 [[package]]
@@ -6162,6 +7310,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.7.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6175,6 +7353,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6182,7 +7370,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6193,7 +7381,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6202,8 +7390,18 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
+dependencies = [
+ "cc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -6236,8 +7434,8 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest",
- "rand_core",
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -6246,8 +7444,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
- "rand_core",
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -6309,6 +7507,9 @@ name = "smallvec"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -6403,12 +7604,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros 0.27.1",
 ]
 
 [[package]]
@@ -6417,7 +7633,20 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -6453,7 +7682,7 @@ version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d033738be190ad9c9a63712cf121e4f33ae9c57845c64021e421c45aac688b5"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.12",
  "num-bigint",
  "substreams",
  "substreams-ethereum-abigen",
@@ -6469,7 +7698,7 @@ checksum = "27ef0adda971fbbd085545e73ccd7efbc12e31139cd301252f478e6b9743ff65"
 dependencies = [
  "anyhow",
  "ethabi 17.2.0",
- "heck",
+ "heck 0.4.1",
  "hex",
  "prettyplease 0.1.25",
  "proc-macro2",
@@ -6486,7 +7715,7 @@ checksum = "0a38e740018de8c2453f08621bab84ac55b0f1bfd42d56cf8b43ad340e670862"
 dependencies = [
  "bigdecimal",
  "ethabi 17.2.0",
- "getrandom",
+ "getrandom 0.2.12",
  "num-bigint",
  "prost 0.11.9",
  "prost-build",
@@ -6501,7 +7730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55c934c70e6ab1fe11a89f401f36e7d9be3fe087687395767a4c13ab3d6bd055"
 dependencies = [
  "ethabi 17.2.0",
- "heck",
+ "heck 0.4.1",
  "hex",
  "num-bigint",
  "proc-macro2",
@@ -6539,7 +7768,7 @@ dependencies = [
  "hex",
  "once_cell",
  "reqwest 0.11.24",
- "semver",
+ "semver 1.0.21",
  "serde",
  "serde_json",
  "sha2",
@@ -6568,6 +7797,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34c9c96de1f835488c1501092847b522be88c9ac6fb0d4c0fbea92992324c8f4"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -6741,6 +7982,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6865,7 +8115,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand",
+ "rand 0.8.5",
  "socket2",
  "tokio",
  "tokio-util",
@@ -6879,7 +8129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "tokio",
 ]
 
@@ -7001,7 +8251,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.37",
 ]
 
 [[package]]
@@ -7012,7 +8262,7 @@ checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap 2.7.0",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.37",
 ]
 
 [[package]]
@@ -7023,7 +8273,7 @@ checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.7.0",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.37",
 ]
 
 [[package]]
@@ -7036,7 +8286,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.37",
 ]
 
 [[package]]
@@ -7066,7 +8316,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7093,7 +8343,7 @@ dependencies = [
  "prost 0.12.4",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7110,7 +8360,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -7120,16 +8370,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-layer"
-version = "0.3.2"
+name = "tower"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.1",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -7182,6 +8446,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
+ "futures 0.3.30",
+ "futures-task",
  "pin-project",
  "tracing",
 ]
@@ -7246,6 +8512,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "triomphe"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7270,7 +8557,7 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
- "rand",
+ "rand 0.8.5",
  "rustls 0.21.10",
  "sha1",
  "thiserror 1.0.56",
@@ -7289,11 +8576,11 @@ dependencies = [
  "futures 0.3.30",
  "hex",
  "hyper 0.14.28",
- "lru",
+ "lru 0.12.2",
  "mockall",
  "mockito",
  "pretty_assertions",
- "rand",
+ "rand 0.8.5",
  "reqwest 0.12.7",
  "rstest",
  "serde",
@@ -7330,12 +8617,12 @@ dependencies = [
  "hex",
  "maplit",
  "pretty_assertions",
- "rand",
+ "rand 0.8.5",
  "rstest",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
  "thiserror 1.0.56",
  "tiny-keccak",
  "tokio",
@@ -7349,6 +8636,7 @@ dependencies = [
 name = "tycho-ethereum"
 version = "0.65.0"
 dependencies = [
+ "alloy",
  "anyhow",
  "async-trait",
  "chrono",
@@ -7357,6 +8645,7 @@ dependencies = [
  "ethcontract",
  "ethers",
  "ethrpc",
+ "futures 0.3.30",
  "humantime",
  "reqwest 0.11.24",
  "serde",
@@ -7364,6 +8653,7 @@ dependencies = [
  "thiserror 1.0.56",
  "tokio",
  "tracing",
+ "tracing-test",
  "tycho-common",
  "unicode-segmentation",
  "url",
@@ -7445,7 +8735,7 @@ dependencies = [
  "hex",
  "itertools 0.12.1",
  "lazy_static",
- "lru",
+ "lru 0.12.2",
  "pretty_assertions",
  "rstest",
  "serde_json",
@@ -7668,7 +8958,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.12",
  "serde",
 ]
 
@@ -7678,8 +8968,8 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
- "getrandom",
- "rand",
+ "getrandom 0.2.12",
+ "rand 0.8.5",
  "serde",
  "uuid-macro-internal",
 ]
@@ -7720,6 +9010,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7743,6 +9042,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -7811,6 +9119,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
+name = "wasmtimer"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0048ad49a55b9deb3953841fa1fc5858f0efbcb7a18868c899a360269fac1b23"
+dependencies = [
+ "futures 0.3.30",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7837,7 +9159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5388522c899d1e1c96a4c307e3797e0f697ba7c77dd8e0e625ecba9dd0342937"
 dependencies = [
  "arrayvec",
- "derive_more",
+ "derive_more 0.99.17",
  "ethabi 18.0.0",
  "ethereum-types 0.14.1",
  "futures 0.3.30",
@@ -8113,6 +9435,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8120,6 +9451,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -8133,7 +9473,7 @@ dependencies = [
  "js-sys",
  "log",
  "pharos",
- "rustc_version",
+ "rustc_version 0.4.0",
  "send_wrapper 0.6.0",
  "thiserror 1.0.56",
  "wasm-bindgen",
@@ -8168,7 +9508,16 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.32",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -8183,10 +9532,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
 
 [[package]]
 name = "zip"

--- a/tycho-common/src/traits.rs
+++ b/tycho-common/src/traits.rs
@@ -13,6 +13,8 @@ use crate::{
     Bytes,
 };
 
+// TODO: Maybe deprecate if we don't need this on the testing module anymore, but I think it will be
+// needed for fetching full snapshots of non-DCI accounts
 #[async_trait]
 pub trait AccountExtractor {
     type Error;
@@ -22,6 +24,23 @@ pub trait AccountExtractor {
         block: Block,
         account_addresses: Vec<Address>,
     ) -> Result<HashMap<Bytes, AccountDelta>, Self::Error>; //TODO: do not return `AccountUpdate` but `Account`
+}
+
+#[derive(Debug, Clone)]
+pub struct StorageSnapshotRequest {
+    pub address: Address,
+    pub slots: Option<Vec<Bytes>>,
+}
+
+#[async_trait]
+pub trait AccountStorageSource {
+    type Error;
+
+    async fn get_storage_snapshots(
+        &self,
+        requests: &[StorageSnapshotRequest],
+        block: &Block,
+    ) -> Result<HashMap<Address, AccountDelta>, Self::Error>;
 }
 
 /// Trait for analyzing a token, including its quality, transfer cost, and transfer tax.

--- a/tycho-common/src/traits.rs
+++ b/tycho-common/src/traits.rs
@@ -13,34 +13,40 @@ use crate::{
     Bytes,
 };
 
-// TODO: Maybe deprecate if we don't need this on the testing module anymore, but I think it will be
-// needed for fetching full snapshots of non-DCI accounts
-#[async_trait]
-pub trait AccountExtractor {
-    type Error;
-
-    async fn get_accounts(
-        &self,
-        block: Block,
-        account_addresses: Vec<Address>,
-    ) -> Result<HashMap<Bytes, AccountDelta>, Self::Error>; //TODO: do not return `AccountUpdate` but `Account`
-}
-
 #[derive(Debug, Clone)]
 pub struct StorageSnapshotRequest {
     pub address: Address,
     pub slots: Option<Vec<Bytes>>,
 }
 
+/// Trait for getting multiple account states from chain data.
 #[async_trait]
-pub trait AccountStorageSource {
+pub trait AccountExtractor {
     type Error;
 
-    async fn get_storage_snapshots(
+    ///
+    ///
+    /// # Arguments
+    ///
+    /// * `block`: The block at which to retrieve the account states.
+    /// * `requests`: A slice of `StorageSnapshotRequest` objects, each containing an address and
+    ///   optional slots.
+    /// Note: If the `slots` field is `None`, the function will return the entire account state.
+    /// That could be a lot of data, so use with caution.
+    ///
+    /// returns: Result<HashMap<Bytes, AccountDelta, RandomState>, Self::Error>
+    /// A result containing a HashMap where the keys are `Bytes` (addresses) and the values are
+    /// `AccountDelta` objects.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// ```
+    async fn get_accounts_at_block(
         &self,
-        requests: &[StorageSnapshotRequest],
         block: &Block,
-    ) -> Result<HashMap<Address, AccountDelta>, Self::Error>;
+        requests: &[StorageSnapshotRequest],
+    ) -> Result<HashMap<Bytes, AccountDelta>, Self::Error>; //TODO: do not return `AccountUpdate` but `Account`
 }
 
 /// Trait for analyzing a token, including its quality, transfer cost, and transfer tax.

--- a/tycho-ethereum/Cargo.toml
+++ b/tycho-ethereum/Cargo.toml
@@ -24,10 +24,12 @@ thiserror.workspace = true
 reqwest.workspace = true
 unicode-segmentation.workspace = true
 url = "2"
+futures = "0.3"
 
 # Required dependencies
 ethers = "^2.0.2"
 web3 = { version = "0.19", default-features = false }
+alloy = { version = "0.14", default-features = true }
 
 # Optional dependencies
 contracts = { git = "https://github.com/cowprotocol/services", rev = "f3678428991e055ceb517f184d1b37244f2d8f51", optional = true }
@@ -37,6 +39,7 @@ ethcontract = { version = "0.25.4", default-features = false, features = [
 ], optional = true }
 clap = { version = "4", features = ["derive", "env"], optional = true }
 humantime = { version = "2.1.0", optional = true }
+tracing-test = "0.2.5"
 
 [features]
 default = []

--- a/tycho-ethereum/src/account_extractor/contract.rs
+++ b/tycho-ethereum/src/account_extractor/contract.rs
@@ -14,20 +14,25 @@ use ethers::{
 };
 use futures::future::try_join_all;
 use serde::{Deserialize, Serialize};
-use tracing::trace;
+use tracing::{trace, warn};
 use tycho_common::{
     models::{blockchain::Block, contract::AccountDelta, Address, Chain, ChangeType},
-    traits::{AccountExtractor, AccountStorageSource, StorageSnapshotRequest},
+    traits::{AccountExtractor, StorageSnapshotRequest},
     Bytes,
 };
 
 use crate::{BytesCodec, RPCError};
 
+/// `EVMAccountExtractor` is a struct that implements the `AccountExtractor` trait for Ethereum
+/// accounts. It is recommended for nodes that do not support batch requests.
 pub struct EVMAccountExtractor {
     provider: Provider<Http>,
     chain: Chain,
 }
 
+/// `EVMBatchAccountExtractor` is a struct that implements the `AccountStorageSource` trait for
+/// Ethereum accounts. It can only be used with nodes that support batch requests. If you are using
+/// a node that does not support batch requests, use `EVMAccountExtractor` instead.
 pub struct EVMBatchAccountExtractor {
     provider: RpcClient,
     chain: Chain,
@@ -37,18 +42,18 @@ pub struct EVMBatchAccountExtractor {
 impl AccountExtractor for EVMAccountExtractor {
     type Error = RPCError;
 
-    async fn get_accounts(
+    async fn get_accounts_at_block(
         &self,
-        block: tycho_common::models::blockchain::Block,
-        account_addresses: Vec<Address>,
-    ) -> Result<HashMap<Bytes, AccountDelta>, RPCError> {
+        block: &Block,
+        requests: &[StorageSnapshotRequest],
+    ) -> Result<HashMap<Bytes, AccountDelta>, Self::Error> {
         let mut updates = HashMap::new();
         let block_id = Some(BlockId::from(block.number));
 
         // Convert addresses to H160 for easier handling
-        let h160_addresses: Vec<H160> = account_addresses
+        let h160_addresses: Vec<H160> = requests
             .iter()
-            .map(H160::from_bytes)
+            .map(|request| H160::from_bytes(&request.address))
             .collect();
 
         // Create futures for balance and code retrieval
@@ -79,7 +84,14 @@ impl AccountExtractor for EVMAccountExtractor {
             let balance = Some(balances[i]);
             let code = Some(Bytes::from(codes[i].to_vec()));
 
-            // Get storage slots (this still needs to be done individually)
+            let slots_request = requests
+                .get(i)
+                .expect("Request should exist");
+            if slots_request.slots.is_some() {
+                // TODO: Implement this
+                warn!("Specific storage slot requests are not supported in EVMAccountExtractor");
+            }
+
             let slots = self
                 .get_storage_range(address, H256::from_bytes(&block.hash))
                 .await?
@@ -182,7 +194,7 @@ impl EVMBatchAccountExtractor {
 
     async fn batch_fetch_account_code_and_balance(
         &self,
-        block: &&Block,
+        block: &Block,
         max_batch_size: usize,
         chunk: &[StorageSnapshotRequest],
     ) -> Result<(HashMap<Bytes, Bytes>, HashMap<Bytes, Bytes>), RPCError> {
@@ -266,26 +278,28 @@ impl EVMBatchAccountExtractor {
         max_batch_size: usize,
         request: &StorageSnapshotRequest,
     ) -> Result<HashMap<Bytes, Option<Bytes>>, RPCError> {
-        let mut storage_batch = self.provider.new_batch();
         let mut storage_requests = Vec::with_capacity(max_batch_size);
 
         let mut result = HashMap::new();
 
-        match request.slots {
+        match request.slots.clone() {
             Some(slots) => {
                 for slot_batch in slots.chunks(max_batch_size) {
+                    let mut storage_batch = self.provider.new_batch();
+
                     for slot in slot_batch {
                         storage_requests.push(Box::pin(
                             storage_batch
                                 .add_call(
                                     "eth_getStorageAt",
-                                    &(&request.address, BlockNumberOrTag::from(block.number), slot),
+                                    &(&request.address, slot, BlockNumberOrTag::from(block.number)),
                                 )
                                 .map_err(|_| {
                                     RPCError::RequestError(ProviderError::CustomError(
                                         "Failed to get storage".to_string(),
                                     ))
-                                })?,
+                                })?
+                                .map_resp(|res: Bytes| res.to_vec()),
                         ));
                     }
 
@@ -299,65 +313,123 @@ impl EVMBatchAccountExtractor {
                             )))
                         })?;
 
-                    // for (idx, slot) in slot_batch.iter().enumerate() {
-                    //     let address = &request.address;
-                    //     let storage_result = storage_requests[idx]
-                    //         .as_mut()
-                    //         .await
-                    //         .map_err(|e| {
-                    //             RPCError::RequestError(ProviderError::CustomError(format!(
-                    //                 "Failed to collect storage request data: {}",
-                    //                 e
-                    //             )))
-                    //         })?;
+                    for (idx, slot) in slot_batch.iter().enumerate() {
+                        let storage_result = storage_requests[idx]
+                            .as_mut()
+                            .await
+                            .map_err(|e| {
+                                RPCError::RequestError(ProviderError::CustomError(format!(
+                                    "Failed to collect storage request data: {}",
+                                    e
+                                )))
+                            })?;
 
-                    //     result.insert(slot.clone(), Some(Bytes::from(storage_result)));
-                    // }
-                    for slot_future in storage_requests {
-                        let slot_result = slot_future.await.map_err(|e| {
-                            RPCError::RequestError(ProviderError::CustomError(format!(
-                                "Failed to collect storage request data: {}",
-                                e
-                            )))
-                        })?;
-                        result.insert(slot_result.key.clone(), Some(slot_result.value.clone()));
+                        let value = if storage_result == [0; 32] {
+                            None
+                        } else {
+                            Some(Bytes::from(storage_result))
+                        };
+
+                        result.insert(slot.clone(), value);
                     }
                 }
             }
             None => {
                 // TODO: Implement this -> Call get_storage_range
+                let storage = self
+                    .get_storage_range(&request.address, block)
+                    .await?;
+                for (key, value) in storage {
+                    result.insert(key, Some(value));
+                }
                 return Ok(result);
             }
         }
 
         Ok(result)
     }
+
+    async fn get_storage_range(
+        &self,
+        address: &Address,
+        block: &Block,
+    ) -> Result<HashMap<Bytes, Bytes>, RPCError> {
+        warn!("Requesting all storage slots for address: {:?}. This request can consume a lot of data, and the method might not be available on the requested chain / node.", address);
+
+        let mut all_slots = HashMap::new();
+        let mut start_key = H256::zero();
+        // let block = format!("0x{:x}", block);
+        loop {
+            // let params = serde_json::json!([
+            //     block, 0, // transaction index, 0 for the state at the end of the block
+            //     address, start_key, 100000 // limit
+            // ]);
+
+            trace!("Requesting storage range for {:?}, block: {:?}", address.clone(), block);
+            let result: StorageRange = self
+                .provider
+                .request(
+                    "debug_storageRangeAt",
+                    &(
+                        block.hash.to_string(),
+                        0, // transaction index, 0 for the state at the end of the block)
+                        address,
+                        start_key,
+                        100000,
+                    ), // limit
+                )
+                .await
+                .map_err(|_| {
+                    RPCError::RequestError(ProviderError::CustomError(
+                        "Failed to get storage".to_string(),
+                    ))
+                })?;
+
+            for (_, entry) in result.storage {
+                all_slots
+                    .insert(Bytes::from(entry.key.as_bytes()), Bytes::from(entry.value.as_bytes()));
+            }
+
+            if let Some(next_key) = result.next_key {
+                start_key = next_key;
+            } else {
+                break;
+            }
+        }
+
+        Ok(all_slots)
+    }
 }
 
 #[async_trait]
-impl AccountStorageSource for EVMBatchAccountExtractor {
+impl AccountExtractor for EVMBatchAccountExtractor {
     type Error = RPCError;
 
-    async fn get_storage_snapshots(
+    async fn get_accounts_at_block(
         &self,
-        requests: &[StorageSnapshotRequest],
         block: &Block,
+        requests: &[StorageSnapshotRequest],
     ) -> Result<HashMap<Address, AccountDelta>, Self::Error> {
         let mut updates = HashMap::new();
 
-        // TODO: Make these configurable and optimize for preventing rate limiting
+        // TODO: Make these configurable and optimize for preventing rate limiting.
+        // TODO: Handle rate limiting / individual connection failures & retries
+
         let max_batch_size = 100;
         let storage_max_batch_size = 10000;
         for chunk in requests.chunks(max_batch_size) {
-            // let (code, balances)
+            // Batch request code and balances of all accounts on the chunk.
+            // Worst case scenario = 2 * chunk_size requests
             let metadata_fut =
-                self.batch_fetch_account_code_and_balance(&block, max_batch_size, chunk);
-            self.batch_fetch_account_code_and_balance(&block, max_batch_size, chunk);
+                self.batch_fetch_account_code_and_balance(block, max_batch_size, chunk);
 
             let mut storage_futures = Vec::new();
+            // Batch requests storage_max_batch_size until
+            // Worst case scenario = chunk_size * (MAX_EVM_STORAGE_LIMIT / storage_max_batch_size)
+            // requests
             for request in chunk.iter() {
                 storage_futures.push(self.fetch_account_storage(
-                    &block,
+                    block,
                     storage_max_batch_size,
                     request,
                 ));
@@ -370,7 +442,10 @@ impl AccountStorageSource for EVMBatchAccountExtractor {
                 let address = &request.address;
                 let code = codes.get(address).cloned();
                 let balance = balances.get(address).cloned();
-                let storage = storage_results[idx].expect("Failed to get storage");
+                let storage = storage_results
+                    .get(idx)
+                    .cloned()
+                    .expect("Failed to get account storage");
 
                 let account_delta = AccountDelta {
                     address: address.clone(),
@@ -410,38 +485,104 @@ mod tests {
 
     use super::*;
 
+    // Common test constants
+    const BALANCER_VAULT_STR: &str = "0xba12222222228d8ba445958a75a0704d566bf2c8";
+    const STETH_STR: &str = "0xae7ab96520de3a18e5e111b5eaab095312d7fe84";
+    const TEST_BLOCK_HASH: &str =
+        "0x7f70ac678819e24c4947a3a95fdab886083892a18ba1a962ebaac31455584042";
+    const TEST_BLOCK_NUMBER: u64 = 20378314;
+
+    // Common token addresses for tests
+    const TOKEN_ADDRESSES: [&str; 5] = [
+        BALANCER_VAULT_STR,
+        STETH_STR,
+        "0x6b175474e89094c44da98b954eedeac495271d0f", // DAI
+        "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599", // WBTC
+        "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", // USDC
+    ];
+
+    // Common storage slots for testing
+    fn get_test_slots() -> HashMap<Bytes, Bytes> {
+        HashMap::from([
+            (
+                Bytes::from_str("0000000000000000000000000000000000000000000000000000000000000000")
+                    .unwrap(),
+                Bytes::from_str("0000000000000000000000000000000000000000000000000000000000000001")
+                    .unwrap(),
+            ),
+            (
+                Bytes::from_str("0000000000000000000000000000000000000000000000000000000000000003")
+                    .unwrap(),
+                Bytes::from_str("00000000000000000000006048a8c631fb7e77eca533cf9c29784e482391e700")
+                    .unwrap(),
+            ),
+            (
+                Bytes::from_str("00015ea75c6f99b2e8663793de8ab1ce7c52e3295bf307bbf9990d4af56f7035")
+                    .unwrap(),
+                Bytes::from_str("0000000000000000000000000000000000000000000000000000000000000001")
+                    .unwrap(),
+            ),
+        ])
+    }
+
+    // Test fixture setup
+    struct TestFixture {
+        block: Block,
+        node_url: String,
+    }
+
+    impl TestFixture {
+        async fn new() -> Self {
+            let node_url = std::env::var("RPC_URL").expect("RPC_URL must be set for testing");
+
+            let block_hash = H256::from_str(TEST_BLOCK_HASH).expect("valid block hash");
+
+            let block = Block::new(
+                TEST_BLOCK_NUMBER,
+                Chain::Ethereum,
+                block_hash.to_bytes(),
+                Default::default(),
+                Default::default(),
+            );
+
+            Self { block, node_url }
+        }
+
+        async fn create_evm_extractor(&self) -> Result<EVMAccountExtractor, RPCError> {
+            EVMAccountExtractor::new(&self.node_url, Chain::Ethereum).await
+        }
+
+        async fn create_batch_extractor(&self) -> Result<EVMBatchAccountExtractor, RPCError> {
+            EVMBatchAccountExtractor::new(&self.node_url, Chain::Ethereum).await
+        }
+
+        fn create_address(address_str: &str) -> Address {
+            Address::from_str(address_str).expect("valid address")
+        }
+
+        fn create_storage_request(
+            address_str: &str,
+            slots: Option<Vec<Bytes>>,
+        ) -> StorageSnapshotRequest {
+            StorageSnapshotRequest { address: Self::create_address(address_str), slots }
+        }
+    }
+
     #[tokio::test]
     #[ignore = "require RPC connection"]
-    async fn test_contract_extractor() -> Result<(), Box<dyn std::error::Error>> {
-        let block_hash =
-            H256::from_str("0x7f70ac678819e24c4947a3a95fdab886083892a18ba1a962ebaac31455584042")
-                .expect("valid block hash");
-        let block_number: u64 = 20378314;
+    async fn test_account_extractor() -> Result<(), Box<dyn std::error::Error>> {
+        let fixture = TestFixture::new().await;
+        let extractor = fixture.create_evm_extractor().await?;
 
-        let accounts: Vec<Address> =
-            vec![Address::from_str("0xba12222222228d8ba445958a75a0704d566bf2c8")
-                .expect("valid address")];
-        let node = std::env::var("RPC_URL").expect("RPC URL must be set for testing");
-        println!("Using node: {}", node);
+        let requests = vec![TestFixture::create_storage_request(BALANCER_VAULT_STR, None)];
 
-        let block = Block::new(
-            block_number,
-            Chain::Ethereum,
-            block_hash.to_bytes(),
-            Default::default(),
-            Default::default(),
-        );
-        let extractor = EVMAccountExtractor::new(&node, Chain::Ethereum).await?;
         let updates = extractor
-            .get_accounts(block, accounts)
+            .get_accounts_at_block(&fixture.block, &requests)
             .await?;
 
         assert_eq!(updates.len(), 1);
         let update = updates
-            .get(
-                &Bytes::from_str("ba12222222228d8ba445958a75a0704d566bf2c8")
-                    .expect("valid address"),
-            )
+            .get(&Bytes::from_str(BALANCER_VAULT_STR).expect("valid address"))
             .expect("update exists");
 
         assert_eq!(update.slots.len(), 47690);
@@ -456,40 +597,22 @@ mod tests {
     /// token by number of holders).
     /// This test takes around 2 mins to run and retreives around 50mb of data
     async fn test_contract_extractor_steth() -> Result<(), Box<dyn std::error::Error>> {
-        let block_hash =
-            H256::from_str("0x7f70ac678819e24c4947a3a95fdab886083892a18ba1a962ebaac31455584042")
-                .expect("valid block hash");
-        let block_number: u64 = 20378314;
+        let fixture = TestFixture::new().await;
+        let extractor = fixture.create_evm_extractor().await?;
 
-        let accounts: Vec<Address> =
-            vec![Address::from_str("0xae7ab96520de3a18e5e111b5eaab095312d7fe84")
-                .expect("valid address")];
-        let node = std::env::var("RPC_URL").expect("RPC URL must be set for testing");
+        let requests = vec![TestFixture::create_storage_request(STETH_STR, None)];
 
-        let extractor = EVMAccountExtractor::new(&node, Chain::Ethereum).await?;
-
-        let block = Block::new(
-            block_number,
-            Chain::Ethereum,
-            block_hash.to_bytes(),
-            Default::default(),
-            Default::default(),
-        );
-
-        println!("Getting accounts for block: {:?}", block_number);
+        println!("Getting accounts for block: {:?}", TEST_BLOCK_NUMBER);
         let start_time = std::time::Instant::now();
         let updates = extractor
-            .get_accounts(block, accounts)
+            .get_accounts_at_block(&fixture.block, &requests)
             .await?;
         let duration = start_time.elapsed();
         println!("Time taken to get accounts: {:?}", duration);
 
         assert_eq!(updates.len(), 1);
         let update = updates
-            .get(
-                &Bytes::from_str("0xae7ab96520de3a18e5e111b5eaab095312d7fe84")
-                    .expect("valid address"),
-            )
+            .get(&Bytes::from_str(STETH_STR).expect("valid address"))
             .expect("update exists");
 
         assert_eq!(update.slots.len(), 789526);
@@ -501,39 +624,19 @@ mod tests {
     #[tokio::test]
     #[ignore = "require RPC connection"]
     async fn test_get_storage_snapshots() -> Result<(), Box<dyn std::error::Error>> {
-        let node = std::env::var("RPC_URL").expect("RPC URL must be set for testing");
-        println!("Using node: {}", node);
+        let fixture = TestFixture::new().await;
+        println!("Using node: {}", fixture.node_url);
 
-        let extractor = EVMBatchAccountExtractor::new(&node, Chain::Ethereum).await?;
-
-        let block_hash =
-            H256::from_str("0x7f70ac678819e24c4947a3a95fdab886083892a18ba1a962ebaac31455584042")
-                .expect("valid block hash");
-
-        let block = Block::new(
-            20378314,
-            Chain::Ethereum,
-            block_hash.to_bytes(),
-            Default::default(),
-            Default::default(),
-        );
+        let extractor = fixture.create_batch_extractor().await?;
 
         let requests = vec![
-            StorageSnapshotRequest {
-                address: Address::from_str("0xba12222222228d8ba445958a75a0704d566bf2c8")
-                    .expect("valid address"),
-                slots: None,
-            },
-            StorageSnapshotRequest {
-                address: Address::from_str("0xae7ab96520de3a18e5e111b5eaab095312d7fe84")
-                    .expect("valid address"),
-                slots: None,
-            },
+            TestFixture::create_storage_request(BALANCER_VAULT_STR, Some(vec![])),
+            TestFixture::create_storage_request(STETH_STR, Some(vec![])),
         ];
 
         let start_time = std::time::Instant::now();
         let result = extractor
-            .get_storage_snapshots(&requests, &block)
+            .get_accounts_at_block(&fixture.block, &requests)
             .await?;
         let duration = start_time.elapsed();
         println!("Time taken to get storage snapshots: {:?}", duration);
@@ -541,8 +644,7 @@ mod tests {
         assert_eq!(result.len(), 2);
 
         // First account check
-        let first_address =
-            Address::from_str("0xba12222222228d8ba445958a75a0704d566bf2c8").expect("valid address");
+        let first_address = TestFixture::create_address(BALANCER_VAULT_STR);
         let first_delta = result
             .get(&first_address)
             .expect("first address should exist");
@@ -553,8 +655,7 @@ mod tests {
         println!("Balance: {:?}", first_delta.balance);
 
         // Second account check
-        let second_address =
-            Address::from_str("0xae7ab96520de3a18e5e111b5eaab095312d7fe84").expect("valid address");
+        let second_address = TestFixture::create_address(STETH_STR);
         let second_delta: &AccountDelta = result
             .get(&second_address)
             .expect("second address should exist");
@@ -563,6 +664,292 @@ mod tests {
         assert!(second_delta.code.is_some());
         assert!(second_delta.balance.is_some());
         println!("Balance: {:?}", second_delta.balance);
+
+        Ok(())
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    #[ignore = "require RPC connection"]
+    async fn test_evm_batch_extractor_new() -> Result<(), Box<dyn std::error::Error>> {
+        let fixture = TestFixture::new().await;
+
+        // Test with valid URL
+        let extractor = EVMBatchAccountExtractor::new(&fixture.node_url, Chain::Ethereum).await?;
+        assert_eq!(extractor.chain, Chain::Ethereum);
+
+        // Test with invalid URL
+        let result = EVMBatchAccountExtractor::new("invalid-url", Chain::Ethereum).await;
+        assert!(result.is_err());
+
+        Ok(())
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    #[ignore = "require RPC connection"]
+    async fn test_batch_fetch_account_code_and_balance() -> Result<(), Box<dyn std::error::Error>> {
+        let fixture = TestFixture::new().await;
+        let extractor = fixture.create_batch_extractor().await?;
+
+        // Test with multiple addresses
+        let requests = vec![
+            TestFixture::create_storage_request(BALANCER_VAULT_STR, Some(Vec::new())),
+            TestFixture::create_storage_request(STETH_STR, Some(Vec::new())),
+        ];
+
+        let (codes, balances) = extractor
+            .batch_fetch_account_code_and_balance(&fixture.block, 10, &requests)
+            .await?;
+
+        // Check that we got code and balance for both addresses
+        assert_eq!(codes.len(), 2);
+        assert_eq!(balances.len(), 2);
+
+        // Check that the first address has code and balance
+        let first_address = TestFixture::create_address(BALANCER_VAULT_STR);
+        assert!(codes.contains_key(&first_address));
+        assert!(balances.contains_key(&first_address));
+
+        // Check that the second address has code and balance
+        let second_address = TestFixture::create_address(STETH_STR);
+        assert!(codes.contains_key(&second_address));
+        assert!(balances.contains_key(&second_address));
+
+        // Verify code is non-empty for contract addresses
+        assert!(!codes
+            .get(&first_address)
+            .unwrap()
+            .is_empty());
+        assert!(!codes
+            .get(&second_address)
+            .unwrap()
+            .is_empty());
+
+        Ok(())
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    #[ignore = "require RPC connection"]
+    async fn test_fetch_account_storage_without_specific_slots(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let fixture = TestFixture::new().await;
+        let extractor = fixture.create_batch_extractor().await?;
+
+        // Create request with specific slots
+        let slots = get_test_slots();
+        let request = TestFixture::create_storage_request(BALANCER_VAULT_STR, None);
+
+        let storage = extractor
+            .fetch_account_storage(&fixture.block, 10, &request)
+            .await?;
+
+        // Verify that we got the storage for all requested slots
+        assert_eq!(storage.len(), 47690);
+
+        // Check that each slot has a value
+        for (key, value) in slots.iter().take(3) {
+            println!("slot: {}", key);
+            assert!(storage.contains_key(key));
+            assert_eq!(
+                storage
+                    .get(key)
+                    .and_then(|v| v.as_ref()),
+                Some(value)
+            ); // Storage value exists and matches
+        }
+
+        Ok(())
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    #[ignore = "require RPC connection"]
+    async fn test_fetch_account_storage_with_specific_slots(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let fixture = TestFixture::new().await;
+        let extractor = fixture.create_batch_extractor().await?;
+
+        // Create request with specific slots
+        let slots = get_test_slots();
+        let slots_request: Vec<Bytes> = slots.keys().cloned().collect();
+        let request = TestFixture::create_storage_request(BALANCER_VAULT_STR, Some(slots_request));
+
+        let storage = extractor
+            .fetch_account_storage(&fixture.block, 10, &request)
+            .await?;
+
+        // Verify that we got the storage for all requested slots
+        assert_eq!(storage.len(), 3);
+
+        // Check that each slot has a value
+        for (key, value) in slots.iter() {
+            println!("slot: {}", key);
+            assert!(storage.contains_key(key));
+            assert_eq!(
+                storage
+                    .get(key)
+                    .and_then(|v| v.as_ref()),
+                Some(value)
+            ); // Storage value exists and matches
+        }
+
+        Ok(())
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    #[ignore = "require RPC connection"]
+    async fn test_get_storage_snapshots_with_specific_slots(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let fixture = TestFixture::new().await;
+        let extractor = fixture.create_batch_extractor().await?;
+
+        // Create request with specific slots
+        let slots = get_test_slots();
+        let slots_request: Vec<Bytes> = slots.keys().cloned().collect();
+
+        let requests =
+            vec![TestFixture::create_storage_request(BALANCER_VAULT_STR, Some(slots_request))];
+
+        let result = extractor
+            .get_accounts_at_block(&fixture.block, &requests)
+            .await?;
+
+        assert_eq!(result.len(), 1);
+
+        // Check the account delta
+        let address = TestFixture::create_address(BALANCER_VAULT_STR);
+        let delta = result
+            .get(&address)
+            .expect("address should exist");
+
+        assert_eq!(delta.address, address);
+        assert_eq!(delta.chain, Chain::Ethereum);
+        assert!(delta.code.is_some());
+        assert!(delta.balance.is_some());
+
+        // Check that storage slots match what we requested
+        assert_eq!(delta.slots.len(), 3);
+        for (key, value) in slots.iter() {
+            assert!(delta.slots.contains_key(key));
+            assert_eq!(
+                delta
+                    .slots
+                    .get(key)
+                    .and_then(|v| v.as_ref()),
+                Some(value)
+            );
+        }
+
+        Ok(())
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    #[ignore = "require RPC connection"]
+    async fn test_get_storage_snapshots_with_empty_slot() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let fixture = TestFixture::new().await;
+        let extractor = fixture.create_batch_extractor().await?;
+
+        // Try to get a slot that was not initialized / is empty
+        let slots_request: Vec<Bytes> = vec![Bytes::from_str(
+            "0000000000000000000000000000000000000000000000000000000000000002",
+        )
+        .unwrap()];
+
+        let requests = vec![TestFixture::create_storage_request(
+            BALANCER_VAULT_STR,
+            Some(slots_request.clone()),
+        )];
+
+        let result = extractor
+            .get_accounts_at_block(&fixture.block, &requests)
+            .await?;
+
+        assert_eq!(result.len(), 1);
+
+        // Check the account delta
+        let address = TestFixture::create_address(BALANCER_VAULT_STR);
+        let delta = result
+            .get(&address)
+            .expect("address should exist");
+
+        assert_eq!(delta.address, address);
+        assert_eq!(delta.chain, Chain::Ethereum);
+        assert!(delta.code.is_some());
+        assert!(delta.balance.is_some());
+
+        // Check that storage slots match what we requested
+        assert_eq!(delta.slots.len(), 1);
+        assert_eq!(
+            delta
+                .slots
+                .get(&slots_request[0])
+                .unwrap(),
+            &None
+        );
+
+        Ok(())
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    #[ignore = "require RPC connection"]
+    async fn test_get_storage_snapshots_multiple_accounts() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let fixture = TestFixture::new().await;
+        let extractor = fixture.create_batch_extractor().await?;
+
+        // Create multiple requests with different token addresses
+        let requests: Vec<_> = TOKEN_ADDRESSES
+            .iter()
+            .map(|&addr| {
+                TestFixture::create_storage_request(
+                    addr,
+                    Some(vec![Bytes::from_str(
+                        "0000000000000000000000000000000000000000000000000000000000000000",
+                    )
+                    .unwrap()]),
+                )
+            })
+            .collect();
+
+        let start_time = std::time::Instant::now();
+        let result = extractor
+            .get_accounts_at_block(&fixture.block, &requests)
+            .await?;
+        let duration = start_time.elapsed();
+        println!(
+            "Time taken to get storage snapshots for {} accounts: {:?}",
+            requests.len(),
+            duration
+        );
+
+        assert_eq!(result.len(), TOKEN_ADDRESSES.len());
+
+        // Check each account has the required data
+        for addr_str in TOKEN_ADDRESSES.iter() {
+            let address = TestFixture::create_address(addr_str);
+            let delta = result
+                .get(&address)
+                .expect("address should exist");
+
+            assert_eq!(delta.address, address);
+            assert_eq!(delta.chain, Chain::Ethereum);
+            assert!(delta.code.is_some());
+            assert!(delta.balance.is_some());
+            assert_eq!(delta.slots.len(), 1);
+
+            println!(
+                "Address: {}, Code size: {}, Has balance: {}",
+                addr_str,
+                delta.code.as_ref().unwrap().len(),
+                delta.balance.is_some()
+            );
+        }
 
         Ok(())
     }

--- a/tycho-indexer/src/main.rs
+++ b/tycho-indexer/src/main.rs
@@ -24,7 +24,7 @@ use tycho_common::{
         Address, Chain, ExtractionState, ImplementationType,
     },
     storage::{ChainGateway, ContractStateGateway, ExtractionStateGateway},
-    traits::AccountExtractor,
+    traits::{AccountExtractor, StorageSnapshotRequest},
     Bytes,
 };
 use tycho_ethereum::{
@@ -511,8 +511,13 @@ async fn get_accounts_data(
         .await
         .expect("Failed to get block data");
 
+    let requests = accounts
+        .iter()
+        .map(|address| StorageSnapshotRequest { address: address.clone(), slots: None })
+        .collect::<Vec<_>>();
+
     let extracted_accounts: HashMap<Bytes, AccountDelta> = account_extractor
-        .get_accounts(block.clone(), accounts)
+        .get_accounts_at_block(&block, &requests)
         .await
         .expect("Failed to extract accounts");
     (block, extracted_accounts)


### PR DESCRIPTION
This pull request introduces a new struct `EVMBatchAccountExtractor` which implements `AccountExtractor` trait to fetch account information (Code, native balance and storage slots). Also, updates the `AccountExtractor` trait to use the new struct `StorageSnapshotRequest` for retrieving account states. Additionally, it includes updates to dependencies in the `Cargo.toml` files and modifies the `tycho-indexer` to use the new struct.

### Important logic decisions:
- Kept old `EVMAccountExtractor` to maintain compatibility with node providers that do not accept batched requests.
- If the `get_accounts_at_block` method gets called without specific storage slots, ALL the storage slots of that contract will be fetched - and a warning will be emitted.
- Whenever specific storage slots are requested, if the returned value is 0, it will be returned as `None`, to avoid trafficking useless data to the clients, as slots with 0 value are considered uninitialized on EVM. 

### Trait and Struct Updates:

* [`tycho-common/src/traits.rs`](diffhunk://#diff-3353cea7380ad36986fe403deac23084d3f3f743f5c7f4735da9f372133534efR16-R48): Added the `StorageSnapshotRequest` struct and updated the `AccountExtractor` trait to include the `get_accounts_at_block` method, which uses the new struct.

### Dependency Updates:

* [`tycho-ethereum/Cargo.toml`](diffhunk://#diff-092ac08b6efa17333f2d2f76c07aadb80b71fb691f717f477677a2670daff3beR27-R32): Added `futures` and `alloy` dependencies, and included `tracing-test` in the features section. [[1]](diffhunk://#diff-092ac08b6efa17333f2d2f76c07aadb80b71fb691f717f477677a2670daff3beR27-R32) [[2]](diffhunk://#diff-092ac08b6efa17333f2d2f76c07aadb80b71fb691f717f477677a2670daff3beR42)

### Codebase Modifications:

* [`tycho-indexer/src/main.rs`](diffhunk://#diff-9b03066676b6f3bc00246e6b874d3ace913f4c0ea0631c0eb74215c6e421f8acL27-R27): Imported the `StorageSnapshotRequest` struct and updated the `get_accounts_data` function to create requests using this struct and call the new `get_accounts_at_block` method. [[1]](diffhunk://#diff-9b03066676b6f3bc00246e6b874d3ace913f4c0ea0631c0eb74215c6e421f8acL27-R27) [[2]](diffhunk://#diff-9b03066676b6f3bc00246e6b874d3ace913f4c0ea0631c0eb74215c6e421f8acR514-R520)