### PR TITLE
fix: cleanly close ws connections on timeouts

### DIFF
--- a/tycho-indexer/src/services/ws.rs
+++ b/tycho-indexer/src/services/ws.rs
@@ -150,6 +150,10 @@ impl WsActor {
             if Instant::now().duration_since(act.heartbeat) > CLIENT_TIMEOUT {
                 warn!("Websocket Client heartbeat failed, disconnecting!");
                 counter!("websocket_connections_dropped", "reason" => "timeout").increment(1);
+                ctx.close(Some(ws::CloseReason {
+                    code: ws::CloseCode::Away,
+                    description: Some("Client heartbeat failed".into()),
+                }));
                 ctx.stop();
                 return;
             }


### PR DESCRIPTION
Currently we would just stop the current actor on a websocket connection timeout and don't initiate the close handshake. This caused our metrics to become distorted as we were monitoring for closed connections and not dropped actors. 