### PR TITLE
fix: remove error logging on RPCClient

### DIFF
--- a/tycho-client/src/rpc.rs
+++ b/tycho-client/src/rpc.rs
@@ -467,10 +467,8 @@ impl RPCClient for HttpRPCClient {
             });
         }
 
-        let accounts = serde_json::from_str::<StateRequestResponse>(&body).map_err(|err| {
-            error!("Failed to parse contract state response: {:?}", &body);
-            RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
-        })?;
+        let accounts = serde_json::from_str::<StateRequestResponse>(&body)
+            .map_err(|err| RPCError::ParseResponse(format!("Error: {err}, Body: {body}")))?;
         trace!(?accounts, "Received contract_state response from Tycho server");
 
         Ok(accounts)
@@ -505,11 +503,8 @@ impl RPCClient for HttpRPCClient {
             .text()
             .await
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
-        let components =
-            serde_json::from_str::<ProtocolComponentRequestResponse>(&body).map_err(|err| {
-                error!("Failed to parse protocol component response: {:?}", &body);
-                RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
-            })?;
+        let components = serde_json::from_str::<ProtocolComponentRequestResponse>(&body)
+            .map_err(|err| RPCError::ParseResponse(format!("Error: {err}, Body: {body}")))?;
         trace!(?components, "Received protocol_components response from Tycho server");
 
         Ok(components)
@@ -566,11 +561,8 @@ impl RPCClient for HttpRPCClient {
             });
         }
 
-        let states =
-            serde_json::from_str::<ProtocolStateRequestResponse>(&body).map_err(|err| {
-                error!("Failed to parse protocol state response: {:?}", &body);
-                RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
-            })?;
+        let states = serde_json::from_str::<ProtocolStateRequestResponse>(&body)
+            .map_err(|err| RPCError::ParseResponse(format!("Error: {err}, Body: {body}")))?;
         trace!(?states, "Received protocol_states response from Tycho server");
 
         Ok(states)
@@ -601,10 +593,8 @@ impl RPCClient for HttpRPCClient {
             .text()
             .await
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
-        let tokens = serde_json::from_str::<TokensRequestResponse>(&body).map_err(|err| {
-            error!("Failed to parse tokens response: {:?}", &body);
-            RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
-        })?;
+        let tokens = serde_json::from_str::<TokensRequestResponse>(&body)
+            .map_err(|err| RPCError::ParseResponse(format!("Error: {err}, Body: {body}")))?;
 
         Ok(tokens)
     }
@@ -635,10 +625,7 @@ impl RPCClient for HttpRPCClient {
             .await
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
         let protocol_systems = serde_json::from_str::<ProtocolSystemsRequestResponse>(&body)
-            .map_err(|err| {
-                error!("Failed to parse protocol systems response: {:?}", &body);
-                RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
-            })?;
+            .map_err(|err| RPCError::ParseResponse(format!("Error: {err}, Body: {body}")))?;
         trace!(?protocol_systems, "Received protocol_systems response from Tycho server");
         Ok(protocol_systems)
     }


### PR DESCRIPTION
We should leave it to the consumer/user of the crate to decide if they want to log the error or not. 