### PR TITLE
feat(tycho-client): Remove panics from client

### DIFF
--- a/tycho-client-py/src/main.rs
+++ b/tycho-client-py/src/main.rs
@@ -1,4 +1,7 @@
 #[tokio::main]
 async fn main() {
-    tycho_client::cli::run_cli().await;
+    if let Err(e) = tycho_client::cli::run_cli().await {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
 }

--- a/tycho-client-py/src/main.rs
+++ b/tycho-client-py/src/main.rs
@@ -1,7 +1,9 @@
+use tycho_client::cli::run_cli;
+
 #[tokio::main]
 async fn main() {
-    if let Err(e) = tycho_client::cli::run_cli().await {
+    run_cli().await.unwrap_or_else(|e| {
         eprintln!("Error: {e}");
         std::process::exit(1);
-    }
+    });
 }

--- a/tycho-client-py/src/main.rs
+++ b/tycho-client-py/src/main.rs
@@ -1,7 +1,7 @@
 #[tokio::main]
 async fn main() {
     if let Err(e) = tycho_client::cli::run_cli().await {
-        eprintln!("Error: {}", e);
+        eprintln!("Error: {e}");
         std::process::exit(1);
     }
 }

--- a/tycho-client/README.md
+++ b/tycho-client/README.md
@@ -154,14 +154,15 @@ For each block, the tycho-client will emit a FeedMessage. Each message is emitte
 
 #### FeedMessage
 
-The main outer message type. It contains both the individual SynchronizerState (one per extractor) and the StateSyncMessage (also one per extractor). Each extractor is supposed to emit one message per block (even if no changes happened in that block) and metadata about the extractors block synchronisation state. The latter
-allows consumers to handle delayed extractors gracefully. 
+The main outer message type. It contains both the individual SynchronizerState (one per extractor) and the StateSyncMessage (also one per 
+extractor). Each extractor is supposed to emit one message per block (even if no changes happened in that block) and metadata about the extractors 
+block synchronization state. The latter allows consumers to handle delayed extractors gracefully. 
 
 [Link to structs](https://github.com/propeller-heads/tycho-indexer/blob/main/tycho-client/src/feed/mod.rs#L305)
 
 #### SynchronizerState
 
-This struct contains metadata about the extractors block synchronisation state. It
+This struct contains metadata about the extractors block synchronization state. It
 allows consumers to handle delayed extractors gracefully. Extractors can have any of the following states:
 
 - `Ready`: the extractor is in sync with the expected block

--- a/tycho-client/src/cli.rs
+++ b/tycho-client/src/cli.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, str::FromStr, time::Duration};
 
 use clap::Parser;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 use tracing_appender::rolling;
 use tycho_common::dto::{Chain, ExtractorIdentity, PaginationParams, ProtocolSystemsRequestBody};
 
@@ -164,7 +164,7 @@ pub async fn run_cli() -> Result<(), String> {
         })
         .collect();
 
-    tracing::info!("Running with exchanges: {:?}", exchanges);
+    info!("Running with exchanges: {:?}", exchanges);
 
     run(exchanges, args).await?;
     Ok(())
@@ -227,7 +227,7 @@ async fn run(exchanges: Vec<(String, Option<String>)>, args: CliArgs) -> Result<
         .collect::<Vec<_>>();
 
     if !not_requested_protocols.is_empty() {
-        tracing::info!("Other available protocols: {}", not_requested_protocols.join(", "));
+        info!("Other available protocols: {}", not_requested_protocols.join(", "));
     }
 
     for (name, address) in exchanges {
@@ -265,7 +265,7 @@ async fn run(exchanges: Vec<(String, Option<String>)>, args: CliArgs) -> Result<
             if let Ok(msg_json) = serde_json::to_string(&msg) {
                 println!("{msg_json}");
             } else {
-                tracing::error!("Failed to serialize FeedMessage");
+                error!("Failed to serialize FeedMessage");
             }
         }
     });
@@ -274,22 +274,22 @@ async fn run(exchanges: Vec<(String, Option<String>)>, args: CliArgs) -> Result<
     tokio::select! {
         res = ws_jh => {
             if let Err(e) = res {
-                tracing::error!("WebSocket connection dropped unexpectedly: {}", e);
+                error!("WebSocket connection dropped unexpectedly: {}", e);
             }
         }
         res = sync_jh => {
             if let Err(e) = res {
-                tracing::error!("BlockSynchronizer stopped unexpectedly: {}", e);
+                error!("BlockSynchronizer stopped unexpectedly: {}", e);
             }
         }
         res = msg_printer => {
             if let Err(e) = res {
-                tracing::error!("Message printer stopped unexpectedly: {}", e);
+                error!("Message printer stopped unexpectedly: {}", e);
             }
         }
     }
 
-    tracing::debug!("RX closed");
+    debug!("RX closed");
     Ok(())
 }
 

--- a/tycho-client/src/deltas.rs
+++ b/tycho-client/src/deltas.rs
@@ -213,7 +213,7 @@ struct Inner {
 
 /// Shared state betweeen all client instances.
 ///
-/// This state is behind a mutex and requires synchronisation to be read of modified.
+/// This state is behind a mutex and requires synchronization to be read of modified.
 impl Inner {
     fn new(cmd_tx: Sender<()>, sink: WebSocketSink, buffer_size: usize) -> Self {
         Self {

--- a/tycho-client/src/deltas.rs
+++ b/tycho-client/src/deltas.rs
@@ -62,39 +62,47 @@ use crate::TYCHO_SERVER_VERSION;
 
 #[derive(Error, Debug)]
 pub enum DeltasError {
-    /// The passed tycho url failed to parse.
+    /// Failed to parse the provided URI.
     #[error("Failed to parse URI: {0}. Error: {1}")]
     UriParsing(String, String),
-    /// Informs you about a subscription being already pending and is awaiting conformation from
-    /// the server.
+
+    /// The requested subscription is already pending and is awaiting confirmation from the server.
     #[error("The requested subscription is already pending")]
     SubscriptionAlreadyPending,
-    /// Informs that an message failed to send via an internal channel or throuh the websocket
-    /// channel. This is most likely fatal and might mean that the implementation is buggy under
-    /// certain conditions.
+
+    /// A message failed to send via an internal channel or through the websocket channel.
+    /// This is typically a fatal error and might indicate a bug in the implementation.
     #[error("{0}")]
     TransportError(String),
-    /// An internal buffer is full. This likely means that messages are not being consumed fast
-    /// enough. If the incoming load emits messages in bursts, consider increasing the buffer size.
+
+    /// The internal message buffer is full. This likely means that messages are not being consumed
+    /// fast enough. If the incoming load emits messages in bursts, consider increasing the buffer
+    /// size.
     #[error("The buffer is full!")]
     BufferFull,
-    /// The client has currently no active connection but it was accessed e.g. by calling
-    /// subscribe.
+
+    /// The client has no active connections but was accessed (e.g., by calling subscribe).
+    /// This typically occurs when trying to use the client before calling connect() or
+    /// after the connection has been closed.
     #[error("The client is not connected!")]
     NotConnected,
+
     /// The connect method was called while the client already had an active connection.
     #[error("The client is already connected!")]
     AlreadyConnected,
+
     /// The connection was closed orderly by the server, e.g. because it restarted.
     #[error("The server closed the connection!")]
     ConnectionClosed,
-    /// The connection was closed unexpectedly by the server.
+
+    /// The connection was closed unexpectedly by the server or encountered a network error.
     #[error("ConnectionError {source}")]
     ConnectionError {
         #[from]
         source: tungstenite::Error,
     },
-    /// Other fatal errors: e.g. if the underlying websockets buffer is full.
+
+    /// A fatal error occurred that cannot be recovered from.
     #[error("Tycho FatalError: {0}")]
     Fatal(String),
 }
@@ -559,21 +567,25 @@ impl DeltasClient for WsDeltasClient {
             let mut guard = self.inner.lock().await;
             let inner = guard
                 .as_mut()
-                .expect("ws not connected");
+                .ok_or_else(|| DeltasError::NotConnected)?;
             trace!("Sending subscribe command");
             inner.new_subscription(&extractor_id, ready_tx)?;
             let cmd = Command::Subscribe { extractor_id, include_state: options.include_state };
             inner
                 .ws_send(tungstenite::protocol::Message::Text(
-                    serde_json::to_string(&cmd).expect("serialize cmd encode error"),
+                    serde_json::to_string(&cmd).map_err(|e| {
+                        DeltasError::TransportError(format!(
+                            "Failed to serialize subscribe command: {e}"
+                        ))
+                    })?,
                 ))
                 .await?;
         }
         trace!("Waiting for subscription response");
-        let rx = ready_rx
-            .await
-            .expect("ready channel closed");
-        trace!("Subscription successfull");
+        let rx = ready_rx.await.map_err(|_| {
+            DeltasError::TransportError("Subscription channel closed unexpectedly".to_string())
+        })?;
+        trace!("Subscription successful");
         Ok(rx)
     }
 
@@ -585,13 +597,13 @@ impl DeltasClient for WsDeltasClient {
             let mut guard = self.inner.lock().await;
             let inner = guard
                 .as_mut()
-                .expect("ws not connected");
+                .ok_or_else(|| DeltasError::NotConnected)?;
 
             WsDeltasClient::unsubscribe_inner(inner, subscription_id, ready_tx).await?;
         }
-        ready_rx
-            .await
-            .expect("ready channel closed");
+        ready_rx.await.map_err(|_| {
+            DeltasError::TransportError("Unsubscribe channel closed unexpectedly".to_string())
+        })?;
 
         Ok(())
     }
@@ -601,7 +613,7 @@ impl DeltasClient for WsDeltasClient {
         if self.is_connected().await {
             return Err(DeltasError::AlreadyConnected);
         }
-        let ws_uri = format!("{}{}/ws", self.uri, TYCHO_SERVER_VERSION);
+        let ws_uri = format!("{uri}{TYCHO_SERVER_VERSION}/ws", uri = self.uri);
         info!(?ws_uri, "Starting TychoWebsocketClient");
 
         let (cmd_tx, mut cmd_rx) = mpsc::channel(self.ws_buffer_size);
@@ -626,18 +638,26 @@ impl DeltasClient for WsDeltasClient {
                     .header(UPGRADE, "websocket")
                     .header(
                         HOST,
-                        this.uri
-                            .host()
-                            .expect("no host found in tycho url"),
+                        this.uri.host().ok_or_else(|| {
+                            DeltasError::UriParsing(
+                                ws_uri.clone(),
+                                "No host found in tycho url".to_string(),
+                            )
+                        })?,
                     )
-                    .header(USER_AGENT, format!("tycho-client-{}", env!("CARGO_PKG_VERSION")));
+                    .header(
+                        USER_AGENT,
+                        format!("tycho-client-{version}", version = env!("CARGO_PKG_VERSION")),
+                    );
 
                 // Add Authorization if one is given
                 if let Some(ref key) = this.auth_key {
                     request_builder = request_builder.header(AUTHORIZATION, key);
                 }
 
-                let request = request_builder.body(()).unwrap();
+                let request = request_builder.body(()).map_err(|e| {
+                    DeltasError::TransportError(format!("Failed to build connection request: {e}"))
+                })?;
                 let (conn, _) = match connect_async(request).await {
                     Ok(conn) => conn,
                     Err(e) => {

--- a/tycho-client/src/deltas.rs
+++ b/tycho-client/src/deltas.rs
@@ -710,7 +710,7 @@ impl DeltasClient for WsDeltasClient {
                             warn!(
                                 ?error,
                                 ?retry_count,
-                                "Connection dropped unexpectedly; Reconnecting"
+                                "Connection dropped unexpectedly; Reconnecting..."
                             );
                             break;
                         } else {

--- a/tycho-client/src/feed/component_tracker.rs
+++ b/tycho-client/src/feed/component_tracker.rs
@@ -211,7 +211,9 @@ where
                 if let Some(comp) = self.components.get(cid) {
                     Some(comp.contract_ids.clone())
                 } else {
-                    warn!("Requested component is not tracked: {cid}.");
+                    warn!(
+                        "Requested component is not tracked: {cid}. Skipping fetching contracts..."
+                    );
                     None
                 }
             })

--- a/tycho-client/src/feed/component_tracker.rs
+++ b/tycho-client/src/feed/component_tracker.rs
@@ -192,18 +192,30 @@ where
         res
     }
 
+    /// Get related contracts for the given component ids. Assumes that the components are already
+    /// tracked, either by calling `start_tracking` or `initialise_components`.
+    ///
+    /// # Arguments
+    ///
+    /// * `ids` - A vector of component IDs to get the contracts for.
+    ///
+    /// # Returns
+    ///
+    /// A HashSet of contract IDs. Components that are not tracked will be logged and skipped.
     pub fn get_contracts_by_component<'a, I: IntoIterator<Item = &'a String>>(
         &self,
         ids: I,
     ) -> HashSet<Bytes> {
         ids.into_iter()
-            .flat_map(|cid| {
-                let comp = self
-                    .components
-                    .get(cid)
-                    .unwrap_or_else(|| panic!("requested component that is not present: {cid}"));
-                comp.contract_ids.iter().cloned()
+            .filter_map(|cid| {
+                if let Some(comp) = self.components.get(cid) {
+                    Some(comp.contract_ids.clone())
+                } else {
+                    warn!("Requested component is not tracked: {cid}.");
+                    None
+                }
             })
+            .flatten()
             .collect()
     }
 

--- a/tycho-client/src/feed/mod.rs
+++ b/tycho-client/src/feed/mod.rs
@@ -596,7 +596,7 @@ mod tests {
     use tokio::sync::{oneshot, Mutex};
     use tycho_common::dto::Chain;
 
-    use super::*;
+    use super::{synchronizer::SynchronizerError, *};
     use crate::feed::synchronizer::SyncResult;
 
     #[derive(Clone)]
@@ -661,7 +661,7 @@ mod tests {
                     .expect("end channel closed!");
                 Ok(())
             } else {
-                Err(anyhow::format_err!("Not connected"))
+                Err(SynchronizerError::CloseError("Not Started".to_string()))
             }
         }
     }

--- a/tycho-client/src/feed/synchronizer.rs
+++ b/tycho-client/src/feed/synchronizer.rs
@@ -42,7 +42,7 @@ pub enum SynchronizerError {
 
     /// Failed to send channel message to the consumer.
     #[error("Failed to send channel message: {0}")]
-    ChannelError(#[from] SendError<StateSyncMessage>),
+    ChannelError(String),
 
     /// Timeout elapsed errors.
     #[error("Timeout error: {0}")]
@@ -58,6 +58,12 @@ pub enum SynchronizerError {
 }
 
 pub type SyncResult<T> = Result<T, SynchronizerError>;
+
+impl From<SendError<StateSyncMessage>> for SynchronizerError {
+    fn from(err: SendError<StateSyncMessage>) -> Self {
+        SynchronizerError::ChannelError(err.to_string())
+    }
+}
 
 #[derive(Clone)]
 pub struct ProtocolStateSynchronizer<R: RPCClient, D: DeltasClient> {

--- a/tycho-client/src/feed/synchronizer.rs
+++ b/tycho-client/src/feed/synchronizer.rs
@@ -549,7 +549,7 @@ where
                                 warn!(
                                     extractor_id=%&this.extractor_id,
                                     retry_count,
-                                    "State synchronisation exited with Ok(())"
+                                    "State synchronization exited with Ok(())"
                                 );
                             }
                         }

--- a/tycho-client/src/main.rs
+++ b/tycho-client/src/main.rs
@@ -2,8 +2,8 @@ use tycho_client::cli::run_cli;
 
 #[tokio::main]
 async fn main() {
-    if let Err(e) = run_cli().await {
+    run_cli().await.unwrap_or_else(|e| {
         eprintln!("Error: {e}");
         std::process::exit(1);
-    }
+    });
 }

--- a/tycho-client/src/main.rs
+++ b/tycho-client/src/main.rs
@@ -2,5 +2,8 @@ use tycho_client::cli::run_cli;
 
 #[tokio::main]
 async fn main() {
-    run_cli().await;
+    if let Err(e) = run_cli().await {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
 }

--- a/tycho-client/src/main.rs
+++ b/tycho-client/src/main.rs
@@ -3,7 +3,7 @@ use tycho_client::cli::run_cli;
 #[tokio::main]
 async fn main() {
     if let Err(e) = run_cli().await {
-        eprintln!("Error: {}", e);
+        eprintln!("Error: {e}");
         std::process::exit(1);
     }
 }

--- a/tycho-client/src/rpc.rs
+++ b/tycho-client/src/rpc.rs
@@ -31,15 +31,20 @@ pub enum RPCError {
     /// The passed tycho url failed to parse.
     #[error("Failed to parse URL: {0}. Error: {1}")]
     UrlParsing(String, String),
+
     /// The request data is not correctly formed.
     #[error("Failed to format request: {0}")]
     FormatRequest(String),
+
     /// Errors forwarded from the HTTP protocol.
     #[error("Unexpected HTTP client error: {0}")]
     HttpClient(String),
+
     /// The response from the server could not be parsed correctly.
     #[error("Failed to parse response: {0}")]
     ParseResponse(String),
+
+    /// Other fatal errors.
     #[error("Fatal error: {0}")]
     Fatal(String),
 }
@@ -392,15 +397,18 @@ impl HttpRPCClient {
         // Add default headers
         let mut headers = header::HeaderMap::new();
         headers.insert(header::CONTENT_TYPE, header::HeaderValue::from_static("application/json"));
-        let user_agent = format!("tycho-client-{}", env!("CARGO_PKG_VERSION"));
+        let user_agent = format!("tycho-client-{version}", version = env!("CARGO_PKG_VERSION"));
         headers.insert(
             header::USER_AGENT,
-            header::HeaderValue::from_str(&user_agent).expect("invalid user agent format"),
+            header::HeaderValue::from_str(&user_agent)
+                .map_err(|e| RPCError::FormatRequest(format!("Invalid user agent format: {e}")))?,
         );
 
         // Add Authorization if one is given
         if let Some(key) = auth_key {
-            let mut auth_value = header::HeaderValue::from_str(key).expect("invalid key format");
+            let mut auth_value = header::HeaderValue::from_str(key).map_err(|e| {
+                RPCError::FormatRequest(format!("Invalid authorization key format: {e}"))
+            })?;
             auth_value.set_sensitive(true);
             headers.insert(header::AUTHORIZATION, auth_value);
         }
@@ -422,12 +430,10 @@ impl RPCClient for HttpRPCClient {
         request: &StateRequestBody,
     ) -> Result<StateRequestResponse, RPCError> {
         // Check if contract ids are specified
-        if request.contract_ids.is_none() ||
-            request
-                .contract_ids
-                .as_ref()
-                .unwrap()
-                .is_empty()
+        if request
+            .contract_ids
+            .as_ref()
+            .is_none_or(|ids| ids.is_empty())
         {
             warn!("No contract ids specified in request.");
         }
@@ -514,13 +520,11 @@ impl RPCClient for HttpRPCClient {
         &self,
         request: &ProtocolStateRequestBody,
     ) -> Result<ProtocolStateRequestResponse, RPCError> {
-        // Check if contract ids are specified
-        if request.protocol_ids.is_none() ||
-            request
-                .protocol_ids
-                .as_ref()
-                .unwrap()
-                .is_empty()
+        // Check if protocol ids are specified
+        if request
+            .protocol_ids
+            .as_ref()
+            .is_none_or(|ids| ids.is_empty())
         {
             warn!("No protocol ids specified in request.");
         }

--- a/tycho-client/src/stream.rs
+++ b/tycho-client/src/stream.rs
@@ -6,7 +6,7 @@ use std::{
 
 use thiserror::Error;
 use tokio::{sync::mpsc::Receiver, task::JoinHandle};
-use tracing::info;
+use tracing::{info, warn};
 use tycho_common::dto::{Chain, ExtractorIdentity, PaginationParams, ProtocolSystemsRequestBody};
 
 use crate::{
@@ -221,7 +221,7 @@ impl TychoStreamBuilder {
                     .collect::<HashSet<_>>()
             })
             .map_err(|e| {
-                tracing::warn!(
+                warn!(
                     "Failed to fetch protocol systems: {e}. Skipping protocol availability check."
                 );
                 e
@@ -243,7 +243,7 @@ impl TychoStreamBuilder {
             })
             .filter(|not_requested_protocols| !not_requested_protocols.is_empty())
         {
-            tracing::info!("Other available protocols: {}", not_requested_protocols.join(", "))
+            info!("Other available protocols: {}", not_requested_protocols.join(", "))
         }
     }
 }

--- a/tycho-client/src/stream.rs
+++ b/tycho-client/src/stream.rs
@@ -29,9 +29,6 @@ pub enum StreamError {
 
     #[error("BlockSynchronizer error: {0}")]
     BlockSynchronizerError(String),
-
-    #[error("Initialization error: {0}")]
-    InitializationError(String),
 }
 
 pub struct TychoStreamBuilder {
@@ -135,6 +132,7 @@ impl TychoStreamBuilder {
         // Attempt to read the authentication key from the environment variable if not provided
         let auth_key = self
             .auth_key
+            .clone()
             .or_else(|| env::var("TYCHO_AUTH_TOKEN").ok());
 
         // Determine the URLs based on the TLS setting
@@ -152,9 +150,9 @@ impl TychoStreamBuilder {
 
         // Initialize the WebSocket client
         let ws_client = WsDeltasClient::new(&tycho_ws_url, auth_key.as_deref())
-            .map_err(|e| StreamError::InitializationError(e.to_string()))?;
+            .map_err(|e| StreamError::SetUpError(e.to_string()))?;
         let rpc_client = HttpRPCClient::new(&tycho_rpc_url, auth_key.as_deref())
-            .map_err(|e| StreamError::InitializationError(e.to_string()))?;
+            .map_err(|e| StreamError::SetUpError(e.to_string()))?;
         let ws_jh = ws_client
             .connect()
             .await
@@ -167,33 +165,8 @@ impl TychoStreamBuilder {
             self.max_missed_blocks,
         );
 
-        let available_protocols_set = rpc_client
-            .get_protocol_systems(&ProtocolSystemsRequestBody {
-                chain: self.chain,
-                pagination: PaginationParams { page: 0, page_size: 100 },
-            })
-            .await
-            .map_err(|e| {
-                StreamError::InitializationError(format!("Failed to fetch protocol systems: {e}"))
-            })?
-            .protocol_systems
-            .into_iter()
-            .collect::<HashSet<_>>();
-
-        let requested_protocol_set = self
-            .exchanges
-            .keys()
-            .cloned()
-            .collect::<HashSet<_>>();
-
-        let not_requested_protocols = available_protocols_set
-            .difference(&requested_protocol_set)
-            .cloned()
-            .collect::<Vec<_>>();
-
-        if !not_requested_protocols.is_empty() {
-            tracing::info!("Other available protocols: {}", not_requested_protocols.join(", "));
-        }
+        self.display_available_protocols(&rpc_client)
+            .await;
 
         // Register each exchange with the BlockSynchronizer
         for (name, filter) in self.exchanges {
@@ -231,6 +204,47 @@ impl TychoStreamBuilder {
         });
 
         Ok((handle, rx))
+    }
+
+    /// Displays the other available protocols not registered to within this stream builder, for the
+    /// given chain.
+    async fn display_available_protocols(&self, rpc_client: &HttpRPCClient) {
+        let available_protocols_set = rpc_client
+            .get_protocol_systems(&ProtocolSystemsRequestBody {
+                chain: self.chain,
+                pagination: PaginationParams { page: 0, page_size: 100 },
+            })
+            .await
+            .map(|resp| {
+                resp.protocol_systems
+                    .into_iter()
+                    .collect::<HashSet<_>>()
+            })
+            .map_err(|e| {
+                tracing::warn!(
+                    "Failed to fetch protocol systems: {e}. Skipping protocol availability check."
+                );
+                e
+            })
+            .ok();
+
+        if let Some(not_requested_protocols) = available_protocols_set
+            .map(|available_protocols_set| {
+                let requested_protocol_set = self
+                    .exchanges
+                    .keys()
+                    .cloned()
+                    .collect::<HashSet<_>>();
+
+                available_protocols_set
+                    .difference(&requested_protocol_set)
+                    .cloned()
+                    .collect::<Vec<_>>()
+            })
+            .filter(|not_requested_protocols| !not_requested_protocols.is_empty())
+        {
+            tracing::info!("Other available protocols: {}", not_requested_protocols.join(", "))
+        }
     }
 }
 


### PR DESCRIPTION
Improve error handling on the tycho-client. This is done by:
- removing all panics
- replacing them with warnings, or by raising appropriate errors

In a few cases it was decided to handle an error internally instead of propagate it. Such cases are:
- **Component Tracker**
Old behaviour: panics if you try fetch linked contracts for components that are not tracking
New behaviour: logs a warning and skips that component. Extended the docs to emphasise that it is expected for `start_tracking` or `initialise_components` to be called before fetching contracts for tracked components.

Bug fix: I also found a bug where if the ws client connection dropped and could not be re-established during the first half of the `state_sync` fn on the ProtocolStateSynchronizer (before the main loop), then we'd retry starting the synchroniser on a broken connection and freeze. This has been fixed here: [22b77b3](https://github.com/propeller-heads/tycho-indexer/pull/561/commits/22b77b3eec28de7403fe98919addf3204c181d6c).