### PR TITLE
refactor: remove server URLs from OpenAPI definition

### DIFF
--- a/tycho-indexer/src/services/mod.rs
+++ b/tycho-indexer/src/services/mod.rs
@@ -97,10 +97,6 @@ where
         #[derive(OpenApi)]
         #[openapi(
             info(title = "Tycho-Indexer RPC",),
-            servers(
-                (url = "https://tycho-beta.propellerheads.xyz/", description = "PropellerHeads hosted service"),
-                (url = "/", description = "Local"),
-            ),
             paths(
                 rpc::health,
                 rpc::protocol_systems,


### PR DESCRIPTION
This is not needed and leads to a confusing swagger UI because it includes all servers on a chain specific Swagger so, so it can lead to confusion if you don't select the correct one (the one you used the swagger URL for).