### PR TITLE
fix(tycho-client): fix block position bug for delayed extractors on start up

### DIFF
--- a/tycho-client/src/feed/block_history.rs
+++ b/tycho-client/src/feed/block_history.rs
@@ -44,12 +44,47 @@ pub enum BlockPosition {
 /// Provides lightweight validation and relative positioning of received block headers
 /// emitted by StateSynchronizer structs.
 impl BlockHistory {
+    /// Create a new BlockHistory from a vector of headers.
+    ///
+    /// The latest block and all connected block preceeding it are added to the history.
+    /// Detached blocks are skipped.
     pub fn new(mut history: Vec<Header>, size: usize) -> Result<Self, BlockHistoryError> {
-        // sort history by block number
+        // sort history by block number in descending order
         history.sort_by_key(|h| h.number);
+        history.reverse();
+
+        // Start with the latest block and build connected chain
+        let mut connected_chain = Vec::new();
+        if let Some(latest) = history.first() {
+            connected_chain.push(latest.clone());
+            let mut current_hash = latest.parent_hash.clone();
+            let mut current_number = latest.number;
+
+            // Find connected blocks in sequence
+            for block in history.iter().skip(1) {
+                // If we find a gap in block numbers, stop building the chain
+                if block.number != current_number - 1 {
+                    break;
+                }
+                // Check hash connection (preceeding block is parent of current block)
+                if block.hash == current_hash {
+                    connected_chain.push(block.clone());
+                    current_hash = block.parent_hash.clone();
+                    current_number = block.number;
+                }
+            }
+        }
+
+        // Reverse to get oldest->newest order
+        connected_chain.reverse();
+
         let cache_size = NonZeroUsize::new(size * 10).ok_or(BlockHistoryError::InvalidCacheSize)?;
 
-        Ok(Self { history: VecDeque::from(history), size, reverts: LruCache::new(cache_size) })
+        Ok(Self {
+            history: VecDeque::from(connected_chain),
+            size,
+            reverts: LruCache::new(cache_size),
+        })
     }
 
     /// Add the block as next block.
@@ -172,17 +207,12 @@ mod test {
         Bytes::from(no.to_be_bytes())
     }
 
-    fn generate_blocks(n: usize, parent: Option<Bytes>) -> Vec<Header> {
+    fn generate_blocks(n: usize, start_n: u64, parent: Option<Bytes>) -> Vec<Header> {
         let mut blocks = Vec::with_capacity(n);
         let mut parent_hash = parent.unwrap_or_else(random_hash);
-        for i in 0..n {
-            let hash = int_hash(i as u64);
-            blocks.push(Header {
-                number: i as u64,
-                hash: hash.clone(),
-                parent_hash,
-                revert: false,
-            });
+        for i in start_n..start_n + n as u64 {
+            let hash = int_hash(i);
+            blocks.push(Header { number: i, hash: hash.clone(), parent_hash, revert: false });
             parent_hash = hash;
         }
         blocks
@@ -190,7 +220,7 @@ mod test {
 
     #[test]
     fn test_push() {
-        let start_blocks = generate_blocks(1, None);
+        let start_blocks = generate_blocks(1, 0, None);
         let new_block =
             Header { number: 1, hash: random_hash(), parent_hash: int_hash(0), revert: false };
         let mut history =
@@ -210,7 +240,7 @@ mod test {
 
     #[test]
     fn test_size_limit() {
-        let blocks = generate_blocks(3, None);
+        let blocks = generate_blocks(3, 0, None);
         let mut history =
             BlockHistory::new(blocks[0..2].to_vec(), 2).expect("failed to create history");
 
@@ -223,7 +253,7 @@ mod test {
 
     #[test]
     fn test_push_revert_push() {
-        let blocks = generate_blocks(5, None);
+        let blocks = generate_blocks(5, 0, None);
         let mut history = BlockHistory::new(blocks.clone(), 5).expect("failed to create history");
         let revert_block =
             Header { number: 2, hash: int_hash(2), parent_hash: int_hash(1), revert: true };
@@ -250,7 +280,7 @@ mod test {
 
     #[test]
     fn test_push_detached_block() {
-        let blocks = generate_blocks(3, None);
+        let blocks = generate_blocks(3, 0, None);
         let mut history = BlockHistory::new(blocks.clone(), 5).expect("failed to create history");
         let new_block =
             Header { number: 2, hash: int_hash(2), parent_hash: random_hash(), revert: true };
@@ -260,15 +290,47 @@ mod test {
         assert!(res.is_err());
     }
 
+    #[test]
+    fn test_new_block_history() {
+        // Create a valid chain of 5 blocks starting from block 5
+        let mut blocks = generate_blocks(5, 5, None);
+
+        // Add some disconnected blocks
+        blocks.push(Header {
+            number: 2, // Gap in block numbers
+            hash: random_hash(),
+            parent_hash: random_hash(),
+            revert: false,
+        });
+        blocks.push(Header {
+            number: 4,
+            hash: random_hash(),
+            parent_hash: random_hash(), // Disconnected
+            revert: false,
+        });
+
+        let history = BlockHistory::new(blocks, 10).expect("failed to create history");
+
+        // Should only contain the original 5 connected blocks
+        assert_eq!(history.history.len(), 5);
+
+        // Verify the blocks are in order
+        let blocks: Vec<_> = history.history.iter().collect();
+        for i in 0..blocks.len() - 1 {
+            assert_eq!(blocks[i].number + 1, blocks[i + 1].number);
+            assert_eq!(blocks[i].hash, blocks[i + 1].parent_hash);
+        }
+    }
+
     #[rstest]
-    #[case(Header { number: 10, hash: random_hash(), parent_hash: int_hash(9), revert: false }, BlockPosition::NextExpected)]
-    #[case(Header { number: 9, hash: int_hash(9), parent_hash: int_hash(8), revert: false }, BlockPosition::Latest)]
-    #[case(Header { number: 11, hash: int_hash(11), parent_hash: int_hash(10), revert: false }, BlockPosition::Advanced)]
-    #[case(Header { number: 7, hash: int_hash(7), parent_hash: int_hash(6), revert: false }, BlockPosition::Delayed)]
-    #[case(Header { number: 9, hash: int_hash(9), parent_hash: int_hash(8), revert: true }, BlockPosition::NextExpected)]
+    #[case(Header { number: 15, hash: int_hash(15), parent_hash: int_hash(14), revert: false }, BlockPosition::NextExpected)]
+    #[case(Header { number: 14, hash: int_hash(14), parent_hash: int_hash(13), revert: false }, BlockPosition::Latest)]
+    #[case(Header { number: 16, hash: int_hash(16), parent_hash: int_hash(15), revert: false }, BlockPosition::Advanced)]
+    #[case(Header { number: 12, hash: int_hash(12), parent_hash: int_hash(11), revert: false }, BlockPosition::Delayed)]
+    #[case(Header { number: 14, hash: int_hash(14), parent_hash: int_hash(13), revert: true }, BlockPosition::NextExpected)]
     fn test_determine_position(#[case] add_block: Header, #[case] exp_pos: BlockPosition) {
-        let start_blocks = generate_blocks(10, None);
-        let history = BlockHistory::new(start_blocks, 15).expect("failed to create history");
+        let start_blocks = generate_blocks(10, 5, None);
+        let history = BlockHistory::new(start_blocks, 20).expect("failed to create history");
 
         let res = history
             .determine_block_position(&add_block)
@@ -277,10 +339,9 @@ mod test {
         assert_eq!(res, exp_pos);
     }
 
-    #[rstest]
-    #[case(Header { number: 9, hash: int_hash(9), parent_hash: int_hash(8), revert: false })]
-    fn test_determine_position_reverted_branch(#[case] add_block: Header) {
-        let start_blocks = generate_blocks(10, None);
+    #[test]
+    fn test_determine_position_reverted_branch() {
+        let start_blocks = generate_blocks(10, 0, None);
         let mut history = BlockHistory::new(start_blocks, 15).expect("failed to create history");
         // revert by 2 blocks, add a new one
         history
@@ -294,6 +355,8 @@ mod test {
                 revert: false,
             })
             .unwrap();
+        let add_block =
+            Header { number: 9, hash: int_hash(9), parent_hash: int_hash(8), revert: false };
 
         let res = history
             .determine_block_position(&add_block)


### PR DESCRIPTION
Delayed extractors on start up were erroring with `Could not determine history` when they tried to catch up to the later blocks. This was due to the fact that on start-up, the BlockHistory created by the client has a gap for the unwitnessed blocks between the delayed extractor's block and the current block the other extractors are on. The `determine_block_position` function was then unable to determine where the catch-up blocks belonged within that gap.

We would also get a similar error if an extractor was delayed longer than the block history cache limit (currently 15 blocks).

Solution: 
1) improve the BlockHistory instantiation logic to skip detached blocks and ensure a fully connected history.
2) update `determine_block_position` to mark blocks older than the oldest in history as delayed.