### PR TITLE
refactor(indexer): log error code for substream error metrics

### DIFF
--- a/tycho-indexer/src/substreams/stream.rs
+++ b/tycho-indexer/src/substreams/stream.rs
@@ -170,7 +170,7 @@ fn stream_blocks(
                                 }
 
                                 error!("Received tonic error {:#}", status);
-                                counter!("substreams_failure", "extractor" => extractor_id.clone(), "cause" => "tonic_error").increment(1);
+                                counter!("substreams_failure", "extractor" => extractor_id.clone(), "cause" => status.code().to_string()).increment(1);
 
                                 // If we reach this point, we must wait a bit before retrying
                                 wait_for_next_retry(&mut backoff, &mut retry_count, &extractor_id).await?;


### PR DESCRIPTION
"Tonic error" does not give us much information. Instead, the error code tells us if it is an internal error, unavailable connection etc.