### PR TITLE
fix: update dockerfile rust version to 1.82

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.81-bookworm AS chef
+FROM rust:1.82-bookworm AS chef
 ARG TARGETPLATFORM=linux/amd64
 WORKDIR /build
 RUN apt-get update && apt-get install -y libpq-dev jq
@@ -12,7 +12,7 @@ RUN ARCH=$(echo $TARGETPLATFORM | sed -e 's/\//_/g') && \
 RUN cargo install cargo-workspaces
 RUN cargo install cargo-chef
 COPY rust-toolchain.toml .
-RUN rustup update 1.81
+RUN rustup update 1.82
 RUN rustup set profile minimal && rustup install stable
 
 FROM chef AS planner


### PR DESCRIPTION
Our main github workflow is failing due to dependencies that require rust version 1.82 and above.