### PR TITLE
fix(postgres): add on_conflict_do_nothing to contract balance and code upserts

### DIFF
--- a/tycho-storage/src/postgres/contract.rs
+++ b/tycho-storage/src/postgres/contract.rs
@@ -1068,11 +1068,13 @@ impl PostgresGateway {
                     tx_id,
                     created_ts,
                 ))
+                .on_conflict_do_nothing()
                 .execute(db)
                 .await
                 .map_err(|err| storage_error_from_diesel(err, "AccountBalance", &hex_addr, None))?;
             diesel::insert_into(schema::contract_code::table)
                 .values(new_contract.new_code(account_id, tx_id, created_ts))
+                .on_conflict_do_nothing()
                 .execute(db)
                 .await
                 .map_err(|err| storage_error_from_diesel(err, "ContractCode", &hex_addr, None))?;


### PR DESCRIPTION
Currently, the docs for this function says "It will not update contract balance or contract code if they already exist though. Since a separate method exists for updating these related components." but it's still not ignoring conflicts. This commit fixes this.