### PR TITLE
refactor: improve Entrypoints methods on PostgresGateway

### DIFF
--- a/tycho-api.yaml
+++ b/tycho-api.yaml
@@ -1,0 +1,1084 @@
+openapi: 3.0.3
+info:
+  title: Tycho-Indexer RPC
+  description: >-
+    Tycho indexer application binary. Runs the actual indexing. Exposes ws and
+    http endpoints to access extracted data
+  license:
+    name: MIT
+  version: 0.66.2
+  x-gitbook-description-document:
+    object: document
+    data:
+      schemaVersion: 8
+    nodes:
+      - object: block
+        type: paragraph
+        isVoid: false
+        data: {}
+        nodes:
+          - object: text
+            leaves:
+              - object: leaf
+                text: >-
+                  Tycho indexer application binary. Runs the actual indexing.
+                  Exposes ws and http endpoints to access extracted data
+                marks: []
+  x-gitbook-description-html: >-
+    <p>Tycho indexer application binary. Runs the actual indexing. Exposes ws
+    and http endpoints to access extracted data</p>
+servers:
+  - url: https://tycho-beta.propellerheads.xyz
+    description: PropellerHeads hosted service for Ethereum
+    x-gitbook-description-html: <p>PropellerHeads hosted service for Ethereum</p>
+  - url: https://tycho-base-beta.propellerheads.xyz
+    description: PropellerHeads hosted service for Base
+    x-gitbook-description-html: <p>PropellerHeads hosted service for Base</p>
+  - url: https://tycho-unichain-beta.propellerheads.xyz
+    description: PropellerHeads hosted service for Unichain
+    x-gitbook-description-html: <p>PropellerHeads hosted service for Unichain</p>
+paths:
+  /v1/contract_state:
+    post:
+      tags:
+        - rpc
+      summary: Retrieve contract states
+      description: >-
+        This endpoint retrieves the state of contracts within a specific
+        execution environment. If no
+
+        contract ids are given, all contracts are returned. Note that
+        `protocol_system` is not a filter;
+
+        it's a way to specify the protocol system associated with the contracts
+        requested and is used to
+
+        ensure that the correct extractor's block status is used when querying
+        the database. If omitted,
+
+        the block status will be determined by a random extractor, which could
+        be risky if the extractor
+
+        is out of sync. Filtering by protocol system is not currently supported
+        on this endpoint and
+
+        should be done client side.
+      operationId: contract_state
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StateRequestBody"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StateRequestResponse"
+          x-gitbook-description-html: <p>OK</p>
+      security:
+        - apiKey: []
+      x-gitbook-description-document:
+        object: document
+        data:
+          schemaVersion: 8
+        nodes:
+          - object: block
+            type: paragraph
+            isVoid: false
+            data: {}
+            nodes:
+              - object: text
+                leaves:
+                  - object: leaf
+                    text: >-
+                      This endpoint retrieves the state of contracts within a
+                      specific execution environment. If no
+
+                      contract ids are given, all contracts are returned. Note
+                      that
+                    marks: []
+                  - object: leaf
+                    text: protocol_system
+                    marks:
+                      - object: mark
+                        type: code
+                        data: {}
+                  - object: leaf
+                    text: >2-
+                       is not a filter;
+                      it's a way to specify the protocol system associated with
+                      the contracts requested and is used to
+
+                      ensure that the correct extractor's block status is used
+                      when querying the database. If omitted,
+
+                      the block status will be determined by a random extractor,
+                      which could be risky if the extractor
+
+                      is out of sync. Filtering by protocol system is not
+                      currently supported on this endpoint and
+
+                      should be done client side.
+                    marks: []
+      x-gitbook-description-html: >-
+        <p>This endpoint retrieves the state of contracts within a specific
+        execution environment. If no<br>contract ids are given, all contracts
+        are returned. Note that <code>protocol_system</code> is not a
+        filter;<br>it's a way to specify the protocol system associated with the
+        contracts requested and is used to<br>ensure that the correct
+        extractor's block status is used when querying the database. If
+        omitted,<br>the block status will be determined by a random extractor,
+        which could be risky if the extractor<br>is out of sync. Filtering by
+        protocol system is not currently supported on this endpoint
+        and<br>should be done client side.</p>
+  /v1/health:
+    get:
+      tags:
+        - rpc
+      summary: Health check endpoint
+      description: This endpoint is used to check the health of the service.
+      operationId: health
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Health"
+          x-gitbook-description-html: <p>OK</p>
+      security:
+        - apiKey: []
+      x-gitbook-description-document:
+        object: document
+        data:
+          schemaVersion: 8
+        nodes:
+          - object: block
+            type: paragraph
+            isVoid: false
+            data: {}
+            nodes:
+              - object: text
+                leaves:
+                  - object: leaf
+                    text: This endpoint is used to check the health of the service.
+                    marks: []
+      x-gitbook-description-html: <p>This endpoint is used to check the health of the service.</p>
+  /v1/protocol_components:
+    post:
+      tags:
+        - rpc
+      summary: Retrieve protocol components
+      description: >-
+        This endpoint retrieves components within a specific execution
+        environment, filtered by various
+
+        criteria.
+      operationId: protocol_components
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProtocolComponentsRequestBody"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProtocolComponentRequestResponse"
+          x-gitbook-description-html: <p>OK</p>
+      security:
+        - apiKey: []
+      x-gitbook-description-document:
+        object: document
+        data:
+          schemaVersion: 8
+        nodes:
+          - object: block
+            type: paragraph
+            isVoid: false
+            data: {}
+            nodes:
+              - object: text
+                leaves:
+                  - object: leaf
+                    text: >-
+                      This endpoint retrieves components within a specific
+                      execution environment, filtered by various
+
+                      criteria.
+                    marks: []
+      x-gitbook-description-html: >-
+        <p>This endpoint retrieves components within a specific execution
+        environment, filtered by various<br>criteria.</p>
+  /v1/protocol_state:
+    post:
+      tags:
+        - rpc
+      summary: Retrieve protocol states
+      description: >-
+        This endpoint retrieves the state of protocols within a specific
+        execution environment.
+      operationId: protocol_state
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProtocolStateRequestBody"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProtocolStateRequestResponse"
+          x-gitbook-description-html: <p>OK</p>
+      security:
+        - apiKey: []
+      x-gitbook-description-document:
+        object: document
+        data:
+          schemaVersion: 8
+        nodes:
+          - object: block
+            type: paragraph
+            isVoid: false
+            data: {}
+            nodes:
+              - object: text
+                leaves:
+                  - object: leaf
+                    text: >-
+                      This endpoint retrieves the state of protocols within a
+                      specific execution environment.
+                    marks: []
+      x-gitbook-description-html: >-
+        <p>This endpoint retrieves the state of protocols within a specific
+        execution environment.</p>
+  /v1/protocol_systems:
+    post:
+      tags:
+        - rpc
+      summary: Retrieve protocol systems
+      description: This endpoint retrieves the protocol systems available in the indexer.
+      operationId: protocol_systems
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProtocolSystemsRequestBody"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProtocolSystemsRequestResponse"
+          x-gitbook-description-html: <p>OK</p>
+      security:
+        - apiKey: []
+      x-gitbook-description-document:
+        object: document
+        data:
+          schemaVersion: 8
+        nodes:
+          - object: block
+            type: paragraph
+            isVoid: false
+            data: {}
+            nodes:
+              - object: text
+                leaves:
+                  - object: leaf
+                    text: >-
+                      This endpoint retrieves the protocol systems available in
+                      the indexer.
+                    marks: []
+      x-gitbook-description-html: >-
+        <p>This endpoint retrieves the protocol systems available in the
+        indexer.</p>
+  /v1/tokens:
+    post:
+      tags:
+        - rpc
+      summary: Retrieve tokens
+      description: >-
+        This endpoint retrieves tokens for a specific execution environment,
+        filtered by various
+
+        criteria. The tokens are returned in a paginated format.
+      operationId: tokens
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TokensRequestBody"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokensRequestResponse"
+          x-gitbook-description-html: <p>OK</p>
+      security:
+        - apiKey: []
+      x-gitbook-description-document:
+        object: document
+        data:
+          schemaVersion: 8
+        nodes:
+          - object: block
+            type: paragraph
+            isVoid: false
+            data: {}
+            nodes:
+              - object: text
+                leaves:
+                  - object: leaf
+                    text: >-
+                      This endpoint retrieves tokens for a specific execution
+                      environment, filtered by various
+
+                      criteria. The tokens are returned in a paginated format.
+                    marks: []
+      x-gitbook-description-html: >-
+        <p>This endpoint retrieves tokens for a specific execution environment,
+        filtered by various<br>criteria. The tokens are returned in a paginated
+        format.</p>
+components:
+  schemas:
+    AccountUpdate:
+      type: object
+      required:
+        - address
+        - chain
+        - slots
+        - change
+      properties:
+        address:
+          type: array
+          items:
+            type: string
+        balance:
+          type: string
+          nullable: true
+        chain:
+          $ref: "#/components/schemas/Chain"
+        change:
+          $ref: "#/components/schemas/ChangeType"
+        code:
+          type: string
+          nullable: true
+        slots:
+          type: object
+          additionalProperties:
+            type: string
+    BlockParam:
+      type: object
+      properties:
+        chain:
+          allOf:
+            - $ref: "#/components/schemas/Chain"
+          nullable: true
+        hash:
+          type: string
+          nullable: true
+        number:
+          type: integer
+          format: int64
+          nullable: true
+      additionalProperties: false
+    Chain:
+      type: string
+      description: Currently supported Blockchains
+      enum:
+        - ethereum
+        - starknet
+        - zksync
+        - arbitrum
+        - base
+        - unichain
+      x-gitbook-description-html: <p>Currently supported Blockchains</p>
+    ChangeType:
+      type: string
+      enum:
+        - Update
+        - Deletion
+        - Creation
+        - Unspecified
+    ContractId:
+      type: object
+      required:
+        - address
+        - chain
+      properties:
+        address:
+          type: string
+        chain:
+          $ref: "#/components/schemas/Chain"
+      additionalProperties: false
+    Health:
+      oneOf:
+        - type: object
+          required:
+            - status
+          properties:
+            status:
+              type: string
+              enum:
+                - Ready
+        - type: object
+          required:
+            - status
+            - message
+          properties:
+            message:
+              type: string
+            status:
+              type: string
+              enum:
+                - Starting
+        - type: object
+          required:
+            - status
+            - message
+          properties:
+            message:
+              type: string
+            status:
+              type: string
+              enum:
+                - NotReady
+      example:
+        message: No db connection
+        status: NotReady
+      discriminator:
+        propertyName: status
+    PaginationParams:
+      type: object
+      description: Pagination parameter
+      properties:
+        page:
+          type: integer
+          format: int64
+          description: What page to retrieve
+          x-gitbook-description-html: <p>What page to retrieve</p>
+        page_size:
+          type: integer
+          format: int64
+          description: How many results to return per page
+          x-gitbook-description-html: <p>How many results to return per page</p>
+      additionalProperties: false
+      x-gitbook-description-html: <p>Pagination parameter</p>
+    PaginationResponse:
+      type: object
+      required:
+        - page
+        - page_size
+        - total
+      properties:
+        page:
+          type: integer
+          format: int64
+        page_size:
+          type: integer
+          format: int64
+        total:
+          type: integer
+          format: int64
+          description: The total number of items available across all pages of results
+          x-gitbook-description-html: >-
+            <p>The total number of items available across all pages of
+            results</p>
+      additionalProperties: false
+    ProtocolComponent:
+      type: object
+      description: Represents the static parts of a protocol component.
+      required:
+        - id
+        - protocol_system
+        - protocol_type_name
+        - chain
+        - tokens
+        - contract_ids
+        - static_attributes
+        - creation_tx
+        - created_at
+      properties:
+        chain:
+          $ref: "#/components/schemas/Chain"
+        change:
+          $ref: "#/components/schemas/ChangeType"
+        contract_ids:
+          type: array
+          items:
+            type: string
+          description: >-
+            Contract addresses involved in the components operations (may be
+            empty for
+
+            native implementations)
+          x-gitbook-description-html: >-
+            <p>Contract addresses involved in the components operations (may be
+            empty for
+
+            native implementations)</p>
+        created_at:
+          type: string
+          format: date-time
+          description: Date time of creation in UTC time
+          x-gitbook-description-html: <p>Date time of creation in UTC time</p>
+        creation_tx:
+          type: string
+          description: Transaction hash which created this component
+          x-gitbook-description-html: <p>Transaction hash which created this component</p>
+        id:
+          type: string
+          description: Unique identifier for this component
+          x-gitbook-description-html: <p>Unique identifier for this component</p>
+        protocol_system:
+          type: string
+          description: Protocol system this component is part of
+          x-gitbook-description-html: <p>Protocol system this component is part of</p>
+        protocol_type_name:
+          type: string
+          description: Type of the protocol system
+          x-gitbook-description-html: <p>Type of the protocol system</p>
+        static_attributes:
+          type: object
+          description: Constant attributes of the component
+          additionalProperties:
+            type: string
+          x-gitbook-description-html: <p>Constant attributes of the component</p>
+        tokens:
+          type: array
+          items:
+            type: string
+          description: Token addresses the component operates on
+          x-gitbook-description-html: <p>Token addresses the component operates on</p>
+      x-gitbook-description-html: <p>Represents the static parts of a protocol component.</p>
+    ProtocolComponentRequestResponse:
+      type: object
+      description: Response from Tycho server for a protocol components request.
+      required:
+        - protocol_components
+        - pagination
+      properties:
+        pagination:
+          $ref: "#/components/schemas/PaginationResponse"
+        protocol_components:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProtocolComponent"
+      x-gitbook-description-html: <p>Response from Tycho server for a protocol components request.</p>
+    ProtocolComponentsRequestBody:
+      type: object
+      required:
+        - protocol_system
+      properties:
+        chain:
+          $ref: "#/components/schemas/Chain"
+        component_ids:
+          type: array
+          items:
+            type: string
+          description: Filter by component ids
+          nullable: true
+          x-gitbook-description-html: <p>Filter by component ids</p>
+        pagination:
+          $ref: "#/components/schemas/PaginationParams"
+        protocol_system:
+          type: string
+          description: >-
+            Filters by protocol, required to correctly apply unconfirmed state
+            from
+
+            ReorgBuffers
+          x-gitbook-description-html: >-
+            <p>Filters by protocol, required to correctly apply unconfirmed
+            state from
+
+            ReorgBuffers</p>
+        tvl_gt:
+          type: number
+          format: double
+          description: >-
+            The minimum TVL of the protocol components to return, denoted in the
+            chain's
+
+            native token.
+          nullable: true
+          x-gitbook-description-html: >-
+            <p>The minimum TVL of the protocol components to return, denoted in
+            the chain's
+
+            native token.</p>
+      additionalProperties: false
+    ProtocolId:
+      type: object
+      required:
+        - id
+        - chain
+      properties:
+        chain:
+          $ref: "#/components/schemas/Chain"
+        id:
+          type: string
+      additionalProperties: false
+      deprecated: true
+    ProtocolStateDelta:
+      type: object
+      description: Represents a change in protocol state.
+      required:
+        - component_id
+        - updated_attributes
+        - deleted_attributes
+      properties:
+        component_id:
+          type: string
+        deleted_attributes:
+          type: array
+          items:
+            type: string
+          uniqueItems: true
+        updated_attributes:
+          type: object
+          additionalProperties:
+            type: string
+      x-gitbook-description-html: <p>Represents a change in protocol state.</p>
+    ProtocolStateRequestBody:
+      type: object
+      description: Max page size supported is 100
+      required:
+        - protocol_system
+      properties:
+        chain:
+          $ref: "#/components/schemas/Chain"
+        include_balances:
+          type: boolean
+          description: >-
+            Whether to include account balances in the response. Defaults to
+            true.
+          x-gitbook-description-html: >-
+            <p>Whether to include account balances in the response. Defaults to
+            true.</p>
+        pagination:
+          $ref: "#/components/schemas/PaginationParams"
+        protocol_ids:
+          type: array
+          items:
+            type: string
+          description: Filters response by protocol components ids
+          nullable: true
+          x-gitbook-description-html: <p>Filters response by protocol components ids</p>
+        protocol_system:
+          type: string
+          description: >-
+            Filters by protocol, required to correctly apply unconfirmed state
+            from
+
+            ReorgBuffers
+          x-gitbook-description-html: >-
+            <p>Filters by protocol, required to correctly apply unconfirmed
+            state from
+
+            ReorgBuffers</p>
+        version:
+          $ref: "#/components/schemas/VersionParam"
+      additionalProperties: false
+      x-gitbook-description-html: <p>Max page size supported is 100</p>
+    ProtocolStateRequestResponse:
+      type: object
+      required:
+        - states
+        - pagination
+      properties:
+        pagination:
+          $ref: "#/components/schemas/PaginationResponse"
+        states:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResponseProtocolState"
+    ProtocolSystemsRequestBody:
+      type: object
+      properties:
+        chain:
+          $ref: "#/components/schemas/Chain"
+        pagination:
+          $ref: "#/components/schemas/PaginationParams"
+      additionalProperties: false
+    ProtocolSystemsRequestResponse:
+      type: object
+      required:
+        - protocol_systems
+        - pagination
+      properties:
+        pagination:
+          $ref: "#/components/schemas/PaginationResponse"
+        protocol_systems:
+          type: array
+          items:
+            type: string
+          description: List of currently supported protocol systems
+          x-gitbook-description-html: <p>List of currently supported protocol systems</p>
+    ResponseAccount:
+      type: object
+      description: >-
+        Account struct for the response from Tycho server for a contract state
+        request.
+
+
+        Code is serialized as a hex string instead of a list of bytes.
+      required:
+        - chain
+        - address
+        - title
+        - slots
+        - native_balance
+        - token_balances
+        - code
+        - code_hash
+        - balance_modify_tx
+        - code_modify_tx
+      properties:
+        address:
+          type: string
+          description: The address of the account as hex encoded string
+          example: "0xc9f2e6ea1637E499406986ac50ddC92401ce1f58"
+          x-gitbook-description-html: <p>The address of the account as hex encoded string</p>
+        balance_modify_tx:
+          type: string
+          description: Transaction hash which last modified native balance
+          example: "0x8f1133bfb054a23aedfe5d25b1d81b96195396d8b88bd5d4bcf865fc1ae2c3f4"
+          x-gitbook-description-html: <p>Transaction hash which last modified native balance</p>
+        chain:
+          $ref: "#/components/schemas/Chain"
+        code:
+          type: string
+          description: The accounts code as hex encoded string
+          example: "0xBADBABE"
+          x-gitbook-description-html: <p>The accounts code as hex encoded string</p>
+        code_hash:
+          type: string
+          description: The hash of above code
+          example: "0x123456789"
+          x-gitbook-description-html: <p>The hash of above code</p>
+        code_modify_tx:
+          type: string
+          description: Transaction hash which last modified code
+          example: "0x8f1133bfb054a23aedfe5d25b1d81b96195396d8b88bd5d4bcf865fc1ae2c3f4"
+          x-gitbook-description-html: <p>Transaction hash which last modified code</p>
+        creation_tx:
+          type: string
+          description: Transaction hash which created the account
+          example: "0x8f1133bfb054a23aedfe5d25b1d81b96195396d8b88bd5d4bcf865fc1ae2c3f4"
+          nullable: true
+          x-gitbook-description-html: <p>Transaction hash which created the account</p>
+        native_balance:
+          type: string
+          description: The balance of the account in the native token
+          example: "0x00"
+          x-gitbook-description-html: <p>The balance of the account in the native token</p>
+        slots:
+          type: object
+          description: Contract storage map of hex encoded string values
+          additionalProperties:
+            type: string
+          example:
+            0x....: 0x....
+          x-gitbook-description-html: <p>Contract storage map of hex encoded string values</p>
+        title:
+          type: string
+          description: >-
+            The title of the account usualy specifying its function within the
+            protocol
+          example: Protocol Vault
+          x-gitbook-description-html: >-
+            <p>The title of the account usualy specifying its function within
+            the protocol</p>
+        token_balances:
+          type: object
+          description: >-
+            Balances of this account in other tokens (only tokens balance that
+            are
+
+            relevant to the protocol are returned here)
+          additionalProperties:
+            type: string
+          example:
+            0x....: 0x....
+          x-gitbook-description-html: >-
+            <p>Balances of this account in other tokens (only tokens balance
+            that are
+
+            relevant to the protocol are returned here)</p>
+      x-gitbook-description-html: >-
+        <p>Account struct for the response from Tycho server for a contract
+        state request.</p>
+
+        <p>Code is serialized as a hex string instead of a list of bytes.</p>
+    ResponseProtocolState:
+      type: object
+      description: >-
+        Protocol State struct for the response from Tycho server for a protocol
+        state request.
+      required:
+        - component_id
+        - attributes
+        - balances
+      properties:
+        attributes:
+          type: object
+          description: |-
+            Attributes of the component. If an attribute's value is a `bigint`,
+            it will be encoded as a big endian signed hex string.
+          additionalProperties:
+            type: string
+          x-gitbook-description-html: >-
+            <p>Attributes of the component. If an attribute's value is a
+            <code>bigint</code>,
+
+            it will be encoded as a big endian signed hex string.</p>
+        balances:
+          type: object
+          description: Sum aggregated balances of the component
+          additionalProperties:
+            type: string
+          x-gitbook-description-html: <p>Sum aggregated balances of the component</p>
+        component_id:
+          type: string
+          description: Component id this state belongs to
+          x-gitbook-description-html: <p>Component id this state belongs to</p>
+      x-gitbook-description-html: >-
+        <p>Protocol State struct for the response from Tycho server for a
+        protocol state request.</p>
+    ResponseToken:
+      type: object
+      description: Token struct for the response from Tycho server for a tokens request.
+      required:
+        - chain
+        - address
+        - symbol
+        - decimals
+        - tax
+        - gas
+        - quality
+      properties:
+        address:
+          type: string
+          description: The address of this token as hex encoded string
+          example: "0xc9f2e6ea1637E499406986ac50ddC92401ce1f58"
+          x-gitbook-description-html: <p>The address of this token as hex encoded string</p>
+        chain:
+          $ref: "#/components/schemas/Chain"
+        decimals:
+          type: integer
+          format: int32
+          description: The number of decimals used to represent token values
+          minimum: 0
+          x-gitbook-description-html: <p>The number of decimals used to represent token values</p>
+        gas:
+          type: array
+          items:
+            type: integer
+            format: int64
+            nullable: true
+            minimum: 0
+          description: Gas usage of the token, currently is always a single averaged value
+          x-gitbook-description-html: >-
+            <p>Gas usage of the token, currently is always a single averaged
+            value</p>
+        quality:
+          type: integer
+          format: int32
+          description: |-
+            Quality is between 0-100, where:
+            - 100: Normal ERC-20 Token behavior
+            - 75: Rebasing token
+            - 50: Fee-on-transfer token
+            - 10: Token analysis failed at first detection
+            - 5: Token analysis failed multiple times (after creation)
+            - 0: Failed to extract attributes, like Decimal or Symbol
+          minimum: 0
+          x-gitbook-description-html: |-
+            <p>Quality is between 0-100, where:</p>
+            <ul>
+            <li>100: Normal ERC-20 Token behavior</li>
+            <li>75: Rebasing token</li>
+            <li>50: Fee-on-transfer token</li>
+            <li>10: Token analysis failed at first detection</li>
+            <li>5: Token analysis failed multiple times (after creation)</li>
+            <li>0: Failed to extract attributes, like Decimal or Symbol</li>
+            </ul>
+        symbol:
+          type: string
+          description: A shorthand symbol for this token (not unique)
+          example: WETH
+          x-gitbook-description-html: <p>A shorthand symbol for this token (not unique)</p>
+        tax:
+          type: integer
+          format: int64
+          description: The tax this token charges on transfers in basis points
+          minimum: 0
+          x-gitbook-description-html: <p>The tax this token charges on transfers in basis points</p>
+      x-gitbook-description-html: >-
+        <p>Token struct for the response from Tycho server for a tokens
+        request.</p>
+    StateRequestBody:
+      type: object
+      description: Maximum page size for this endpoint is 100
+      properties:
+        chain:
+          $ref: "#/components/schemas/Chain"
+        contract_ids:
+          type: array
+          items:
+            type: string
+          description: Filters response by contract addresses
+          nullable: true
+          x-gitbook-description-html: <p>Filters response by contract addresses</p>
+        pagination:
+          $ref: "#/components/schemas/PaginationParams"
+        protocol_system:
+          type: string
+          description: >-
+            Does not filter response, only required to correctly apply
+            unconfirmed state
+
+            from ReorgBuffers
+          x-gitbook-description-html: >-
+            <p>Does not filter response, only required to correctly apply
+            unconfirmed state
+
+            from ReorgBuffers</p>
+        version:
+          $ref: "#/components/schemas/VersionParam"
+      additionalProperties: false
+      x-gitbook-description-html: <p>Maximum page size for this endpoint is 100</p>
+    StateRequestResponse:
+      type: object
+      description: Response from Tycho server for a contract state request.
+      required:
+        - accounts
+        - pagination
+      properties:
+        accounts:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResponseAccount"
+        pagination:
+          $ref: "#/components/schemas/PaginationResponse"
+      x-gitbook-description-html: <p>Response from Tycho server for a contract state request.</p>
+    TokensRequestBody:
+      type: object
+      properties:
+        chain:
+          $ref: "#/components/schemas/Chain"
+        min_quality:
+          type: integer
+          format: int32
+          description: |-
+            Quality is between 0-100, where:
+            - 100: Normal ERC-20 Token behavior
+            - 75: Rebasing token
+            - 50: Fee-on-transfer token
+            - 10: Token analysis failed at first detection
+            - 5: Token analysis failed multiple times (after creation)
+            - 0: Failed to extract attributes, like Decimal or Symbol
+          nullable: true
+          x-gitbook-description-html: |-
+            <p>Quality is between 0-100, where:</p>
+            <ul>
+            <li>100: Normal ERC-20 Token behavior</li>
+            <li>75: Rebasing token</li>
+            <li>50: Fee-on-transfer token</li>
+            <li>10: Token analysis failed at first detection</li>
+            <li>5: Token analysis failed multiple times (after creation)</li>
+            <li>0: Failed to extract attributes, like Decimal or Symbol</li>
+            </ul>
+        pagination:
+          $ref: "#/components/schemas/PaginationParams"
+        token_addresses:
+          type: array
+          items:
+            type: string
+          description: Filters tokens by addresses
+          nullable: true
+          x-gitbook-description-html: <p>Filters tokens by addresses</p>
+        traded_n_days_ago:
+          type: integer
+          format: int64
+          description: Filters tokens by recent trade activity
+          nullable: true
+          minimum: 0
+          x-gitbook-description-html: <p>Filters tokens by recent trade activity</p>
+      additionalProperties: false
+    TokensRequestResponse:
+      type: object
+      description: Response from Tycho server for a tokens request.
+      required:
+        - tokens
+        - pagination
+      properties:
+        pagination:
+          $ref: "#/components/schemas/PaginationResponse"
+        tokens:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResponseToken"
+      x-gitbook-description-html: <p>Response from Tycho server for a tokens request.</p>
+    VersionParam:
+      type: object
+      description: >-
+        The version of the requested state, given as either a timestamp or a
+        block.
+
+
+        If block is provided, the state at that exact block is returned. Will
+        error if the block
+
+        has not been processed yet. If timestamp is provided, the state at the
+        latest block before
+
+        that timestamp is returned.
+
+        Defaults to the current time.
+      properties:
+        block:
+          allOf:
+            - $ref: "#/components/schemas/BlockParam"
+          nullable: true
+        timestamp:
+          type: string
+          format: date-time
+          nullable: true
+      additionalProperties: false
+      x-gitbook-description-html: >-
+        <p>The version of the requested state, given as either a timestamp or a
+        block.</p>
+
+        <p>If block is provided, the state at that exact block is returned. Will
+        error if the block
+
+        has not been processed yet. If timestamp is provided, the state at the
+        latest block before
+
+        that timestamp is returned.
+
+        Defaults to the current time.</p>
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: authorization
+      description: Use 'sampletoken' as value for testing
+      x-gitbook-description-html: <p>Use 'sampletoken' as value for testing</p>

--- a/tycho-common/src/models/blockchain.rs
+++ b/tycho-common/src/models/blockchain.rs
@@ -364,11 +364,11 @@ pub struct EntryPointWithTracingParams {
     /// The entry point to trace, containing the target contract address and function signature
     pub entry_point: EntryPoint,
     /// The tracing parameters for this entry point
-    pub params: EntryPointTracingParams,
+    pub params: TracingParams,
 }
 
 impl EntryPointWithTracingParams {
-    pub fn new(entry_point: EntryPoint, params: EntryPointTracingParams) -> Self {
+    pub fn new(entry_point: EntryPoint, params: TracingParams) -> Self {
         Self { entry_point, params }
     }
 }
@@ -376,13 +376,13 @@ impl EntryPointWithTracingParams {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, Hash)]
 /// An entry point to trace. Different types of entry points tracing will be supported in the
 /// future. Like RPC debug tracing, symbolic execution, etc.
-pub enum EntryPointTracingParams {
+pub enum TracingParams {
     /// Uses RPC calls to retrieve the called addresses and retriggers
-    RPCTracer(RPCTracerEntryPoint),
+    RPCTracer(RPCTracerParams),
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Eq, Hash)]
-pub struct RPCTracerEntryPoint {
+pub struct RPCTracerParams {
     /// The caller address of the transaction, if not provided tracing will use the default value
     /// for an address defined by the VM.
     pub caller: Option<Address>,
@@ -390,14 +390,14 @@ pub struct RPCTracerEntryPoint {
     pub calldata: Bytes,
 }
 
-impl RPCTracerEntryPoint {
+impl RPCTracerParams {
     pub fn new(caller: Option<Address>, calldata: Bytes) -> Self {
         Self { caller, calldata }
     }
 }
 
 // Ensure serialization order, required by the storage layer
-impl Serialize for RPCTracerEntryPoint {
+impl Serialize for RPCTracerParams {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -698,7 +698,7 @@ pub mod fixtures {
 
         use serde_json;
 
-        let entry_point = RPCTracerEntryPoint::new(
+        let entry_point = RPCTracerParams::new(
             Some(Address::from_str("0x1234567890123456789012345678901234567890").unwrap()),
             Bytes::from_str("0xabcdef").unwrap(),
         );
@@ -709,7 +709,7 @@ pub mod fixtures {
         assert!(serialized.find("\"caller\"").unwrap() < serialized.find("\"calldata\"").unwrap());
 
         // Verify we can deserialize it back
-        let deserialized: RPCTracerEntryPoint = serde_json::from_str(&serialized).unwrap();
+        let deserialized: RPCTracerParams = serde_json::from_str(&serialized).unwrap();
         assert_eq!(entry_point, deserialized);
     }
 }

--- a/tycho-common/src/storage.rs
+++ b/tycho-common/src/storage.rs
@@ -12,7 +12,7 @@ use crate::{
     dto,
     models::{
         blockchain::{
-            Block, EntryPoint, EntryPointTracingParams, EntryPointWithTracingParams,
+            Block, EntryPoint, TracingParams, EntryPointWithTracingParams,
             TracedEntryPoint, TracingResult, Transaction,
         },
         contract::{Account, AccountBalance, AccountDelta},
@@ -512,7 +512,7 @@ pub trait EntryPointGateway {
         &self,
         entry_points_params: &[(
             EntryPointId,
-            Vec<(EntryPointTracingParams, Option<ComponentId>)>,
+            Vec<(TracingParams, Option<ComponentId>)>,
         )],
     ) -> Result<(), StorageError>;
 

--- a/tycho-common/src/storage.rs
+++ b/tycho-common/src/storage.rs
@@ -12,8 +12,8 @@ use crate::{
     dto,
     models::{
         blockchain::{
-            Block, EntryPoint, TracingParams, EntryPointWithTracingParams,
-            TracedEntryPoint, TracingResult, Transaction,
+            Block, EntryPoint, EntryPointWithTracingParams, TracedEntryPoint, TracingParams,
+            TracingResult, Transaction,
         },
         contract::{Account, AccountBalance, AccountDelta},
         protocol::{
@@ -504,16 +504,13 @@ pub trait EntryPointGateway {
     /// Upserts a list of entry points into the database.
     async fn upsert_entry_points(
         &self,
-        entry_points: &[(ComponentId, Vec<EntryPoint>)],
+        entry_points: &HashMap<ComponentId, HashSet<EntryPoint>>,
     ) -> Result<(), StorageError>;
 
     /// Upserts a list of entry points with their tracing params into the database.
     async fn upsert_entry_point_tracing_params(
         &self,
-        entry_points_params: &[(
-            EntryPointId,
-            Vec<(TracingParams, Option<ComponentId>)>,
-        )],
+        entry_points_params: &HashMap<EntryPointId, HashSet<(TracingParams, Option<ComponentId>)>>,
     ) -> Result<(), StorageError>;
 
     /// Retrieves a list of entry points from the database.

--- a/tycho-common/src/storage.rs
+++ b/tycho-common/src/storage.rs
@@ -11,7 +11,10 @@ use thiserror::Error;
 use crate::{
     dto,
     models::{
-        blockchain::{Block, EntryPointWithData, TracedEntryPoint, TracingResult, Transaction},
+        blockchain::{
+            Block, EntryPoint, EntryPointTracingData, EntryPointWithData, TracedEntryPoint,
+            TracingResult, Transaction,
+        },
         contract::{Account, AccountBalance, AccountDelta},
         protocol::{
             ComponentBalance, ProtocolComponent, ProtocolComponentState,
@@ -498,11 +501,23 @@ impl EntryPointFilter {
 // Trait for entry point gateway operations.
 #[async_trait]
 pub trait EntryPointGateway {
-    /// Upserts a list of entry points with their tracing data into the database.
-    async fn upsert_entry_points_with_data(
+    /// Upserts a list of entry points into the database.
+    async fn upsert_entry_points(
         &self,
-        entry_points: &[(ComponentId, Vec<EntryPointWithData>)],
+        entry_points: &[(ComponentId, Vec<EntryPoint>)],
     ) -> Result<(), StorageError>;
+
+    /// Upserts a list of entry points with their tracing data into the database.
+    async fn upsert_entry_point_tracing_data(
+        &self,
+        entry_points_data: &[(EntryPointId, Vec<(EntryPointTracingData, Option<ComponentId>)>)],
+    ) -> Result<(), StorageError>;
+
+    /// Retrieves a list of entry points from the database.
+    async fn get_entry_points(
+        &self,
+        filter: EntryPointFilter,
+    ) -> Result<Vec<EntryPoint>, StorageError>;
 
     /// Retrieves a list of entry points with their tracing data from the database.
     async fn get_entry_points_with_data(

--- a/tycho-common/src/storage.rs
+++ b/tycho-common/src/storage.rs
@@ -12,8 +12,8 @@ use crate::{
     dto,
     models::{
         blockchain::{
-            Block, EntryPoint, EntryPointTracingData, EntryPointWithData, TracedEntryPoint,
-            TracingResult, Transaction,
+            Block, EntryPoint, EntryPointTracingParams, EntryPointWithTracingParams,
+            TracedEntryPoint, TracingResult, Transaction,
         },
         contract::{Account, AccountBalance, AccountDelta},
         protocol::{
@@ -507,10 +507,13 @@ pub trait EntryPointGateway {
         entry_points: &[(ComponentId, Vec<EntryPoint>)],
     ) -> Result<(), StorageError>;
 
-    /// Upserts a list of entry points with their tracing data into the database.
-    async fn upsert_entry_point_tracing_data(
+    /// Upserts a list of entry points with their tracing params into the database.
+    async fn upsert_entry_point_tracing_params(
         &self,
-        entry_points_data: &[(EntryPointId, Vec<(EntryPointTracingData, Option<ComponentId>)>)],
+        entry_points_params: &[(
+            EntryPointId,
+            Vec<(EntryPointTracingParams, Option<ComponentId>)>,
+        )],
     ) -> Result<(), StorageError>;
 
     /// Retrieves a list of entry points from the database.
@@ -520,10 +523,10 @@ pub trait EntryPointGateway {
     ) -> Result<Vec<EntryPoint>, StorageError>;
 
     /// Retrieves a list of entry points with their tracing data from the database.
-    async fn get_entry_points_with_data(
+    async fn get_entry_points_tracing_params(
         &self,
         filter: EntryPointFilter,
-    ) -> Result<Vec<EntryPointWithData>, StorageError>;
+    ) -> Result<Vec<EntryPointWithTracingParams>, StorageError>;
 
     /// Upserts a list of traced entry points into the database.
     async fn upsert_traced_entry_points(

--- a/tycho-common/src/traits.rs
+++ b/tycho-common/src/traits.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 
 use crate::{
     models::{
-        blockchain::{Block, BlockTag, EntryPointWithData, TracedEntryPoint},
+        blockchain::{Block, BlockTag, EntryPointWithTracingParams, TracedEntryPoint},
         contract::AccountDelta,
         token::{CurrencyToken, TokenQuality, TransferCost, TransferTax},
         Address, Balance, BlockHash,
@@ -115,6 +115,6 @@ pub trait EntryPointTracer {
     async fn trace(
         &self,
         block_hash: BlockHash,
-        entry_points: Vec<EntryPointWithData>,
+        entry_points: Vec<EntryPointWithTracingParams>,
     ) -> Result<Vec<TracedEntryPoint>, Self::Error>;
 }

--- a/tycho-ethereum/src/entrypoint_tracer/tracer.rs
+++ b/tycho-ethereum/src/entrypoint_tracer/tracer.rs
@@ -16,9 +16,7 @@ use thiserror::Error;
 use tycho_common::{
     keccak256,
     models::{
-        blockchain::{
-            TracingParams, EntryPointWithTracingParams, TracedEntryPoint, TracingResult,
-        },
+        blockchain::{EntryPointWithTracingParams, TracedEntryPoint, TracingParams, TracingResult},
         Address, BlockHash,
     },
     traits::EntryPointTracer,

--- a/tycho-ethereum/src/entrypoint_tracer/tracer.rs
+++ b/tycho-ethereum/src/entrypoint_tracer/tracer.rs
@@ -17,7 +17,7 @@ use tycho_common::{
     keccak256,
     models::{
         blockchain::{
-            EntryPointTracingParams, EntryPointWithTracingParams, TracedEntryPoint, TracingResult,
+            TracingParams, EntryPointWithTracingParams, TracedEntryPoint, TracingResult,
         },
         Address, BlockHash,
     },
@@ -81,7 +81,7 @@ impl EntryPointTracer for EVMEntrypointService {
         let mut results = Vec::new();
         for entry_point in &entry_points {
             match &entry_point.params {
-                EntryPointTracingParams::RPCTracer(ref rpc_entry_point) => {
+                TracingParams::RPCTracer(ref rpc_entry_point) => {
                     // First call to get the list of called addresses
                     // TODO: Can we only use one call to get the retriggers and called addresses?
                     let call_trace = self
@@ -188,7 +188,7 @@ mod tests {
     use std::env;
 
     use tycho_common::{
-        models::blockchain::{EntryPoint, RPCTracerEntryPoint},
+        models::blockchain::{EntryPoint, RPCTracerParams},
         Bytes,
     };
 
@@ -206,7 +206,7 @@ mod tests {
                     Bytes::from_str("0xEdf63cce4bA70cbE74064b7687882E71ebB0e988").unwrap(),
                     "getRate()".to_string(),
                 ),
-                EntryPointTracingParams::RPCTracer(RPCTracerEntryPoint::new(
+                TracingParams::RPCTracer(RPCTracerParams::new(
                     None,
                     Bytes::from(&keccak256("getRate()").to_vec()[0..4]),
                 )),
@@ -217,7 +217,7 @@ mod tests {
                     Bytes::from_str("0x8f4E8439b970363648421C692dd897Fb9c0Bd1D9").unwrap(),
                     "getRate()".to_string(),
                 ),
-                EntryPointTracingParams::RPCTracer(RPCTracerEntryPoint::new(
+                TracingParams::RPCTracer(RPCTracerParams::new(
                     None,
                     Bytes::from(&keccak256("getRate()")[0..4]),
                 )),

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    slice,
     str::FromStr,
     sync::Arc,
 };
@@ -1310,7 +1311,7 @@ impl ExtractorGateway for ExtractorPgGateway {
                 .await?;
         }
         self.state_gateway
-            .upsert_block(&[changes.block.clone()])
+            .upsert_block(slice::from_ref(&changes.block))
             .await?;
 
         let mut new_protocol_components: Vec<ProtocolComponent> = vec![];
@@ -1325,7 +1326,7 @@ impl ExtractorGateway for ExtractorPgGateway {
 
             // Insert transaction
             self.state_gateway
-                .upsert_tx(&[tx_update.tx.clone()])
+                .upsert_tx(slice::from_ref(&tx_update.tx))
                 .await?;
 
             let hash: TxHash = tx_update.tx.hash.clone();

--- a/tycho-indexer/src/main.rs
+++ b/tycho-indexer/src/main.rs
@@ -3,7 +3,7 @@ use std::{
     collections::HashMap,
     fs::File,
     io::Read,
-    process,
+    process, slice,
     str::FromStr,
     sync::{mpsc, Arc},
 };
@@ -457,12 +457,12 @@ async fn initialize_accounts(
         .await;
 
     cached_gw
-        .upsert_block(&[block.clone()])
+        .upsert_block(slice::from_ref(&block))
         .await
         .expect("Failed to insert block");
 
     cached_gw
-        .upsert_tx(&[tx.clone()])
+        .upsert_tx(slice::from_ref(&tx))
         .await
         .expect("Failed to insert tx");
 

--- a/tycho-storage/migrations/2025-04-09_dci_entry_points/down.sql
+++ b/tycho-storage/migrations/2025-04-09_dci_entry_points/down.sql
@@ -1,6 +1,7 @@
 DROP TABLE IF EXISTS "entry_point_tracing_result";
-DROP TABLE IF EXISTS "entry_point_tracing_data_calls_account";
-DROP TABLE IF EXISTS "protocol_component_holds_entry_point_tracing_data";
-DROP TABLE IF EXISTS "entry_point_tracing_data";
+DROP TABLE IF EXISTS "entry_point_tracing_params_calls_account";
+DROP TABLE IF EXISTS "debug_protocol_component_has_entry_point_tracing_params";
+DROP TABLE IF EXISTS "protocol_component_uses_entry_point";
+DROP TABLE IF EXISTS "entry_point_tracing_params";
 DROP TABLE IF EXISTS "entry_point";
 DROP TYPE IF EXISTS entry_point_tracing_type;

--- a/tycho-storage/migrations/2025-04-09_dci_entry_points/up.sql
+++ b/tycho-storage/migrations/2025-04-09_dci_entry_points/up.sql
@@ -23,10 +23,20 @@ CREATE TABLE IF NOT EXISTS "entry_point_tracing_data"(
     UNIQUE ("entry_point_id", "tracing_type", "data")
 );
 
+-- Keep tracks of the m2m relation between protocol components and entry point tracing data
+-- NOTE: Currently this is not mandatory, we should not rely on it for production code. It is only used for debugging purposes.
+-- Worst case scenario, we can delete the table
 CREATE TABLE IF NOT EXISTS "protocol_component_holds_entry_point_tracing_data"(
     "protocol_component_id" bigint REFERENCES "protocol_component"(id) ON DELETE CASCADE NOT NULL,
     "entry_point_tracing_data_id" bigint REFERENCES "entry_point_tracing_data"(id) ON DELETE CASCADE NOT NULL,
     PRIMARY KEY ("protocol_component_id", "entry_point_tracing_data_id")
+);
+
+-- Keep tracks of the m2m relation between protocol components and entry points
+CREATE TABLE IF NOT EXISTS "protocol_component_holds_entry_point"(
+    "protocol_component_id" bigint REFERENCES "protocol_component"(id) ON DELETE CASCADE NOT NULL,
+    "entry_point_id" bigint REFERENCES "entry_point"(id) ON DELETE CASCADE NOT NULL,
+    PRIMARY KEY ("protocol_component_id", "entry_point_id")
 );
 
 CREATE TABLE IF NOT EXISTS "entry_point_tracing_result"(

--- a/tycho-storage/src/postgres/cache.rs
+++ b/tycho-storage/src/postgres/cache.rs
@@ -42,7 +42,7 @@ use tycho_common::{
 
 use super::{PostgresError, PostgresGateway};
 
-type NewEntryPointParams = (models::blockchain::EntryPointTracingParams, Option<ComponentId>);
+type NewEntryPointParams = (models::blockchain::TracingParams, Option<ComponentId>);
 
 /// Represents different types of database write operations.
 #[derive(PartialEq, Clone, Debug)]
@@ -1184,7 +1184,7 @@ impl EntryPointGateway for CachedGateway {
         &self,
         entry_points_params: &[(
             models::EntryPointId,
-            Vec<(models::blockchain::EntryPointTracingParams, Option<ComponentId>)>,
+            Vec<(models::blockchain::TracingParams, Option<ComponentId>)>,
         )],
     ) -> Result<(), StorageError> {
         self.add_op(WriteOp::UpsertEntryPointTracingParams(entry_points_params.to_vec()))

--- a/tycho-storage/src/postgres/cache.rs
+++ b/tycho-storage/src/postgres/cache.rs
@@ -1249,7 +1249,7 @@ impl Gateway for CachedGateway {}
 
 #[cfg(test)]
 mod test_serial_db {
-    use std::{collections::HashSet, str::FromStr, time::Duration};
+    use std::{collections::HashSet, slice, str::FromStr, time::Duration};
 
     use tycho_common::models::ChangeType;
 
@@ -1517,11 +1517,11 @@ mod test_serial_db {
                 .start_transaction(&block_1, None)
                 .await;
             cached_gw
-                .upsert_block(&[block_1.clone()])
+                .upsert_block(slice::from_ref(&block_1))
                 .await
                 .expect("Upsert block 1 ok");
             cached_gw
-                .upsert_tx(&[tx_1.clone()])
+                .upsert_tx(slice::from_ref(&tx_1))
                 .await
                 .expect("Upsert tx 1 ok");
             cached_gw
@@ -1535,7 +1535,7 @@ mod test_serial_db {
                 .start_transaction(&block_2, None)
                 .await;
             cached_gw
-                .upsert_block(&[block_2.clone()])
+                .upsert_block(slice::from_ref(&block_2))
                 .await
                 .expect("Upsert block 2 ok");
             cached_gw
@@ -1549,7 +1549,7 @@ mod test_serial_db {
                 .start_transaction(&block_3, None)
                 .await;
             cached_gw
-                .upsert_block(&[block_3.clone()])
+                .upsert_block(slice::from_ref(&block_3))
                 .await
                 .expect("Upsert block 3 ok");
             cached_gw

--- a/tycho-storage/src/postgres/chain.rs
+++ b/tycho-storage/src/postgres/chain.rs
@@ -264,7 +264,7 @@ impl PostgresGateway {
 
 #[cfg(test)]
 mod test {
-    use std::{str::FromStr, time::Duration};
+    use std::{slice, str::FromStr, time::Duration};
 
     use diesel_async::AsyncConnection;
     use tycho_common::models::Chain;
@@ -360,7 +360,7 @@ mod test {
         let gw = EVMGateway::from_connection(&mut conn).await;
         let block = block("0xbadbabe000000000000000000000000000000000000000000000000000000000");
 
-        gw.upsert_block(&[block.clone()], &mut conn)
+        gw.upsert_block(slice::from_ref(&block), &mut conn)
             .await
             .unwrap();
         let retrieved_block = gw
@@ -384,7 +384,7 @@ mod test {
             yesterday_midnight(),
         );
 
-        gw.upsert_block(&[block.clone()], &mut conn)
+        gw.upsert_block(slice::from_ref(&block), &mut conn)
             .await
             .unwrap();
         let retrieved_block = gw
@@ -458,7 +458,7 @@ mod test {
             index: 1,
         };
 
-        gw.upsert_tx(&[tx.clone()], &mut conn)
+        gw.upsert_tx(slice::from_ref(&tx), &mut conn)
             .await
             .unwrap();
         let retrieved_tx = gw

--- a/tycho-storage/src/postgres/contract.rs
+++ b/tycho-storage/src/postgres/contract.rs
@@ -1,4 +1,7 @@
-use std::collections::{hash_map::Entry, HashMap, HashSet};
+use std::{
+    collections::{hash_map::Entry, HashMap, HashSet},
+    slice,
+};
 
 use chrono::{NaiveDateTime, Utc};
 use diesel::{
@@ -719,7 +722,7 @@ impl PostgresGateway {
         let chain = id.chain;
 
         let mut all_balances = self
-            .get_account_balances(&chain, Some(&[id.address.clone()]), version, true, conn)
+            .get_account_balances(&chain, Some(slice::from_ref(&id.address)), version, true, conn)
             .await?;
         let account_balances = all_balances
             .get_mut(&id.address)

--- a/tycho-storage/src/postgres/entry_point.rs
+++ b/tycho-storage/src/postgres/entry_point.rs
@@ -1,17 +1,12 @@
-#![allow(unused)] //TODO: Remove this once we have usage in extractors
-use std::{
-    collections::{HashMap, HashSet},
-    ops::Deref,
-};
+use std::collections::{HashMap, HashSet};
 
-use async_trait::async_trait;
 use diesel::{prelude::*, upsert::excluded};
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
-use itertools::Itertools;
 use tycho_common::{
     models::{
         blockchain::{
-            EntryPoint, EntryPointTracingData, EntryPointWithData, TracedEntryPoint, TracingResult,
+            EntryPoint, EntryPointTracingParams, EntryPointWithTracingParams, TracedEntryPoint,
+            TracingResult,
         },
         Chain, ComponentId, EntryPointId,
     },
@@ -21,15 +16,12 @@ use tycho_common::{
 
 use super::{
     orm::{
-        self, EntryPointTracingType, NewEntryPoint, NewEntryPointTracingData,
-        NewEntryPointTracingDataCallsAccount, NewEntryPointTracingResult,
-        NewProtocolComponentHoldsEntryPointTracingData,
+        self, EntryPointTracingType, NewEntryPoint, NewEntryPointTracingParams,
+        NewEntryPointTracingParamsCallsAccount, NewEntryPointTracingResult,
+        NewProtocolComponentHasEntryPointTracingParams, NewProtocolComponentUsesEntryPoint,
     },
     schema::{self},
     storage_error_from_diesel, PostgresError, PostgresGateway,
-};
-use crate::postgres::{
-    orm::NewProtocolComponentHoldsEntryPoint, schema::component_balance::new_balance,
 };
 
 impl PostgresGateway {
@@ -46,7 +38,7 @@ impl PostgresGateway {
         chain: &Chain,
         conn: &mut AsyncPgConnection,
     ) -> Result<(), StorageError> {
-        use schema::{entry_point::dsl::*, protocol_component_holds_entry_point::dsl::*};
+        use schema::{entry_point::dsl::*, protocol_component_uses_entry_point::dsl::*};
 
         let chain_id = self.get_chain_id(chain);
 
@@ -123,7 +115,7 @@ impl PostgresGateway {
                     }
                 };
 
-                pc_entry_point_links.push(NewProtocolComponentHoldsEntryPoint {
+                pc_entry_point_links.push(NewProtocolComponentUsesEntryPoint {
                     protocol_component_id: *pc_id,
                     entry_point_id: *ep_id,
                 });
@@ -133,7 +125,7 @@ impl PostgresGateway {
         // Insert links between protocol components and entry points
         // Design choice: we don't want to delete previously inserted links here, they are
         // cumulative
-        diesel::insert_into(protocol_component_holds_entry_point)
+        diesel::insert_into(protocol_component_uses_entry_point)
             .values(&pc_entry_point_links)
             .on_conflict_do_nothing()
             .execute(conn)
@@ -141,7 +133,7 @@ impl PostgresGateway {
             .map_err(|e| {
                 storage_error_from_diesel(
                     e,
-                    "ProtocolComponentHoldsEntryPoint",
+                    "ProtocolComponentUsesEntryPoint",
                     "Batch upsert",
                     None,
                 )
@@ -149,21 +141,22 @@ impl PostgresGateway {
         Ok(())
     }
 
-    /// Upsert entry point tracing data into the database.
+    /// Upsert entry point tracing params into the database.
     ///
     /// # Arguments
     ///
-    /// * `new_data` - A map of entry point ids to a list of tracing data and optional component id.
+    /// * `new_data` - A map of entry point ids to a list of tracing params and optional component
+    ///   id related to the tracing params.
     /// * `conn` - The database connection to use.
-    pub(crate) async fn upsert_entry_point_tracing_data(
+    pub(crate) async fn upsert_entry_point_tracing_params(
         &self,
-        new_data: &HashMap<EntryPointId, &Vec<(EntryPointTracingData, Option<ComponentId>)>>,
+        new_data: &HashMap<EntryPointId, &Vec<(EntryPointTracingParams, Option<ComponentId>)>>,
         chain: &Chain,
         conn: &mut AsyncPgConnection,
     ) -> Result<(), StorageError> {
         use schema::{
-            entry_point_tracing_data::dsl::*,
-            protocol_component_holds_entry_point_tracing_data::dsl::*,
+            debug_protocol_component_has_entry_point_tracing_params::dsl::*,
+            entry_point_tracing_params::dsl::*,
         };
 
         let input_external_ids: Vec<EntryPointId> = new_data
@@ -173,16 +166,16 @@ impl PostgresGateway {
         let entry_point_ids =
             orm::EntryPoint::ids_by_external_ids(&input_external_ids, conn).await?;
 
-        let mut new_tracing_data = Vec::new();
+        let mut new_tracing_params = Vec::new();
         for (ep_id, ep) in new_data.iter() {
             let entry_point_id_ = entry_point_ids
                 .get(ep_id)
                 .ok_or_else(|| {
                     StorageError::NotFound("EntryPoint".to_string(), ep_id.to_string())
                 })?;
-            for (_data, _) in ep.iter() {
-                let db_data = match _data {
-                    EntryPointTracingData::RPCTracer(rpc_tracer) => {
+            for (params, _) in ep.iter() {
+                let db_params = match params {
+                    EntryPointTracingParams::RPCTracer(rpc_tracer) => {
                         serde_json::to_value(rpc_tracer).map_err(|e| {
                             StorageError::Unexpected(format!(
                                 "Failed to serialize RPCTracerEntryPoint: {e}"
@@ -190,45 +183,47 @@ impl PostgresGateway {
                         })?
                     }
                 };
-                new_tracing_data.push(NewEntryPointTracingData {
+                new_tracing_params.push(NewEntryPointTracingParams {
                     entry_point_id: *entry_point_id_,
-                    tracing_type: EntryPointTracingType::from(_data),
-                    data: Some(db_data),
+                    tracing_type: EntryPointTracingType::from(params),
+                    data: Some(db_params),
                 });
             }
         }
 
-        diesel::insert_into(entry_point_tracing_data)
-            .values(&new_tracing_data)
+        diesel::insert_into(entry_point_tracing_params)
+            .values(&new_tracing_params)
             .on_conflict_do_nothing()
             .execute(conn)
             .await
-            .map_err(|e| storage_error_from_diesel(e, "EntryPointData", "Batch upsert", None))?;
+            .map_err(|e| {
+                storage_error_from_diesel(e, "EntryPointTracingParams", "Batch upsert", None)
+            })?;
 
-        let new_links_data: &Vec<(&EntryPointTracingData, &String)> = &new_data
+        let new_links: &Vec<(&EntryPointTracingParams, &String)> = &new_data
             .values()
             .flat_map(|ep| {
                 ep.iter()
-                    .filter_map(|(tracing_data, pc_ext_id)| {
+                    .filter_map(|(params, pc_ext_id)| {
                         pc_ext_id
                             .as_ref()
-                            .map(|pc_ext_id| (tracing_data, pc_ext_id))
+                            .map(|pc_ext_id| (params, pc_ext_id))
                     })
             })
             .collect::<Vec<_>>();
 
         // Insert links between protocol components and tracing params
-        if !new_links_data.is_empty() {
+        if !new_links.is_empty() {
             let chain_id = self.get_chain_id(chain);
 
-            // Fetch entry points data, we can't use .returning() on the insert above because it
-            // doesn't return the ids on conflicts.
-            let data_ids = orm::EntryPointTracingData::ids_by_entry_point_with_data(
+            // Fetch entry points tracing params, we can't use .returning() on the insert above
+            // because it doesn't return the ids on conflicts.
+            let params_ids = orm::EntryPointTracingParams::ids_by_entry_point_with_tracing_params(
                 &new_data
                     .iter()
                     .flat_map(|(ep_id, ep)| {
                         ep.iter()
-                            .map(|_data| (ep_id.clone(), _data.0.clone()))
+                            .map(|params| (ep_id.clone(), params.0.clone()))
                     })
                     .collect::<Vec<_>>(),
                 conn,
@@ -236,7 +231,7 @@ impl PostgresGateway {
             .await?;
 
             let pc_ids = orm::ProtocolComponent::ids_by_external_ids(
-                &new_links_data
+                &new_links
                     .iter()
                     .map(|(_, pc_ext_id)| pc_ext_id.as_str())
                     .collect::<Vec<_>>(),
@@ -249,8 +244,8 @@ impl PostgresGateway {
             .map(|(id_, ext_id)| (ext_id, id_))
             .collect::<HashMap<_, _>>();
 
-            let mut pc_tracing_data_links = Vec::new();
-            for (ep, pc_ext_id) in new_links_data.iter() {
+            let mut pc_tracing_params_links = Vec::new();
+            for (ep, pc_ext_id) in new_links.iter() {
                 let pc_id = match pc_ids.get(*pc_ext_id) {
                     Some(_id) => _id,
                     None => {
@@ -261,31 +256,31 @@ impl PostgresGateway {
                     }
                 };
 
-                let data_id = match data_ids.get(ep) {
+                let params_id = match params_ids.get(ep) {
                     Some(_id) => _id,
                     None => {
                         return Err(StorageError::NotFound(
-                            "EntryPointTracingData".to_string(),
+                            "EntryPointTracingParams".to_string(),
                             format!("{ep:?}"),
                         ));
                     }
                 };
 
-                pc_tracing_data_links.push(NewProtocolComponentHoldsEntryPointTracingData {
+                pc_tracing_params_links.push(NewProtocolComponentHasEntryPointTracingParams {
                     protocol_component_id: *pc_id,
-                    entry_point_tracing_data_id: *data_id,
+                    entry_point_tracing_params_id: *params_id,
                 });
             }
 
-            diesel::insert_into(protocol_component_holds_entry_point_tracing_data)
-                .values(&pc_tracing_data_links)
+            diesel::insert_into(debug_protocol_component_has_entry_point_tracing_params)
+                .values(&pc_tracing_params_links)
                 .on_conflict_do_nothing()
                 .execute(conn)
                 .await
                 .map_err(|e| {
                     storage_error_from_diesel(
                         e,
-                        "ProtocolComponentHoldsEntryPointData",
+                        "ProtocolComponentHasEntryPointTracingParams",
                         "Batch upsert",
                         None,
                     )
@@ -295,35 +290,35 @@ impl PostgresGateway {
         Ok(())
     }
 
-    /// Get entry points with data from the database.
+    /// Get entry points tracing params from the database.
     ///
     /// # Arguments
     ///
     /// * `filter` - The filter to apply to the query.
     /// * `conn` - The database connection to use.
-    pub(crate) async fn get_entry_points_with_data(
+    pub(crate) async fn get_entry_points_tracing_params(
         &self,
         filter: EntryPointFilter,
         conn: &mut AsyncPgConnection,
-    ) -> Result<Vec<EntryPointWithData>, StorageError> {
+    ) -> Result<Vec<EntryPointWithTracingParams>, StorageError> {
         use schema::{
-            entry_point as ep, entry_point_tracing_data as eptd, protocol_component as pc,
-            protocol_component_holds_entry_point as pchep,
+            entry_point as ep, entry_point_tracing_params as eptp, protocol_component as pc,
+            protocol_component_uses_entry_point as pcuep,
         };
 
         let ps_id = self.get_protocol_system_id(&filter.protocol_system);
         let results = schema::entry_point::table
-            .inner_join(eptd::table.on(ep::id.eq(eptd::entry_point_id)))
-            .inner_join(pchep::table.on(ep::id.eq(pchep::entry_point_id)))
-            .inner_join(pc::table.on(pchep::protocol_component_id.eq(pc::id)))
+            .inner_join(eptp::table.on(ep::id.eq(eptp::entry_point_id)))
+            .inner_join(pcuep::table.on(ep::id.eq(pcuep::entry_point_id)))
+            .inner_join(pc::table.on(pcuep::protocol_component_id.eq(pc::id)))
             .filter(pc::protocol_system_id.eq(ps_id))
-            .select((orm::EntryPoint::as_select(), orm::EntryPointTracingData::as_select()))
-            .load::<(orm::EntryPoint, orm::EntryPointTracingData)>(conn)
+            .select((orm::EntryPoint::as_select(), orm::EntryPointTracingParams::as_select()))
+            .load::<(orm::EntryPoint, orm::EntryPointTracingParams)>(conn)
             .await
             .map_err(|err| {
                 storage_error_from_diesel(
                     err,
-                    "EntryPointWithData",
+                    "EntryPointWithTracingParams",
                     "None",
                     Some(format!("protocol: {:?}", filter.protocol_system)),
                 )
@@ -331,7 +326,10 @@ impl PostgresGateway {
 
         Ok(results
             .into_iter()
-            .map(|(ep, data)| EntryPointWithData { entry_point: ep.into(), data: (&data).into() })
+            .map(|(ep, params)| EntryPointWithTracingParams {
+                entry_point: ep.into(),
+                params: (&params).into(),
+            })
             .collect())
     }
 
@@ -348,13 +346,13 @@ impl PostgresGateway {
     ) -> Result<Vec<EntryPoint>, StorageError> {
         use schema::{
             entry_point as ep, protocol_component as pc,
-            protocol_component_holds_entry_point as pchep,
+            protocol_component_uses_entry_point as pcuep,
         };
 
         let ps_id = self.get_protocol_system_id(&filter.protocol_system);
         let results = schema::entry_point::table
-            .inner_join(pchep::table.on(ep::id.eq(pchep::entry_point_id)))
-            .inner_join(pc::table.on(pchep::protocol_component_id.eq(pc::id)))
+            .inner_join(pcuep::table.on(ep::id.eq(pcuep::entry_point_id)))
+            .inner_join(pc::table.on(pcuep::protocol_component_id.eq(pc::id)))
             .filter(pc::protocol_system_id.eq(ps_id))
             .select(orm::EntryPoint::as_select())
             .load::<orm::EntryPoint>(conn)
@@ -386,7 +384,7 @@ impl PostgresGateway {
         conn: &mut AsyncPgConnection,
     ) -> Result<(), StorageError> {
         use schema::{
-            entry_point_tracing_data_calls_account::dsl::*, entry_point_tracing_result::dsl::*,
+            entry_point_tracing_params_calls_account::dsl::*, entry_point_tracing_result::dsl::*,
         };
 
         let block_hashes: HashSet<_> = traced_entry_points
@@ -401,16 +399,18 @@ impl PostgresGateway {
             .map_err(PostgresError::from)?;
         let block_id_map: HashMap<_, _> = blocks.into_iter().collect();
 
-        let data_ids = orm::EntryPointTracingData::ids_by_entry_point_with_data(
+        let params_ids = orm::EntryPointTracingParams::ids_by_entry_point_with_tracing_params(
             &traced_entry_points
                 .iter()
                 .map(|tep| {
                     (
-                        tep.entry_point_with_data
+                        tep.entry_point_with_params
                             .entry_point
                             .external_id
                             .clone(),
-                        tep.entry_point_with_data.data.clone(),
+                        tep.entry_point_with_params
+                            .params
+                            .clone(),
                     )
                 })
                 .collect::<Vec<_>>(),
@@ -420,12 +420,12 @@ impl PostgresGateway {
 
         let mut values = Vec::with_capacity(traced_entry_points.len());
         for tep in traced_entry_points {
-            let data_id = data_ids
-                .get(&tep.entry_point_with_data.data)
+            let params_id = params_ids
+                .get(&tep.entry_point_with_params.params)
                 .ok_or_else(|| {
                     StorageError::NotFound(
-                        "EntryPointTracingData".to_string(),
-                        tep.entry_point_with_data
+                        "EntryPointTracingParams".to_string(),
+                        tep.entry_point_with_params
                             .entry_point
                             .external_id
                             .clone(),
@@ -442,20 +442,20 @@ impl PostgresGateway {
                     )
                 })?;
 
-            let tracing_data = serde_json::to_value(&tep.tracing_result).map_err(|e| {
+            let tracing_result = serde_json::to_value(&tep.tracing_result).map_err(|e| {
                 StorageError::Unexpected(format!("Failed to serialize TracingResult: {e}"))
             })?;
 
             values.push(NewEntryPointTracingResult {
-                entry_point_tracing_data_id: *data_id,
+                entry_point_tracing_params_id: *params_id,
                 detection_block: block_id,
-                detection_data: tracing_data,
+                detection_data: tracing_result,
             });
         }
 
         diesel::insert_into(entry_point_tracing_result)
             .values(&values)
-            .on_conflict(schema::entry_point_tracing_result::entry_point_tracing_data_id)
+            .on_conflict(schema::entry_point_tracing_result::entry_point_tracing_params_id)
             .do_update()
             .set((
                 detection_block.eq(excluded(detection_block)),
@@ -488,9 +488,9 @@ impl PostgresGateway {
         let account_id_map: HashMap<_, _> = accounts.into_iter().collect();
 
         let mut new_entry_point_calls_account = Vec::new();
-        for (tep, &data_id) in traced_entry_points
+        for (tep, &params_id) in traced_entry_points
             .iter()
-            .zip(data_ids.values())
+            .zip(params_ids.values())
         {
             for address in &tep.tracing_result.called_addresses {
                 let acc_id = account_id_map
@@ -499,14 +499,14 @@ impl PostgresGateway {
                         StorageError::NotFound("Account".to_string(), address.to_string())
                     })?;
 
-                new_entry_point_calls_account.push(NewEntryPointTracingDataCallsAccount {
-                    entry_point_tracing_data_id: data_id,
+                new_entry_point_calls_account.push(NewEntryPointTracingParamsCallsAccount {
+                    entry_point_tracing_params_id: params_id,
                     account_id: *acc_id,
                 });
             }
         }
 
-        diesel::insert_into(entry_point_tracing_data_calls_account)
+        diesel::insert_into(entry_point_tracing_params_calls_account)
             .values(&new_entry_point_calls_account)
             .on_conflict_do_nothing() // Design choice: we don't want to delete previously inserted links here, they are
             // cumulative
@@ -531,7 +531,8 @@ impl PostgresGateway {
         conn: &mut AsyncPgConnection,
     ) -> Result<HashMap<EntryPointId, Vec<TracingResult>>, StorageError> {
         use schema::{
-            entry_point as ep, entry_point_tracing_data as eptd, entry_point_tracing_result as eptr,
+            entry_point as ep, entry_point_tracing_params as eptp,
+            entry_point_tracing_result as eptr,
         };
         let entry_point_ids = orm::EntryPoint::ids_by_external_ids(
             &entry_points
@@ -543,9 +544,9 @@ impl PostgresGateway {
         .await?;
 
         let results = schema::entry_point_tracing_result::table
-            .inner_join(eptd::table.on(eptr::entry_point_tracing_data_id.eq(eptd::id)))
-            .inner_join(ep::table.on(eptd::entry_point_id.eq(ep::id)))
-            .filter(eptd::entry_point_id.eq_any(entry_point_ids.values().cloned()))
+            .inner_join(eptp::table.on(eptr::entry_point_tracing_params_id.eq(eptp::id)))
+            .inner_join(ep::table.on(eptp::entry_point_id.eq(ep::id)))
+            .filter(eptp::entry_point_id.eq_any(entry_point_ids.values().cloned()))
             .select((ep::external_id, eptr::detection_data))
             .load::<(String, serde_json::Value)>(conn)
             .await
@@ -561,8 +562,8 @@ impl PostgresGateway {
 
         results_by_entry_point
             .into_iter()
-            .map(|(ep_ext_id, data)| {
-                let converted_data = data
+            .map(|(ep_ext_id, tracing_result)| {
+                let converted_tracing_result = tracing_result
                     .into_iter()
                     .map(|d| {
                         serde_json::from_value(d).map_err(|e| {
@@ -572,7 +573,7 @@ impl PostgresGateway {
                         })
                     })
                     .collect::<Result<Vec<_>, StorageError>>()?;
-                Ok((ep_ext_id, converted_data))
+                Ok((ep_ext_id, converted_tracing_result))
             })
             .collect()
     }
@@ -587,7 +588,7 @@ mod test {
         keccak256,
         models::{
             blockchain::{
-                EntryPointTracingData, RPCTracerEntryPoint, TracedEntryPoint, TracingResult,
+                EntryPointTracingParams, RPCTracerEntryPoint, TracedEntryPoint, TracingResult,
             },
             FinancialType, ImplementationType, StoreKey,
         },
@@ -661,29 +662,27 @@ mod test {
         .await;
     }
 
-    fn rpc_tracer_entry_point() -> (EntryPoint, EntryPointTracingData) {
+    fn rpc_tracer_entry_point() -> (EntryPoint, EntryPointTracingParams) {
         (
-            EntryPoint {
-                external_id: "0xEdf63cce4bA70cbE74064b7687882E71ebB0e988:getRate()".to_string(),
-                target: Bytes::from_str("0xEdf63cce4bA70cbE74064b7687882E71ebB0e988").unwrap(),
-                signature: "getRate()".to_string(),
-            },
-            EntryPointTracingData::RPCTracer(RPCTracerEntryPoint {
-                caller: None,
-                data: Bytes::from(&keccak256("getRate()")[0..4]),
-            }),
+            EntryPoint::new(
+                "0xEdf63cce4bA70cbE74064b7687882E71ebB0e988:getRate()".to_string(),
+                Bytes::from_str("0xEdf63cce4bA70cbE74064b7687882E71ebB0e988").unwrap(),
+                "getRate()".to_string(),
+            ),
+            EntryPointTracingParams::RPCTracer(RPCTracerEntryPoint::new(
+                None,
+                Bytes::from(&keccak256("getRate()")[0..4]),
+            )),
         )
     }
 
     fn traced_entry_point() -> TracedEntryPoint {
-        let (entry_point, data) = rpc_tracer_entry_point();
-        TracedEntryPoint {
-            entry_point_with_data: EntryPointWithData::new(entry_point, data),
-            detection_block_hash: Bytes::from_str(
-                "88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6",
-            )
-            .unwrap(),
-            tracing_result: TracingResult::new(
+        let (entry_point, params) = rpc_tracer_entry_point();
+        TracedEntryPoint::new(
+            EntryPointWithTracingParams::new(entry_point, params),
+            Bytes::from_str("88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6")
+                .unwrap(),
+            TracingResult::new(
                 vec![(
                     Bytes::from_str("0x6B175474E89094C44Da98b954EedeAC495271d0F").unwrap(),
                     StoreKey::from_str(
@@ -697,7 +696,7 @@ mod test {
                     .into_iter()
                     .collect(),
             ),
-        }
+        )
     }
 
     #[tokio::test]
@@ -730,7 +729,7 @@ mod test {
         setup_data(&mut conn).await;
         let gw = PostgresGateway::from_connection(&mut conn).await;
 
-        let (entry_point, data) = rpc_tracer_entry_point();
+        let (entry_point, params) = rpc_tracer_entry_point();
 
         gw.insert_entry_points(
             &HashMap::from([("pc_0", &vec![entry_point.clone()])]),
@@ -740,10 +739,10 @@ mod test {
         .await
         .unwrap();
 
-        gw.upsert_entry_point_tracing_data(
+        gw.upsert_entry_point_tracing_params(
             &HashMap::from([(
                 entry_point.external_id.clone(),
-                &vec![(data.clone(), Some("pc_0".to_string()))],
+                &vec![(params.clone(), Some("pc_0".to_string()))],
             )]),
             &Chain::Ethereum,
             &mut conn,
@@ -753,11 +752,14 @@ mod test {
 
         let filter = EntryPointFilter::new("test_protocol".to_string());
         let retrieved_entry_points = gw
-            .get_entry_points_with_data(filter, &mut conn)
+            .get_entry_points_tracing_params(filter, &mut conn)
             .await
             .unwrap();
 
-        assert_eq!(retrieved_entry_points[0], EntryPointWithData::new(entry_point, data));
+        assert_eq!(
+            retrieved_entry_points[0],
+            EntryPointWithTracingParams::new(entry_point, params)
+        );
     }
 
     #[tokio::test]
@@ -766,7 +768,7 @@ mod test {
         setup_data(&mut conn).await;
         let gw = PostgresGateway::from_connection(&mut conn).await;
 
-        let (entry_point, data) = rpc_tracer_entry_point();
+        let entry_point = rpc_tracer_entry_point().0;
         gw.insert_entry_points(
             &HashMap::from([("pc_0", &vec![entry_point.clone()])]),
             &Chain::Ethereum,
@@ -797,7 +799,7 @@ mod test {
         setup_data(&mut conn).await;
         let gw = PostgresGateway::from_connection(&mut conn).await;
 
-        let (entry_point, data) = rpc_tracer_entry_point();
+        let (entry_point, params) = rpc_tracer_entry_point();
         let traced_entry_point = traced_entry_point();
 
         gw.insert_entry_points(
@@ -808,10 +810,10 @@ mod test {
         .await
         .unwrap();
 
-        gw.upsert_entry_point_tracing_data(
+        gw.upsert_entry_point_tracing_params(
             &HashMap::from([(
                 entry_point.external_id.clone(),
-                &vec![(data.clone(), Some("pc_0".to_string()))],
+                &vec![(params.clone(), Some("pc_0".to_string()))],
             )]),
             &Chain::Ethereum,
             &mut conn,

--- a/tycho-storage/src/postgres/orm.rs
+++ b/tycho-storage/src/postgres/orm.rs
@@ -16,8 +16,8 @@ use tycho_common::{
     models::{
         self,
         blockchain::{
-            TracingParams as EntryPointTracingParamsCommon,
             EntryPointWithTracingParams as EntryPointWithTracingParamsCommon,
+            TracingParams as EntryPointTracingParamsCommon,
         },
         Address, AttrStoreKey, Balance, BlockHash, Code, CodeHash, ComponentId, ContractId,
         EntryPointId, PaginationParams, StoreVal, TxHash,

--- a/tycho-storage/src/postgres/orm.rs
+++ b/tycho-storage/src/postgres/orm.rs
@@ -16,7 +16,7 @@ use tycho_common::{
     models::{
         self,
         blockchain::{
-            EntryPointTracingParams as EntryPointTracingParamsCommon,
+            TracingParams as EntryPointTracingParamsCommon,
             EntryPointWithTracingParams as EntryPointWithTracingParamsCommon,
         },
         Address, AttrStoreKey, Balance, BlockHash, Code, CodeHash, ComponentId, ContractId,
@@ -1766,10 +1766,10 @@ pub enum EntryPointTracingType {
     RpcTracer,
 }
 
-impl From<&models::blockchain::EntryPointTracingParams> for EntryPointTracingType {
-    fn from(value: &models::blockchain::EntryPointTracingParams) -> Self {
+impl From<&models::blockchain::TracingParams> for EntryPointTracingType {
+    fn from(value: &models::blockchain::TracingParams) -> Self {
         match value {
-            models::blockchain::EntryPointTracingParams::RPCTracer(_) => Self::RpcTracer,
+            models::blockchain::TracingParams::RPCTracer(_) => Self::RpcTracer,
         }
     }
 }
@@ -1858,13 +1858,13 @@ pub struct EntryPointTracingParams {
     pub modified_ts: NaiveDateTime,
 }
 
-impl From<&EntryPointTracingParams> for models::blockchain::EntryPointTracingParams {
+impl From<&EntryPointTracingParams> for models::blockchain::TracingParams {
     fn from(value: &EntryPointTracingParams) -> Self {
         match value.tracing_type {
             EntryPointTracingType::RpcTracer => {
-                let rpc_tracer: models::blockchain::RPCTracerEntryPoint =
+                let rpc_tracer: models::blockchain::RPCTracerParams =
                     serde_json::from_value(value.data.clone().unwrap()).unwrap();
-                models::blockchain::EntryPointTracingParams::RPCTracer(rpc_tracer)
+                models::blockchain::TracingParams::RPCTracer(rpc_tracer)
             }
         }
     }

--- a/tycho-storage/src/postgres/orm.rs
+++ b/tycho-storage/src/postgres/orm.rs
@@ -32,9 +32,9 @@ use super::{
         component_tvl, contract_code, contract_storage, contract_storage_default, entry_point,
         entry_point_tracing_data, entry_point_tracing_data_calls_account,
         entry_point_tracing_result, extraction_state, protocol_component,
-        protocol_component_holds_contract, protocol_component_holds_entry_point_tracing_data,
-        protocol_component_holds_token, protocol_state, protocol_state_default, protocol_system,
-        protocol_type, token, transaction,
+        protocol_component_holds_contract, protocol_component_holds_entry_point,
+        protocol_component_holds_entry_point_tracing_data, protocol_component_holds_token,
+        protocol_state, protocol_state_default, protocol_system, protocol_type, token, transaction,
     },
     versioning::{StoredVersionedRow, VersionedRow},
     PostgresError, MAX_TS, MAX_VERSION_TS,
@@ -2040,23 +2040,31 @@ pub struct NewEntryPointTracingResult {
     pub detection_data: serde_json::Value,
 }
 
-#[derive(Identifiable, Queryable, Associations, Selectable)]
-#[diesel(belongs_to(ProtocolComponent))]
-#[diesel(belongs_to(EntryPointTracingData))]
-#[diesel(table_name = protocol_component_holds_entry_point_tracing_data)]
-#[diesel(primary_key(protocol_component_id, entry_point_tracing_data_id))]
-#[diesel(check_for_backend(diesel::pg::Pg))]
-pub struct ProtocolComponentHoldsEntryPointTracingData {
-    pub protocol_component_id: i64,
-    pub entry_point_tracing_data_id: i64,
-}
-
 #[derive(Insertable)]
 #[diesel(table_name = protocol_component_holds_entry_point_tracing_data)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct NewProtocolComponentHoldsEntryPointTracingData {
     pub protocol_component_id: i64,
     pub entry_point_tracing_data_id: i64,
+}
+
+#[derive(Identifiable, Queryable, Associations, Selectable)]
+#[diesel(belongs_to(ProtocolComponent))]
+#[diesel(belongs_to(EntryPoint))]
+#[diesel(table_name = protocol_component_holds_entry_point)]
+#[diesel(primary_key(protocol_component_id, entry_point_id))]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct ProtocolComponentHoldsEntryPoint {
+    pub protocol_component_id: i64,
+    pub entry_point_id: i64,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = protocol_component_holds_entry_point)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct NewProtocolComponentHoldsEntryPoint {
+    pub protocol_component_id: i64,
+    pub entry_point_id: i64,
 }
 
 #[derive(Identifiable, Queryable, Associations, Selectable)]

--- a/tycho-storage/src/postgres/orm.rs
+++ b/tycho-storage/src/postgres/orm.rs
@@ -16,8 +16,8 @@ use tycho_common::{
     models::{
         self,
         blockchain::{
-            EntryPointTracingData as EntryPointTracingDataCommon,
-            EntryPointWithData as EntryPointWithDataCommon,
+            EntryPointTracingParams as EntryPointTracingParamsCommon,
+            EntryPointWithTracingParams as EntryPointWithTracingParamsCommon,
         },
         Address, AttrStoreKey, Balance, BlockHash, Code, CodeHash, ComponentId, ContractId,
         EntryPointId, PaginationParams, StoreVal, TxHash,
@@ -29,12 +29,13 @@ use tycho_common::{
 use super::{
     schema::{
         account, account_balance, block, chain, component_balance, component_balance_default,
-        component_tvl, contract_code, contract_storage, contract_storage_default, entry_point,
-        entry_point_tracing_data, entry_point_tracing_data_calls_account,
+        component_tvl, contract_code, contract_storage, contract_storage_default,
+        debug_protocol_component_has_entry_point_tracing_params, entry_point,
+        entry_point_tracing_params, entry_point_tracing_params_calls_account,
         entry_point_tracing_result, extraction_state, protocol_component,
-        protocol_component_holds_contract, protocol_component_holds_entry_point,
-        protocol_component_holds_entry_point_tracing_data, protocol_component_holds_token,
-        protocol_state, protocol_state_default, protocol_system, protocol_type, token, transaction,
+        protocol_component_holds_contract, protocol_component_holds_token,
+        protocol_component_uses_entry_point, protocol_state, protocol_state_default,
+        protocol_system, protocol_type, token, transaction,
     },
     versioning::{StoredVersionedRow, VersionedRow},
     PostgresError, MAX_TS, MAX_VERSION_TS,
@@ -1765,10 +1766,10 @@ pub enum EntryPointTracingType {
     RpcTracer,
 }
 
-impl From<&models::blockchain::EntryPointTracingData> for EntryPointTracingType {
-    fn from(value: &models::blockchain::EntryPointTracingData) -> Self {
+impl From<&models::blockchain::EntryPointTracingParams> for EntryPointTracingType {
+    fn from(value: &models::blockchain::EntryPointTracingParams) -> Self {
         match value {
-            models::blockchain::EntryPointTracingData::RPCTracer(_) => Self::RpcTracer,
+            models::blockchain::EntryPointTracingParams::RPCTracer(_) => Self::RpcTracer,
         }
     }
 }
@@ -1846,9 +1847,9 @@ pub struct NewEntryPoint {
 
 #[derive(Identifiable, Queryable, Associations, Selectable)]
 #[diesel(belongs_to(EntryPoint))]
-#[diesel(table_name = entry_point_tracing_data)]
+#[diesel(table_name = entry_point_tracing_params)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
-pub struct EntryPointTracingData {
+pub struct EntryPointTracingParams {
     pub id: i64,
     pub entry_point_id: i64,
     pub tracing_type: EntryPointTracingType,
@@ -1857,36 +1858,38 @@ pub struct EntryPointTracingData {
     pub modified_ts: NaiveDateTime,
 }
 
-impl From<&EntryPointTracingData> for models::blockchain::EntryPointTracingData {
-    fn from(value: &EntryPointTracingData) -> Self {
+impl From<&EntryPointTracingParams> for models::blockchain::EntryPointTracingParams {
+    fn from(value: &EntryPointTracingParams) -> Self {
         match value.tracing_type {
             EntryPointTracingType::RpcTracer => {
                 let rpc_tracer: models::blockchain::RPCTracerEntryPoint =
                     serde_json::from_value(value.data.clone().unwrap()).unwrap();
-                models::blockchain::EntryPointTracingData::RPCTracer(rpc_tracer)
+                models::blockchain::EntryPointTracingParams::RPCTracer(rpc_tracer)
             }
         }
     }
 }
 
-impl EntryPointTracingData {
-    /// Retrieves the database id of an entry point tracing data from an `EntryPointWithData`.
+impl EntryPointTracingParams {
+    /// Retrieves the database id of an entry point tracing params from an
+    /// `EntryPointWithTracingParams`.
     #[allow(dead_code)]
-    pub(crate) async fn id_from_entry_point_with_data(
-        entry_point: &EntryPointWithDataCommon,
+    pub(crate) async fn id_from_entry_point_with_tracing_params(
+        entry_point: &EntryPointWithTracingParamsCommon,
         conn: &mut AsyncPgConnection,
     ) -> Result<i64, StorageError> {
-        let tracing_type = EntryPointTracingType::from(&entry_point.data);
-        let data = match &entry_point.data {
-            EntryPointTracingDataCommon::RPCTracer(rpc_tracer) => serde_json::to_value(rpc_tracer)
-                .map_err(|e| {
+        let tracing_type = EntryPointTracingType::from(&entry_point.params);
+        let data = match &entry_point.params {
+            EntryPointTracingParamsCommon::RPCTracer(rpc_tracer) => {
+                serde_json::to_value(rpc_tracer).map_err(|e| {
                     StorageError::Unexpected(format!(
                         "Failed to serialize RPCTracerEntryPoint: {e}"
                     ))
-                })?,
+                })?
+            }
         };
 
-        let id_ = super::schema::entry_point_tracing_data::table
+        let id_ = super::schema::entry_point_tracing_params::table
             .inner_join(super::schema::entry_point::table)
             .filter(super::schema::entry_point::target.eq(entry_point.entry_point.target.clone()))
             .filter(
@@ -1895,9 +1898,9 @@ impl EntryPointTracingData {
                     .signature
                     .clone()),
             )
-            .filter(super::schema::entry_point_tracing_data::tracing_type.eq(tracing_type))
-            .filter(super::schema::entry_point_tracing_data::data.eq(data))
-            .select(super::schema::entry_point_tracing_data::id)
+            .filter(super::schema::entry_point_tracing_params::tracing_type.eq(tracing_type))
+            .filter(super::schema::entry_point_tracing_params::data.eq(data))
+            .select(super::schema::entry_point_tracing_params::id)
             .first::<i64>(conn)
             .await
             .map_err(PostgresError::from)?;
@@ -1905,20 +1908,21 @@ impl EntryPointTracingData {
         Ok(id_)
     }
 
-    // Retrieves the database ids of entry point tracing data from a list of entry points with data.
-    pub(crate) async fn ids_by_entry_point_with_data(
-        entry_points_with_data: &[(EntryPointId, EntryPointTracingDataCommon)],
+    // Retrieves the database ids of entry point tracing params from a list of entry points ids and
+    // tracing params.
+    pub(crate) async fn ids_by_entry_point_with_tracing_params(
+        entry_points_with_tracing_params: &[(EntryPointId, EntryPointTracingParamsCommon)],
         conn: &mut AsyncPgConnection,
-    ) -> Result<HashMap<EntryPointTracingDataCommon, i64>, StorageError> {
-        if entry_points_with_data.is_empty() {
+    ) -> Result<HashMap<EntryPointTracingParamsCommon, i64>, StorageError> {
+        if entry_points_with_tracing_params.is_empty() {
             return Ok(HashMap::new());
         }
 
-        let (external_ids, data): (HashSet<_>, HashSet<_>) = entry_points_with_data
+        let (external_ids, params): (HashSet<_>, HashSet<_>) = entry_points_with_tracing_params
             .iter()
-            .map(|(ep_id, data)| {
-                let data = match data {
-                    EntryPointTracingDataCommon::RPCTracer(rpc_tracer) => {
+            .map(|(ep_id, params)| {
+                let params = match params {
+                    EntryPointTracingParamsCommon::RPCTracer(rpc_tracer) => {
                         serde_json::to_value(rpc_tracer).map_err(|e| {
                             StorageError::Unexpected(format!(
                                 "Failed to serialize RPCTracerEntryPoint: {e}"
@@ -1926,27 +1930,27 @@ impl EntryPointTracingData {
                         })?
                     }
                 };
-                Ok((ep_id, data))
+                Ok((ep_id, params))
             })
             .collect::<Result<Vec<_>, StorageError>>()?
             .into_iter()
             .unzip();
 
-        let tuple_data = entry_points_with_data
+        let tuples = entry_points_with_tracing_params
             .iter()
-            .map(|(ep_id, data)| (ep_id, EntryPointTracingType::from(data), data))
+            .map(|(ep_id, params)| (ep_id, EntryPointTracingType::from(params), params))
             .collect::<Vec<_>>();
 
-        let tuple_ids_to_entry_point_with_data: HashMap<
-            (&EntryPointId, &EntryPointTracingType, &EntryPointTracingDataCommon),
-            &EntryPointTracingDataCommon,
-        > = tuple_data
+        let tuples_to_tracing_params: HashMap<
+            (&EntryPointId, &EntryPointTracingType, &EntryPointTracingParamsCommon),
+            &EntryPointTracingParamsCommon,
+        > = tuples
             .iter()
-            .zip(entry_points_with_data)
-            .map(|((ep_id, tracing_type, data), ep)| ((*ep_id, tracing_type, *data), &ep.1))
+            .zip(entry_points_with_tracing_params)
+            .map(|((ep_id, tracing_type, params), ep)| ((*ep_id, tracing_type, *params), &ep.1))
             .collect();
 
-        let res = entry_point_tracing_data::table
+        let res = entry_point_tracing_params::table
             .inner_join(entry_point::table)
             .filter(
                 // Not filtered by tracing type eq_any because of a diesel bug with OID, shouldn't
@@ -1954,23 +1958,23 @@ impl EntryPointTracingData {
                 // below.
                 entry_point::external_id
                     .eq_any(external_ids)
-                    .and(entry_point_tracing_data::data.eq_any(data)),
+                    .and(entry_point_tracing_params::data.eq_any(params)),
             )
             .select((
                 entry_point::external_id,
-                entry_point_tracing_data::tracing_type,
-                entry_point_tracing_data::data,
-                entry_point_tracing_data::id,
+                entry_point_tracing_params::tracing_type,
+                entry_point_tracing_params::data,
+                entry_point_tracing_params::id,
             ))
             .load::<(EntryPointId, EntryPointTracingType, Option<serde_json::Value>, i64)>(conn)
             .await
             .map_err(PostgresError::from)?
             .into_iter()
-            .filter_map(|(ext_id, tracing_type, data, id)| {
-                let tracing_data = match tracing_type {
+            .filter_map(|(ext_id, tracing_type, params, id)| {
+                let tracing_params = match tracing_type {
                     EntryPointTracingType::RpcTracer => {
-                        let data_value = match data {
-                            Some(data) => data,
+                        let params_value = match params {
+                            Some(params) => params,
                             None => {
                                 return Some(Err(StorageError::Unexpected(
                                     "Data should be Some for RpcTracer".to_string(),
@@ -1978,8 +1982,8 @@ impl EntryPointTracingData {
                             }
                         };
 
-                        match serde_json::from_value(data_value) {
-                            Ok(d) => EntryPointTracingDataCommon::RPCTracer(d),
+                        match serde_json::from_value(params_value) {
+                            Ok(p) => EntryPointTracingParamsCommon::RPCTracer(p),
                             Err(e) => {
                                 return Some(Err(StorageError::Unexpected(format!(
                                     "Failed to deserialize RPCTracerEntryPoint: {e}"
@@ -1989,8 +1993,8 @@ impl EntryPointTracingData {
                     }
                 };
 
-                tuple_ids_to_entry_point_with_data
-                    .get(&(&ext_id, &tracing_type, &tracing_data))
+                tuples_to_tracing_params
+                    .get(&(&ext_id, &tracing_type, &tracing_params))
                     .map(|ep| Ok(((*ep).clone(), id)))
             })
             .collect::<Result<HashMap<_, _>, StorageError>>()?;
@@ -2000,9 +2004,9 @@ impl EntryPointTracingData {
 }
 
 #[derive(Insertable)]
-#[diesel(table_name = entry_point_tracing_data)]
+#[diesel(table_name = entry_point_tracing_params)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
-pub struct NewEntryPointTracingData {
+pub struct NewEntryPointTracingParams {
     pub entry_point_id: i64,
     pub tracing_type: EntryPointTracingType,
     pub data: Option<serde_json::Value>,
@@ -2013,7 +2017,7 @@ pub struct NewEntryPointTracingData {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct EntryPointTracingResult {
     #[allow(dead_code)]
-    entry_point_tracing_data_id: i64,
+    entry_point_tracing_params_id: i64,
     #[allow(dead_code)]
     detection_block: i64,
     #[allow(dead_code)]
@@ -2028,53 +2032,53 @@ pub struct EntryPointTracingResult {
 #[diesel(table_name = entry_point_tracing_result)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct NewEntryPointTracingResult {
-    pub entry_point_tracing_data_id: i64,
+    pub entry_point_tracing_params_id: i64,
     pub detection_block: i64,
     pub detection_data: serde_json::Value,
 }
 
 #[derive(Insertable)]
-#[diesel(table_name = protocol_component_holds_entry_point_tracing_data)]
+#[diesel(table_name = debug_protocol_component_has_entry_point_tracing_params)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
-pub struct NewProtocolComponentHoldsEntryPointTracingData {
+pub struct NewProtocolComponentHasEntryPointTracingParams {
     pub protocol_component_id: i64,
-    pub entry_point_tracing_data_id: i64,
+    pub entry_point_tracing_params_id: i64,
 }
 
 #[derive(Identifiable, Queryable, Associations, Selectable)]
 #[diesel(belongs_to(ProtocolComponent))]
 #[diesel(belongs_to(EntryPoint))]
-#[diesel(table_name = protocol_component_holds_entry_point)]
+#[diesel(table_name = protocol_component_uses_entry_point)]
 #[diesel(primary_key(protocol_component_id, entry_point_id))]
 #[diesel(check_for_backend(diesel::pg::Pg))]
-pub struct ProtocolComponentHoldsEntryPoint {
+pub struct ProtocolComponentUsesEntryPoint {
     pub protocol_component_id: i64,
     pub entry_point_id: i64,
 }
 
 #[derive(Insertable)]
-#[diesel(table_name = protocol_component_holds_entry_point)]
+#[diesel(table_name = protocol_component_uses_entry_point)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
-pub struct NewProtocolComponentHoldsEntryPoint {
+pub struct NewProtocolComponentUsesEntryPoint {
     pub protocol_component_id: i64,
     pub entry_point_id: i64,
 }
 
 #[derive(Identifiable, Queryable, Associations, Selectable)]
-#[diesel(belongs_to(EntryPointTracingData))]
+#[diesel(belongs_to(EntryPointTracingParams))]
 #[diesel(belongs_to(Account))]
-#[diesel(table_name = entry_point_tracing_data_calls_account)]
-#[diesel(primary_key(entry_point_tracing_data_id, account_id))]
+#[diesel(table_name = entry_point_tracing_params_calls_account)]
+#[diesel(primary_key(entry_point_tracing_params_id, account_id))]
 #[diesel(check_for_backend(diesel::pg::Pg))]
-pub struct EntryPointTracingDataCallsAccount {
-    pub entry_point_tracing_data_id: i64,
+pub struct EntryPointTracingParamsCallsAccount {
+    pub entry_point_tracing_params_id: i64,
     pub account_id: i64,
 }
 
 #[derive(Insertable)]
-#[diesel(table_name = entry_point_tracing_data_calls_account)]
+#[diesel(table_name = entry_point_tracing_params_calls_account)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
-pub struct NewEntryPointTracingDataCallsAccount {
-    pub entry_point_tracing_data_id: i64,
+pub struct NewEntryPointTracingParamsCallsAccount {
+    pub entry_point_tracing_params_id: i64,
     pub account_id: i64,
 }

--- a/tycho-storage/src/postgres/protocol.rs
+++ b/tycho-storage/src/postgres/protocol.rs
@@ -1745,7 +1745,7 @@ impl PostgresGateway {
 
 #[cfg(test)]
 mod test {
-    use std::str::FromStr;
+    use std::{slice, str::FromStr};
 
     use diesel_async::AsyncConnection;
     use rstest::rstest;
@@ -3242,7 +3242,7 @@ mod test {
             Default::default(),
         );
 
-        gw.add_protocol_components(&[original_component.clone()], &mut conn)
+        gw.add_protocol_components(slice::from_ref(&original_component), &mut conn)
             .await
             .expect("adding components failed");
 

--- a/tycho-storage/src/postgres/schema.rs
+++ b/tycho-storage/src/postgres/schema.rs
@@ -196,6 +196,13 @@ diesel::table! {
 }
 
 diesel::table! {
+    debug_protocol_component_has_entry_point_tracing_params (protocol_component_id, entry_point_tracing_params_id) {
+        protocol_component_id -> Int8,
+        entry_point_tracing_params_id -> Int8,
+    }
+}
+
+diesel::table! {
     entry_point (id) {
         id -> Int8,
         external_id -> Text,
@@ -210,7 +217,7 @@ diesel::table! {
     use diesel::sql_types::*;
     use super::sql_types::EntryPointTracingType;
 
-    entry_point_tracing_data (id) {
+    entry_point_tracing_params (id) {
         id -> Int8,
         entry_point_id -> Int8,
         tracing_type -> EntryPointTracingType,
@@ -221,8 +228,8 @@ diesel::table! {
 }
 
 diesel::table! {
-    entry_point_tracing_data_calls_account (entry_point_tracing_data_id, account_id) {
-        entry_point_tracing_data_id -> Int8,
+    entry_point_tracing_params_calls_account (entry_point_tracing_params_id, account_id) {
+        entry_point_tracing_params_id -> Int8,
         account_id -> Int8,
     }
 }
@@ -230,7 +237,7 @@ diesel::table! {
 diesel::table! {
     entry_point_tracing_result (id) {
         id -> Int8,
-        entry_point_tracing_data_id -> Int8,
+        entry_point_tracing_params_id -> Int8,
         detection_block -> Int8,
         detection_data -> Jsonb,
         inserted_ts -> Timestamptz,
@@ -282,25 +289,18 @@ diesel::table! {
 }
 
 diesel::table! {
-    protocol_component_holds_entry_point (protocol_component_id, entry_point_id) {
-        protocol_component_id -> Int8,
-        entry_point_id -> Int8,
-    }
-}
-
-diesel::table! {
-    protocol_component_holds_entry_point_tracing_data (protocol_component_id, entry_point_tracing_data_id) {
-        protocol_component_id -> Int8,
-        entry_point_tracing_data_id -> Int8,
-    }
-}
-
-diesel::table! {
     protocol_component_holds_token (protocol_component_id, token_id) {
         protocol_component_id -> Int8,
         token_id -> Int8,
         inserted_ts -> Timestamptz,
         modified_ts -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    protocol_component_uses_entry_point (protocol_component_id, entry_point_id) {
+        protocol_component_id -> Int8,
+        entry_point_id -> Int8,
     }
 }
 
@@ -377,11 +377,13 @@ diesel::joinable!(block -> chain (chain_id));
 diesel::joinable!(component_tvl -> protocol_component (protocol_component_id));
 diesel::joinable!(contract_code -> account (account_id));
 diesel::joinable!(contract_code -> transaction (modify_tx));
-diesel::joinable!(entry_point_tracing_data -> entry_point (entry_point_id));
-diesel::joinable!(entry_point_tracing_data_calls_account -> account (account_id));
-diesel::joinable!(entry_point_tracing_data_calls_account -> entry_point_tracing_data (entry_point_tracing_data_id));
+diesel::joinable!(debug_protocol_component_has_entry_point_tracing_params -> entry_point_tracing_params (entry_point_tracing_params_id));
+diesel::joinable!(debug_protocol_component_has_entry_point_tracing_params -> protocol_component (protocol_component_id));
+diesel::joinable!(entry_point_tracing_params -> entry_point (entry_point_id));
+diesel::joinable!(entry_point_tracing_params_calls_account -> account (account_id));
+diesel::joinable!(entry_point_tracing_params_calls_account -> entry_point_tracing_params (entry_point_tracing_params_id));
 diesel::joinable!(entry_point_tracing_result -> block (detection_block));
-diesel::joinable!(entry_point_tracing_result -> entry_point_tracing_data (entry_point_tracing_data_id));
+diesel::joinable!(entry_point_tracing_result -> entry_point_tracing_params (entry_point_tracing_params_id));
 diesel::joinable!(extraction_state -> block (block_id));
 diesel::joinable!(extraction_state -> chain (chain_id));
 diesel::joinable!(protocol_component -> chain (chain_id));
@@ -389,12 +391,10 @@ diesel::joinable!(protocol_component -> protocol_system (protocol_system_id));
 diesel::joinable!(protocol_component -> protocol_type (protocol_type_id));
 diesel::joinable!(protocol_component_holds_contract -> contract_code (contract_code_id));
 diesel::joinable!(protocol_component_holds_contract -> protocol_component (protocol_component_id));
-diesel::joinable!(protocol_component_holds_entry_point -> entry_point (entry_point_id));
-diesel::joinable!(protocol_component_holds_entry_point -> protocol_component (protocol_component_id));
-diesel::joinable!(protocol_component_holds_entry_point_tracing_data -> entry_point_tracing_data (entry_point_tracing_data_id));
-diesel::joinable!(protocol_component_holds_entry_point_tracing_data -> protocol_component (protocol_component_id));
 diesel::joinable!(protocol_component_holds_token -> protocol_component (protocol_component_id));
 diesel::joinable!(protocol_component_holds_token -> token (token_id));
+diesel::joinable!(protocol_component_uses_entry_point -> entry_point (entry_point_id));
+diesel::joinable!(protocol_component_uses_entry_point -> protocol_component (protocol_component_id));
 diesel::joinable!(token -> account (account_id));
 diesel::joinable!(token_price -> token (token_id));
 diesel::joinable!(transaction -> block (block_id));
@@ -414,16 +414,16 @@ diesel::allow_tables_to_appear_in_same_query!(
     chain,
     component_tvl,
     contract_code,
+    debug_protocol_component_has_entry_point_tracing_params,
     entry_point,
-    entry_point_tracing_data,
-    entry_point_tracing_data_calls_account,
+    entry_point_tracing_params,
+    entry_point_tracing_params_calls_account,
     entry_point_tracing_result,
     extraction_state,
     protocol_component,
     protocol_component_holds_contract,
-    protocol_component_holds_entry_point,
-    protocol_component_holds_entry_point_tracing_data,
     protocol_component_holds_token,
+    protocol_component_uses_entry_point,
     protocol_system,
     protocol_type,
     token,

--- a/tycho-storage/src/postgres/schema.rs
+++ b/tycho-storage/src/postgres/schema.rs
@@ -282,6 +282,13 @@ diesel::table! {
 }
 
 diesel::table! {
+    protocol_component_holds_entry_point (protocol_component_id, entry_point_id) {
+        protocol_component_id -> Int8,
+        entry_point_id -> Int8,
+    }
+}
+
+diesel::table! {
     protocol_component_holds_entry_point_tracing_data (protocol_component_id, entry_point_tracing_data_id) {
         protocol_component_id -> Int8,
         entry_point_tracing_data_id -> Int8,
@@ -382,6 +389,8 @@ diesel::joinable!(protocol_component -> protocol_system (protocol_system_id));
 diesel::joinable!(protocol_component -> protocol_type (protocol_type_id));
 diesel::joinable!(protocol_component_holds_contract -> contract_code (contract_code_id));
 diesel::joinable!(protocol_component_holds_contract -> protocol_component (protocol_component_id));
+diesel::joinable!(protocol_component_holds_entry_point -> entry_point (entry_point_id));
+diesel::joinable!(protocol_component_holds_entry_point -> protocol_component (protocol_component_id));
 diesel::joinable!(protocol_component_holds_entry_point_tracing_data -> entry_point_tracing_data (entry_point_tracing_data_id));
 diesel::joinable!(protocol_component_holds_entry_point_tracing_data -> protocol_component (protocol_component_id));
 diesel::joinable!(protocol_component_holds_token -> protocol_component (protocol_component_id));
@@ -412,6 +421,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     extraction_state,
     protocol_component,
     protocol_component_holds_contract,
+    protocol_component_holds_entry_point,
     protocol_component_holds_entry_point_tracing_data,
     protocol_component_holds_token,
     protocol_system,


### PR DESCRIPTION
This PR improves some logic related to `Entrypoints`, specifically:

- The main link with protocol components has been moved from the `EntrypointTracingParams` to the `Entrypoint`. The old link stays for debugging purposes but becomes optional
- The methods to insert and get `Entrypoint` and `EntrypointTracingParams` are now separated. This granularity was needed to be able to insert new data more with more flexibility from the extractor.
- Improved namings, change from `TracingData` to `TracingParams` for clarity. 

All these changes have previously been discussed [here](https://propellerswap.slack.com/archives/C05MPCJUQPM/p1747236824357709)