### PR TITLE
chore: fix deletion script

### DIFF
--- a/tycho-api.yaml
+++ b/tycho-api.yaml
@@ -1,0 +1,1084 @@
+openapi: 3.0.3
+info:
+  title: Tycho-Indexer RPC
+  description: >-
+    Tycho indexer application binary. Runs the actual indexing. Exposes ws and
+    http endpoints to access extracted data
+  license:
+    name: MIT
+  version: 0.66.2
+  x-gitbook-description-document:
+    object: document
+    data:
+      schemaVersion: 8
+    nodes:
+      - object: block
+        type: paragraph
+        isVoid: false
+        data: {}
+        nodes:
+          - object: text
+            leaves:
+              - object: leaf
+                text: >-
+                  Tycho indexer application binary. Runs the actual indexing.
+                  Exposes ws and http endpoints to access extracted data
+                marks: []
+  x-gitbook-description-html: >-
+    <p>Tycho indexer application binary. Runs the actual indexing. Exposes ws
+    and http endpoints to access extracted data</p>
+servers:
+  - url: https://tycho-beta.propellerheads.xyz
+    description: PropellerHeads hosted service for Ethereum
+    x-gitbook-description-html: <p>PropellerHeads hosted service for Ethereum</p>
+  - url: https://tycho-base-beta.propellerheads.xyz
+    description: PropellerHeads hosted service for Base
+    x-gitbook-description-html: <p>PropellerHeads hosted service for Base</p>
+  - url: https://tycho-unichain-beta.propellerheads.xyz
+    description: PropellerHeads hosted service for Unichain
+    x-gitbook-description-html: <p>PropellerHeads hosted service for Unichain</p>
+paths:
+  /v1/contract_state:
+    post:
+      tags:
+        - rpc
+      summary: Retrieve contract states
+      description: >-
+        This endpoint retrieves the state of contracts within a specific
+        execution environment. If no
+
+        contract ids are given, all contracts are returned. Note that
+        `protocol_system` is not a filter;
+
+        it's a way to specify the protocol system associated with the contracts
+        requested and is used to
+
+        ensure that the correct extractor's block status is used when querying
+        the database. If omitted,
+
+        the block status will be determined by a random extractor, which could
+        be risky if the extractor
+
+        is out of sync. Filtering by protocol system is not currently supported
+        on this endpoint and
+
+        should be done client side.
+      operationId: contract_state
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StateRequestBody"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StateRequestResponse"
+          x-gitbook-description-html: <p>OK</p>
+      security:
+        - apiKey: []
+      x-gitbook-description-document:
+        object: document
+        data:
+          schemaVersion: 8
+        nodes:
+          - object: block
+            type: paragraph
+            isVoid: false
+            data: {}
+            nodes:
+              - object: text
+                leaves:
+                  - object: leaf
+                    text: >-
+                      This endpoint retrieves the state of contracts within a
+                      specific execution environment. If no
+
+                      contract ids are given, all contracts are returned. Note
+                      that
+                    marks: []
+                  - object: leaf
+                    text: protocol_system
+                    marks:
+                      - object: mark
+                        type: code
+                        data: {}
+                  - object: leaf
+                    text: >2-
+                       is not a filter;
+                      it's a way to specify the protocol system associated with
+                      the contracts requested and is used to
+
+                      ensure that the correct extractor's block status is used
+                      when querying the database. If omitted,
+
+                      the block status will be determined by a random extractor,
+                      which could be risky if the extractor
+
+                      is out of sync. Filtering by protocol system is not
+                      currently supported on this endpoint and
+
+                      should be done client side.
+                    marks: []
+      x-gitbook-description-html: >-
+        <p>This endpoint retrieves the state of contracts within a specific
+        execution environment. If no<br>contract ids are given, all contracts
+        are returned. Note that <code>protocol_system</code> is not a
+        filter;<br>it's a way to specify the protocol system associated with the
+        contracts requested and is used to<br>ensure that the correct
+        extractor's block status is used when querying the database. If
+        omitted,<br>the block status will be determined by a random extractor,
+        which could be risky if the extractor<br>is out of sync. Filtering by
+        protocol system is not currently supported on this endpoint
+        and<br>should be done client side.</p>
+  /v1/health:
+    get:
+      tags:
+        - rpc
+      summary: Health check endpoint
+      description: This endpoint is used to check the health of the service.
+      operationId: health
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Health"
+          x-gitbook-description-html: <p>OK</p>
+      security:
+        - apiKey: []
+      x-gitbook-description-document:
+        object: document
+        data:
+          schemaVersion: 8
+        nodes:
+          - object: block
+            type: paragraph
+            isVoid: false
+            data: {}
+            nodes:
+              - object: text
+                leaves:
+                  - object: leaf
+                    text: This endpoint is used to check the health of the service.
+                    marks: []
+      x-gitbook-description-html: <p>This endpoint is used to check the health of the service.</p>
+  /v1/protocol_components:
+    post:
+      tags:
+        - rpc
+      summary: Retrieve protocol components
+      description: >-
+        This endpoint retrieves components within a specific execution
+        environment, filtered by various
+
+        criteria.
+      operationId: protocol_components
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProtocolComponentsRequestBody"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProtocolComponentRequestResponse"
+          x-gitbook-description-html: <p>OK</p>
+      security:
+        - apiKey: []
+      x-gitbook-description-document:
+        object: document
+        data:
+          schemaVersion: 8
+        nodes:
+          - object: block
+            type: paragraph
+            isVoid: false
+            data: {}
+            nodes:
+              - object: text
+                leaves:
+                  - object: leaf
+                    text: >-
+                      This endpoint retrieves components within a specific
+                      execution environment, filtered by various
+
+                      criteria.
+                    marks: []
+      x-gitbook-description-html: >-
+        <p>This endpoint retrieves components within a specific execution
+        environment, filtered by various<br>criteria.</p>
+  /v1/protocol_state:
+    post:
+      tags:
+        - rpc
+      summary: Retrieve protocol states
+      description: >-
+        This endpoint retrieves the state of protocols within a specific
+        execution environment.
+      operationId: protocol_state
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProtocolStateRequestBody"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProtocolStateRequestResponse"
+          x-gitbook-description-html: <p>OK</p>
+      security:
+        - apiKey: []
+      x-gitbook-description-document:
+        object: document
+        data:
+          schemaVersion: 8
+        nodes:
+          - object: block
+            type: paragraph
+            isVoid: false
+            data: {}
+            nodes:
+              - object: text
+                leaves:
+                  - object: leaf
+                    text: >-
+                      This endpoint retrieves the state of protocols within a
+                      specific execution environment.
+                    marks: []
+      x-gitbook-description-html: >-
+        <p>This endpoint retrieves the state of protocols within a specific
+        execution environment.</p>
+  /v1/protocol_systems:
+    post:
+      tags:
+        - rpc
+      summary: Retrieve protocol systems
+      description: This endpoint retrieves the protocol systems available in the indexer.
+      operationId: protocol_systems
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProtocolSystemsRequestBody"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProtocolSystemsRequestResponse"
+          x-gitbook-description-html: <p>OK</p>
+      security:
+        - apiKey: []
+      x-gitbook-description-document:
+        object: document
+        data:
+          schemaVersion: 8
+        nodes:
+          - object: block
+            type: paragraph
+            isVoid: false
+            data: {}
+            nodes:
+              - object: text
+                leaves:
+                  - object: leaf
+                    text: >-
+                      This endpoint retrieves the protocol systems available in
+                      the indexer.
+                    marks: []
+      x-gitbook-description-html: >-
+        <p>This endpoint retrieves the protocol systems available in the
+        indexer.</p>
+  /v1/tokens:
+    post:
+      tags:
+        - rpc
+      summary: Retrieve tokens
+      description: >-
+        This endpoint retrieves tokens for a specific execution environment,
+        filtered by various
+
+        criteria. The tokens are returned in a paginated format.
+      operationId: tokens
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TokensRequestBody"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokensRequestResponse"
+          x-gitbook-description-html: <p>OK</p>
+      security:
+        - apiKey: []
+      x-gitbook-description-document:
+        object: document
+        data:
+          schemaVersion: 8
+        nodes:
+          - object: block
+            type: paragraph
+            isVoid: false
+            data: {}
+            nodes:
+              - object: text
+                leaves:
+                  - object: leaf
+                    text: >-
+                      This endpoint retrieves tokens for a specific execution
+                      environment, filtered by various
+
+                      criteria. The tokens are returned in a paginated format.
+                    marks: []
+      x-gitbook-description-html: >-
+        <p>This endpoint retrieves tokens for a specific execution environment,
+        filtered by various<br>criteria. The tokens are returned in a paginated
+        format.</p>
+components:
+  schemas:
+    AccountUpdate:
+      type: object
+      required:
+        - address
+        - chain
+        - slots
+        - change
+      properties:
+        address:
+          type: array
+          items:
+            type: string
+        balance:
+          type: string
+          nullable: true
+        chain:
+          $ref: "#/components/schemas/Chain"
+        change:
+          $ref: "#/components/schemas/ChangeType"
+        code:
+          type: string
+          nullable: true
+        slots:
+          type: object
+          additionalProperties:
+            type: string
+    BlockParam:
+      type: object
+      properties:
+        chain:
+          allOf:
+            - $ref: "#/components/schemas/Chain"
+          nullable: true
+        hash:
+          type: string
+          nullable: true
+        number:
+          type: integer
+          format: int64
+          nullable: true
+      additionalProperties: false
+    Chain:
+      type: string
+      description: Currently supported Blockchains
+      enum:
+        - ethereum
+        - starknet
+        - zksync
+        - arbitrum
+        - base
+        - unichain
+      x-gitbook-description-html: <p>Currently supported Blockchains</p>
+    ChangeType:
+      type: string
+      enum:
+        - Update
+        - Deletion
+        - Creation
+        - Unspecified
+    ContractId:
+      type: object
+      required:
+        - address
+        - chain
+      properties:
+        address:
+          type: string
+        chain:
+          $ref: "#/components/schemas/Chain"
+      additionalProperties: false
+    Health:
+      oneOf:
+        - type: object
+          required:
+            - status
+          properties:
+            status:
+              type: string
+              enum:
+                - Ready
+        - type: object
+          required:
+            - status
+            - message
+          properties:
+            message:
+              type: string
+            status:
+              type: string
+              enum:
+                - Starting
+        - type: object
+          required:
+            - status
+            - message
+          properties:
+            message:
+              type: string
+            status:
+              type: string
+              enum:
+                - NotReady
+      example:
+        message: No db connection
+        status: NotReady
+      discriminator:
+        propertyName: status
+    PaginationParams:
+      type: object
+      description: Pagination parameter
+      properties:
+        page:
+          type: integer
+          format: int64
+          description: What page to retrieve
+          x-gitbook-description-html: <p>What page to retrieve</p>
+        page_size:
+          type: integer
+          format: int64
+          description: How many results to return per page
+          x-gitbook-description-html: <p>How many results to return per page</p>
+      additionalProperties: false
+      x-gitbook-description-html: <p>Pagination parameter</p>
+    PaginationResponse:
+      type: object
+      required:
+        - page
+        - page_size
+        - total
+      properties:
+        page:
+          type: integer
+          format: int64
+        page_size:
+          type: integer
+          format: int64
+        total:
+          type: integer
+          format: int64
+          description: The total number of items available across all pages of results
+          x-gitbook-description-html: >-
+            <p>The total number of items available across all pages of
+            results</p>
+      additionalProperties: false
+    ProtocolComponent:
+      type: object
+      description: Represents the static parts of a protocol component.
+      required:
+        - id
+        - protocol_system
+        - protocol_type_name
+        - chain
+        - tokens
+        - contract_ids
+        - static_attributes
+        - creation_tx
+        - created_at
+      properties:
+        chain:
+          $ref: "#/components/schemas/Chain"
+        change:
+          $ref: "#/components/schemas/ChangeType"
+        contract_ids:
+          type: array
+          items:
+            type: string
+          description: >-
+            Contract addresses involved in the components operations (may be
+            empty for
+
+            native implementations)
+          x-gitbook-description-html: >-
+            <p>Contract addresses involved in the components operations (may be
+            empty for
+
+            native implementations)</p>
+        created_at:
+          type: string
+          format: date-time
+          description: Date time of creation in UTC time
+          x-gitbook-description-html: <p>Date time of creation in UTC time</p>
+        creation_tx:
+          type: string
+          description: Transaction hash which created this component
+          x-gitbook-description-html: <p>Transaction hash which created this component</p>
+        id:
+          type: string
+          description: Unique identifier for this component
+          x-gitbook-description-html: <p>Unique identifier for this component</p>
+        protocol_system:
+          type: string
+          description: Protocol system this component is part of
+          x-gitbook-description-html: <p>Protocol system this component is part of</p>
+        protocol_type_name:
+          type: string
+          description: Type of the protocol system
+          x-gitbook-description-html: <p>Type of the protocol system</p>
+        static_attributes:
+          type: object
+          description: Constant attributes of the component
+          additionalProperties:
+            type: string
+          x-gitbook-description-html: <p>Constant attributes of the component</p>
+        tokens:
+          type: array
+          items:
+            type: string
+          description: Token addresses the component operates on
+          x-gitbook-description-html: <p>Token addresses the component operates on</p>
+      x-gitbook-description-html: <p>Represents the static parts of a protocol component.</p>
+    ProtocolComponentRequestResponse:
+      type: object
+      description: Response from Tycho server for a protocol components request.
+      required:
+        - protocol_components
+        - pagination
+      properties:
+        pagination:
+          $ref: "#/components/schemas/PaginationResponse"
+        protocol_components:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProtocolComponent"
+      x-gitbook-description-html: <p>Response from Tycho server for a protocol components request.</p>
+    ProtocolComponentsRequestBody:
+      type: object
+      required:
+        - protocol_system
+      properties:
+        chain:
+          $ref: "#/components/schemas/Chain"
+        component_ids:
+          type: array
+          items:
+            type: string
+          description: Filter by component ids
+          nullable: true
+          x-gitbook-description-html: <p>Filter by component ids</p>
+        pagination:
+          $ref: "#/components/schemas/PaginationParams"
+        protocol_system:
+          type: string
+          description: >-
+            Filters by protocol, required to correctly apply unconfirmed state
+            from
+
+            ReorgBuffers
+          x-gitbook-description-html: >-
+            <p>Filters by protocol, required to correctly apply unconfirmed
+            state from
+
+            ReorgBuffers</p>
+        tvl_gt:
+          type: number
+          format: double
+          description: >-
+            The minimum TVL of the protocol components to return, denoted in the
+            chain's
+
+            native token.
+          nullable: true
+          x-gitbook-description-html: >-
+            <p>The minimum TVL of the protocol components to return, denoted in
+            the chain's
+
+            native token.</p>
+      additionalProperties: false
+    ProtocolId:
+      type: object
+      required:
+        - id
+        - chain
+      properties:
+        chain:
+          $ref: "#/components/schemas/Chain"
+        id:
+          type: string
+      additionalProperties: false
+      deprecated: true
+    ProtocolStateDelta:
+      type: object
+      description: Represents a change in protocol state.
+      required:
+        - component_id
+        - updated_attributes
+        - deleted_attributes
+      properties:
+        component_id:
+          type: string
+        deleted_attributes:
+          type: array
+          items:
+            type: string
+          uniqueItems: true
+        updated_attributes:
+          type: object
+          additionalProperties:
+            type: string
+      x-gitbook-description-html: <p>Represents a change in protocol state.</p>
+    ProtocolStateRequestBody:
+      type: object
+      description: Max page size supported is 100
+      required:
+        - protocol_system
+      properties:
+        chain:
+          $ref: "#/components/schemas/Chain"
+        include_balances:
+          type: boolean
+          description: >-
+            Whether to include account balances in the response. Defaults to
+            true.
+          x-gitbook-description-html: >-
+            <p>Whether to include account balances in the response. Defaults to
+            true.</p>
+        pagination:
+          $ref: "#/components/schemas/PaginationParams"
+        protocol_ids:
+          type: array
+          items:
+            type: string
+          description: Filters response by protocol components ids
+          nullable: true
+          x-gitbook-description-html: <p>Filters response by protocol components ids</p>
+        protocol_system:
+          type: string
+          description: >-
+            Filters by protocol, required to correctly apply unconfirmed state
+            from
+
+            ReorgBuffers
+          x-gitbook-description-html: >-
+            <p>Filters by protocol, required to correctly apply unconfirmed
+            state from
+
+            ReorgBuffers</p>
+        version:
+          $ref: "#/components/schemas/VersionParam"
+      additionalProperties: false
+      x-gitbook-description-html: <p>Max page size supported is 100</p>
+    ProtocolStateRequestResponse:
+      type: object
+      required:
+        - states
+        - pagination
+      properties:
+        pagination:
+          $ref: "#/components/schemas/PaginationResponse"
+        states:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResponseProtocolState"
+    ProtocolSystemsRequestBody:
+      type: object
+      properties:
+        chain:
+          $ref: "#/components/schemas/Chain"
+        pagination:
+          $ref: "#/components/schemas/PaginationParams"
+      additionalProperties: false
+    ProtocolSystemsRequestResponse:
+      type: object
+      required:
+        - protocol_systems
+        - pagination
+      properties:
+        pagination:
+          $ref: "#/components/schemas/PaginationResponse"
+        protocol_systems:
+          type: array
+          items:
+            type: string
+          description: List of currently supported protocol systems
+          x-gitbook-description-html: <p>List of currently supported protocol systems</p>
+    ResponseAccount:
+      type: object
+      description: >-
+        Account struct for the response from Tycho server for a contract state
+        request.
+
+
+        Code is serialized as a hex string instead of a list of bytes.
+      required:
+        - chain
+        - address
+        - title
+        - slots
+        - native_balance
+        - token_balances
+        - code
+        - code_hash
+        - balance_modify_tx
+        - code_modify_tx
+      properties:
+        address:
+          type: string
+          description: The address of the account as hex encoded string
+          example: "0xc9f2e6ea1637E499406986ac50ddC92401ce1f58"
+          x-gitbook-description-html: <p>The address of the account as hex encoded string</p>
+        balance_modify_tx:
+          type: string
+          description: Transaction hash which last modified native balance
+          example: "0x8f1133bfb054a23aedfe5d25b1d81b96195396d8b88bd5d4bcf865fc1ae2c3f4"
+          x-gitbook-description-html: <p>Transaction hash which last modified native balance</p>
+        chain:
+          $ref: "#/components/schemas/Chain"
+        code:
+          type: string
+          description: The accounts code as hex encoded string
+          example: "0xBADBABE"
+          x-gitbook-description-html: <p>The accounts code as hex encoded string</p>
+        code_hash:
+          type: string
+          description: The hash of above code
+          example: "0x123456789"
+          x-gitbook-description-html: <p>The hash of above code</p>
+        code_modify_tx:
+          type: string
+          description: Transaction hash which last modified code
+          example: "0x8f1133bfb054a23aedfe5d25b1d81b96195396d8b88bd5d4bcf865fc1ae2c3f4"
+          x-gitbook-description-html: <p>Transaction hash which last modified code</p>
+        creation_tx:
+          type: string
+          description: Transaction hash which created the account
+          example: "0x8f1133bfb054a23aedfe5d25b1d81b96195396d8b88bd5d4bcf865fc1ae2c3f4"
+          nullable: true
+          x-gitbook-description-html: <p>Transaction hash which created the account</p>
+        native_balance:
+          type: string
+          description: The balance of the account in the native token
+          example: "0x00"
+          x-gitbook-description-html: <p>The balance of the account in the native token</p>
+        slots:
+          type: object
+          description: Contract storage map of hex encoded string values
+          additionalProperties:
+            type: string
+          example:
+            0x....: 0x....
+          x-gitbook-description-html: <p>Contract storage map of hex encoded string values</p>
+        title:
+          type: string
+          description: >-
+            The title of the account usualy specifying its function within the
+            protocol
+          example: Protocol Vault
+          x-gitbook-description-html: >-
+            <p>The title of the account usualy specifying its function within
+            the protocol</p>
+        token_balances:
+          type: object
+          description: >-
+            Balances of this account in other tokens (only tokens balance that
+            are
+
+            relevant to the protocol are returned here)
+          additionalProperties:
+            type: string
+          example:
+            0x....: 0x....
+          x-gitbook-description-html: >-
+            <p>Balances of this account in other tokens (only tokens balance
+            that are
+
+            relevant to the protocol are returned here)</p>
+      x-gitbook-description-html: >-
+        <p>Account struct for the response from Tycho server for a contract
+        state request.</p>
+
+        <p>Code is serialized as a hex string instead of a list of bytes.</p>
+    ResponseProtocolState:
+      type: object
+      description: >-
+        Protocol State struct for the response from Tycho server for a protocol
+        state request.
+      required:
+        - component_id
+        - attributes
+        - balances
+      properties:
+        attributes:
+          type: object
+          description: |-
+            Attributes of the component. If an attribute's value is a `bigint`,
+            it will be encoded as a big endian signed hex string.
+          additionalProperties:
+            type: string
+          x-gitbook-description-html: >-
+            <p>Attributes of the component. If an attribute's value is a
+            <code>bigint</code>,
+
+            it will be encoded as a big endian signed hex string.</p>
+        balances:
+          type: object
+          description: Sum aggregated balances of the component
+          additionalProperties:
+            type: string
+          x-gitbook-description-html: <p>Sum aggregated balances of the component</p>
+        component_id:
+          type: string
+          description: Component id this state belongs to
+          x-gitbook-description-html: <p>Component id this state belongs to</p>
+      x-gitbook-description-html: >-
+        <p>Protocol State struct for the response from Tycho server for a
+        protocol state request.</p>
+    ResponseToken:
+      type: object
+      description: Token struct for the response from Tycho server for a tokens request.
+      required:
+        - chain
+        - address
+        - symbol
+        - decimals
+        - tax
+        - gas
+        - quality
+      properties:
+        address:
+          type: string
+          description: The address of this token as hex encoded string
+          example: "0xc9f2e6ea1637E499406986ac50ddC92401ce1f58"
+          x-gitbook-description-html: <p>The address of this token as hex encoded string</p>
+        chain:
+          $ref: "#/components/schemas/Chain"
+        decimals:
+          type: integer
+          format: int32
+          description: The number of decimals used to represent token values
+          minimum: 0
+          x-gitbook-description-html: <p>The number of decimals used to represent token values</p>
+        gas:
+          type: array
+          items:
+            type: integer
+            format: int64
+            nullable: true
+            minimum: 0
+          description: Gas usage of the token, currently is always a single averaged value
+          x-gitbook-description-html: >-
+            <p>Gas usage of the token, currently is always a single averaged
+            value</p>
+        quality:
+          type: integer
+          format: int32
+          description: |-
+            Quality is between 0-100, where:
+            - 100: Normal ERC-20 Token behavior
+            - 75: Rebasing token
+            - 50: Fee-on-transfer token
+            - 10: Token analysis failed at first detection
+            - 5: Token analysis failed multiple times (after creation)
+            - 0: Failed to extract attributes, like Decimal or Symbol
+          minimum: 0
+          x-gitbook-description-html: |-
+            <p>Quality is between 0-100, where:</p>
+            <ul>
+            <li>100: Normal ERC-20 Token behavior</li>
+            <li>75: Rebasing token</li>
+            <li>50: Fee-on-transfer token</li>
+            <li>10: Token analysis failed at first detection</li>
+            <li>5: Token analysis failed multiple times (after creation)</li>
+            <li>0: Failed to extract attributes, like Decimal or Symbol</li>
+            </ul>
+        symbol:
+          type: string
+          description: A shorthand symbol for this token (not unique)
+          example: WETH
+          x-gitbook-description-html: <p>A shorthand symbol for this token (not unique)</p>
+        tax:
+          type: integer
+          format: int64
+          description: The tax this token charges on transfers in basis points
+          minimum: 0
+          x-gitbook-description-html: <p>The tax this token charges on transfers in basis points</p>
+      x-gitbook-description-html: >-
+        <p>Token struct for the response from Tycho server for a tokens
+        request.</p>
+    StateRequestBody:
+      type: object
+      description: Maximum page size for this endpoint is 100
+      properties:
+        chain:
+          $ref: "#/components/schemas/Chain"
+        contract_ids:
+          type: array
+          items:
+            type: string
+          description: Filters response by contract addresses
+          nullable: true
+          x-gitbook-description-html: <p>Filters response by contract addresses</p>
+        pagination:
+          $ref: "#/components/schemas/PaginationParams"
+        protocol_system:
+          type: string
+          description: >-
+            Does not filter response, only required to correctly apply
+            unconfirmed state
+
+            from ReorgBuffers
+          x-gitbook-description-html: >-
+            <p>Does not filter response, only required to correctly apply
+            unconfirmed state
+
+            from ReorgBuffers</p>
+        version:
+          $ref: "#/components/schemas/VersionParam"
+      additionalProperties: false
+      x-gitbook-description-html: <p>Maximum page size for this endpoint is 100</p>
+    StateRequestResponse:
+      type: object
+      description: Response from Tycho server for a contract state request.
+      required:
+        - accounts
+        - pagination
+      properties:
+        accounts:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResponseAccount"
+        pagination:
+          $ref: "#/components/schemas/PaginationResponse"
+      x-gitbook-description-html: <p>Response from Tycho server for a contract state request.</p>
+    TokensRequestBody:
+      type: object
+      properties:
+        chain:
+          $ref: "#/components/schemas/Chain"
+        min_quality:
+          type: integer
+          format: int32
+          description: |-
+            Quality is between 0-100, where:
+            - 100: Normal ERC-20 Token behavior
+            - 75: Rebasing token
+            - 50: Fee-on-transfer token
+            - 10: Token analysis failed at first detection
+            - 5: Token analysis failed multiple times (after creation)
+            - 0: Failed to extract attributes, like Decimal or Symbol
+          nullable: true
+          x-gitbook-description-html: |-
+            <p>Quality is between 0-100, where:</p>
+            <ul>
+            <li>100: Normal ERC-20 Token behavior</li>
+            <li>75: Rebasing token</li>
+            <li>50: Fee-on-transfer token</li>
+            <li>10: Token analysis failed at first detection</li>
+            <li>5: Token analysis failed multiple times (after creation)</li>
+            <li>0: Failed to extract attributes, like Decimal or Symbol</li>
+            </ul>
+        pagination:
+          $ref: "#/components/schemas/PaginationParams"
+        token_addresses:
+          type: array
+          items:
+            type: string
+          description: Filters tokens by addresses
+          nullable: true
+          x-gitbook-description-html: <p>Filters tokens by addresses</p>
+        traded_n_days_ago:
+          type: integer
+          format: int64
+          description: Filters tokens by recent trade activity
+          nullable: true
+          minimum: 0
+          x-gitbook-description-html: <p>Filters tokens by recent trade activity</p>
+      additionalProperties: false
+    TokensRequestResponse:
+      type: object
+      description: Response from Tycho server for a tokens request.
+      required:
+        - tokens
+        - pagination
+      properties:
+        pagination:
+          $ref: "#/components/schemas/PaginationResponse"
+        tokens:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResponseToken"
+      x-gitbook-description-html: <p>Response from Tycho server for a tokens request.</p>
+    VersionParam:
+      type: object
+      description: >-
+        The version of the requested state, given as either a timestamp or a
+        block.
+
+
+        If block is provided, the state at that exact block is returned. Will
+        error if the block
+
+        has not been processed yet. If timestamp is provided, the state at the
+        latest block before
+
+        that timestamp is returned.
+
+        Defaults to the current time.
+      properties:
+        block:
+          allOf:
+            - $ref: "#/components/schemas/BlockParam"
+          nullable: true
+        timestamp:
+          type: string
+          format: date-time
+          nullable: true
+      additionalProperties: false
+      x-gitbook-description-html: >-
+        <p>The version of the requested state, given as either a timestamp or a
+        block.</p>
+
+        <p>If block is provided, the state at that exact block is returned. Will
+        error if the block
+
+        has not been processed yet. If timestamp is provided, the state at the
+        latest block before
+
+        that timestamp is returned.
+
+        Defaults to the current time.</p>
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: authorization
+      description: Use 'sampletoken' as value for testing
+      x-gitbook-description-html: <p>Use 'sampletoken' as value for testing</p>

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    slice,
     str::FromStr,
     sync::Arc,
 };
@@ -1310,7 +1311,7 @@ impl ExtractorGateway for ExtractorPgGateway {
                 .await?;
         }
         self.state_gateway
-            .upsert_block(&[changes.block.clone()])
+            .upsert_block(slice::from_ref(&changes.block))
             .await?;
 
         let mut new_protocol_components: Vec<ProtocolComponent> = vec![];
@@ -1325,7 +1326,7 @@ impl ExtractorGateway for ExtractorPgGateway {
 
             // Insert transaction
             self.state_gateway
-                .upsert_tx(&[tx_update.tx.clone()])
+                .upsert_tx(slice::from_ref(&tx_update.tx))
                 .await?;
 
             let hash: TxHash = tx_update.tx.hash.clone();

--- a/tycho-indexer/src/main.rs
+++ b/tycho-indexer/src/main.rs
@@ -3,7 +3,7 @@ use std::{
     collections::HashMap,
     fs::File,
     io::Read,
-    process,
+    process, slice,
     str::FromStr,
     sync::{mpsc, Arc},
 };
@@ -462,12 +462,12 @@ async fn initialize_accounts(
         .await;
 
     cached_gw
-        .upsert_block(&[block.clone()])
+        .upsert_block(slice::from_ref(&block))
         .await
         .expect("Failed to insert block");
 
     cached_gw
-        .upsert_tx(&[tx.clone()])
+        .upsert_tx(slice::from_ref(&tx))
         .await
         .expect("Failed to insert tx");
 

--- a/tycho-storage/sql_scripts/remove_protocol_system.sh
+++ b/tycho-storage/sql_scripts/remove_protocol_system.sh
@@ -131,6 +131,7 @@ WHERE id IN (SELECT account_id FROM tokens_to_delete);
 
 --- Find and remove all linked accounts (accounts are not cascade deleted on component deletions). Note, this will cascade 
 --- delete the linked contract code entries too.
+
 --- Delete linked balances for all accounts exclusively linked to the protocol components of the system being deleted. This
 --- is explicitly done to ensure we delete balances for accounts that are removed as components, but kept as tokens.
 DELETE FROM account_balance
@@ -150,6 +151,27 @@ WHERE account_id IN (
         AND ps2.name <> :'protocol_system_name'
     )
 );
+
+--- Delete linked contract code for all accounts exclusively linked to the protocol components of the system being deleted. This
+--- is explicitly done to ensure we delete contract code for accounts that are removed as components, but kept as tokens.
+DELETE FROM contract_code
+WHERE account_id IN (
+    SELECT DISTINCT cc.account_id
+    FROM contract_code cc
+    JOIN protocol_component_holds_contract pchc ON pchc.contract_code_id = cc.id
+    JOIN protocol_component pc ON pchc.protocol_component_id = pc.id
+    JOIN protocol_system ps ON pc.protocol_system_id = ps.id
+    WHERE ps.name = :'protocol_system_name'
+    AND NOT EXISTS (
+        SELECT 1
+        FROM protocol_component_holds_contract pchc2
+        JOIN protocol_component pc2 ON pchc2.protocol_component_id = pc2.id
+        JOIN protocol_system ps2 ON pc2.protocol_system_id = ps2.id
+        WHERE pchc2.contract_code_id = cc.id
+        AND ps2.name <> :'protocol_system_name'
+    )
+);
+
 --- Delete accounts exclusively linked to the protocol components of the system being deleted, skipping accounts that are
 --- linked used as tokens by other protocol systems.
 DELETE FROM account

--- a/tycho-storage/src/postgres/cache.rs
+++ b/tycho-storage/src/postgres/cache.rs
@@ -1117,7 +1117,7 @@ impl Gateway for CachedGateway {}
 
 #[cfg(test)]
 mod test_serial_db {
-    use std::{collections::HashSet, str::FromStr, time::Duration};
+    use std::{collections::HashSet, slice, str::FromStr, time::Duration};
 
     use tycho_common::models::ChangeType;
 
@@ -1385,11 +1385,11 @@ mod test_serial_db {
                 .start_transaction(&block_1, None)
                 .await;
             cached_gw
-                .upsert_block(&[block_1.clone()])
+                .upsert_block(slice::from_ref(&block_1))
                 .await
                 .expect("Upsert block 1 ok");
             cached_gw
-                .upsert_tx(&[tx_1.clone()])
+                .upsert_tx(slice::from_ref(&tx_1))
                 .await
                 .expect("Upsert tx 1 ok");
             cached_gw
@@ -1403,7 +1403,7 @@ mod test_serial_db {
                 .start_transaction(&block_2, None)
                 .await;
             cached_gw
-                .upsert_block(&[block_2.clone()])
+                .upsert_block(slice::from_ref(&block_2))
                 .await
                 .expect("Upsert block 2 ok");
             cached_gw
@@ -1417,7 +1417,7 @@ mod test_serial_db {
                 .start_transaction(&block_3, None)
                 .await;
             cached_gw
-                .upsert_block(&[block_3.clone()])
+                .upsert_block(slice::from_ref(&block_3))
                 .await
                 .expect("Upsert block 3 ok");
             cached_gw

--- a/tycho-storage/src/postgres/chain.rs
+++ b/tycho-storage/src/postgres/chain.rs
@@ -264,7 +264,7 @@ impl PostgresGateway {
 
 #[cfg(test)]
 mod test {
-    use std::{str::FromStr, time::Duration};
+    use std::{slice, str::FromStr, time::Duration};
 
     use diesel_async::AsyncConnection;
     use tycho_common::models::Chain;
@@ -360,7 +360,7 @@ mod test {
         let gw = EVMGateway::from_connection(&mut conn).await;
         let block = block("0xbadbabe000000000000000000000000000000000000000000000000000000000");
 
-        gw.upsert_block(&[block.clone()], &mut conn)
+        gw.upsert_block(slice::from_ref(&block), &mut conn)
             .await
             .unwrap();
         let retrieved_block = gw
@@ -384,7 +384,7 @@ mod test {
             yesterday_midnight(),
         );
 
-        gw.upsert_block(&[block.clone()], &mut conn)
+        gw.upsert_block(slice::from_ref(&block), &mut conn)
             .await
             .unwrap();
         let retrieved_block = gw
@@ -458,7 +458,7 @@ mod test {
             index: 1,
         };
 
-        gw.upsert_tx(&[tx.clone()], &mut conn)
+        gw.upsert_tx(slice::from_ref(&tx), &mut conn)
             .await
             .unwrap();
         let retrieved_tx = gw

--- a/tycho-storage/src/postgres/contract.rs
+++ b/tycho-storage/src/postgres/contract.rs
@@ -1,4 +1,7 @@
-use std::collections::{hash_map::Entry, HashMap, HashSet};
+use std::{
+    collections::{hash_map::Entry, HashMap, HashSet},
+    slice,
+};
 
 use chrono::{NaiveDateTime, Utc};
 use diesel::{
@@ -719,7 +722,7 @@ impl PostgresGateway {
         let chain = id.chain;
 
         let mut all_balances = self
-            .get_account_balances(&chain, Some(&[id.address.clone()]), version, true, conn)
+            .get_account_balances(&chain, Some(slice::from_ref(&id.address)), version, true, conn)
             .await?;
         let account_balances = all_balances
             .get_mut(&id.address)

--- a/tycho-storage/src/postgres/protocol.rs
+++ b/tycho-storage/src/postgres/protocol.rs
@@ -1812,7 +1812,7 @@ impl PostgresGateway {
 
 #[cfg(test)]
 mod test {
-    use std::str::FromStr;
+    use std::{slice, str::FromStr};
 
     use diesel_async::AsyncConnection;
     use rstest::rstest;
@@ -3309,7 +3309,7 @@ mod test {
             Default::default(),
         );
 
-        gw.add_protocol_components(&[original_component.clone()], &mut conn)
+        gw.add_protocol_components(slice::from_ref(&original_component), &mut conn)
             .await
             .expect("adding components failed");
 


### PR DESCRIPTION
Currently the script doesn't delete contract code if the account is still used as a token. This commit fixes this.