### PR TITLE
fix: order protocol states query by protocol component

### DIFF
--- a/tycho-storage/src/postgres/orm.rs
+++ b/tycho-storage/src/postgres/orm.rs
@@ -718,7 +718,7 @@ impl ProtocolState {
         // Apply pagination and fetch total count
         let count: Option<i64> = if let Some(pagination) = pagination_params {
             component_query = component_query
-                .order_by(protocol_system::id)
+                .order_by(protocol_component::id)
                 .limit(pagination.page_size)
                 .offset(pagination.page * pagination.page_size);
 


### PR DESCRIPTION
To ensure consistency with the application of pagination. Ordering by protocol system makes no sense as we filter for only 1 protocol system in the same query.