### PR TITLE
feat: add pagination to EntryPointGateway

### DIFF
--- a/tycho-common/src/models/blockchain.rs
+++ b/tycho-common/src/models/blockchain.rs
@@ -700,13 +700,15 @@ pub mod fixtures {
                 .len(),
             2
         );
+        let mut expected_entry_points = changes1
+            .entrypoints
+            .values()
+            .flat_map(|ep| ep.iter())
+            .map(|ep| ep.signature.clone())
+            .collect::<Vec<_>>();
+        expected_entry_points.sort();
         assert_eq!(
-            changes1
-                .entrypoints
-                .values()
-                .flat_map(|ep| ep.iter())
-                .map(|ep| ep.signature.clone())
-                .collect::<Vec<_>>(),
+            expected_entry_points,
             vec!["function()".to_string(), "function_2()".to_string()],
         );
     }

--- a/tycho-common/src/storage.rs
+++ b/tycho-common/src/storage.rs
@@ -512,37 +512,56 @@ impl EntryPointFilter {
 #[async_trait]
 pub trait EntryPointGateway {
     /// Upserts a list of entry points into the database.
+    ///
+    /// * `entry_points` - The map of component ids to their entry points to upsert.
     async fn upsert_entry_points(
         &self,
         entry_points: &HashMap<ComponentId, HashSet<EntryPoint>>,
     ) -> Result<(), StorageError>;
 
     /// Upserts a list of entry points with their tracing params into the database.
+    ///
+    /// * `entry_points_params` - The map of entry points to their tracing params to upsert and
+    ///   optionally a component id used for debugging only.
     async fn upsert_entry_point_tracing_params(
         &self,
         entry_points_params: &HashMap<EntryPointId, HashSet<(TracingParams, Option<ComponentId>)>>,
     ) -> Result<(), StorageError>;
 
     /// Retrieves a map of component ids to a set of entry points from the database.
+    ///
+    /// * `filter` - The EntryPointFilter to apply to the query.
+    /// * `pagination_params` - The pagination parameters to apply to the query, if None, all
+    ///   results are returned.
     async fn get_entry_points(
         &self,
         filter: EntryPointFilter,
-    ) -> Result<HashMap<ComponentId, HashSet<EntryPoint>>, StorageError>;
+        pagination_params: Option<&PaginationParams>,
+    ) -> Result<WithTotal<HashMap<ComponentId, HashSet<EntryPoint>>>, StorageError>;
 
     /// Retrieves a map of component ids to a set of entry points with their tracing data from the
     /// database.
+    ///
+    /// * `filter` - The EntryPointFilter to apply to the query.
+    /// * `pagination_params` - The pagination parameters to apply to the query, if None, all
+    ///   results are returned.
     async fn get_entry_points_tracing_params(
         &self,
         filter: EntryPointFilter,
-    ) -> Result<HashMap<ComponentId, HashSet<EntryPointWithTracingParams>>, StorageError>;
+        pagination_params: Option<&PaginationParams>,
+    ) -> Result<WithTotal<HashMap<ComponentId, HashSet<EntryPointWithTracingParams>>>, StorageError>;
 
     /// Upserts a list of traced entry points into the database.
+    ///
+    /// * `traced_entry_points` - The list of traced entry points to upsert.
     async fn upsert_traced_entry_points(
         &self,
         traced_entry_points: &[TracedEntryPoint],
     ) -> Result<(), StorageError>;
 
     /// Retrieves all tracing results for a set of entry points from the database.
+    ///
+    /// * `entry_points` - The set of entry points to retrieve tracing results for.
     async fn get_traced_entry_points(
         &self,
         entry_points: &HashSet<EntryPointId>,

--- a/tycho-common/src/storage.rs
+++ b/tycho-common/src/storage.rs
@@ -511,19 +511,23 @@ impl EntryPointFilter {
 // Trait for entry point gateway operations.
 #[async_trait]
 pub trait EntryPointGateway {
-    /// Upserts a list of entry points into the database.
+    /// Inserts a list of entry points into the database.
     ///
-    /// * `entry_points` - The map of component ids to their entry points to upsert.
-    async fn upsert_entry_points(
+    /// * `entry_points` - The map of component ids to their entry points to insert.
+    ///
+    /// Note: This function ignores conflicts on inserts.
+    async fn insert_entry_points(
         &self,
         entry_points: &HashMap<ComponentId, HashSet<EntryPoint>>,
     ) -> Result<(), StorageError>;
 
-    /// Upserts a list of entry points with their tracing params into the database.
+    /// Inserts a list of entry points with their tracing params into the database.
     ///
-    /// * `entry_points_params` - The map of entry points to their tracing params to upsert and
+    /// * `entry_points_params` - The map of entry points to their tracing params to insert and
     ///   optionally a component id used for debugging only.
-    async fn upsert_entry_point_tracing_params(
+    ///
+    /// Note: This function ignores conflicts on inserts.
+    async fn insert_entry_point_tracing_params(
         &self,
         entry_points_params: &HashMap<EntryPointId, HashSet<(TracingParams, Option<ComponentId>)>>,
     ) -> Result<(), StorageError>;
@@ -551,7 +555,8 @@ pub trait EntryPointGateway {
         pagination_params: Option<&PaginationParams>,
     ) -> Result<WithTotal<HashMap<ComponentId, HashSet<EntryPointWithTracingParams>>>, StorageError>;
 
-    /// Upserts a list of traced entry points into the database.
+    /// Upserts a list of traced entry points into the database. Updates the result if it already
+    /// exists for the same entry point and tracing params.
     ///
     /// * `traced_entry_points` - The list of traced entry points to upsert.
     async fn upsert_traced_entry_points(

--- a/tycho-storage/src/postgres/cache.rs
+++ b/tycho-storage/src/postgres/cache.rs
@@ -527,7 +527,7 @@ impl DBCacheWriteExecutor {
             }
             WriteOp::UpsertEntryPoints(new_entry_points) => {
                 self.state_gateway
-                    .insert_entry_points(new_entry_points, &self.chain, conn)
+                    .upsert_entry_points(new_entry_points, &self.chain, conn)
                     .await?
             }
             WriteOp::UpsertEntryPointTracingParams(new_entry_point_tracing_params) => {
@@ -1193,13 +1193,14 @@ impl EntryPointGateway for CachedGateway {
     async fn get_entry_points(
         &self,
         filter: EntryPointFilter,
-    ) -> Result<HashMap<ComponentId, HashSet<EntryPoint>>, StorageError> {
+        pagination_params: Option<&PaginationParams>,
+    ) -> Result<WithTotal<HashMap<ComponentId, HashSet<EntryPoint>>>, StorageError> {
         let mut conn =
             self.pool.get().await.map_err(|e| {
                 StorageError::Unexpected(format!("Failed to retrieve connection: {e}"))
             })?;
         self.state_gateway
-            .get_entry_points(filter, &mut conn)
+            .get_entry_points(filter, pagination_params, &mut conn)
             .await
     }
 
@@ -1207,13 +1208,15 @@ impl EntryPointGateway for CachedGateway {
     async fn get_entry_points_tracing_params(
         &self,
         filter: EntryPointFilter,
-    ) -> Result<HashMap<ComponentId, HashSet<EntryPointWithTracingParams>>, StorageError> {
+        pagination_params: Option<&PaginationParams>,
+    ) -> Result<WithTotal<HashMap<ComponentId, HashSet<EntryPointWithTracingParams>>>, StorageError>
+    {
         let mut conn =
             self.pool.get().await.map_err(|e| {
                 StorageError::Unexpected(format!("Failed to retrieve connection: {e}"))
             })?;
         self.state_gateway
-            .get_entry_points_tracing_params(filter, &mut conn)
+            .get_entry_points_tracing_params(filter, pagination_params, &mut conn)
             .await
     }
 


### PR DESCRIPTION
This commit updates the EntryPointGateway trait to include pagination parameters for the get_entry_points and get_entry_points_tracing_params methods, returning results wrapped in a WithTotal struct. This is needed by the RPC methods.