### PR TITLE
feat: extend tycho-client to handle dci data

### DIFF
--- a/tycho-client/src/deltas.rs
+++ b/tycho-client/src/deltas.rs
@@ -904,7 +904,7 @@ mod tests {
                         "component_tvl": {
                             "protocol_1": 1000.0
                         },
-                        "dci_data": {
+                        "dci_update": {
                             "new_entrypoints": {},
                             "new_entrypoint_params": {},
                             "trace_results": {}
@@ -1212,7 +1212,7 @@ mod tests {
                         "component_tvl": {
                             "protocol_1": 1000.0
                         },
-                        "dci_data": {
+                        "dci_update": {
                             "new_entrypoints": {},
                             "new_entrypoint_params": {},
                             "trace_results": {}

--- a/tycho-client/src/deltas.rs
+++ b/tycho-client/src/deltas.rs
@@ -903,6 +903,11 @@ mod tests {
                         },
                         "component_tvl": {
                             "protocol_1": 1000.0
+                        },
+                        "dci_data": {
+                            "new_entrypoints": {},
+                            "new_entrypoint_params": {},
+                            "trace_results": {}
                         }
                     }
                 }
@@ -1206,6 +1211,11 @@ mod tests {
                         },
                         "component_tvl": {
                             "protocol_1": 1000.0
+                        },
+                        "dci_data": {
+                            "new_entrypoints": {},
+                            "new_entrypoint_params": {},
+                            "trace_results": {}
                         }
                     }
                 }

--- a/tycho-client/src/feed/component_tracker.rs
+++ b/tycho-client/src/feed/component_tracker.rs
@@ -3,14 +3,14 @@ use std::collections::{HashMap, HashSet};
 use tracing::{debug, instrument, warn};
 use tycho_common::{
     dto::{BlockChanges, Chain, DCIData, ProtocolComponent, ProtocolComponentsRequestBody},
-    Bytes,
+    models::{Address, ComponentId, ProtocolSystem},
 };
 
 use crate::{rpc::RPCClient, RPCError};
 
 #[derive(Clone, Debug)]
 pub(crate) enum ComponentFilterVariant {
-    Ids(Vec<String>),
+    Ids(Vec<ComponentId>),
     /// MinimumTVLRange is a tuple of (remove_tvl_threshold, add_tvl_threshold). Components that
     /// drop below the remove threshold will be removed from tracking, components that exceed the
     /// add threshold will be added. This helps buffer against components that fluctuate on the
@@ -69,25 +69,34 @@ impl ComponentFilter {
     /// * `ids` - A vector of component IDs to include in the filter. Only components with these IDs
     ///   will be tracked.
     #[allow(non_snake_case)] // for backwards compatibility
-    pub fn Ids(ids: Vec<String>) -> ComponentFilter {
+    pub fn Ids(ids: Vec<ComponentId>) -> ComponentFilter {
         ComponentFilter { variant: ComponentFilterVariant::Ids(ids) }
     }
+}
+
+/// Information about an entrypoint, including which components use it and what contracts it
+/// interacts with
+#[derive(Default)]
+struct EntrypointRelations {
+    /// Set of component ids for components that have this entrypoint
+    components: HashSet<ComponentId>,
+    /// Set of detected contracts for the entrypoint
+    contracts: HashSet<Address>,
 }
 
 /// Helper struct to determine which components and contracts are being tracked atm.
 pub struct ComponentTracker<R: RPCClient> {
     chain: Chain,
-    protocol_system: String,
+    protocol_system: ProtocolSystem,
     filter: ComponentFilter,
     // We will need to request a snapshot for components/contracts that we did not emit as
     // snapshot for yet but are relevant now, e.g. because min tvl threshold exceeded.
-    pub components: HashMap<String, ProtocolComponent>,
-    /// Map of entrypoint id to a tuple of (set of component ids for components that have this
-    /// entrypoint, set of detected contracts for the entrypoint)
-    pub entrypoints: HashMap<String, (HashSet<String>, HashSet<Bytes>)>,
+    pub components: HashMap<ComponentId, ProtocolComponent>,
+    /// Map of entrypoint id to its associated components and contracts
+    entrypoints: HashMap<String, EntrypointRelations>,
     /// Derived from tracked components. We need this if subscribed to a vm extractor because
     /// updates are emitted on a contract level instead of a component level.
-    pub contracts: HashSet<Bytes>,
+    pub contracts: HashSet<Address>,
     /// Client to retrieve necessary protocol components from the rpc.
     rpc_client: R,
 }
@@ -134,13 +143,13 @@ where
             .map(|pc| (pc.id.clone(), pc))
             .collect::<HashMap<_, _>>();
 
-        self.initialise_contracts();
+        self.reinitialize_contracts();
 
         Ok(())
     }
 
     /// Initialise the tracked contracts list from tracked components and their entrypoints
-    fn initialise_contracts(&mut self) {
+    fn reinitialize_contracts(&mut self) {
         // Add contracts from all tracked components
         self.contracts = self
             .components
@@ -154,44 +163,54 @@ where
             .keys()
             .cloned()
             .collect::<HashSet<_>>();
-        for (_, (components, contracts)) in self.entrypoints.iter() {
-            if !components.is_disjoint(&tracked_component_ids) {
+        for entrypoint in self.entrypoints.values() {
+            if !entrypoint
+                .components
+                .is_disjoint(&tracked_component_ids)
+            {
                 self.contracts
-                    .extend(contracts.iter().cloned());
+                    .extend(entrypoint.contracts.iter().cloned());
             }
         }
     }
 
     /// Update the tracked contracts list with contracts associated with the given components
-    fn update_contracts(&mut self, components: Vec<String>) {
+    fn update_contracts(&mut self, components: Vec<ComponentId>) {
         // Only process components that are actually being tracked. Convert to HashSet for
         // efficient lookup.
         let tracked_component_ids = components
-            .iter()
-            .filter(|&id| self.components.contains_key(id))
-            .map(|s| s.to_string())
+            .into_iter()
+            .filter(|id| self.components.contains_key(id))
             .collect::<HashSet<_>>();
 
         // Add contracts from the components
         for comp in &tracked_component_ids {
-            if let Some(component) = self.components.get(comp) {
-                self.contracts
-                    .extend(component.contract_ids.iter().cloned());
-            }
+            let component = self
+                .components
+                .get(comp)
+                .expect("Component should exist as it was filtered above");
+            self.contracts
+                .extend(component.contract_ids.iter().cloned());
         }
 
         // Identify entrypoints linked to the given components
-        for (_, (components, contracts)) in self.entrypoints.iter() {
-            if !components.is_disjoint(&tracked_component_ids) {
+        for entrypoint in self.entrypoints.values() {
+            if !entrypoint
+                .components
+                .is_disjoint(&tracked_component_ids)
+            {
                 self.contracts
-                    .extend(contracts.iter().cloned());
+                    .extend(entrypoint.contracts.iter().cloned());
             }
         }
     }
 
-    /// Add a new component to be tracked
+    /// Add new components to be tracked
     #[instrument(skip(self, new_components))]
-    pub async fn start_tracking(&mut self, new_components: &[&String]) -> Result<(), RPCError> {
+    pub async fn start_tracking(
+        &mut self,
+        new_components: &[&ComponentId],
+    ) -> Result<(), RPCError> {
         if new_components.is_empty() {
             return Ok(());
         }
@@ -226,10 +245,10 @@ where
 
     /// Stop tracking components
     #[instrument(skip(self, to_remove))]
-    pub fn stop_tracking<'a, I: IntoIterator<Item = &'a String> + std::fmt::Debug>(
+    pub fn stop_tracking<'a, I: IntoIterator<Item = &'a ComponentId> + std::fmt::Debug>(
         &mut self,
         to_remove: I,
-    ) -> HashMap<String, ProtocolComponent> {
+    ) -> HashMap<ComponentId, ProtocolComponent> {
         let mut removed_components = HashMap::new();
 
         for component_id in to_remove {
@@ -240,7 +259,7 @@ where
 
         // Refresh the tracked contracts list. This is more reliable and efficient than directly
         // removing contracts from the list because some contracts are shared between components.
-        self.initialise_contracts();
+        self.reinitialize_contracts();
 
         debug!(n_components = removed_components.len(), "StoppedTracking");
         removed_components
@@ -252,23 +271,29 @@ where
         for (entrypoint, traces) in &dci_data.trace_results {
             self.entrypoints
                 .entry(entrypoint.clone())
-                .or_insert_with(|| (HashSet::new(), HashSet::new()))
-                .1
+                .or_default()
+                .contracts
                 .extend(traces.called_addresses.iter().cloned());
         }
 
         // Update linked components for entrypoints
         for (component, entrypoints) in &dci_data.new_entrypoints {
             for entrypoint in entrypoints {
-                let (components, contracts) = self
+                let entrypoint_info = self
                     .entrypoints
                     .entry(entrypoint.external_id.clone())
-                    .or_insert_with(|| (HashSet::new(), HashSet::new()));
-                components.insert(component.clone());
+                    .or_default();
+                entrypoint_info
+                    .components
+                    .insert(component.clone());
                 // If the component is tracked, add the detected contracts to the tracker
                 if self.components.contains_key(component) {
-                    self.contracts
-                        .extend(contracts.iter().cloned());
+                    self.contracts.extend(
+                        entrypoint_info
+                            .contracts
+                            .iter()
+                            .cloned(),
+                    );
                 }
             }
         }
@@ -279,7 +304,7 @@ where
     pub fn get_contracts_by_component<'a, I: IntoIterator<Item = &'a String>>(
         &self,
         ids: I,
-    ) -> HashSet<Bytes> {
+    ) -> HashSet<Address> {
         ids.into_iter()
             .flat_map(|cid| {
                 let comp = self
@@ -291,7 +316,7 @@ where
             .collect()
     }
 
-    pub fn get_tracked_component_ids(&self) -> Vec<String> {
+    pub fn get_tracked_component_ids(&self) -> Vec<ComponentId> {
         self.components
             .keys()
             .cloned()
@@ -300,7 +325,10 @@ where
 
     /// Given BlockChanges, filter out components that are no longer relevant and return the
     /// components that need to be added or removed.
-    pub fn filter_updated_components(&self, deltas: &BlockChanges) -> (Vec<String>, Vec<String>) {
+    pub fn filter_updated_components(
+        &self,
+        deltas: &BlockChanges,
+    ) -> (Vec<ComponentId>, Vec<ComponentId>) {
         match &self.filter.variant {
             ComponentFilterVariant::Ids(_) => (Default::default(), Default::default()),
             ComponentFilterVariant::MinimumTVLRange((remove_tvl, add_tvl)) => deltas
@@ -315,7 +343,10 @@ where
 
 #[cfg(test)]
 mod test {
-    use tycho_common::dto::{PaginationResponse, ProtocolComponentRequestResponse};
+    use tycho_common::{
+        dto::{PaginationResponse, ProtocolComponentRequestResponse},
+        Bytes,
+    };
 
     use super::*;
     use crate::rpc::MockRPCClient;
@@ -330,7 +361,7 @@ mod test {
         )
     }
 
-    fn components_response() -> (Vec<Bytes>, ProtocolComponent) {
+    fn components_response() -> (Vec<Address>, ProtocolComponent) {
         let contract_ids = vec![Bytes::from("0x1234"), Bytes::from("0xbabe")];
         let component = ProtocolComponent {
             id: "Component1".to_string(),

--- a/tycho-client/src/feed/component_tracker.rs
+++ b/tycho-client/src/feed/component_tracker.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use tracing::{debug, instrument, warn};
 use tycho_common::{
-    dto::{BlockChanges, Chain, DCIData, ProtocolComponent, ProtocolComponentsRequestBody},
+    dto::{BlockChanges, Chain, DCIUpdate, ProtocolComponent, ProtocolComponentsRequestBody},
     models::{Address, ComponentId, ProtocolSystem},
 };
 
@@ -266,9 +266,9 @@ where
     }
 
     /// Updates the tracked entrypoints and contracts based on the given DCI data.
-    pub fn process_entrypoints(&mut self, dci_data: &DCIData) -> Result<(), RPCError> {
+    pub fn process_entrypoints(&mut self, dci_update: &DCIUpdate) -> Result<(), RPCError> {
         // Update detected contracts for entrypoints
-        for (entrypoint, traces) in &dci_data.trace_results {
+        for (entrypoint, traces) in &dci_update.trace_results {
             self.entrypoints
                 .entry(entrypoint.clone())
                 .or_default()
@@ -277,7 +277,7 @@ where
         }
 
         // Update linked components for entrypoints
-        for (component, entrypoints) in &dci_data.new_entrypoints {
+        for (component, entrypoints) in &dci_update.new_entrypoints {
             for entrypoint in entrypoints {
                 let entrypoint_info = self
                     .entrypoints

--- a/tycho-client/src/feed/synchronizer.rs
+++ b/tycho-client/src/feed/synchronizer.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -18,8 +14,8 @@ use tokio::{
 use tracing::{debug, error, info, instrument, trace, warn};
 use tycho_common::{
     dto::{
-        BlockChanges, BlockParam, ExtractorIdentity, ProtocolComponent, ResponseAccount,
-        ResponseProtocolState, VersionParam,
+        BlockChanges, BlockParam, EntryPointWithTracingParams, ExtractorIdentity,
+        ProtocolComponent, ResponseAccount, ResponseProtocolState, TracingResult, VersionParam,
     },
     Bytes,
 };
@@ -58,6 +54,7 @@ struct SharedState {
 pub struct ComponentWithState {
     pub state: ResponseProtocolState,
     pub component: ProtocolComponent,
+    pub entrypoints: Vec<(EntryPointWithTracingParams, TracingResult)>,
 }
 
 #[derive(Clone, PartialEq, Debug, Default, Serialize, Deserialize)]
@@ -178,17 +175,11 @@ where
     }
 
     /// Retrieves state snapshots of the requested components
-    ///
-    /// TODO:
-    /// Future considerations:
-    /// The current design separates the concepts of snapshots and deltas, therefore requiring us to
-    /// fetch data for snapshots that might already exist in the deltas messages. This is
-    /// unnecessary and could be optimized by removing snapshots entirely and only using deltas.
     #[allow(deprecated)]
     async fn get_snapshots<'a, I: IntoIterator<Item = &'a String>>(
         &self,
         header: Header,
-        tracked_components: &ComponentTracker<R>,
+        tracked_components: &mut ComponentTracker<R>,
         ids: Option<I>,
     ) -> SyncResult<StateSyncMessage> {
         if !self.include_snapshots {
@@ -204,27 +195,34 @@ where
         );
 
         // Use given ids or use all if not passed
-        let request_ids = ids
-            .map(|it| {
-                it.into_iter()
-                    .cloned()
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_else(|| tracked_components.get_tracked_component_ids());
-
-        let component_ids = request_ids
-            .iter()
-            .collect::<HashSet<_>>();
+        let component_ids: Vec<_> = match ids {
+            Some(ids) => ids.into_iter().cloned().collect(),
+            None => tracked_components.get_tracked_component_ids(),
+        };
 
         if component_ids.is_empty() {
             return Ok(StateSyncMessage { header, ..Default::default() });
         }
 
+        // Fetch entrypoints
+        let entrypoints_result = self
+            .rpc_client
+            .get_traced_entry_points_paginated(
+                self.extractor_id.chain,
+                &self.extractor_id.name,
+                &component_ids,
+                100,
+                4,
+            )
+            .await?;
+        tracked_components.process_entrypoints(&entrypoints_result.clone().into())?;
+
+        // Fetch protocol states
         let mut protocol_states = self
             .rpc_client
             .get_protocol_states_paginated(
                 self.extractor_id.chain,
-                &request_ids,
+                &component_ids,
                 &self.extractor_id.name,
                 self.retrieve_balances,
                 &version,
@@ -245,9 +243,17 @@ where
                 if let Some(state) = protocol_states.remove(&component.id) {
                     Some((
                         component.id.clone(),
-                        ComponentWithState { state, component: component.clone() },
+                        ComponentWithState {
+                            state,
+                            component: component.clone(),
+                            entrypoints: entrypoints_result
+                                .traced_entry_points
+                                .get(&component.id)
+                                .cloned()
+                                .unwrap_or_default(),
+                        },
                     ))
-                } else if component_ids.contains(&&component.id) {
+                } else if component_ids.contains(&component.id) {
                     // only emit error event if we requested this component
                     let component_id = &component.id;
                     error!(?component_id, "Missing state for native component!");
@@ -258,7 +264,8 @@ where
             })
             .collect();
 
-        let contract_ids = tracked_components.get_contracts_by_component(component_ids.clone());
+        // Fetch contract states
+        let contract_ids = tracked_components.get_contracts_by_component(&component_ids);
         let vm_storage = if !contract_ids.is_empty() {
             let ids: Vec<Bytes> = contract_ids
                 .clone()
@@ -286,7 +293,7 @@ where
                 .components
                 .iter()
                 .filter_map(|(id, comp)| {
-                    if component_ids.contains(&id) {
+                    if component_ids.contains(id) {
                         Some(
                             comp.contract_ids
                                 .iter()
@@ -356,7 +363,7 @@ where
         info!(height = &block.number, "Deltas received. Retrieving snapshot");
         let header = Header::from_block(first_msg.get_block(), first_msg.is_revert());
         let snapshot = self
-            .get_snapshots::<Vec<&String>>(Header::from_block(&block, false), &tracker, None)
+            .get_snapshots::<Vec<&String>>(Header::from_block(&block, false), &mut tracker, None)
             .await
             .map_err(|rpc_err| anyhow::format_err!("failed to get initial snapshot: {}", rpc_err))?
             .merge(StateSyncMessage {
@@ -380,6 +387,7 @@ where
             if let Some(mut deltas) = msg_rx.recv().await {
                 let header = Header::from_block(deltas.get_block(), deltas.is_revert());
                 debug!(block_number=?header.number, "Received delta message");
+
                 let (snapshots, removed_components) = {
                     // 1. Remove components based on latest changes
                     // 2. Add components based on latest changes, query those for snapshots
@@ -399,7 +407,7 @@ where
                         .start_tracking(requiring_snapshot.as_slice())
                         .await?;
                     let snapshots = self
-                        .get_snapshots(header.clone(), &tracker, Some(requiring_snapshot))
+                        .get_snapshots(header.clone(), &mut tracker, Some(requiring_snapshot))
                         .await?
                         .snapshots;
 
@@ -408,13 +416,18 @@ where
                     } else {
                         Default::default()
                     };
+
                     (snapshots, removed_components)
                 };
 
-                // 3. Filter deltas by currently tracked components / contracts
+                // 3. Update entrypoints on the tracker (affects which contracts are tracked)
+                tracker.process_entrypoints(&deltas.dci_data)?;
+
+                // 4. Filter deltas by currently tracked components / contracts
                 self.filter_deltas(&mut deltas, &tracker);
                 let n_changes = deltas.n_changes();
 
+                // 5. Send the message
                 let next = StateSyncMessage {
                     header: header.clone(),
                     snapshots,
@@ -527,12 +540,15 @@ where
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashSet;
+
     use test_log::test;
     use tycho_common::dto::{
-        Block, Chain, PaginationResponse, ProtocolComponentRequestResponse,
+        Block, Chain, DCIData, EntryPoint, PaginationResponse, ProtocolComponentRequestResponse,
         ProtocolComponentsRequestBody, ProtocolStateRequestBody, ProtocolStateRequestResponse,
-        ProtocolSystemsRequestBody, ProtocolSystemsRequestResponse, StateRequestBody,
-        StateRequestResponse, TokensRequestBody, TokensRequestResponse,
+        ProtocolSystemsRequestBody, ProtocolSystemsRequestResponse, RPCTracerParams,
+        StateRequestBody, StateRequestResponse, TokensRequestBody, TokensRequestResponse,
+        TracedEntryPointRequestBody, TracedEntryPointRequestResponse, TracingParams,
     };
     use uuid::Uuid;
 
@@ -592,6 +608,15 @@ mod test {
         ) -> Result<ProtocolSystemsRequestResponse, RPCError> {
             self.0
                 .get_protocol_systems(request)
+                .await
+        }
+
+        async fn get_traced_entry_points(
+            &self,
+            request: &TracedEntryPointRequestBody,
+        ) -> Result<TracedEntryPointRequestResponse, RPCError> {
+            self.0
+                .get_traced_entry_points(request)
                 .await
         }
     }
@@ -673,6 +698,13 @@ mod test {
         let mut rpc = MockRPCClient::new();
         rpc.expect_get_protocol_states()
             .returning(|_| Ok(state_snapshot_native()));
+        rpc.expect_get_traced_entry_points()
+            .returning(|_| {
+                Ok(TracedEntryPointRequestResponse {
+                    traced_entry_points: HashMap::new(),
+                    pagination: PaginationResponse::new(0, 20, 0),
+                })
+            });
         let state_sync = with_mocked_clients(true, Some(rpc), None);
         let mut tracker = ComponentTracker::new(
             Chain::Ethereum,
@@ -694,7 +726,11 @@ mod test {
                     .map(|state| {
                         (
                             state.component_id.clone(),
-                            ComponentWithState { state, component: component.clone() },
+                            ComponentWithState {
+                                state,
+                                component: component.clone(),
+                                entrypoints: vec![],
+                            },
                         )
                     })
                     .collect(),
@@ -705,7 +741,7 @@ mod test {
         };
 
         let snap = state_sync
-            .get_snapshots(header, &tracker, Some(&components_arg))
+            .get_snapshots(header, &mut tracker, Some(&components_arg))
             .await
             .expect("Retrieving snapshot failed");
 
@@ -722,6 +758,35 @@ mod test {
         }
     }
 
+    fn traced_entry_point_response() -> TracedEntryPointRequestResponse {
+        TracedEntryPointRequestResponse {
+            traced_entry_points: HashMap::from([(
+                "Component1".to_string(),
+                vec![(
+                    EntryPointWithTracingParams {
+                        entry_point: EntryPoint {
+                            external_id: "entrypoint_a".to_string(),
+                            target: Bytes::from("0x0badc0ffee"),
+                            signature: "sig()".to_string(),
+                        },
+                        params: TracingParams::RPCTracer(RPCTracerParams {
+                            caller: Some(Bytes::from("0x0badc0ffee")),
+                            calldata: Bytes::from("0x0badc0ffee"),
+                        }),
+                    },
+                    TracingResult {
+                        retriggers: HashSet::from([(
+                            Bytes::from("0x0badc0ffee"),
+                            Bytes::from("0x0badc0ffee"),
+                        )]),
+                        called_addresses: HashSet::from([Bytes::from("0x0badc0ffee")]),
+                    },
+                )],
+            )]),
+            pagination: PaginationResponse::new(0, 20, 0),
+        }
+    }
+
     #[test(tokio::test)]
     async fn test_get_snapshots_vm() {
         let header = Header::default();
@@ -730,6 +795,8 @@ mod test {
             .returning(|_| Ok(state_snapshot_native()));
         rpc.expect_get_contract_state()
             .returning(|_| Ok(state_snapshot_vm()));
+        rpc.expect_get_traced_entry_points()
+            .returning(|_| Ok(traced_entry_point_response()));
         let state_sync = with_mocked_clients(false, Some(rpc), None);
         let mut tracker = ComponentTracker::new(
             Chain::Ethereum,
@@ -757,6 +824,26 @@ mod test {
                             ..Default::default()
                         },
                         component: component.clone(),
+                        entrypoints: vec![(
+                            EntryPointWithTracingParams {
+                                entry_point: EntryPoint {
+                                    external_id: "entrypoint_a".to_string(),
+                                    target: Bytes::from("0x0badc0ffee"),
+                                    signature: "sig()".to_string(),
+                                },
+                                params: TracingParams::RPCTracer(RPCTracerParams {
+                                    caller: Some(Bytes::from("0x0badc0ffee")),
+                                    calldata: Bytes::from("0x0badc0ffee"),
+                                }),
+                            },
+                            TracingResult {
+                                retriggers: HashSet::from([(
+                                    Bytes::from("0x0badc0ffee"),
+                                    Bytes::from("0x0badc0ffee"),
+                                )]),
+                                called_addresses: HashSet::from([Bytes::from("0x0badc0ffee")]),
+                            },
+                        )],
                     },
                 )]
                 .into_iter()
@@ -772,7 +859,7 @@ mod test {
         };
 
         let snap = state_sync
-            .get_snapshots(header, &tracker, Some(&components_arg))
+            .get_snapshots(header, &mut tracker, Some(&components_arg))
             .await
             .expect("Retrieving snapshot failed");
 
@@ -859,6 +946,15 @@ mod test {
                     pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
                 })
             });
+        rpc_client
+            .expect_get_traced_entry_points()
+            .returning(|_| {
+                Ok(TracedEntryPointRequestResponse {
+                    traced_entry_points: HashMap::new(),
+                    pagination: PaginationResponse::new(0, 20, 0),
+                })
+            });
+
         // Mock deltas client and messages
         let mut deltas_client = MockDeltasClient::new();
         let (tx, rx) = channel(1);
@@ -892,6 +988,36 @@ mod test {
                     ts: Default::default(),
                 },
                 revert: false,
+                dci_data: DCIData {
+                    new_entrypoints: HashMap::from([(
+                        "Component1".to_string(),
+                        HashSet::from([EntryPoint {
+                            external_id: "entrypoint_a".to_string(),
+                            target: Bytes::from("0x0badc0ffee"),
+                            signature: "sig()".to_string(),
+                        }]),
+                    )]),
+                    new_entrypoint_params: HashMap::from([(
+                        "entrypoint_a".to_string(),
+                        HashSet::from([(
+                            TracingParams::RPCTracer(RPCTracerParams {
+                                caller: Some(Bytes::from("0x0badc0ffee")),
+                                calldata: Bytes::from("0x0badc0ffee"),
+                            }),
+                            Some("Component1".to_string()),
+                        )]),
+                    )]),
+                    trace_results: HashMap::from([(
+                        "entrypoint_a".to_string(),
+                        TracingResult {
+                            retriggers: HashSet::from([(
+                                Bytes::from("0x0badc0ffee"),
+                                Bytes::from("0x0badc0ffee"),
+                            )]),
+                            called_addresses: HashSet::from([Bytes::from("0x0badc0ffee")]),
+                        },
+                    )]),
+                },
                 ..Default::default()
             },
             BlockChanges {
@@ -966,6 +1092,7 @@ mod test {
                                 id: "Component1".to_string(),
                                 ..Default::default()
                             },
+                            entrypoints: vec![],
                         },
                     ),
                     (
@@ -979,6 +1106,7 @@ mod test {
                                 id: "Component2".to_string(),
                                 ..Default::default()
                             },
+                            entrypoints: vec![],
                         },
                     ),
                 ]
@@ -1011,6 +1139,7 @@ mod test {
                                 id: "Component3".to_string(),
                                 ..Default::default()
                             },
+                            entrypoints: vec![],
                         },
                     ),
                 ]
@@ -1082,7 +1211,6 @@ mod test {
                     pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
                 })
             });
-
         rpc_client
             .expect_get_protocol_states()
             .with(mockall::predicate::function(move |request_params: &ProtocolStateRequestBody| {
@@ -1115,7 +1243,6 @@ mod test {
                     pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
                 })
             });
-
         rpc_client
             .expect_get_protocol_states()
             .returning(|_| {
@@ -1131,6 +1258,14 @@ mod test {
                         },
                     ],
                     pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
+                })
+            });
+        rpc_client
+            .expect_get_traced_entry_points()
+            .returning(|_| {
+                Ok(TracedEntryPointRequestResponse {
+                    traced_entry_points: HashMap::new(),
+                    pagination: PaginationResponse::new(0, 20, 0),
                 })
             });
 
@@ -1240,6 +1375,7 @@ mod test {
                             id: "Component3".to_string(),
                             ..Default::default()
                         },
+                        entrypoints: vec![], // TODO: add entrypoints?
                     },
                 )]
                 .into_iter()

--- a/tycho-client/src/feed/synchronizer.rs
+++ b/tycho-client/src/feed/synchronizer.rs
@@ -421,7 +421,7 @@ where
                 };
 
                 // 3. Update entrypoints on the tracker (affects which contracts are tracked)
-                tracker.process_entrypoints(&deltas.dci_data)?;
+                tracker.process_entrypoints(&deltas.dci_update)?;
 
                 // 4. Filter deltas by currently tracked components / contracts
                 self.filter_deltas(&mut deltas, &tracker);
@@ -544,7 +544,7 @@ mod test {
 
     use test_log::test;
     use tycho_common::dto::{
-        Block, Chain, DCIData, EntryPoint, PaginationResponse, ProtocolComponentRequestResponse,
+        Block, Chain, DCIUpdate, EntryPoint, PaginationResponse, ProtocolComponentRequestResponse,
         ProtocolComponentsRequestBody, ProtocolStateRequestBody, ProtocolStateRequestResponse,
         ProtocolSystemsRequestBody, ProtocolSystemsRequestResponse, RPCTracerParams,
         StateRequestBody, StateRequestResponse, TokensRequestBody, TokensRequestResponse,
@@ -988,7 +988,7 @@ mod test {
                     ts: Default::default(),
                 },
                 revert: false,
-                dci_data: DCIData {
+                dci_update: DCIUpdate {
                     new_entrypoints: HashMap::from([(
                         "Component1".to_string(),
                         HashSet::from([EntryPoint {

--- a/tycho-client/src/rpc.rs
+++ b/tycho-client/src/rpc.rs
@@ -19,7 +19,7 @@ use tycho_common::{
         ProtocolComponentsRequestBody, ProtocolStateRequestBody, ProtocolStateRequestResponse,
         ProtocolSystemsRequestBody, ProtocolSystemsRequestResponse, ResponseToken,
         StateRequestBody, StateRequestResponse, TokensRequestBody, TokensRequestResponse,
-        VersionParam,
+        TracedEntryPointRequestBody, TracedEntryPointRequestResponse, VersionParam,
     },
     Bytes,
 };
@@ -375,6 +375,61 @@ pub trait RPCClient: Send + Sync {
         &self,
         request: &ProtocolSystemsRequestBody,
     ) -> Result<ProtocolSystemsRequestResponse, RPCError>;
+
+    async fn get_traced_entry_points(
+        &self,
+        request: &TracedEntryPointRequestBody,
+    ) -> Result<TracedEntryPointRequestResponse, RPCError>;
+
+    async fn get_traced_entry_points_paginated(
+        &self,
+        chain: Chain,
+        protocol_system: &str,
+        component_ids: &[String],
+        chunk_size: usize,
+        concurrency: usize,
+    ) -> Result<TracedEntryPointRequestResponse, RPCError> {
+        let semaphore = Arc::new(Semaphore::new(concurrency));
+        let chunked_bodies = component_ids
+            .chunks(chunk_size)
+            .map(|c| TracedEntryPointRequestBody {
+                chain,
+                protocol_system: protocol_system.to_string(),
+                component_ids: Some(c.to_vec()),
+                pagination: PaginationParams { page: 0, page_size: chunk_size as i64 },
+            })
+            .collect::<Vec<_>>();
+
+        let mut tasks = Vec::new();
+        for body in chunked_bodies.iter() {
+            let sem = semaphore.clone();
+            tasks.push(async move {
+                let _permit = sem
+                    .acquire()
+                    .await
+                    .map_err(|_| RPCError::Fatal("Semaphore dropped".to_string()))?;
+                self.get_traced_entry_points(body).await
+            });
+        }
+
+        try_join_all(tasks)
+            .await
+            .map(|responses| {
+                let traced_entry_points = responses
+                    .clone()
+                    .into_iter()
+                    .flat_map(|r| r.traced_entry_points)
+                    .collect();
+                let total = responses
+                    .iter()
+                    .map(|r| r.pagination.total)
+                    .sum();
+                TracedEntryPointRequestResponse {
+                    traced_entry_points,
+                    pagination: PaginationResponse { page: 0, page_size: chunk_size as i64, total },
+                }
+            })
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -642,17 +697,56 @@ impl RPCClient for HttpRPCClient {
         trace!(?protocol_systems, "Received protocol_systems response from Tycho server");
         Ok(protocol_systems)
     }
+
+    async fn get_traced_entry_points(
+        &self,
+        request: &TracedEntryPointRequestBody,
+    ) -> Result<TracedEntryPointRequestResponse, RPCError> {
+        let uri = format!(
+            "{}/{TYCHO_SERVER_VERSION}/traced_entry_points",
+            self.url
+                .to_string()
+                .trim_end_matches('/')
+        );
+        debug!(%uri, "Sending traced_entry_points request to Tycho server");
+        trace!(?request, "Sending request to Tycho server");
+
+        let response = self
+            .http_client
+            .post(&uri)
+            .json(request)
+            .send()
+            .await
+            .map_err(|e| RPCError::HttpClient(e.to_string()))?;
+        trace!(?response, "Received response from Tycho server");
+
+        let body = response
+            .text()
+            .await
+            .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
+        let entrypoints =
+            serde_json::from_str::<TracedEntryPointRequestResponse>(&body).map_err(|err| {
+                error!("Failed to parse traced_entry_points response: {:?}", &body);
+                RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
+            })?;
+        trace!(?entrypoints, "Received traced_entry_points response from Tycho server");
+        Ok(entrypoints)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, str::FromStr};
+    use std::{
+        collections::{HashMap, HashSet},
+        str::FromStr,
+    };
 
     use mockito::Server;
     use rstest::rstest;
     // TODO: remove once deprecated ProtocolId struct is removed
     #[allow(deprecated)]
     use tycho_common::dto::ProtocolId;
+    use tycho_common::dto::TracingParams;
 
     use super::*;
 
@@ -1028,5 +1122,98 @@ mod tests {
 
         mocked_server.assert();
         assert_eq!(protocol_systems, vec!["system1", "system2"]);
+    }
+
+    #[tokio::test]
+    async fn test_get_traced_entry_points() {
+        let mut server = Server::new_async().await;
+        let server_resp = r#"
+        {
+            "traced_entry_points": {
+                "component_1": [
+                    [
+                        {
+                            "entry_point": {
+                                "external_id": "entrypoint_a",
+                                "target": "0x0000000000000000000000000000000000000001",
+                                "signature": "sig()"
+                            },
+                            "params": {
+                                "method": "rpctracer",
+                                "caller": "0x000000000000000000000000000000000000000a",
+                                "calldata": "0x000000000000000000000000000000000000000b"
+                            }
+                        },
+                        {
+                            "retriggers": [
+                                [
+                                    "0x00000000000000000000000000000000000000aa",
+                                    "0x0000000000000000000000000000000000000aaa"
+                                ]
+                            ],
+                            "called_addresses": [
+                                "0x0000000000000000000000000000000000aaaa"
+                            ]
+                        }
+                    ]
+                ]
+            },
+            "pagination": {
+                "page": 0,
+                "page_size": 20,
+                "total": 1
+            }
+        }
+        "#;
+        // test that the response is deserialized correctly
+        serde_json::from_str::<TracedEntryPointRequestResponse>(server_resp).expect("deserialize");
+
+        let mocked_server = server
+            .mock("POST", "/v1/traced_entry_points")
+            .expect(1)
+            .with_body(server_resp)
+            .create_async()
+            .await;
+        let client = HttpRPCClient::new(server.url().as_str(), None).expect("create client");
+
+        let response = client
+            .get_traced_entry_points(&Default::default())
+            .await
+            .expect("get traced entry points");
+        let entrypoints = response.traced_entry_points;
+
+        mocked_server.assert();
+        assert_eq!(entrypoints.len(), 1);
+        let comp1_entrypoints = entrypoints
+            .get("component_1")
+            .expect("component_1 entrypoints should exist");
+        assert_eq!(comp1_entrypoints.len(), 1);
+
+        let (entrypoint, trace_result) = &comp1_entrypoints[0];
+        assert_eq!(entrypoint.entry_point.external_id, "entrypoint_a");
+        assert_eq!(
+            entrypoint.entry_point.target,
+            Bytes::from_str("0x0000000000000000000000000000000000000001").unwrap()
+        );
+        assert_eq!(entrypoint.entry_point.signature, "sig()");
+        let TracingParams::RPCTracer(rpc_params) = &entrypoint.params;
+        assert_eq!(
+            rpc_params.caller,
+            Some(Bytes::from("0x000000000000000000000000000000000000000a"))
+        );
+        assert_eq!(rpc_params.calldata, Bytes::from("0x000000000000000000000000000000000000000b"));
+
+        assert_eq!(
+            trace_result.retriggers,
+            HashSet::from([(
+                Bytes::from("0x00000000000000000000000000000000000000aa"),
+                Bytes::from("0x0000000000000000000000000000000000000aaa")
+            )])
+        );
+        assert_eq!(trace_result.called_addresses.len(), 1);
+        assert_eq!(
+            trace_result.called_addresses,
+            HashSet::from([Bytes::from("0x0000000000000000000000000000000000aaaa")])
+        );
     }
 }

--- a/tycho-common/src/dto.rs
+++ b/tycho-common/src/dto.rs
@@ -241,7 +241,7 @@ pub struct BlockChanges {
     pub component_balances: HashMap<String, TokenBalances>,
     pub account_balances: HashMap<Bytes, HashMap<Bytes, AccountBalance>>,
     pub component_tvl: HashMap<String, f64>,
-    pub dci_data: DCIData,
+    pub dci_update: DCIUpdate,
 }
 
 impl BlockChanges {
@@ -258,7 +258,7 @@ impl BlockChanges {
         deleted_protocol_components: HashMap<String, ProtocolComponent>,
         component_balances: HashMap<String, HashMap<Bytes, ComponentBalance>>,
         account_balances: HashMap<Bytes, HashMap<Bytes, AccountBalance>>,
-        dci_data: DCIData,
+        dci_update: DCIUpdate,
     ) -> Self {
         BlockChanges {
             extractor: extractor.to_owned(),
@@ -277,7 +277,7 @@ impl BlockChanges {
                 .collect(),
             account_balances,
             component_tvl: HashMap::new(),
-            dci_data,
+            dci_update,
         }
     }
 
@@ -980,11 +980,11 @@ impl PartialEq for ProtocolComponentsRequestBody {
             _ => false,
         };
 
-        self.protocol_system == other.protocol_system
-            && self.component_ids == other.component_ids
-            && tvl_close_enough
-            && self.chain == other.chain
-            && self.pagination == other.pagination
+        self.protocol_system == other.protocol_system &&
+            self.component_ids == other.component_ids &&
+            tvl_close_enough &&
+            self.chain == other.chain &&
+            self.pagination == other.pagination
     }
 }
 
@@ -1326,9 +1326,13 @@ impl ProtocolSystemsRequestResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
-pub struct DCIData {
+pub struct DCIUpdate {
+    /// Map of component id to the new entrypoints associated with the component
     pub new_entrypoints: HashMap<String, HashSet<EntryPoint>>,
+    /// Map of entrypoint id to the new entrypoint params associtated with it (and optionally the
+    /// component linked to those params)
     pub new_entrypoint_params: HashMap<String, HashSet<(TracingParams, Option<String>)>>,
+    /// Map of entrypoint id to its trace result
     pub trace_results: HashMap<String, TracingResult>,
 }
 
@@ -1438,7 +1442,7 @@ pub struct TracedEntryPointRequestResponse {
     pub pagination: PaginationResponse,
 }
 
-impl From<TracedEntryPointRequestResponse> for DCIData {
+impl From<TracedEntryPointRequestResponse> for DCIUpdate {
     fn from(response: TracedEntryPointRequestResponse) -> Self {
         let mut new_entrypoints = HashMap::new();
         let mut new_entrypoint_params = HashMap::new();
@@ -1482,7 +1486,7 @@ impl From<TracedEntryPointRequestResponse> for DCIData {
             }
         }
 
-        DCIData { new_entrypoints, new_entrypoint_params, trace_results }
+        DCIUpdate { new_entrypoints, new_entrypoint_params, trace_results }
     }
 }
 
@@ -1959,7 +1963,7 @@ mod test {
             "component_tvl": {
                 "protocol_1": 1000.0
             },
-            "dci_data": {
+            "dci_update": {
                 "new_entrypoints": {
                     "component_1": [
                         {
@@ -2074,7 +2078,7 @@ mod test {
                     }
                 },
                 "component_tvl": {},
-                "dci_data": {
+                "dci_update": {
                     "new_entrypoints": {
                         "0xde6faedbcae38eec6d33ad61473a04a6dd7f6e28": [
                             {

--- a/tycho-common/src/dto.rs
+++ b/tycho-common/src/dto.rs
@@ -1958,6 +1958,37 @@ mod test {
             },
             "component_tvl": {
                 "protocol_1": 1000.0
+            },
+            "dci_data": {
+                "new_entrypoints": {
+                    "component_1": [
+                        {
+                            "external_id": "0x01:sig()",
+                            "target": "0x01",
+                            "signature": "sig()"
+                        }
+                    ]
+                },
+                "new_entrypoint_params": {
+                    "0x01:sig()": [
+                        [
+                            {
+                                "method": "rpctracer",
+                                "caller": "0x01",
+                                "calldata": "0x02"
+                            },
+                            "component_1"
+                        ]
+                    ]
+                },
+                "trace_results": {
+                    "0x01:sig()": {
+                        "retriggers": [
+                            ["0x01", "0x02"]
+                        ],
+                        "called_addresses": ["0x03", "0x04"]
+                    }
+                }
             }
         }
         "#;
@@ -1975,60 +2006,60 @@ mod test {
                 "extractor": "uniswap_v2",
                 "chain": "ethereum",
                 "block": {
-                "number": 19291517,
-                "hash": "0xbc3ea4896c0be8da6229387a8571b72818aa258daf4fab46471003ad74c4ee83",
-                "parent_hash": "0x89ca5b8d593574cf6c886f41ef8208bf6bdc1a90ef36046cb8c84bc880b9af8f",
-                "chain": "ethereum",
-                "ts": "2024-02-23T16:35:35"
+                    "number": 19291517,
+                    "hash": "0xbc3ea4896c0be8da6229387a8571b72818aa258daf4fab46471003ad74c4ee83",
+                    "parent_hash": "0x89ca5b8d593574cf6c886f41ef8208bf6bdc1a90ef36046cb8c84bc880b9af8f",
+                    "chain": "ethereum",
+                    "ts": "2024-02-23T16:35:35"
                 },
                 "finalized_block_height": 0,
                 "revert": false,
                 "new_tokens": {},
                 "account_updates": {
-                            "0x7a250d5630b4cf539739df2c5dacb4c659f2488d": {
-                                "address": "0x7a250d5630b4cf539739df2c5dacb4c659f2488d",
-                                "chain": "ethereum",
-                                "slots": {},
-                                "balance": "0x01f4",
-                                "code": "",
-                                "change": "Update"
-                            }
-                        },
+                    "0x7a250d5630b4cf539739df2c5dacb4c659f2488d": {
+                        "address": "0x7a250d5630b4cf539739df2c5dacb4c659f2488d",
+                        "chain": "ethereum",
+                        "slots": {},
+                        "balance": "0x01f4",
+                        "code": "",
+                        "change": "Update"
+                    }
+                },
                 "state_updates": {
                     "0xde6faedbcae38eec6d33ad61473a04a6dd7f6e28": {
                         "component_id": "0xde6faedbcae38eec6d33ad61473a04a6dd7f6e28",
                         "updated_attributes": {
-                        "reserve0": "0x87f7b5973a7f28a8b32404",
-                        "reserve1": "0x09e9564b11"
+                            "reserve0": "0x87f7b5973a7f28a8b32404",
+                            "reserve1": "0x09e9564b11"
                         },
-                        "deleted_attributes": [ ]
+                        "deleted_attributes": []
                     },
                     "0x99c59000f5a76c54c4fd7d82720c045bdcf1450d": {
                         "component_id": "0x99c59000f5a76c54c4fd7d82720c045bdcf1450d",
                         "updated_attributes": {
-                        "reserve1": "0x44d9a8fd662c2f4d03",
-                        "reserve0": "0x500b1261f811d5bf423e"
+                            "reserve1": "0x44d9a8fd662c2f4d03",
+                            "reserve0": "0x500b1261f811d5bf423e"
                         },
-                        "deleted_attributes": [ ]
+                        "deleted_attributes": []
                     }
                 },
-                "new_protocol_components": { },
-                "deleted_protocol_components": { },
+                "new_protocol_components": {},
+                "deleted_protocol_components": {},
                 "component_balances": {
                     "0x99c59000f5a76c54c4fd7d82720c045bdcf1450d": {
                         "0x9012744b7a564623b6c3e40b144fc196bdedf1a9": {
-                        "token": "0x9012744b7a564623b6c3e40b144fc196bdedf1a9",
-                        "balance": "0x500b1261f811d5bf423e",
-                        "balance_float": 3.779935574269033E23,
-                        "modify_tx": "0xe46c4db085fb6c6f3408a65524555797adb264e1d5cf3b66ad154598f85ac4bf",
-                        "component_id": "0x99c59000f5a76c54c4fd7d82720c045bdcf1450d"
+                            "token": "0x9012744b7a564623b6c3e40b144fc196bdedf1a9",
+                            "balance": "0x500b1261f811d5bf423e",
+                            "balance_float": 3.779935574269033E23,
+                            "modify_tx": "0xe46c4db085fb6c6f3408a65524555797adb264e1d5cf3b66ad154598f85ac4bf",
+                            "component_id": "0x99c59000f5a76c54c4fd7d82720c045bdcf1450d"
                         },
                         "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": {
-                        "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-                        "balance": "0x44d9a8fd662c2f4d03",
-                        "balance_float": 1.270062661329837E21,
-                        "modify_tx": "0xe46c4db085fb6c6f3408a65524555797adb264e1d5cf3b66ad154598f85ac4bf",
-                        "component_id": "0x99c59000f5a76c54c4fd7d82720c045bdcf1450d"
+                            "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                            "balance": "0x44d9a8fd662c2f4d03",
+                            "balance_float": 1.270062661329837E21,
+                            "modify_tx": "0xe46c4db085fb6c6f3408a65524555797adb264e1d5cf3b66ad154598f85ac4bf",
+                            "component_id": "0x99c59000f5a76c54c4fd7d82720c045bdcf1450d"
                         }
                     }
                 },
@@ -2042,9 +2073,40 @@ mod test {
                         }
                     }
                 },
-                "component_tvl": { }
+                "component_tvl": {},
+                "dci_data": {
+                    "new_entrypoints": {
+                        "0xde6faedbcae38eec6d33ad61473a04a6dd7f6e28": [
+                            {
+                                "external_id": "0x01:sig()",
+                                "target": "0x01",
+                                "signature": "sig()"
+                            }
+                        ]
+                    },
+                    "new_entrypoint_params": {
+                        "0x01:sig()": [
+                            [
+                                {
+                                    "method": "rpctracer",
+                                    "caller": "0x01",
+                                    "calldata": "0x02"
+                                },
+                                "0xde6faedbcae38eec6d33ad61473a04a6dd7f6e28"
+                            ]
+                        ]
+                    },
+                    "trace_results": {
+                        "0x01:sig()": {
+                            "retriggers": [
+                                ["0x01", "0x02"]
+                            ],
+                            "called_addresses": ["0x03", "0x04"]
+                        }
+                    }
+                }
             }
-            }
+        }
         "#;
         serde_json::from_str::<WebSocketMessage>(json_data).expect("parsing failed");
     }

--- a/tycho-common/src/dto.rs
+++ b/tycho-common/src/dto.rs
@@ -241,6 +241,7 @@ pub struct BlockChanges {
     pub component_balances: HashMap<String, TokenBalances>,
     pub account_balances: HashMap<Bytes, HashMap<Bytes, AccountBalance>>,
     pub component_tvl: HashMap<String, f64>,
+    pub dci_data: DCIData,
 }
 
 impl BlockChanges {
@@ -257,6 +258,7 @@ impl BlockChanges {
         deleted_protocol_components: HashMap<String, ProtocolComponent>,
         component_balances: HashMap<String, HashMap<Bytes, ComponentBalance>>,
         account_balances: HashMap<Bytes, HashMap<Bytes, AccountBalance>>,
+        dci_data: DCIData,
     ) -> Self {
         BlockChanges {
             extractor: extractor.to_owned(),
@@ -275,6 +277,7 @@ impl BlockChanges {
                 .collect(),
             account_balances,
             component_tvl: HashMap::new(),
+            dci_data,
         }
     }
 
@@ -1322,6 +1325,13 @@ impl ProtocolSystemsRequestResponse {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
+pub struct DCIData {
+    pub new_entrypoints: HashMap<String, HashSet<EntryPoint>>,
+    pub new_entrypoint_params: HashMap<String, HashSet<(TracingParams, Option<String>)>>,
+    pub trace_results: HashMap<String, TracingResult>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, ToSchema, Eq, Hash, Clone)]
 pub struct TracedEntryPointRequestBody {
     #[serde(default)]
@@ -1426,6 +1436,54 @@ pub struct TracedEntryPointRequestResponse {
     /// tracing parameters and its corresponding tracing results.
     pub traced_entry_points: HashMap<String, Vec<(EntryPointWithTracingParams, TracingResult)>>,
     pub pagination: PaginationResponse,
+}
+
+impl From<TracedEntryPointRequestResponse> for DCIData {
+    fn from(response: TracedEntryPointRequestResponse) -> Self {
+        let mut new_entrypoints = HashMap::new();
+        let mut new_entrypoint_params = HashMap::new();
+        let mut trace_results = HashMap::new();
+
+        for (component, traces) in response.traced_entry_points {
+            let mut entrypoints = HashSet::new();
+
+            for (entrypoint, trace) in traces {
+                let entrypoint_id = entrypoint
+                    .entry_point
+                    .external_id
+                    .clone();
+
+                // Collect entrypoints
+                entrypoints.insert(entrypoint.entry_point.clone());
+
+                // Collect entrypoint params
+                new_entrypoint_params
+                    .entry(entrypoint_id.clone())
+                    .or_insert_with(HashSet::new)
+                    .insert((entrypoint.params, Some(component.clone())));
+
+                // Collect trace results
+                trace_results
+                    .entry(entrypoint_id)
+                    .and_modify(|existing_trace: &mut TracingResult| {
+                        // Merge traces for the same entrypoint
+                        existing_trace
+                            .retriggers
+                            .extend(trace.retriggers.clone());
+                        existing_trace
+                            .called_addresses
+                            .extend(trace.called_addresses.clone());
+                    })
+                    .or_insert(trace);
+            }
+
+            if !entrypoints.is_empty() {
+                new_entrypoints.insert(component, entrypoints);
+            }
+        }
+
+        DCIData { new_entrypoints, new_entrypoint_params, trace_results }
+    }
 }
 
 pub struct AddEntrypointRequestBody {

--- a/tycho-common/src/models/blockchain.rs
+++ b/tycho-common/src/models/blockchain.rs
@@ -89,7 +89,7 @@ pub struct BlockAggregatedChanges {
     pub component_balances: HashMap<ComponentId, HashMap<Bytes, ComponentBalance>>,
     pub account_balances: HashMap<Address, HashMap<Address, AccountBalance>>,
     pub component_tvl: HashMap<String, f64>,
-    pub dci_data: DCIData,
+    pub dci_update: DCIUpdate,
 }
 
 impl BlockAggregatedChanges {
@@ -108,7 +108,7 @@ impl BlockAggregatedChanges {
         component_balances: HashMap<ComponentId, HashMap<Bytes, ComponentBalance>>,
         account_balances: HashMap<Address, HashMap<Address, AccountBalance>>,
         component_tvl: HashMap<String, f64>,
-        dci_data: DCIData,
+        dci_update: DCIUpdate,
     ) -> Self {
         Self {
             extractor: extractor.to_string(),
@@ -124,7 +124,7 @@ impl BlockAggregatedChanges {
             component_balances,
             account_balances,
             component_tvl,
-            dci_data,
+            dci_update,
         }
     }
 }
@@ -156,7 +156,7 @@ impl NormalisedMessage for BlockAggregatedChanges {
             component_balances: self.component_balances.clone(),
             account_balances: self.account_balances.clone(),
             component_tvl: self.component_tvl.clone(),
-            dci_data: self.dci_data.clone(),
+            dci_update: self.dci_update.clone(),
         })
     }
 
@@ -176,7 +176,7 @@ impl BlockScoped for BlockAggregatedChanges {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
-pub struct DCIData {
+pub struct DCIUpdate {
     pub new_entrypoints: HashMap<ComponentId, HashSet<EntryPoint>>,
     pub new_entrypoint_params: HashMap<EntryPointId, HashSet<(TracingParams, Option<ComponentId>)>>,
     pub trace_results: HashMap<EntryPointId, TracingResult>,

--- a/tycho-common/src/models/blockchain.rs
+++ b/tycho-common/src/models/blockchain.rs
@@ -89,7 +89,7 @@ pub struct BlockAggregatedChanges {
     pub component_balances: HashMap<ComponentId, HashMap<Bytes, ComponentBalance>>,
     pub account_balances: HashMap<Address, HashMap<Address, AccountBalance>>,
     pub component_tvl: HashMap<String, f64>,
-    pub trace_results: HashMap<EntryPointId, TracingResult>,
+    pub dci_data: DCIData,
 }
 
 impl BlockAggregatedChanges {
@@ -108,7 +108,7 @@ impl BlockAggregatedChanges {
         component_balances: HashMap<ComponentId, HashMap<Bytes, ComponentBalance>>,
         account_balances: HashMap<Address, HashMap<Address, AccountBalance>>,
         component_tvl: HashMap<String, f64>,
-        trace_results: HashMap<EntryPointId, TracingResult>,
+        dci_data: DCIData,
     ) -> Self {
         Self {
             extractor: extractor.to_string(),
@@ -124,7 +124,7 @@ impl BlockAggregatedChanges {
             component_balances,
             account_balances,
             component_tvl,
-            trace_results,
+            dci_data,
         }
     }
 }
@@ -156,7 +156,7 @@ impl NormalisedMessage for BlockAggregatedChanges {
             component_balances: self.component_balances.clone(),
             account_balances: self.account_balances.clone(),
             component_tvl: self.component_tvl.clone(),
-            trace_results: self.trace_results.clone(),
+            dci_data: self.dci_data.clone(),
         })
     }
 
@@ -173,6 +173,13 @@ impl BlockScoped for BlockAggregatedChanges {
     fn block(&self) -> Block {
         self.block.clone()
     }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DCIData {
+    pub new_entrypoints: HashMap<ComponentId, HashSet<EntryPoint>>,
+    pub new_entrypoint_params: HashMap<EntryPointId, HashSet<(TracingParams, Option<ComponentId>)>>,
+    pub trace_results: HashMap<EntryPointId, TracingResult>,
 }
 
 /// Changes grouped by their respective transaction.
@@ -367,7 +374,7 @@ pub enum BlockTag {
     /// Block by number
     Number(u64),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct EntryPoint {
     /// Entry point id
     pub external_id: String,
@@ -434,7 +441,7 @@ impl Serialize for RPCTracerParams {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct TracingResult {
     /// A set of (address, storage slot) pairs representing state that contain a called address.
     /// If any of these storage slots change, the execution path might change.

--- a/tycho-indexer/src/extractor/models.rs
+++ b/tycho-indexer/src/extractor/models.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use tycho_common::{
     models::{
         blockchain::{
-            Block, BlockAggregatedChanges, BlockScoped, TracedEntryPoint, TracingResult,
+            Block, BlockAggregatedChanges, BlockScoped, DCIData, TracedEntryPoint, TracingResult,
             Transaction, TxWithChanges,
         },
         contract::{AccountBalance, AccountChangesWithTx},
@@ -237,7 +237,11 @@ impl BlockChanges {
             component_balances: aggregated_changes.balance_changes,
             account_balances: aggregated_changes.account_balance_changes,
             component_tvl: HashMap::new(),
-            trace_results: aggregated_trace_results,
+            dci_data: DCIData {
+                new_entrypoints: aggregated_changes.entrypoints,
+                new_entrypoint_params: aggregated_changes.entrypoint_params,
+                trace_results: aggregated_trace_results,
+            },
         })
     }
 

--- a/tycho-indexer/src/extractor/models.rs
+++ b/tycho-indexer/src/extractor/models.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use tycho_common::{
     models::{
         blockchain::{
-            Block, BlockAggregatedChanges, BlockScoped, DCIData, TracedEntryPoint, TracingResult,
+            Block, BlockAggregatedChanges, BlockScoped, DCIUpdate, TracedEntryPoint, TracingResult,
             Transaction, TxWithChanges,
         },
         contract::{AccountBalance, AccountChangesWithTx},
@@ -237,7 +237,7 @@ impl BlockChanges {
             component_balances: aggregated_changes.balance_changes,
             account_balances: aggregated_changes.account_balance_changes,
             component_tvl: HashMap::new(),
-            dci_data: DCIData {
+            dci_update: DCIUpdate {
                 new_entrypoints: aggregated_changes.entrypoints,
                 new_entrypoint_params: aggregated_changes.entrypoint_params,
                 trace_results: aggregated_trace_results,

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -14,7 +14,7 @@ use tokio::sync::Mutex;
 use tracing::{debug, error, info, instrument, trace, warn};
 use tycho_common::{
     models::{
-        blockchain::{Block, BlockAggregatedChanges, BlockTag, DCIData},
+        blockchain::{Block, BlockAggregatedChanges, BlockTag, DCIUpdate},
         contract::{Account, AccountBalance, AccountDelta},
         protocol::{
             ComponentBalance, ProtocolComponent, ProtocolComponentState,
@@ -1172,7 +1172,7 @@ where
             component_balances: combined_component_balances,
             account_balances: combined_account_balances,
             component_tvl: HashMap::new(),
-            dci_data: DCIData::default(), // TODO: get reverted entrypoint info?
+            dci_update: DCIUpdate::default(), // TODO: get reverted entrypoint info?
         };
 
         debug!("Successfully retrieved all previous states during revert!");

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -14,7 +14,7 @@ use tokio::sync::Mutex;
 use tracing::{debug, error, info, instrument, trace, warn};
 use tycho_common::{
     models::{
-        blockchain::{Block, BlockAggregatedChanges, BlockTag},
+        blockchain::{Block, BlockAggregatedChanges, BlockTag, DCIData},
         contract::{Account, AccountBalance, AccountDelta},
         protocol::{
             ComponentBalance, ProtocolComponent, ProtocolComponentState,
@@ -1172,7 +1172,7 @@ where
             component_balances: combined_component_balances,
             account_balances: combined_account_balances,
             component_tvl: HashMap::new(),
-            trace_results: HashMap::new(), // TODO: get reverted tracing results
+            dci_data: DCIData::default(), // TODO: get reverted entrypoint info?
         };
 
         debug!("Successfully retrieved all previous states during revert!");


### PR DESCRIPTION
This PR covers the following:
- extends RPCClient to include `get_traced_entry_points` endpoint and support auto-pagination
- extends the emitted message models to include all entrypoint data (entrypoints, params and traces)
- extends the component_tracker to track entrypoints and monitor which contracts to filter accordingly
- extends the client's protocol synchronizer to use the updated component_tracker and entrypoint data where necessary