### PR TITLE
feat(dci): add revert logic

### DIFF
--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/cache.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/cache.rs
@@ -152,7 +152,7 @@ where
     }
 
     /// Gets a mutable entry to a value in the permanent layer.
-    pub(super) fn permanent_entry(&mut self, k: &K) -> Entry<K, V> {
+    pub(super) fn permanent_entry<'a>(&'a mut self, k: &K) -> Entry<'a, K, V> {
         self.permanent.entry(k.clone())
     }
 
@@ -160,11 +160,11 @@ where
     ///
     /// If the block is not found, we check if the block is the child of the latest pending
     /// block. If it is, a new layer is created. Otherwise, an error is returned.
-    pub(super) fn pending_entry(
-        &mut self,
+    pub(super) fn pending_entry<'a>(
+        &'a mut self,
         block: &Block,
         k: &K,
-    ) -> Result<Entry<K, V>, DCICacheError> {
+    ) -> Result<Entry<'a, K, V>, DCICacheError> {
         let layer = self.validate_and_ensure_block_layer(block)?;
         Ok(layer.data.entry(k.clone()))
     }

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/cache.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/cache.rs
@@ -1,0 +1,27 @@
+use std::collections::{HashMap, HashSet};
+
+use tycho_common::models::{
+    blockchain::{EntryPoint, EntryPointWithTracingParams, TracingParams, TracingResult},
+    Address, EntryPointId, StoreKey,
+};
+
+/// A unique identifier for a storage location, consisting of an address and a storage key.
+type StorageLocation = (Address, StoreKey);
+
+pub(super) struct DCICache {
+    pub(super) ep_id_to_entrypoint: HashMap<EntryPointId, EntryPoint>,
+    pub(super) entrypoint_results: HashMap<(EntryPointId, TracingParams), TracingResult>,
+    pub(super) retriggers: HashMap<StorageLocation, HashSet<EntryPointWithTracingParams>>,
+    pub(super) tracked_contracts: HashMap<Address, Option<HashSet<StoreKey>>>,
+}
+
+impl DCICache {
+    pub(super) fn new_empty() -> Self {
+        Self {
+            ep_id_to_entrypoint: HashMap::new(),
+            entrypoint_results: HashMap::new(),
+            retriggers: HashMap::new(),
+            tracked_contracts: HashMap::new(),
+        }
+    }
+}

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/cache.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/cache.rs
@@ -27,7 +27,7 @@ pub(super) struct DCICache {
 }
 
 impl DCICache {
-    pub(super) fn new_empty() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             ep_id_to_entrypoint: VersionedCache::new(),
             entrypoint_results: VersionedCache::new(),
@@ -487,7 +487,7 @@ mod tests {
 
     #[test]
     fn test_dci_cache_revert() {
-        let mut cache = DCICache::new_empty();
+        let mut cache = DCICache::new();
         let block1 = create_test_block(1, "0x01", "0x00");
         let block2 = create_test_block(2, "0x02", "0x01");
 

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/dci.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/dci.rs
@@ -290,6 +290,8 @@ where
         }
 
         // Update the entrypoint cache from the block changes
+        // Perf: when syncing we can completely bypass the reorgs handling logic and push directly
+        // to the permanent cache
         self.cache
             .ep_id_to_entrypoint
             .extend_pending(
@@ -348,14 +350,7 @@ where
         storage_source: AE,
         tracer: T,
     ) -> Self {
-        Self {
-            chain,
-            protocol,
-            entrypoint_gw,
-            storage_source,
-            tracer,
-            cache: DCICache::new_empty(),
-        }
+        Self { chain, protocol, entrypoint_gw, storage_source, tracer, cache: DCICache::new() }
     }
 
     /// Initialize the DynamicContractIndexer. Loads all the entrypoints and their respective
@@ -503,6 +498,8 @@ where
         new_tracing_results: &[TracedEntryPoint],
     ) -> Result<(), ExtractionError> {
         // Update the cache with the traced entrypoints
+        // Perf: when syncing we can completely bypass the reorgs handling logic and push directly
+        // to the permanent cache
         for traced_entry_point in new_tracing_results.iter() {
             for location in traced_entry_point
                 .tracing_result

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/dci.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/dci.rs
@@ -281,6 +281,8 @@ where
             }
 
             // Update the cache with new traced entrypoints
+            self.cache
+                .handle_finality(block_changes.finalized_block_height)?;
             self.update_cache(&block_changes.block, &traced_entry_points)?;
 
             // Update the block changes with the traced entrypoints
@@ -328,7 +330,7 @@ where
     }
 
     async fn process_revert(&mut self, target_block: &BlockHash) -> Result<(), ExtractionError> {
-        self.cache.revert_to(target_block);
+        self.cache.revert_to(target_block)?;
         Ok(())
     }
 }

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/dci.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/dci.rs
@@ -15,15 +15,13 @@ use tycho_common::{
     traits::{AccountExtractor, EntryPointTracer, StorageSnapshotRequest},
 };
 
-use super::{
+use super::cache::DCICache;
+use crate::extractor::{
     models::{BlockChanges, TxWithStorageChanges},
     ExtractionError, ExtractorExtension,
 };
 
-/// A unique identifier for a storage location, consisting of an address and a storage key.
-type StorageLocation = (Address, StoreKey);
-
-pub(super) struct DynamicContractIndexer<AE, T, G>
+pub(crate) struct DynamicContractIndexer<AE, T, G>
 where
     AE: AccountExtractor + Send + Sync,
     T: EntryPointTracer + Send + Sync,
@@ -35,26 +33,6 @@ where
     storage_source: AE,
     tracer: T,
     cache: DCICache,
-}
-
-#[allow(unused)]
-struct DCICache {
-    ep_id_to_entrypoint: HashMap<EntryPointId, EntryPoint>,
-    entrypoint_results: HashMap<(EntryPointId, TracingParams), TracingResult>,
-    retriggers: HashMap<StorageLocation, HashSet<EntryPointWithTracingParams>>,
-    tracked_contracts: HashMap<Address, Option<HashSet<StoreKey>>>,
-}
-
-impl DCICache {
-    #[allow(unused)]
-    fn new_empty() -> Self {
-        Self {
-            ep_id_to_entrypoint: HashMap::new(),
-            entrypoint_results: HashMap::new(),
-            retriggers: HashMap::new(),
-            tracked_contracts: HashMap::new(),
-        }
-    }
 }
 
 #[async_trait]
@@ -346,8 +324,7 @@ where
         Ok(())
     }
 
-    #[allow(unused)]
-    async fn process_revert(&mut self, target_block: &BlockHash) -> Result<(), ExtractionError> {
+    async fn process_revert(&mut self, _target_block: &BlockHash) -> Result<(), ExtractionError> {
         // TODO: Handle reverts, need to cleanup reverted internal state
         todo!()
     }
@@ -651,12 +628,6 @@ where
         }
 
         Ok(tracked_updates)
-    }
-
-    // TODO: Handle reverts, need to cleanup reverted internal state
-    #[allow(unused)]
-    pub(super) fn process_revert(&mut self, target_block: u64) -> Result<(), ExtractionError> {
-        todo!()
     }
 }
 

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/mod.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/mod.rs
@@ -1,0 +1,2 @@
+pub mod cache;
+pub(super) mod dci;

--- a/tycho-indexer/src/extractor/mod.rs
+++ b/tycho-indexer/src/extractor/mod.rs
@@ -17,6 +17,7 @@ use tycho_common::{
 
 use crate::{
     extractor::{
+        dynamic_contract_indexer::cache::DCICacheError,
         models::BlockChanges,
         reorg_buffer::{
             AccountStateIdType, AccountStateKeyType, AccountStateValueType, ProtocolStateIdType,
@@ -64,6 +65,8 @@ pub enum ExtractionError {
     TracingError(String),
     #[error("Account extraction error: {0}")]
     AccountExtractionError(String),
+    #[error("DCI cache error: {0}")]
+    DCICacheError(#[from] DCICacheError),
 }
 
 #[derive(Error, Debug)]

--- a/tycho-indexer/src/extractor/runner.rs
+++ b/tycho-indexer/src/extractor/runner.rs
@@ -31,7 +31,7 @@ use tycho_storage::postgres::cache::CachedGateway;
 use crate::{
     extractor::{
         chain_state::ChainState,
-        dynamic_contract_indexer::DynamicContractIndexer,
+        dynamic_contract_indexer::dci::DynamicContractIndexer,
         post_processors::POST_PROCESSOR_REGISTRY,
         protocol_cache::ProtocolMemoryCache,
         protocol_extractor::{ExtractorPgGateway, ProtocolExtractor},

--- a/tycho-indexer/src/testing.rs
+++ b/tycho-indexer/src/testing.rs
@@ -651,21 +651,6 @@ mock! {
     impl Gateway for Gateway {}
 }
 
-// mock! {
-//     pub AccountExtractor {}
-
-//     #[async_trait]
-//     impl tycho_common::traits::AccountExtractor for AccountExtractor {
-//         type Error = String;
-
-//         async fn get_accounts_at_block(
-//         &self,
-//         block: &Block,
-//         requests: &[StorageSnapshotRequest],
-//     ) -> Result<HashMap<Bytes, AccountDelta>, Self::Error>;
-//     }
-// }
-
 #[cfg(test)]
 pub fn evm_contract_slots(data: impl IntoIterator<Item = (i32, i32)>) -> HashMap<Bytes, Bytes> {
     data.into_iter()


### PR DESCRIPTION
This PR implements the logic needed by DCI to properly deal with chain reorgs. 

It moves all dci related files into a "folder module".

We added a helper structs which is essentially a wrapper around HashMap. This struct helps to efficiently keep track of the permanent and pending state and provides functions to revert the cache state to a previous state.

**Review commit by commit suggested**