### PR TITLE
fix(storage): fix bug that filters out contracts missing a creation_tx

### DIFF
--- a/tycho-common/src/dto.rs
+++ b/tycho-common/src/dto.rs
@@ -661,6 +661,7 @@ pub struct ResponseAccount {
     #[serde(with = "hex_bytes")]
     pub code_modify_tx: Bytes,
     /// Transaction hash which created the account
+    #[deprecated(note = "The `creation_tx` field is deprecated.")]
     #[schema(value_type=Option<String>, example="0x8f1133bfb054a23aedfe5d25b1d81b96195396d8b88bd5d4bcf865fc1ae2c3f4")]
     #[serde(with = "hex_bytes_option")]
     pub creation_tx: Option<Bytes>,

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -2564,7 +2564,7 @@ mod test_serial_db {
                     .unwrap(),
                 Bytes::zero(32),
                 VM_TX_HASH_0.parse().unwrap(),
-                Some(VM_TX_HASH_0.parse().unwrap()),
+                None,
             ),
             _ => panic!("Unknown version"),
         }

--- a/tycho-storage/src/postgres/contract.rs
+++ b/tycho-storage/src/postgres/contract.rs
@@ -761,15 +761,6 @@ impl PostgresGateway {
                 )
             })?;
 
-        let creation_tx = match account_orm.creation_tx {
-            Some(tx) => schema::transaction::table
-                .filter(schema::transaction::id.eq(tx))
-                .select(schema::transaction::hash)
-                .first::<Bytes>(conn)
-                .await
-                .ok(),
-            None => None,
-        };
         let mut account = Account::new(
             chain,
             account_orm.address,
@@ -782,7 +773,7 @@ impl PostgresGateway {
             // TODO: remove balance_modify_tx from Account
             Bytes::zero(32),
             code_tx,
-            creation_tx,
+            None,
         );
 
         if include_slots {

--- a/tycho-storage/src/postgres/contract.rs
+++ b/tycho-storage/src/postgres/contract.rs
@@ -825,7 +825,11 @@ impl PostgresGateway {
                         .on(creation_tx.eq(schema::transaction::id.nullable())),
                 )
                 .filter(chain_id.eq(chain_db_id))
-                .filter(created_at.le(version_ts))
+                .filter(
+                    created_at
+                        .is_null()
+                        .or(created_at.le(version_ts)),
+                )
                 .filter(
                     deleted_at
                         .is_null()
@@ -853,7 +857,11 @@ impl PostgresGateway {
                         .on(creation_tx.eq(schema::transaction::id.nullable())),
                 )
                 .filter(chain_id.eq(chain_db_id))
-                .filter(created_at.le(version_ts))
+                .filter(
+                    created_at
+                        .is_null() // can be null if the account was initially added as a token
+                        .or(created_at.le(version_ts)),
+                )
                 .filter(
                     deleted_at
                         .is_null()


### PR DESCRIPTION
When an account is added as a token, no creation_tx is assigned to the account entry. Since the `get_contracts` DB gateway function uses the linked `creation_tx` to apply versioning to, if it is set to NULL we will always filter it out when we apply versioning. Therefore we should only apply versioning to account entries that have a creation_tx specified.

Done in this PR:
- do not filter out accounts that have no `creation_tx`
- optimise the queries: 
    - remove transaction table join (creation tx isn't always available and is misleading for DCI added contracts as they are linked to the transaction where DCI detected them and not where the contract was created)
    - improve count query (and skip if no pagination was applied)