### PR TITLE
feat(hook-support): implement metadata generator for Euler Swap

### DIFF
--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/component_metadata.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/component_metadata.rs
@@ -61,7 +61,20 @@ impl Clone for MetadataRequest {
     }
 }
 
+impl MetadataRequest {
+    pub fn new(
+        request_id: RequestId,
+        component_id: ComponentId,
+        request_type: MetadataRequestType,
+        transport: Box<dyn RequestTransport>,
+        tx_hash: TxHash,
+    ) -> Self {
+        Self { request_id, component_id, request_type, transport, tx_hash }
+    }
+}
+
 #[derive(Clone)]
+#[cfg_attr(test, derive(PartialEq, Debug))]
 pub enum MetadataRequestType {
     ComponentBalance { token_addresses: Vec<Address> },
     Tvl,

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/component_metadata.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/component_metadata.rs
@@ -44,9 +44,6 @@ pub struct MetadataRequest {
     pub component_id: ComponentId,
     pub request_type: MetadataRequestType,
     pub transport: Box<dyn RequestTransport>,
-    // tx_hash: Transaction hash that triggered this metadata request
-    // Used to map balance/limit changes back to specific on-chain events
-    pub tx_hash: TxHash,
 }
 
 impl Clone for MetadataRequest {
@@ -56,7 +53,6 @@ impl Clone for MetadataRequest {
             component_id: self.component_id.clone(),
             request_type: self.request_type.clone(),
             transport: self.transport.clone_box(),
-            tx_hash: self.tx_hash.clone(),
         }
     }
 }
@@ -67,9 +63,8 @@ impl MetadataRequest {
         component_id: ComponentId,
         request_type: MetadataRequestType,
         transport: Box<dyn RequestTransport>,
-        tx_hash: TxHash,
     ) -> Self {
-        Self { request_id, component_id, request_type, transport, tx_hash }
+        Self { request_id, component_id, request_type, transport }
     }
 }
 

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/euler/metadata_generator.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/euler/metadata_generator.rs
@@ -1,0 +1,258 @@
+use tycho_common::models::{blockchain::Block, protocol::ProtocolComponent, TxHash};
+
+use crate::extractor::dynamic_contract_indexer::component_metadata::{
+    MetadataError, MetadataRequest, MetadataRequestGenerator, MetadataRequestType, RpcTransport,
+};
+
+pub struct EulerMetadataGenerator {
+    rpc_url: String,
+}
+
+impl EulerMetadataGenerator {
+    pub fn new(rpc_url: String) -> Self {
+        Self { rpc_url }
+    }
+}
+
+impl MetadataRequestGenerator for EulerMetadataGenerator {
+    fn generate_requests(
+        &self,
+        component: &ProtocolComponent,
+        block: &Block,
+    ) -> Result<Vec<MetadataRequest>, MetadataError> {
+        let mut requests = vec![];
+
+        let balance_transport = RpcTransport::new(
+            self.rpc_url.clone(),
+            "eth_call".to_string(),
+            vec![serde_json::json!([
+                  {
+                    "data": "0x0902f1ac", // getReserves()
+                    "to": component.id
+                  },
+                  block.number.to_string() //TODO: should it be formatted as a hex string?
+                ]
+            )],
+        );
+        requests.push(MetadataRequest::new(
+            format!("euler_balance_{}", component.id),
+            component.id.clone(),
+            MetadataRequestType::ComponentBalance { token_addresses: component.tokens.clone() },
+            Box::new(balance_transport),
+            TxHash::zero(32), //TODO: how can we get the tx hash?
+        ));
+
+        let limits_transport_0to1 = RpcTransport::new(
+            self.rpc_url.clone(),
+            "eth_call".to_string(),
+            vec![serde_json::json!([
+              {
+                "data": format!("0xaaed87a3000000000000000000000000{}000000000000000000000000{}", component.tokens[0], component.tokens[1]),
+                "to": component.id
+              },
+              block.number.to_string()
+            ])],
+        );
+        requests.push(MetadataRequest::new(
+            format!("euler_limits_{}", component.id),
+            component.id.clone(),
+            // Euler swap only has pools with 2 tokens
+            MetadataRequestType::Limits {
+                token_pair: vec![(component.tokens[0].clone(), component.tokens[1].clone())],
+            },
+            Box::new(limits_transport_0to1),
+            TxHash::zero(32), //TODO: how can we get the tx hash?
+        ));
+
+        let limits_transport_1to0 = RpcTransport::new(
+            self.rpc_url.clone(),
+            "eth_call".to_string(),
+            vec![serde_json::json!([
+              {
+                "data": format!("0xaaed87a3000000000000000000000000{}000000000000000000000000{}", component.tokens[1], component.tokens[0]),
+                "to": component.id
+              },
+              block.number.to_string()
+            ])],
+        );
+        requests.push(MetadataRequest::new(
+            format!("euler_limits_{}", component.id),
+            component.id.clone(),
+            // Euler swap only has pools with 2 tokens
+            MetadataRequestType::Limits {
+                token_pair: vec![(component.tokens[1].clone(), component.tokens[0].clone())],
+            },
+            Box::new(limits_transport_1to0),
+            TxHash::zero(32), //TODO: how can we get the tx hash?
+        ));
+
+        Ok(requests)
+    }
+
+    fn generate_balance_only_requests(
+        &self,
+        component: &ProtocolComponent,
+        block: &Block,
+    ) -> Result<Vec<MetadataRequest>, MetadataError> {
+        let mut requests = vec![];
+
+        let balance_transport = RpcTransport::new(
+            self.rpc_url.clone(),
+            "eth_call".to_string(),
+            vec![serde_json::json!([
+                  {
+                    "data": "0x0902f1ac", // getReserves()
+                    "to": component.id
+                  },
+                  block.number.to_string()
+                ]
+            )],
+        );
+        requests.push(MetadataRequest::new(
+            format!("euler_balance_{}", component.id),
+            component.id.clone(),
+            MetadataRequestType::ComponentBalance { token_addresses: component.tokens.clone() },
+            Box::new(balance_transport),
+            TxHash::zero(32), //TODO: how can we get the tx hash?
+        ));
+        Ok(requests)
+    }
+
+    fn supported_metadata_types(&self) -> Vec<MetadataRequestType> {
+        vec![
+            MetadataRequestType::ComponentBalance { token_addresses: vec![] },
+            MetadataRequestType::Limits { token_pair: vec![] },
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDateTime;
+    use tycho_common::{
+        models::{Chain, TxHash},
+        Bytes,
+    };
+
+    use super::*;
+
+    fn create_test_component() -> ProtocolComponent {
+        ProtocolComponent {
+            id: "0xbeef".to_string(),
+            tokens: vec![
+                Bytes::from("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"), // USDC
+                Bytes::from("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"), // WETH
+            ],
+            ..Default::default()
+        }
+    }
+
+    fn create_test_block() -> Block {
+        Block::new(
+            12345,
+            Chain::Ethereum,
+            Bytes::from("0x1234567890123456789012345678901234567890123456789012345678901234"),
+            Bytes::from("0x1234567890123456789012345678901234567890123456789012345678901233"),
+            NaiveDateTime::parse_from_str("2023-01-01T00:00:00", "%Y-%m-%dT%H:%M:%S").unwrap(),
+        )
+    }
+
+    #[test]
+    fn test_generate_requests() {
+        let generator =
+            EulerMetadataGenerator::new("https://eth-mainnet.alchemyapi.io/v2/test".to_string());
+        let component = create_test_component();
+        let block = create_test_block();
+
+        let requests = generator
+            .generate_requests(&component, &block)
+            .unwrap();
+
+        assert_eq!(requests.len(), 3);
+
+        // Balance request
+        assert_eq!(requests[0].component_id, component.id);
+        assert_eq!(
+            requests[0].request_type,
+            MetadataRequestType::ComponentBalance { token_addresses: component.tokens.clone() }
+        );
+        assert_eq!(requests[0].request_id, "euler_balance_0xbeef".to_string());
+        assert_eq!(requests[0].transport.routing_key(), "rpc_default".to_string());
+        assert_eq!(
+            requests[0].transport.deduplication_id(),
+            "eth_call_[[{\"data\":\"0x0902f1ac\",\"to\":\"0xbeef\"},\"12345\"]]".to_string()
+        );
+
+        // Limits request 0 to 1
+        assert_eq!(requests[1].component_id, component.id);
+        assert_eq!(
+            requests[1].request_type,
+            MetadataRequestType::Limits {
+                token_pair: vec![(component.tokens[0].clone(), component.tokens[1].clone())]
+            }
+        );
+        assert_eq!(requests[1].request_id, "euler_limits_0xbeef".to_string());
+        assert_eq!(requests[1].transport.routing_key(), "rpc_default".to_string());
+        assert_eq!(
+            requests[1].transport.deduplication_id(),
+            "eth_call_[[{\"data\":\"0xaaed87a30000000000000000000000000xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb480000000000000000000000000xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2\",\"to\":\"0xbeef\"},\"12345\"]]".to_string()
+        );
+
+        // Limits request 1 to 0
+        assert_eq!(requests[2].component_id, component.id);
+        assert_eq!(
+            requests[2].request_type,
+            MetadataRequestType::Limits {
+                token_pair: vec![(component.tokens[1].clone(), component.tokens[0].clone())]
+            }
+        );
+        assert_eq!(requests[2].request_id, "euler_limits_0xbeef".to_string());
+        assert_eq!(requests[2].transport.routing_key(), "rpc_default".to_string());
+        assert_eq!(
+            requests[2].transport.deduplication_id(),
+            "eth_call_[[{\"data\":\"0xaaed87a30000000000000000000000000xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000000xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\",\"to\":\"0xbeef\"},\"12345\"]]".to_string()
+        );
+    }
+
+    #[test]
+    fn test_generate_balance_only_requests() {
+        let generator =
+            EulerMetadataGenerator::new("https://eth-mainnet.alchemyapi.io/v2/test".to_string());
+        let component = create_test_component();
+        let block = create_test_block();
+
+        let requests = generator
+            .generate_balance_only_requests(&component, &block)
+            .unwrap();
+
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].component_id, component.id);
+        assert_eq!(
+            requests[0].request_type,
+            MetadataRequestType::ComponentBalance { token_addresses: component.tokens.clone() }
+        );
+        assert_eq!(requests[0].tx_hash, TxHash::zero(32));
+        assert_eq!(requests[0].request_id, "euler_balance_0xbeef".to_string());
+        assert_eq!(requests[0].transport.routing_key(), "rpc_default".to_string());
+        assert_eq!(
+            requests[0].transport.deduplication_id(),
+            "eth_call_[[{\"data\":\"0x0902f1ac\",\"to\":\"0xbeef\"},\"12345\"]]".to_string()
+        );
+    }
+
+    #[test]
+    fn test_supported_metadata_types() {
+        let generator =
+            EulerMetadataGenerator::new("https://eth-mainnet.alchemyapi.io/v2/test".to_string());
+        let supported_types = generator.supported_metadata_types();
+
+        let expected_types = vec![
+            MetadataRequestType::ComponentBalance { token_addresses: vec![] },
+            MetadataRequestType::Limits { token_pair: vec![] },
+        ];
+
+        assert_eq!(supported_types, expected_types);
+    }
+
+    //TODO: add RPC execution tests when the orchestrator logic is implemented
+}

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/euler/metadata_generator.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/euler/metadata_generator.rs
@@ -9,6 +9,7 @@ pub struct EulerMetadataGenerator {
 }
 
 impl EulerMetadataGenerator {
+    #[allow(dead_code)]
     pub fn new(rpc_url: String) -> Self {
         Self { rpc_url }
     }

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/euler/mod.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/euler/mod.rs
@@ -1,0 +1,1 @@
+mod metadata_generator;

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/hook_dci.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/hook_dci.rs
@@ -140,6 +140,9 @@ where
         // 1. Filter components with swap hooks (beforeSwap/afterSwap only)
         // TODO: How can I get the components that were created in the previous blocks?
         // Do we need to fetch them on startup and store them in the cache?
+
+        // TODO: Need to keep track of the link between component and the transaction that updated
+        // it.
         let swap_hook_components = self.extract_components_with_swap_hooks(block_changes);
 
         if swap_hook_components.is_empty() {

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/mod.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/mod.rs
@@ -2,5 +2,6 @@ pub mod cache;
 mod component_metadata;
 pub(super) mod dci;
 mod entrypoint_generator;
+mod euler;
 mod hook_dci;
 mod hook_orchestrator;


### PR DESCRIPTION
This PR adds metadata generator for Euler Swap

TODOs:
- [x] Add a way to get the tx hash in `MetadataRequestGenerator`
- [ ] Add real RPC calls tests