### PR TITLE
feat: Generalise Header and add ProtocolSim

### DIFF
--- a/tycho-client/src/feed/block_history.rs
+++ b/tycho-client/src/feed/block_history.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use tracing::error;
 use tycho_common::Bytes;
 
-use crate::feed::Header;
+use crate::feed::BlockHeader;
 
 #[derive(Debug, Error)]
 pub enum BlockHistoryError {
@@ -22,8 +22,8 @@ pub enum BlockHistoryError {
 }
 
 pub struct BlockHistory {
-    history: VecDeque<Header>,
-    reverts: LruCache<Bytes, Header>,
+    history: VecDeque<BlockHeader>,
+    reverts: LruCache<Bytes, BlockHeader>,
     size: usize,
 }
 
@@ -48,7 +48,7 @@ impl BlockHistory {
     ///
     /// The latest block and all connected block preceeding it are added to the history.
     /// Detached blocks are skipped.
-    pub fn new(mut history: Vec<Header>, size: usize) -> Result<Self, BlockHistoryError> {
+    pub fn new(mut history: Vec<BlockHeader>, size: usize) -> Result<Self, BlockHistoryError> {
         // sort history by block number in descending order
         history.sort_by_key(|h| h.number);
         history.reverse();
@@ -91,7 +91,7 @@ impl BlockHistory {
     ///
     /// May error if the block does not fit the tip of the chain, or if history is empty and the
     /// block is a revert.
-    pub fn push(&mut self, block: Header) -> Result<(), BlockHistoryError> {
+    pub fn push(&mut self, block: BlockHeader) -> Result<(), BlockHistoryError> {
         let pos = self.determine_block_position(&block)?;
         match pos {
             BlockPosition::NextExpected => {
@@ -144,7 +144,7 @@ impl BlockHistory {
     /// find the fork block.
     pub fn determine_block_position(
         &self,
-        block: &Header,
+        block: &BlockHeader,
     ) -> Result<BlockPosition, BlockHistoryError> {
         let latest = self
             .latest()
@@ -198,11 +198,11 @@ impl BlockHistory {
             .any(|b| &b.hash == h)
     }
 
-    pub fn latest(&self) -> Option<&Header> {
+    pub fn latest(&self) -> Option<&BlockHeader> {
         self.history.back()
     }
 
-    pub fn oldest(&self) -> Option<&Header> {
+    pub fn oldest(&self) -> Option<&BlockHeader> {
         self.history.front()
     }
 }
@@ -227,12 +227,12 @@ mod test {
         Bytes::from(no.to_be_bytes())
     }
 
-    fn generate_blocks(n: usize, start_n: u64, parent: Option<Bytes>) -> Vec<Header> {
+    fn generate_blocks(n: usize, start_n: u64, parent: Option<Bytes>) -> Vec<BlockHeader> {
         let mut blocks = Vec::with_capacity(n);
         let mut parent_hash = parent.unwrap_or_else(random_hash);
         for i in start_n..start_n + n as u64 {
             let hash = int_hash(i);
-            blocks.push(Header {
+            blocks.push(BlockHeader {
                 number: i,
                 hash: hash.clone(),
                 parent_hash,
@@ -247,7 +247,7 @@ mod test {
     #[test]
     fn test_push() {
         let start_blocks = generate_blocks(1, 0, None);
-        let new_block = Header {
+        let new_block = BlockHeader {
             number: 1,
             hash: random_hash(),
             parent_hash: int_hash(0),
@@ -286,14 +286,14 @@ mod test {
     fn test_push_revert_push() {
         let blocks = generate_blocks(5, 0, None);
         let mut history = BlockHistory::new(blocks.clone(), 5).expect("failed to create history");
-        let revert_block = Header {
+        let revert_block = BlockHeader {
             number: 2,
             hash: int_hash(2),
             parent_hash: int_hash(1),
             revert: true,
             ..Default::default()
         };
-        let new_block = Header {
+        let new_block = BlockHeader {
             number: 3,
             hash: random_hash(),
             parent_hash: int_hash(2),
@@ -323,7 +323,7 @@ mod test {
     fn test_push_detached_block() {
         let blocks = generate_blocks(3, 0, None);
         let mut history = BlockHistory::new(blocks.clone(), 5).expect("failed to create history");
-        let new_block = Header {
+        let new_block = BlockHeader {
             number: 2,
             hash: int_hash(2),
             parent_hash: random_hash(),
@@ -342,14 +342,14 @@ mod test {
         let mut blocks = generate_blocks(5, 5, None);
 
         // Add some disconnected blocks
-        blocks.push(Header {
+        blocks.push(BlockHeader {
             number: 2, // Gap in block numbers
             hash: random_hash(),
             parent_hash: random_hash(),
             revert: false,
             ..Default::default()
         });
-        blocks.push(Header {
+        blocks.push(BlockHeader {
             number: 4,
             hash: random_hash(),
             parent_hash: random_hash(), // Disconnected
@@ -371,13 +371,13 @@ mod test {
     }
 
     #[rstest]
-    #[case(Header { number: 15, hash: int_hash(15), parent_hash: int_hash(14), revert: false,..Default::default() }, BlockPosition::NextExpected)]
-    #[case(Header { number: 14, hash: int_hash(14), parent_hash: int_hash(13), revert: false,..Default::default() }, BlockPosition::Latest)]
-    #[case(Header { number: 16, hash: int_hash(16), parent_hash: int_hash(15), revert: false ,..Default::default()}, BlockPosition::Advanced)]
-    #[case(Header { number: 12, hash: int_hash(12), parent_hash: int_hash(11), revert: false ,..Default::default()}, BlockPosition::Delayed)]
-    #[case(Header { number: 14, hash: int_hash(14), parent_hash: int_hash(13), revert: true ,..Default::default()}, BlockPosition::NextExpected)]
-    #[case(Header { number: 1, hash: int_hash(1), parent_hash: int_hash(0), revert: false ,..Default::default()}, BlockPosition::Delayed)]
-    fn test_determine_position(#[case] add_block: Header, #[case] exp_pos: BlockPosition) {
+    #[case(BlockHeader { number: 15, hash: int_hash(15), parent_hash: int_hash(14), revert: false,..Default::default() }, BlockPosition::NextExpected)]
+    #[case(BlockHeader { number: 14, hash: int_hash(14), parent_hash: int_hash(13), revert: false,..Default::default() }, BlockPosition::Latest)]
+    #[case(BlockHeader { number: 16, hash: int_hash(16), parent_hash: int_hash(15), revert: false ,..Default::default()}, BlockPosition::Advanced)]
+    #[case(BlockHeader { number: 12, hash: int_hash(12), parent_hash: int_hash(11), revert: false ,..Default::default()}, BlockPosition::Delayed)]
+    #[case(BlockHeader { number: 14, hash: int_hash(14), parent_hash: int_hash(13), revert: true ,..Default::default()}, BlockPosition::NextExpected)]
+    #[case(BlockHeader { number: 1, hash: int_hash(1), parent_hash: int_hash(0), revert: false ,..Default::default()}, BlockPosition::Delayed)]
+    fn test_determine_position(#[case] add_block: BlockHeader, #[case] exp_pos: BlockPosition) {
         let start_blocks = generate_blocks(10, 5, None);
         let history = BlockHistory::new(start_blocks, 20).expect("failed to create history");
 
@@ -394,7 +394,7 @@ mod test {
         let mut history = BlockHistory::new(start_blocks, 15).expect("failed to create history");
         // revert by 2 blocks, add a new one
         history
-            .push(Header {
+            .push(BlockHeader {
                 number: 7,
                 hash: int_hash(7),
                 parent_hash: int_hash(6),
@@ -403,7 +403,7 @@ mod test {
             })
             .unwrap();
         history
-            .push(Header {
+            .push(BlockHeader {
                 number: 8,
                 hash: random_hash(),
                 parent_hash: int_hash(7),
@@ -411,7 +411,7 @@ mod test {
                 ..Default::default()
             })
             .unwrap();
-        let add_block = Header {
+        let add_block = BlockHeader {
             number: 9,
             hash: int_hash(9),
             parent_hash: int_hash(8),

--- a/tycho-common/src/lib.rs
+++ b/tycho-common/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod dto;
 pub mod hex_bytes;
-pub mod serde_primitives;
-
 pub mod models;
+pub mod serde_primitives;
+pub mod simulation;
 pub mod storage;
 pub mod traits;
 

--- a/tycho-common/src/simulation/errors.rs
+++ b/tycho-common/src/simulation/errors.rs
@@ -1,0 +1,38 @@
+use thiserror::Error;
+
+use crate::simulation::protocol_sim::GetAmountOutResult;
+
+/// Represents the outer-level, user-facing errors of the tycho-simulation package.
+///
+/// `SimulationError` encompasses all possible errors that can occur in the package,
+/// wrapping lower-level errors in a user-friendly way for easier handling and display.
+/// Variants:
+/// - `RecoverableError`: Indicates that the simulation has failed with a recoverable error.
+///   Retrying at a later time may succeed. It may have failed due to a temporary issue, such as a
+///   network problem.
+/// - `InvalidInput`: Indicates that the simulation has failed due to bad input parameters.
+/// - `FatalError`: There is a bug with this pool or protocol - do not attempt simulation again.
+#[derive(Error, Debug)]
+pub enum SimulationError {
+    #[error("Fatal error: {0}")]
+    FatalError(String),
+    #[error("Invalid input: {0}")]
+    InvalidInput(String, Option<GetAmountOutResult>),
+    #[error("Recoverable error: {0}")]
+    RecoverableError(String),
+}
+
+#[derive(Debug)]
+pub enum TransitionError<T> {
+    OutOfOrder { state: T, event: T },
+    MissingAttribute(String),
+    DecodeError(String),
+    InvalidEventType(),
+    SimulationError(SimulationError),
+}
+
+impl<T> From<SimulationError> for TransitionError<T> {
+    fn from(error: SimulationError) -> Self {
+        TransitionError::SimulationError(error)
+    }
+}

--- a/tycho-common/src/simulation/mod.rs
+++ b/tycho-common/src/simulation/mod.rs
@@ -1,0 +1,2 @@
+pub mod errors;
+pub mod protocol_sim;

--- a/tycho-common/src/simulation/protocol_sim.rs
+++ b/tycho-common/src/simulation/protocol_sim.rs
@@ -1,0 +1,170 @@
+use std::{any::Any, collections::HashMap, fmt};
+
+use num_bigint::BigUint;
+
+use crate::{
+    dto::ProtocolStateDelta,
+    models::token::Token,
+    simulation::errors::{SimulationError, TransitionError},
+    Bytes,
+};
+
+#[derive(Default)]
+pub struct Balances {
+    pub component_balances: HashMap<String, HashMap<Bytes, Bytes>>,
+    pub account_balances: HashMap<Bytes, HashMap<Bytes, Bytes>>,
+}
+
+/// GetAmountOutResult struct represents the result of getting the amount out of a trading pair
+///
+/// # Fields
+///
+/// * `amount`: BigUint, the amount of the trading pair
+/// * `gas`: BigUint, the gas of the trading pair
+#[derive(Debug)]
+pub struct GetAmountOutResult {
+    pub amount: BigUint,
+    pub gas: BigUint,
+    pub new_state: Box<dyn ProtocolSim>,
+}
+
+impl GetAmountOutResult {
+    /// Constructs a new GetAmountOutResult struct with the given amount and gas
+    pub fn new(amount: BigUint, gas: BigUint, new_state: Box<dyn ProtocolSim>) -> Self {
+        GetAmountOutResult { amount, gas, new_state }
+    }
+
+    /// Aggregates the given GetAmountOutResult struct to the current one.
+    /// It updates the amount with the other's amount and adds the other's gas to the current one's
+    /// gas.
+    pub fn aggregate(&mut self, other: &Self) {
+        self.amount = other.amount.clone();
+        self.gas += &other.gas;
+    }
+}
+
+impl fmt::Display for GetAmountOutResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "amount = {}, gas = {}", self.amount, self.gas)
+    }
+}
+
+/// ProtocolSim trait
+/// This trait defines the methods that a protocol state must implement in order to be used
+/// in the trade simulation.
+pub trait ProtocolSim: std::fmt::Debug + Send + Sync + 'static {
+    /// Returns the fee of the protocol as ratio
+    ///
+    /// E.g. if the fee is 1%, the value returned would be 0.01.
+    fn fee(&self) -> f64;
+
+    /// Returns the protocol's current spot price of two tokens
+    ///
+    /// Currency pairs are meant to be compared against one another in
+    /// order to understand how much of the quote currency is required
+    /// to buy one unit of the base currency.
+    ///
+    /// E.g. if ETH/USD is trading at 1000, we need 1000 USD (quote)
+    /// to buy 1 ETH (base currency).
+    ///
+    /// # Arguments
+    ///
+    /// * `a` - Base Token: refers to the token that is the quantity of a pair. For the pair
+    ///   BTC/USDT, BTC would be the base asset.
+    /// * `b` - Quote Token: refers to the token that is the price of a pair. For the symbol
+    ///   BTC/USDT, USDT would be the quote asset.
+    fn spot_price(&self, base: &Token, quote: &Token) -> Result<f64, SimulationError>;
+
+    /// Returns the amount out given an amount in and input/output tokens.
+    ///
+    /// # Arguments
+    ///
+    /// * `amount_in` - The amount in of the input token.
+    /// * `token_in` - The input token ERC20 token.
+    /// * `token_out` - The output token ERC20 token.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing a `GetAmountOutResult` struct on success or a
+    ///  `SimulationError` on failure.
+    fn get_amount_out(
+        &self,
+        amount_in: BigUint,
+        token_in: &Token,
+        token_out: &Token,
+    ) -> Result<GetAmountOutResult, SimulationError>;
+
+    /// Computes the maximum amount that can be traded between two tokens.
+    ///
+    /// This function calculates the maximum possible trade amount between two tokens,
+    /// taking into account the protocol's specific constraints and mechanics.
+    /// The implementation details vary by protocol - for example:
+    /// - For constant product AMMs (like Uniswap V2), this is based on available reserves
+    /// - For concentrated liquidity AMMs (like Uniswap V3), this considers liquidity across tick
+    ///   ranges
+    ///
+    /// Note: if there are no limits, the returned amount will be a "soft" limit,
+    ///       meaning that the actual amount traded could be higher but it's advised to not
+    ///       exceed it.
+    ///
+    /// # Arguments
+    /// * `sell_token` - The address of the token being sold
+    /// * `buy_token` - The address of the token being bought
+    ///
+    /// # Returns
+    /// * `Ok((Option<BigUint>, Option<BigUint>))` - A tuple containing:
+    ///   - First element: The maximum input amount
+    ///   - Second element: The maximum output amount
+    ///
+    /// This means that for `let res = get_limits(...)` the amount input domain for `get_amount_out`
+    /// would be `[0, res.0]` and the amount input domain for `get_amount_in` would be `[0,
+    /// res.1]`
+    ///
+    /// * `Err(SimulationError)` - If any unexpected error occurs
+    fn get_limits(
+        &self,
+        sell_token: Bytes,
+        buy_token: Bytes,
+    ) -> Result<(BigUint, BigUint), SimulationError>;
+
+    /// Decodes and applies a protocol state delta to the state
+    ///
+    /// Will error if the provided delta is missing any required attributes or if any of the
+    /// attribute values cannot be decoded.
+    ///
+    /// # Arguments
+    ///
+    /// * `delta` - A `ProtocolStateDelta` from the tycho indexer
+    ///
+    /// # Returns
+    ///
+    /// * `Result<(), TransitionError<String>>` - A `Result` containing `()` on success or a
+    ///   `TransitionError` on failure.
+    fn delta_transition(
+        &mut self,
+        delta: ProtocolStateDelta,
+        tokens: &HashMap<Bytes, Token>,
+        balances: &Balances,
+    ) -> Result<(), TransitionError<String>>;
+
+    /// Clones the protocol state as a trait object.
+    /// This allows the state to be cloned when it is being used as a `Box<dyn ProtocolSim>`.
+    fn clone_box(&self) -> Box<dyn ProtocolSim>;
+
+    /// Allows downcasting of the trait object to its underlying type.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Allows downcasting of the trait object to its mutable underlying type.
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+
+    /// Compares two protocol states for equality.
+    /// This method must be implemented to define how two protocol states are considered equal
+    /// (used for tests).
+    fn eq(&self, other: &dyn ProtocolSim) -> bool;
+}
+
+impl Clone for Box<dyn ProtocolSim> {
+    fn clone(&self) -> Box<dyn ProtocolSim> {
+        self.clone_box()
+    }
+}


### PR DESCRIPTION
Done:
- Generalise Header by creating a HeaderLike trait. Rename Header to BlockHeader
- Move ProtocolSim from simulation (and also GetAmountOutResult, Balances, SimulationError and TransitionError)

This is needed for RFQs where we only need the timestamp

Corresponding PRs:
- https://github.com/propeller-heads/tycho-simulation/pull/257
- https://github.com/propeller-heads/tycho-execution/pull/240