### PR TITLE
feat: add metadata response parser

### DIFF
--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/component_metadata.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/component_metadata.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)] // TODO: Remove when implementation is complete
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -43,6 +43,7 @@ pub struct ComponentTracingMetadata {
 
 type RequestId = String;
 // Represents a request to a provider.
+#[cfg_attr(test, derive(Debug))]
 pub struct MetadataRequest {
     pub request_id: RequestId,
     pub component_id: ComponentId,
@@ -93,7 +94,7 @@ pub enum MetadataRequestType {
 /// Common implementations include:
 /// - `DefiLLamaHttpTransport`: For REST API calls to Defillama API (e.g., DeFiLlama TVL data)
 /// - `RpcTransport`: For JSON-RPC calls to blockchain nodes
-pub trait RequestTransport: Send + Sync {
+pub trait RequestTransport: Send + Sync + Debug {
     /// Returns a routing key that identifies which provider should handle this request.
     ///
     /// The routing key groups requests by their destination provider, enabling efficient
@@ -484,7 +485,7 @@ pub struct MetadataResult {
 }
 
 // Simple enum for actual metadata values
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum MetadataValue {
     Balances(HashMap<Address, Bytes>),
     Limits(Vec<((Address, Address), (Bytes, Bytes))>),

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/component_metadata.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/component_metadata.rs
@@ -244,6 +244,30 @@ pub trait MetadataRequestGenerator: Send + Sync {
     fn supported_metadata_types(&self) -> Vec<MetadataRequestType>;
 }
 
+pub trait MetadataResponseParser: Send + Sync {
+    /// Parses the response from the provider and returns the metadata value.
+    ///
+    /// # Arguments
+    ///
+    /// * `component` - The protocol component that the request is for
+    /// * `request_type` - The type of request that was made
+    /// * `response` - The response from the provider
+    ///
+    /// # Returns
+    ///
+    /// A `MetadataValue` that represents the parsed metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `MetadataError` if the response cannot be parsed.
+    fn parse_response(
+        &self,
+        component: &ProtocolComponent,
+        request_type: &MetadataRequestType,
+        response: &Value,
+    ) -> Result<MetadataValue, MetadataError>;
+}
+
 /// Registry that manages the mapping between protocol components and their metadata generators.
 ///
 /// This registry is the central configuration point for determining which generator should


### PR DESCRIPTION
This PR adds a customizable way to decode values returned by RPC/API calls. This will need to be implemented for each hook protocol. 

It also adds the first implementation of this trait for `EulerSwap`