### PR TITLE
fix: Specify minimum rust version

### DIFF
--- a/tycho-common/Cargo.toml
+++ b/tycho-common/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 categories.workspace = true
 readme = "README.md"
-
+rust-version = "1.87.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Unsigned `is_multiple_of` used in `serde_primitives::decode_hex_with_prefix()` is stabilized only in `1.87` version of rust as per this issue https://github.com/rust-lang/rust/pull/137383 
Building the package with older version fails with 
```
error[E0658]: use of unstable library feature `unsigned_is_multiple_of`
 --> tycho-common/src/serde_primitives.rs:8:24
  |
8 |     if !stripped.len().is_multiple_of(2) {
  |                        ^^^^^^^^^^^^^^
  |
  = note: see issue #128101 <https://github.com/rust-lang/rust/issues/128101> for more information
```