### PR TITLE
refactor: properly handle index cration in migrations

### DIFF
--- a/tycho-storage/migrations/2025-07-21_index_protocol_components/up.sql
+++ b/tycho-storage/migrations/2025-07-21_index_protocol_components/up.sql
@@ -1,2 +1,2 @@
 CREATE INDEX IF NOT EXISTS idx_protocol_system_id_external_id ON protocol_component (protocol_system_id, external_id);
-CREATE INDEX idx_protocol_component_system_id ON protocol_component (protocol_system_id);
+CREATE INDEX IF NOT EXISTS idx_protocol_component_system_id ON protocol_component (protocol_system_id);


### PR DESCRIPTION
This PR adds a missing "IF NOT EXISTS" in the new migration, this helps in case the index has already been manually created