### PR TITLE
feat: Add new error type for tracing execution failure

### DIFF
--- a/tycho-common/src/traits.rs
+++ b/tycho-common/src/traits.rs
@@ -144,5 +144,5 @@ pub trait EntryPointTracer: Sync {
         &self,
         block_hash: BlockHash,
         entry_points: Vec<EntryPointWithTracingParams>,
-    ) -> Result<Vec<TracedEntryPoint>, Self::Error>;
+    ) -> Vec<Result<TracedEntryPoint, Self::Error>>;
 }

--- a/tycho-ethereum/src/entrypoint_tracer/mod.rs
+++ b/tycho-ethereum/src/entrypoint_tracer/mod.rs
@@ -24,6 +24,8 @@ pub struct AccessListResult {
     pub access_list: Vec<AccessListEntry>,
     #[serde(rename = "gasUsed")]
     pub gas_used: String,
+    #[serde(rename = "error")]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -79,6 +81,10 @@ pub fn build_state_overrides(
 
 impl AccessListResult {
     pub fn try_get_accessed_slots(&self) -> Result<HashMap<Address, HashSet<Bytes>>, RPCError> {
+        if let Some(error) = &self.error {
+            return Err(RPCError::TracingFailure(error.to_string()));
+        }
+
         let mut out = HashMap::new();
 
         for entry in &self.access_list {

--- a/tycho-ethereum/src/entrypoint_tracer/tracer.rs
+++ b/tycho-ethereum/src/entrypoint_tracer/tracer.rs
@@ -227,7 +227,7 @@ impl EVMEntrypointService {
             .body(batch_params.get().to_string())
             .send()
             .await
-            .map_err(|e| RPCError::UnknownError(format!("HTTP request failed: {}", e)))?;
+            .map_err(|e| RPCError::RequestError(e.to_string()))?;
 
         let batch_response: Vec<Value> = response.json().await.map_err(|e| {
             RPCError::UnknownError(format!("Failed to parse batch response: {}", e))
@@ -246,7 +246,10 @@ impl EVMEntrypointService {
         let access_list_data = access_list_result
             .get("result")
             .ok_or_else(|| {
-                RPCError::UnknownError("Missing result in access list response".to_string())
+                RPCError::UnknownError(format!(
+                    "Missing result in access list response: {:?}",
+                    access_list_result
+                ))
             })?;
 
         let access_list: AccessListResult = serde_json::from_value(access_list_data.clone())
@@ -265,13 +268,16 @@ impl EVMEntrypointService {
         // Parse trace response
         let trace_result = &batch_response[1];
         if let Some(error) = trace_result.get("error") {
-            return Err(RPCError::UnknownError(format!("debug_traceCall failed: {}", error)));
+            return Err(RPCError::TracingFailure(format!("debug_traceCall failed: {}", error)));
         }
 
         let trace_data = trace_result
             .get("result")
             .ok_or_else(|| {
-                RPCError::UnknownError("Missing result in trace response".to_string())
+                RPCError::UnknownError(format!(
+                    "Missing result in trace response: {:?}",
+                    trace_result
+                ))
             })?;
 
         let pre_state_trace: GethTrace = serde_json::from_value(trace_data.clone())
@@ -654,6 +660,70 @@ mod tests {
             .unwrap();
 
         assert_eq!(traced_entry_points, vec![]);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a RPC connection"]
+    async fn test_trace_failing_call() {
+        let url = env::var("RPC_URL").expect("RPC_URL is not set");
+        let tracer = EVMEntrypointService::try_from_url(&url).unwrap();
+        let entry_points = vec![EntryPointWithTracingParams::new(
+            EntryPoint::new(
+                "1a8f81c256aee9c640e14bb0453ce247ea0dfe6f:unknown()".to_string(),
+                Bytes::from_str("1a8f81c256aee9c640e14bb0453ce247ea0dfe6f").unwrap(),
+                "unknown()".to_string(),
+            ),
+            TracingParams::RPCTracer(RPCTracerParams::new(
+                None,
+                Bytes::from(&keccak256("unknown()").to_vec()[0..4]),
+            )),
+        )];
+        let traced_entry_points = tracer
+            .trace(
+                // Block 22589134 hash
+                Bytes::from_str(
+                    "0xf5e2c5bc64ba61e1230e34b2d5d8906416633100919b477d17a7c6fd69cde31d",
+                )
+                .unwrap(),
+                entry_points.clone(),
+            )
+            .await;
+
+        assert_eq!(traced_entry_points.len(), 1);
+        dbg!(&traced_entry_points[0]);
+        assert!(matches!(traced_entry_points[0], Err(RPCError::TracingFailure(_))));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a RPC connection"]
+    async fn test_trace_failing_rpc() {
+        let url = "https://fake_rpc.com/eth";
+        let tracer = EVMEntrypointService::try_from_url(url).unwrap();
+        let entry_points = vec![EntryPointWithTracingParams::new(
+            EntryPoint::new(
+                "1a8f81c256aee9c640e14bb0453ce247ea0dfe6f:unknown()".to_string(),
+                Bytes::from_str("1a8f81c256aee9c640e14bb0453ce247ea0dfe6f").unwrap(),
+                "unknown()".to_string(),
+            ),
+            TracingParams::RPCTracer(RPCTracerParams::new(
+                None,
+                Bytes::from(&keccak256("unknown()").to_vec()[0..4]),
+            )),
+        )];
+        let traced_entry_points = tracer
+            .trace(
+                // Block 22589134 hash
+                Bytes::from_str(
+                    "0xf5e2c5bc64ba61e1230e34b2d5d8906416633100919b477d17a7c6fd69cde31d",
+                )
+                .unwrap(),
+                entry_points.clone(),
+            )
+            .await;
+
+        assert_eq!(traced_entry_points.len(), 1);
+        dbg!(&traced_entry_points[0]);
+        assert!(matches!(traced_entry_points[0], Err(RPCError::RequestError(_))));
     }
 
     #[tokio::test]

--- a/tycho-ethereum/src/entrypoint_tracer/tracer.rs
+++ b/tycho-ethereum/src/entrypoint_tracer/tracer.rs
@@ -289,22 +289,28 @@ impl EntryPointTracer for EVMEntrypointService {
         &self,
         block_hash: BlockHash,
         entry_points: Vec<EntryPointWithTracingParams>,
-    ) -> Result<Vec<TracedEntryPoint>, Self::Error> {
+    ) -> Vec<Result<TracedEntryPoint, Self::Error>> {
         let mut results = Vec::new();
         for entry_point in &entry_points {
-            match &entry_point.params {
+            let result = match &entry_point.params {
                 TracingParams::RPCTracer(ref rpc_entry_point) => {
                     // Use batched RPC call for both access list and trace
-                    let (accessed_slots, pre_state_trace) = self
+                    let (accessed_slots, pre_state_trace) = match self
                         .batch_trace_and_access_list(
                             &entry_point.entry_point.target,
                             rpc_entry_point,
                             &block_hash,
                         )
-                        .await?;
+                        .await
+                    {
+                        Ok(trace) => trace,
+                        Err(e) => {
+                            results.push(Err(e));
+                            continue;
+                        }
+                    };
 
                     let called_addresses: Vec<Address> = accessed_slots.keys().cloned().collect();
-
                     // Provides a very simplistic way of finding retriggers. A better way would
                     // involve using the structure of callframes. So basically iterate the call
                     // tree in a parent child manner then search the
@@ -334,19 +340,22 @@ impl EntryPointTracer for EVMEntrypointService {
                         }
                         retriggers
                     } else {
-                        return Err(RPCError::UnknownError(
+                        results.push(Err(RPCError::UnknownError(
                             "invalid trace result for PreStateTracer".to_string(),
-                        ));
+                        )));
+                        continue;
                     };
-                    results.push(TracedEntryPoint::new(
+
+                    Ok(TracedEntryPoint::new(
                         entry_point.clone(),
                         block_hash.clone(),
                         TracingResult::new(retriggers, accessed_slots),
-                    ));
+                    ))
                 }
-            }
+            };
+            results.push(result);
         }
-        Ok(results)
+        results
     }
 }
 
@@ -400,6 +409,8 @@ mod tests {
                 entry_points.clone(),
             )
             .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
             .unwrap();
 
         assert_eq!(
@@ -553,6 +564,8 @@ mod tests {
                 entry_points.clone(),
             )
             .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
             .unwrap();
 
         assert_eq!(
@@ -636,6 +649,8 @@ mod tests {
                 entry_points.clone(),
             )
             .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
             .unwrap();
 
         assert_eq!(traced_entry_points, vec![]);
@@ -685,6 +700,8 @@ mod tests {
                 entry_points.clone(),
             )
             .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
             .unwrap();
 
         assert!(traced_entry_points[0]

--- a/tycho-ethereum/src/lib.rs
+++ b/tycho-ethereum/src/lib.rs
@@ -12,10 +12,7 @@ pub mod token_pre_processor;
 #[macro_use]
 extern crate pretty_assertions;
 
-use ethers::{
-    providers::ProviderError,
-    types::{H160, H256, U256},
-};
+use ethers::types::{H160, H256, U256};
 use thiserror::Error;
 use tycho_common::{models::blockchain::BlockTag, Bytes};
 use web3::types::BlockNumber;
@@ -25,7 +22,9 @@ pub enum RPCError {
     #[error("RPC setup error: {0}")]
     SetupError(String),
     #[error("RPC error: {0}")]
-    RequestError(#[from] ProviderError),
+    RequestError(String),
+    #[error("Tracing failure: {0}")]
+    TracingFailure(String),
     #[error("Unknown error: {0}")]
     UnknownError(String),
 }

--- a/tycho-ethereum/src/token_analyzer/rpc_client.rs
+++ b/tycho-ethereum/src/token_analyzer/rpc_client.rs
@@ -19,6 +19,6 @@ impl EthereumRpcClient {
             .get_block_number()
             .await
             .map(|number| number.as_u64())
-            .map_err(RPCError::RequestError)
+            .map_err(|e| RPCError::RequestError(e.to_string()))
     }
 }

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/dci.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/dci.rs
@@ -191,7 +191,8 @@ where
                     block_hash = %block_changes.block.hash
                 ))
                 .await
-                .into_iter()// TODO: properly handle errors, should either retry or pause the related components depending on the error
+                .into_iter() // TODO: properly handle errors, should either retry or pause the related components
+                // depending on the error
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|e| ExtractionError::TracingError(format!("{e:?}")))?;
 

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/dci.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/dci.rs
@@ -191,6 +191,8 @@ where
                     block_hash = %block_changes.block.hash
                 ))
                 .await
+                .into_iter()// TODO: properly handle errors, should either retry or pause the related components depending on the error
+                .collect::<Result<Vec<_>, _>>()
                 .map_err(|e| ExtractionError::TracingError(format!("{e:?}")))?;
 
             tracing::debug!(traced_entry_points = ?traced_entry_points, "DCI: Traced entrypoints");
@@ -1210,11 +1212,11 @@ mod tests {
                 )]),
             )
             .return_once(move |_, _| {
-                Ok(vec![TracedEntryPoint::new(
+                vec![Ok(TracedEntryPoint::new(
                     EntryPointWithTracingParams::new(get_entrypoint(9), get_tracing_params(9)),
                     Bytes::zero(32),
                     get_tracing_result(9),
-                )])
+                ))]
             });
 
         account_extractor
@@ -1398,18 +1400,18 @@ mod tests {
                 }),
             )
             .return_once(move |_, _| {
-                Ok(vec![
-                    TracedEntryPoint::new(
+                vec![
+                    Ok(TracedEntryPoint::new(
                         EntryPointWithTracingParams::new(get_entrypoint(1), get_tracing_params(1)),
                         Bytes::zero(32),
                         get_tracing_result(1),
-                    ),
-                    TracedEntryPoint::new(
+                    )),
+                    Ok(TracedEntryPoint::new(
                         EntryPointWithTracingParams::new(get_entrypoint(4), get_tracing_params(1)),
                         Bytes::zero(32),
                         get_tracing_result(5),
-                    ),
-                ])
+                    )),
+                ]
             });
 
         // Should only be called for new accounts, so account 0x01 and 0x11 are ignored because
@@ -1549,11 +1551,11 @@ mod tests {
             .return_once({
                 let token_address = token_address.clone();
                 move |_, _| {
-                    Ok(vec![TracedEntryPoint::new(
+                    vec![Ok(TracedEntryPoint::new(
                         EntryPointWithTracingParams::new(get_entrypoint(9), get_tracing_params(9)),
                         Bytes::zero(32),
                         get_tracing_result_with_address(&token_address),
-                    )])
+                    ))]
                 }
             });
 
@@ -1650,11 +1652,11 @@ mod tests {
                 )]),
             )
             .return_once(move |_, _| {
-                Ok(vec![TracedEntryPoint::new(
+                vec![Ok(TracedEntryPoint::new(
                     EntryPointWithTracingParams::new(get_entrypoint(9), get_tracing_params(9)),
                     Bytes::zero(32),
                     get_tracing_result_with_address(&blacklisted_address_for_trace),
-                )])
+                ))]
             });
 
         // Expect specific slots to be requested for the blacklisted address
@@ -1738,11 +1740,11 @@ mod tests {
                 )]),
             )
             .return_once(move |_, _| {
-                Ok(vec![TracedEntryPoint::new(
+                vec![Ok(TracedEntryPoint::new(
                     EntryPointWithTracingParams::new(get_entrypoint(9), get_tracing_params(9)),
                     Bytes::zero(32),
                     get_tracing_result_with_address(&normal_address_for_trace),
-                )])
+                ))]
             });
 
         // Expect all slots (None) to be requested for normal contracts

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/dci.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/dci.rs
@@ -1971,7 +1971,7 @@ mod tests {
                 let tracked_address = tracked_address.clone();
                 let new_slot = new_slot.clone();
                 move |_, _| {
-                    Ok(vec![TracedEntryPoint::new(
+                    vec![Ok(TracedEntryPoint::new(
                         EntryPointWithTracingParams::new(get_entrypoint(9), get_tracing_params(9)),
                         Bytes::zero(32),
                         get_tracing_result_with_addresses_and_slots(vec![
@@ -1980,7 +1980,7 @@ mod tests {
                                 vec![Bytes::from(0x22_u8).lpad(32, 0), new_slot],
                             ), // One existing slot, one new
                         ]),
-                    )])
+                    ))]
                 }
             });
 
@@ -2059,13 +2059,13 @@ mod tests {
                 let existing_slot = existing_slot.clone();
                 let new_slot = new_slot.clone();
                 move |_, _| {
-                    Ok(vec![TracedEntryPoint::new(
+                    vec![Ok(TracedEntryPoint::new(
                         EntryPointWithTracingParams::new(get_entrypoint(9), get_tracing_params(9)),
                         Bytes::zero(32),
                         get_tracing_result_with_addresses_and_slots(vec![
                             (token_address.clone(), vec![existing_slot, new_slot]), // One existing slot, one new
                         ]),
-                    )])
+                    ))]
                 }
             });
 
@@ -2161,14 +2161,14 @@ mod tests {
             .return_once({
                 let new_account = new_account.clone();
                 move |_, _| {
-                    Ok(vec![TracedEntryPoint::new(
+                    vec![Ok(TracedEntryPoint::new(
                         EntryPointWithTracingParams::new(get_entrypoint(9), get_tracing_params(9)),
                         Bytes::zero(32),
                         // Account with empty slots - this is the key scenario
                         get_tracing_result_with_addresses_and_slots(vec![
                             (new_account.clone(), vec![]), // No slots!
                         ]),
-                    )])
+                    ))]
                 }
             });
 
@@ -2252,13 +2252,13 @@ mod tests {
                 let token_address = token_address.clone();
                 let existing_slot = existing_slot.clone();
                 move |_, _| {
-                    Ok(vec![TracedEntryPoint::new(
+                    vec![Ok(TracedEntryPoint::new(
                         EntryPointWithTracingParams::new(get_entrypoint(9), get_tracing_params(9)),
                         Bytes::zero(32),
                         get_tracing_result_with_addresses_and_slots(vec![
                             (token_address.clone(), vec![existing_slot]), // Only existing slots, no new ones
                         ]),
-                    )])
+                    ))]
                 }
             });
 


### PR DESCRIPTION
We want DCI to differentiate tracing errors between recoverable and unrecoverable.

For example if it's a connection issue with the RPC, we should retry the tracing later. But if it's an EVM execution failure, it means the entrypoint is wrong and we don't need to retry.

This PR is the first step toward this. It improves the tracer to return a different error if the tracing fails because of a EVM execution failure.

Additionally, it refactors the tracer to return specific error per request instead of batch scoped error.