### PR TITLE
fix: Simplify GetAmountOutParams to hold Bytes only

### DIFF
--- a/tycho-common/src/models/protocol.rs
+++ b/tycho-common/src/models/protocol.rs
@@ -7,8 +7,8 @@ use tracing::warn;
 
 use crate::{
     models::{
-        blockchain::Transaction, token::Token, Address, AttrStoreKey, Balance, Chain, ChangeType,
-        ComponentId, MergeError, StoreVal, TxHash,
+        blockchain::Transaction, Address, AttrStoreKey, Balance, Chain, ChangeType, ComponentId,
+        MergeError, StoreVal, TxHash,
     },
     Bytes,
 };
@@ -319,8 +319,8 @@ impl ProtocolChangesWithTx {
 
 pub struct GetAmountOutParams {
     pub amount_in: BigUint,
-    pub token_in: Token,
-    pub token_out: Token,
+    pub token_in: Bytes,
+    pub token_out: Bytes,
     pub sender: Bytes,
     pub receiver: Bytes,
 }

--- a/tycho-indexer/src/services/ws.rs
+++ b/tycho-indexer/src/services/ws.rs
@@ -945,7 +945,7 @@ mod tests {
         for i in 0..num_clients {
             let (connection, _) = tokio_tungstenite::connect_async(&url)
                 .await
-                .unwrap_or_else(|_| panic!("Failed to connect client {}", i));
+                .unwrap_or_else(|_| panic!("Failed to connect client {i}"));
             connections.push(connection);
         }
 
@@ -960,11 +960,11 @@ mod tests {
             .map(|(i, mut connection)| {
                 let msg_text = msg_text.clone();
                 async move {
-                    println!("Client {} sending subscription request", i);
+                    println!("Client {i} sending subscription request");
                     connection
                         .send(Message::Text(msg_text))
                         .await
-                        .unwrap_or_else(|_| panic!("Failed to send from client {}", i));
+                        .unwrap_or_else(|_| panic!("Failed to send from client {i}"));
 
                     // Try to receive response
                     let start = std::time::Instant::now();
@@ -994,14 +994,14 @@ mod tests {
             .count();
         let failed = results.len() - successful;
 
-        println!("Test completed in {:?}", total_time);
-        println!("Results: {} successful, {} failed", successful, failed);
+        println!("Test completed in {total_time:?}");
+        println!("Results: {successful} successful, {failed} failed");
 
         // With the original deadlock-prone code, we expect some failures due to timeouts
         // caused by the mutex being held during block_on() calls
 
         if failed > 0 {
-            println!("DEADLOCK ISSUE DETECTED: {} out of {} clients failed", failed, num_clients);
+            println!("DEADLOCK ISSUE DETECTED: {failed} out of {num_clients} clients failed");
             println!("This indicates the deadlock problem exists in the original code");
         } else {
             println!("ALL CLIENTS SUCCEEDED - deadlock not reproduced");


### PR DESCRIPTION
We don't need the full Token object here. This is only used in the quote method for now and in execution we don't really have the full `Token` objects

Also fix clippy warnings
