### PR TITLE
feat: change version of github actions/checkout to v5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Calculate Dockerfile hash
         id: dockerfile_hash
@@ -62,7 +62,7 @@ jobs:
       DATABASE_URL: postgres://postgres:mypassword@localhost:5432/tycho_indexer_0
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup toolchain
         id: toolchain
         uses: dtolnay/rust-toolchain@nightly
@@ -141,7 +141,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: pg-formatter-action
         uses: kayibal/pg-formatter-action@master

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install PostgreSQL Client on macOS
         if: runner.os == 'macOS'
         run: |
@@ -57,7 +57,7 @@ jobs:
   publish-crate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable


### PR DESCRIPTION
[INFRA-158](https://propeller-heads.atlassian.net/browse/INFRA-158) - update ci/cd github **actions/checkout** to v5 due to upgrade ci/cd runner

[INFRA-158]: https://propeller-heads.atlassian.net/browse/INFRA-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ