### PR TITLE
fix: correctly get all values from cache when needed.

### DIFF
--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/dci.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/dci.rs
@@ -489,7 +489,7 @@ where
                 for key in contract_store.keys() {
                     let location = (account.clone(), key.clone());
                     // Check if this storage location triggers any entrypoints
-                    if let Some(entrypoints) = self.cache.retriggers.get_all(&location) {
+                    if let Some(entrypoints) = self.cache.retriggers.get_all(location) {
                         for entrypoint in entrypoints.into_iter().flatten() {
                             // Only insert if we haven't seen this entrypoint before or if this tx
                             // is later
@@ -607,19 +607,34 @@ where
                 let tracked_keys: Option<HashSet<&StoreKey>> = match self
                     .cache
                     .tracked_contracts
-                    .get_all(account)
+                    .get_all(account.clone())
                 {
                     // Early skip if the contract is not tracked
                     None => continue,
-                    // None is winning over specific keys, it means the whole contract is tracked
-                    Some(keys) if keys.iter().any(|k| k.is_none()) => None,
-                    // Else we aggregate the tracked keys
-                    Some(keys) => Some(
-                        keys.into_iter()
-                            .flatten()
-                            .flatten()
-                            .collect(),
-                    ),
+                    Some(keys) => {
+                        let mut result = HashSet::new();
+                        let mut whole_contract_tracked = false;
+
+                        for key in keys {
+                            match key {
+                                None => {
+                                    // None is winning over specific keys, it means the whole
+                                    // contract is tracked
+                                    whole_contract_tracked = true;
+                                    break;
+                                }
+                                Some(inner) => {
+                                    result.extend(inner.iter());
+                                }
+                            }
+                        }
+
+                        if whole_contract_tracked {
+                            None
+                        } else {
+                            Some(result)
+                        }
+                    }
                 };
 
                 let mut slot_updates = contract_store


### PR DESCRIPTION
In some cases we need a full cache lookup. For example when getting retriggers or tracked slots we want to return all the elements and not only the last one.

This commit adds a `get_all` function on the `VersionedCache` to allow for this. We now use it instead of a simple `.get()` when needed inside DCI implementation