### PR TITLE
feat: implement pausing component in DCI

### DIFF
--- a/tycho-common/src/models/blockchain.rs
+++ b/tycho-common/src/models/blockchain.rs
@@ -534,13 +534,13 @@ impl std::fmt::Display for RPCTracerParams {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let caller_str = match &self.caller {
             Some(addr) => format!("caller={}", addr),
-            None => "caller=default".to_string(),
+            None => String::new(),
         };
 
-        let calldata_str = if self.calldata.len() >= 4 {
+        let calldata_str = if self.calldata.len() >= 8 {
             format!(
                 "calldata=0x{}..({} bytes)",
-                hex::encode(&self.calldata[..4]),
+                hex::encode(&self.calldata[..8]),
                 self.calldata.len()
             )
         } else {

--- a/tycho-common/src/models/blockchain.rs
+++ b/tycho-common/src/models/blockchain.rs
@@ -530,6 +530,34 @@ impl RPCTracerParams {
     }
 }
 
+impl std::fmt::Display for RPCTracerParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let caller_str = match &self.caller {
+            Some(addr) => format!("caller={}", addr),
+            None => "caller=default".to_string(),
+        };
+
+        let calldata_str = if self.calldata.len() >= 4 {
+            format!(
+                "calldata=0x{}..({} bytes)",
+                hex::encode(&self.calldata[..4]),
+                self.calldata.len()
+            )
+        } else {
+            format!("calldata={}", self.calldata)
+        };
+
+        let overrides_str = match &self.state_overrides {
+            Some(overrides) if !overrides.is_empty() => {
+                format!(", {} state override(s)", overrides.len())
+            }
+            _ => String::new(),
+        };
+
+        write!(f, "{}, {}{}", caller_str, calldata_str, overrides_str)
+    }
+}
+
 // Ensure serialization order, required by the storage layer
 impl Serialize for RPCTracerParams {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/tycho-common/src/storage.rs
+++ b/tycho-common/src/storage.rs
@@ -510,6 +510,7 @@ pub trait ProtocolGateway {
 
 /// Filters for entry points queries in the database.
 // Shalow but can be used to add more filters without breaking backwards compatibility in the future
+#[derive(Debug, Clone)]
 pub struct EntryPointFilter {
     pub protocol_system: ProtocolSystem,
     pub component_ids: Option<Vec<ComponentId>>,

--- a/tycho-ethereum/src/entrypoint_tracer/tracer.rs
+++ b/tycho-ethereum/src/entrypoint_tracer/tracer.rs
@@ -33,7 +33,7 @@ use tycho_common::{
 };
 
 use super::{build_state_overrides, AccessListResult};
-use crate::{BytesCodec, RPCError, ReqwestError, SerdeJsonError};
+use crate::{BytesCodec, RPCError, RequestError, ReqwestError, SerdeJsonError};
 
 pub struct EVMEntrypointService {
     rpc_url: url::Url,
@@ -247,23 +247,23 @@ impl EVMEntrypointService {
             .send()
             .await
             .map_err(|e| {
-                RPCError::ReqwestError(ReqwestError {
+                RPCError::RequestError(RequestError::Reqwest(ReqwestError {
                     msg: format!(
                         "Failed to send request to {} (block: {}, params: {})",
                         target, block_hash, params
                     ),
                     source: e,
-                })
+                }))
             })?;
 
         let batch_response: Vec<Value> = response.json().await.map_err(|e| {
-            RPCError::ReqwestError(ReqwestError {
+            RPCError::RequestError(RequestError::Reqwest(ReqwestError {
                 msg: format!(
                     "Failed to parse batch response for {} (block: {}, params: {})",
                     target, block_hash, params
                 ),
                 source: e,
-            })
+            }))
         })?;
 
         if batch_response.len() != 2 {
@@ -483,6 +483,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::RequestError;
 
     #[tokio::test]
     #[ignore = "requires a RPC connection"]
@@ -1067,13 +1068,17 @@ mod tests {
 
         // Verify all results are RequestError
         for result in &results {
-            assert!(matches!(result, Err(RPCError::ReqwestError(_))));
+            assert!(matches!(result, Err(RPCError::RequestError(RequestError::Reqwest(_)))));
         }
 
         // Verify ordering is preserved by checking that error messages contain the expected target
         // addresses
         for (i, result) in results.iter().enumerate() {
-            if let Err(RPCError::ReqwestError(ReqwestError { msg, source: _ })) = result {
+            if let Err(RPCError::RequestError(RequestError::Reqwest(ReqwestError {
+                msg,
+                source: _,
+            }))) = result
+            {
                 let expected_target = &entry_points[i].entry_point.target;
                 assert!(
                     msg.contains(&expected_target.to_string()),
@@ -1244,7 +1249,7 @@ mod tests {
             Ok(_) => {
                 panic!("Expected second request to fail, but it succeeded");
             }
-            Err(RPCError::ReqwestError(ReqwestError { msg, source: _ })) => {
+            Err(RPCError::RequestError(RequestError::Reqwest(ReqwestError { msg, source: _ }))) => {
                 assert!(
                     msg.contains("0x0000000000000000000000000000000000000002"),
                     "Error message should contain the target address of the failed request"

--- a/tycho-ethereum/src/lib.rs
+++ b/tycho-ethereum/src/lib.rs
@@ -46,24 +46,37 @@ impl Display for ReqwestError {
 }
 
 #[derive(Error, Debug)]
+pub enum RequestError {
+    Reqwest(ReqwestError),
+    Other(String),
+}
+
+impl Display for RequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RequestError::Reqwest(e) => write!(f, "{}: {}", e.msg, e.source),
+            RequestError::Other(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+#[derive(Error, Debug)]
 pub enum RPCError {
     #[error("RPC setup error: {0}")]
     SetupError(String),
-    #[error("RPC error: {0}")]
-    RequestError(String),
+    #[error("Request error: {0}")]
+    RequestError(RequestError),
     #[error("Tracing failure: {0}")]
     TracingFailure(String),
     #[error("Serialize error: {0}")]
     SerializeError(SerdeJsonError),
-    #[error("Reqwest error: {0}")]
-    ReqwestError(ReqwestError),
     #[error("Unknown error: {0}")]
     UnknownError(String),
 }
 
 impl RPCError {
     pub fn should_retry(&self) -> bool {
-        matches!(self, Self::RequestError(_) | Self::ReqwestError(_))
+        matches!(self, Self::RequestError(_))
     }
 }
 

--- a/tycho-ethereum/src/lib.rs
+++ b/tycho-ethereum/src/lib.rs
@@ -29,6 +29,12 @@ pub enum RPCError {
     UnknownError(String),
 }
 
+impl RPCError {
+    pub fn should_retry(&self) -> bool {
+        matches!(self, Self::RequestError(_))
+    }
+}
+
 pub struct BlockTagWrapper(BlockTag);
 
 impl From<BlockTagWrapper> for BlockNumber {

--- a/tycho-ethereum/src/token_analyzer/rpc_client.rs
+++ b/tycho-ethereum/src/token_analyzer/rpc_client.rs
@@ -1,6 +1,6 @@
 use ethers::providers::{Http, Middleware, Provider};
 
-use crate::RPCError;
+use crate::{RPCError, RequestError};
 
 pub struct EthereumRpcClient {
     ethers_client: ethers::providers::Provider<Http>,
@@ -19,6 +19,6 @@ impl EthereumRpcClient {
             .get_block_number()
             .await
             .map(|number| number.as_u64())
-            .map_err(|e| RPCError::RequestError(e.to_string()))
+            .map_err(|e| RPCError::RequestError(RequestError::Other(e.to_string())))
     }
 }

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/hook_dci.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/hook_dci.rs
@@ -1024,6 +1024,12 @@ mod tests {
             });
 
         gateway
+            .expect_get_entry_points()
+            .return_once(move |_, _| {
+                Box::pin(async move { Ok(WithTotal { entity: HashMap::new(), total: None }) })
+            });
+
+        gateway
             .expect_get_traced_entry_points()
             .return_once(move |_| Box::pin(async move { Ok(HashMap::new()) }));
 
@@ -1777,6 +1783,11 @@ mod tests {
                 });
 
             db_gateway
+                .expect_get_entry_points()
+                .return_once(move |_, _| {
+                    Box::pin(async move { Ok(WithTotal { entity: HashMap::new(), total: None }) })
+                });
+            db_gateway
                 .expect_get_traced_entry_points()
                 .return_once(move |_| Box::pin(async move { Ok(HashMap::new()) }));
 
@@ -1960,6 +1971,12 @@ mod tests {
             // Setup expectations for initialization
             db_gateway
                 .expect_get_entry_points_tracing_params()
+                .return_once(move |_, _| {
+                    Box::pin(async move { Ok(WithTotal { entity: HashMap::new(), total: None }) })
+                });
+
+            db_gateway
+                .expect_get_entry_points()
                 .return_once(move |_, _| {
                     Box::pin(async move { Ok(WithTotal { entity: HashMap::new(), total: None }) })
                 });

--- a/tycho-indexer/src/services/deltas_buffer.rs
+++ b/tycho-indexer/src/services/deltas_buffer.rs
@@ -845,7 +845,7 @@ mod test {
 
     #[test]
     fn test_get_new_components() {
-        let exp = vec![
+        let exp = [
             ProtocolComponent::new(
                 "component3",
                 "native_swap",


### PR DESCRIPTION
This PR resolves [ENG-4707](https://propeller-heads.atlassian.net/jira/software/projects/ENG/boards/24/backlog?label=Cairoline&selectedIssue=ENG-4707) and [ENG-4844](https://propeller-heads.atlassian.net/jira/software/projects/ENG/boards/24/backlog?label=Cairoline&selectedIssue=ENG-4844).

We've added a configurable retry logic inside the ethereum tracer and added the logic in DCI and its cache to emit the "paused" state attribute for all the related components when a tracing fails after all the retries. 

[ENG-4707]: https://propeller-heads.atlassian.net/browse/ENG-4707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-4844]: https://propeller-heads.atlassian.net/browse/ENG-4844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ