### PR TITLE
chore: Reduce the size of a error enum

### DIFF
--- a/tycho-client/src/deltas.rs
+++ b/tycho-client/src/deltas.rs
@@ -417,7 +417,7 @@ impl WsDeltasClient {
     /// connection is established if not already connected.
     async fn ensure_connection(&self) -> Result<(), DeltasError> {
         if self.dead.load(Ordering::SeqCst) {
-            return Err(DeltasError::NotConnected)
+            return Err(DeltasError::NotConnected);
         };
         if !self.is_connected().await {
             self.conn_notify.notified().await;

--- a/tycho-client/src/feed/synchronizer.rs
+++ b/tycho-client/src/feed/synchronizer.rs
@@ -1895,7 +1895,7 @@ mod test {
         rpc_client
             .expect_get_protocol_states()
             .returning(|_| {
-                Err(RPCError::HttpClient("Test error during snapshot retrieval".to_string()))
+                Err(RPCError::HttpClient("Test error during snapshot retrieval".into()))
             });
 
         // Set up deltas client to send one message that will trigger snapshot retrieval


### PR DESCRIPTION
A large enum used in several places can cause a negative runtime impact. In fact, this is so common that the community created several lints to prevent such a scenario.

- [large_enum_variant](https://rust-lang.github.io/rust-clippy/master/?groups=perf#large_enum_variant)
- [result_large_err](https://rust-lang.github.io/rust-clippy/master/?groups=perf#result_large_err)
- [variant_size_differences](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/types/static.VARIANT_SIZE_DIFFERENCES.html)

This PR cuts 8 bytes from the `RPCError` structure through the use of `Box<str>`, which doesn't change any intended behavior. Of course, 8 bytes probably won't make much of a difference but it is still worth the change IMO.
