### PR TITLE
feat: add new envs for dynamic timmings

### DIFF
--- a/tycho-client/src/stream.rs
+++ b/tycho-client/src/stream.rs
@@ -48,7 +48,19 @@ impl TychoStreamBuilder {
     /// Creates a new `TychoStreamBuilder` with the given Tycho URL and blockchain network.
     /// Initializes the builder with default values for block time and timeout based on the chain.
     pub fn new(tycho_url: &str, chain: Chain) -> Self {
-        let (block_time, timeout, max_missed_blocks) = Self::default_timing(&chain);
+        let (mut block_time, mut timeout, mut max_missed_blocks) = Self::default_timing(&chain);
+
+        // dynamically override with env variables
+        let read = |k: &str, d: u64| {
+            std::env::var(k)
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(d)
+        };
+        block_time = read("TYCHO_CLIENT_BLOCK_TIME_SECS", block_time);
+        timeout = read("TYCHO_CLIENT_TIMEOUT_SECS", timeout);
+        max_missed_blocks = read("TYCHO_CLIENT_MAX_MISSED_BLOCKS", max_missed_blocks);
+
         Self {
             tycho_url: tycho_url.to_string(),
             chain,


### PR DESCRIPTION
### tycho-client: dynamic timings
- Add env overrides for client timing defaults in `TychoStreamBuilder::new`:
  - `TYCHO_CLIENT_BLOCK_TIME_SECS`, `TYCHO_CLIENT_TIMEOUT_SECS`, `TYCHO_CLIENT_MAX_MISSED_BLOCKS`
- Use small `env_u64` helper to avoid repetitive parsing.
- Backward-compatible: falls back to chain defaults when env vars are unset.
- No changes needed on Python client (CLI flags already available).