### PR TITLE
fix: handle buffer overflow in client

### DIFF
--- a/tycho-client/src/feed/synchronizer.rs
+++ b/tycho-client/src/feed/synchronizer.rs
@@ -456,7 +456,7 @@ where
     ///
     /// The returned `end_rx` (if any) should be reused for retry attempts since the close
     /// signal may still arrive and we want to remain cancellable across retries.
-    #[instrument(skip(self, block_tx), fields(extractor_id = %self.extractor_id))]
+    #[instrument(skip(self, block_tx, end_rx), fields(extractor_id = %self.extractor_id))]
     async fn state_sync(
         &mut self,
         block_tx: &mut Sender<StateSyncMessage<BlockHeader>>,

--- a/tycho-indexer/src/services/deltas_buffer.rs
+++ b/tycho-indexer/src/services/deltas_buffer.rs
@@ -845,7 +845,7 @@ mod test {
 
     #[test]
     fn test_get_new_components() {
-        let exp = vec![
+        let exp = [
             ProtocolComponent::new(
                 "component3",
                 "native_swap",


### PR DESCRIPTION
Automatically unsubscribes from a protocol if client can't keep up with message flow. This will force the client to reconnect which clears the buffer and thus gives the client a chance to recover. This behaviour is better compared to dropping the message with a warning which most certainly leads to corrupted state.