### PR TITLE
fix: Fix chrono deprecation errors post update

### DIFF
--- a/tycho-client/src/feed/mod.rs
+++ b/tycho-client/src/feed/mod.rs
@@ -60,7 +60,7 @@ impl BlockHeader {
             number: block.number,
             parent_hash: block.parent_hash.clone(),
             revert,
-            timestamp: block.ts.timestamp() as u64,
+            timestamp: block.ts.and_utc().timestamp() as u64,
         }
     }
 }

--- a/tycho-client/src/feed/synchronizer.rs
+++ b/tycho-client/src/feed/synchronizer.rs
@@ -1918,7 +1918,9 @@ mod test {
                         number: 1,
                         parent_hash: Bytes::from("0x0000"),
                         chain: Chain::Ethereum,
-                        ts: chrono::NaiveDateTime::from_timestamp_opt(1234567890, 0).unwrap(),
+                        ts: chrono::DateTime::from_timestamp(1234567890, 0)
+                            .unwrap()
+                            .naive_utc(),
                     },
                     revert: false,
                     // Add a new component to trigger snapshot request
@@ -2129,7 +2131,9 @@ mod test {
                         number: 1,
                         parent_hash: Bytes::from("0x0000"),
                         chain: Chain::Ethereum,
-                        ts: chrono::NaiveDateTime::from_timestamp_opt(1234567890, 0).unwrap(),
+                        ts: chrono::DateTime::from_timestamp(1234567890, 0)
+                            .unwrap()
+                            .naive_utc(),
                     },
                     revert: false,
                     ..Default::default()

--- a/tycho-common/src/dto.rs
+++ b/tycho-common/src/dto.rs
@@ -2108,7 +2108,7 @@ mod test {
                 models::Chain::Ethereum,
                 Bytes::from_str("0x0000000000000000000000000000000000000000000000000000000000000003").unwrap(),
                 Bytes::from_str("0x0000000000000000000000000000000000000000000000000000000000000002").unwrap(),
-                NaiveDateTime::from_timestamp_opt(base_ts + 3000, 0).unwrap(),
+                chrono::DateTime::from_timestamp(base_ts + 3000, 0).unwrap().naive_utc(),
             ),
             finalized_block_height: 1,
             revert: true,
@@ -2136,7 +2136,7 @@ mod test {
                     static_attributes: HashMap::new(),
                     change: models::ChangeType::Creation,
                     creation_tx: Bytes::from_str("0x000000000000000000000000000000000000000000000000000000000000c351").unwrap(),
-                    created_at: NaiveDateTime::from_timestamp_opt(base_ts + 5000, 0).unwrap(),
+                    created_at: chrono::DateTime::from_timestamp(base_ts + 5000, 0).unwrap().naive_utc(),
                 }),
             ]),
             deleted_protocol_components: HashMap::from([
@@ -2153,7 +2153,7 @@ mod test {
                     static_attributes: HashMap::new(),
                     change: models::ChangeType::Deletion,
                     creation_tx: Bytes::from_str("0x0000000000000000000000000000000000000000000000000000000000009c41").unwrap(),
-                    created_at: NaiveDateTime::from_timestamp_opt(base_ts + 4000, 0).unwrap(),
+                    created_at: chrono::DateTime::from_timestamp(base_ts + 4000, 0).unwrap().naive_utc(),
                 }),
             ]),
             component_balances: HashMap::from([

--- a/tycho-common/src/models/contract.rs
+++ b/tycho-common/src/models/contract.rs
@@ -489,7 +489,7 @@ pub type AccountToContractChange = HashMap<Address, HashMap<StoreKey, ContractSt
 mod test {
     use std::str::FromStr;
 
-    use chrono::NaiveDateTime;
+    use chrono::DateTime;
     use rstest::rstest;
 
     use super::*;
@@ -672,7 +672,9 @@ mod test {
             ]),
             change: ChangeType::Creation,
             creation_tx: tx_hash,
-            created_at: NaiveDateTime::from_timestamp_opt(1000, 0).unwrap(),
+            created_at: DateTime::from_timestamp(1000, 0)
+                .unwrap()
+                .naive_utc(),
         }
     }
 

--- a/tycho-ethereum/src/account_extractor/contract.rs
+++ b/tycho-ethereum/src/account_extractor/contract.rs
@@ -6,7 +6,7 @@ use alloy::{
     rpc::client::{ClientBuilder, RpcClient},
 };
 use async_trait::async_trait;
-use chrono::NaiveDateTime;
+use chrono::DateTime;
 use ethers::{
     middleware::Middleware,
     prelude::{BlockId, Http, Provider, H160, H256, U256},
@@ -189,8 +189,9 @@ impl EVMAccountExtractor {
             hash: block.hash.unwrap().to_bytes(),
             parent_hash: block.parent_hash.to_bytes(),
             chain: Chain::Ethereum,
-            ts: NaiveDateTime::from_timestamp_opt(block.timestamp.as_u64() as i64, 0)
-                .expect("Failed to convert timestamp"),
+            ts: DateTime::from_timestamp(block.timestamp.as_u64() as i64, 0)
+                .expect("Failed to convert timestamp")
+                .naive_utc(),
         })
     }
 }

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/cache.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/cache.rs
@@ -600,7 +600,7 @@ where
 mod tests {
     use std::collections::HashSet;
 
-    use chrono::NaiveDateTime;
+    use chrono::DateTime;
     use tycho_common::{
         models::{
             blockchain::{
@@ -619,7 +619,9 @@ mod tests {
             number,
             hash: BlockHash::from(hash),
             parent_hash: BlockHash::from(parent_hash),
-            ts: NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+            ts: DateTime::from_timestamp(0, 0)
+                .unwrap()
+                .naive_utc(),
             chain: Chain::Ethereum,
         }
     }

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/entrypoint_generator.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/entrypoint_generator.rs
@@ -1050,7 +1050,7 @@ mod tests {
     }
 
     fn create_test_component() -> ProtocolComponent {
-        use chrono::NaiveDateTime;
+        use chrono::DateTime;
         use tycho_common::models::{Chain, ChangeType, TxHash};
 
         ProtocolComponent {
@@ -1068,7 +1068,9 @@ mod tests {
             .collect(),
             change: ChangeType::Creation,
             creation_tx: TxHash::from([0u8; 32]),
-            created_at: NaiveDateTime::from_timestamp_opt(1640995200, 0).unwrap(),
+            created_at: DateTime::from_timestamp(1640995200, 0)
+                .unwrap()
+                .naive_utc(),
         }
     }
 
@@ -1088,7 +1090,7 @@ mod tests {
     }
 
     fn create_test_context() -> HookTracerContext {
-        use chrono::NaiveDateTime;
+        use chrono::DateTime;
         use tycho_common::models::{blockchain::Block, BlockHash, Chain};
 
         HookTracerContext {
@@ -1097,7 +1099,9 @@ mod tests {
                 hash: BlockHash::from([0u8; 32]),
                 parent_hash: BlockHash::from([0u8; 32]),
                 chain: Chain::Ethereum,
-                ts: NaiveDateTime::from_timestamp_opt(1640995200, 0).unwrap(),
+                ts: DateTime::from_timestamp(1640995200, 0)
+                    .unwrap()
+                    .naive_utc(),
             },
         }
     }
@@ -1360,49 +1364,46 @@ mod tests {
 
         // Verify the entrypoint has storage overrides
         let entrypoint = &entrypoints[0];
-        if let TracingParams::RPCTracer(rpc_params) = &entrypoint.params {
-            let state_overrides = rpc_params
-                .state_overrides
-                .as_ref()
-                .unwrap();
+        let TracingParams::RPCTracer(rpc_params) = &entrypoint.params;
+        let state_overrides = rpc_params
+            .state_overrides
+            .as_ref()
+            .unwrap();
 
-            // Should have overrides for both router and pool manager
-            assert_eq!(state_overrides.len(), 2);
+        // Should have overrides for both router and pool manager
+        assert_eq!(state_overrides.len(), 2);
 
-            // Check pool manager has storage overrides
-            let pool_manager = Address::from(hex!("000000000004444c5dc75cB358380D2e3dE08A90"));
-            let pool_manager_overrides = state_overrides
-                .get(&pool_manager)
-                .unwrap();
+        // Check pool manager has storage overrides
+        let pool_manager = Address::from(hex!("000000000004444c5dc75cB358380D2e3dE08A90"));
+        let pool_manager_overrides = state_overrides
+            .get(&pool_manager)
+            .unwrap();
 
-            if let Some(StorageOverride::Diff(storage_diff)) = &pool_manager_overrides.slots {
-                // Should have at least 2 slots: ERC6909 slot + detected slot for token0
-                assert!(storage_diff.len() >= 2);
+        if let Some(StorageOverride::Diff(storage_diff)) = &pool_manager_overrides.slots {
+            // Should have at least 2 slots: ERC6909 slot + detected slot for token0
+            assert!(storage_diff.len() >= 2);
 
-                // All slots should have the same amount_in value (1000)
-                let expected_amount = Bytes::from(
-                    U256::from(1000u64)
-                        .to_be_bytes::<32>()
-                        .as_slice(),
-                );
-                for (_slot, value) in storage_diff {
-                    assert_eq!(value, &expected_amount);
-                }
-
-                // Verify that the detected slot for token0 is included
-                let detected_slot_key = Bytes::from([0x12; 32]);
-                assert!(storage_diff.contains_key(&detected_slot_key));
-                assert_eq!(
-                    storage_diff
-                        .get(&detected_slot_key)
-                        .unwrap(),
-                    &expected_amount
-                );
-            } else {
-                panic!("Expected storage diff but found none");
+            // All slots should have the same amount_in value (1000)
+            let expected_amount = Bytes::from(
+                U256::from(1000u64)
+                    .to_be_bytes::<32>()
+                    .as_slice(),
+            );
+            for value in storage_diff.values() {
+                assert_eq!(value, &expected_amount);
             }
+
+            // Verify that the detected slot for token0 is included
+            let detected_slot_key = Bytes::from([0x12; 32]);
+            assert!(storage_diff.contains_key(&detected_slot_key));
+            assert_eq!(
+                storage_diff
+                    .get(&detected_slot_key)
+                    .unwrap(),
+                &expected_amount
+            );
         } else {
-            panic!("Expected RPCTracer params but found different type");
+            panic!("Expected storage diff but found none");
         }
     }
 
@@ -1486,39 +1487,36 @@ mod tests {
 
         // Verify the entrypoint has storage overrides
         let entrypoint = &entrypoints[0];
-        if let TracingParams::RPCTracer(rpc_params) = &entrypoint.params {
-            let state_overrides = rpc_params
-                .state_overrides
-                .as_ref()
-                .unwrap();
+        let TracingParams::RPCTracer(rpc_params) = &entrypoint.params;
+        let state_overrides = rpc_params
+            .state_overrides
+            .as_ref()
+            .unwrap();
 
-            // Should have overrides for both router and pool manager
-            assert_eq!(state_overrides.len(), 2);
+        // Should have overrides for both router and pool manager
+        assert_eq!(state_overrides.len(), 2);
 
-            // Check pool manager has storage overrides
-            let pool_manager = Address::from(hex!("000000000004444c5dc75cB358380D2e3dE08A90"));
-            let pool_manager_overrides = state_overrides
-                .get(&pool_manager)
-                .unwrap();
+        // Check pool manager has storage overrides
+        let pool_manager = Address::from(hex!("000000000004444c5dc75cB358380D2e3dE08A90"));
+        let pool_manager_overrides = state_overrides
+            .get(&pool_manager)
+            .unwrap();
 
-            if let Some(StorageOverride::Diff(storage_diff)) = &pool_manager_overrides.slots {
-                // Should have exactly 1 slot: only ERC6909 slot
-                assert_eq!(storage_diff.len(), 1);
+        if let Some(StorageOverride::Diff(storage_diff)) = &pool_manager_overrides.slots {
+            // Should have exactly 1 slot: only ERC6909 slot
+            assert_eq!(storage_diff.len(), 1);
 
-                // The slot should have the amount_in value (500)
-                let expected_amount = Bytes::from(
-                    U256::from(500u64)
-                        .to_be_bytes::<32>()
-                        .as_slice(),
-                );
-                for (_slot, value) in storage_diff {
-                    assert_eq!(value, &expected_amount);
-                }
-            } else {
-                panic!("Expected storage diff but found none");
+            // The slot should have the amount_in value (500)
+            let expected_amount = Bytes::from(
+                U256::from(500u64)
+                    .to_be_bytes::<32>()
+                    .as_slice(),
+            );
+            for value in storage_diff.values() {
+                assert_eq!(value, &expected_amount);
             }
         } else {
-            panic!("Expected RPCTracer params but found different type");
+            panic!("Expected storage diff but found none");
         }
     }
 }

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/hook_dci.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/hook_dci.rs
@@ -1004,7 +1004,9 @@ mod tests {
             static_attributes,
             change: ChangeType::Creation,
             creation_tx: TxHash::from([0u8; 32]),
-            created_at: chrono::NaiveDateTime::from_timestamp_opt(1234567890, 0).unwrap(),
+            created_at: chrono::DateTime::from_timestamp(1234567890, 0)
+                .unwrap()
+                .naive_utc(),
         }
     }
 
@@ -1682,11 +1684,9 @@ mod tests {
                 Chain::Ethereum,
                 Bytes::from(block_number).lpad(32, 0),
                 Bytes::from(block_number - 1).lpad(32, 0),
-                chrono::NaiveDateTime::from_timestamp_opt(
-                    1719849000 + (block_number * 12) as i64,
-                    0,
-                )
-                .unwrap(),
+                chrono::DateTime::from_timestamp(1719849000 + (block_number * 12) as i64, 0)
+                    .unwrap()
+                    .naive_utc(),
             )
         }
 
@@ -1927,7 +1927,9 @@ mod tests {
                     "0x97e6d877bd7e6587c29711ee80b873d4eac8c49fc616145e6326e07a5e41bf1810",
                 )
                 .unwrap(), // Real parent hash
-                chrono::NaiveDateTime::from_timestamp_opt(1724251307, 0).unwrap(), /* Real timestamp */
+                chrono::DateTime::from_timestamp(1724251307, 0)
+                    .unwrap()
+                    .naive_utc(), /* Real timestamp */
             );
             let tx = create_test_transaction(1);
 

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/metadata_orchestrator.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/metadata_orchestrator.rs
@@ -414,7 +414,7 @@ enum RequestMode {
 mod tests {
     use std::sync::Arc;
 
-    use chrono::NaiveDateTime;
+    use chrono::DateTime;
     use mockall::predicate::*;
     use serde_json::json;
     use tycho_common::{
@@ -436,7 +436,9 @@ mod tests {
             chain: Chain::Ethereum,
             hash: Bytes::from(vec![1, 2, 3, 4]),
             parent_hash: Bytes::from(vec![0, 0, 0, 0]),
-            ts: NaiveDateTime::from_timestamp_opt(1234567890, 0).unwrap(),
+            ts: DateTime::from_timestamp(1234567890, 0)
+                .unwrap()
+                .naive_utc(),
         }
     }
 
@@ -453,7 +455,9 @@ mod tests {
             static_attributes,
             change: ChangeType::Creation,
             creation_tx: TxHash::from([0u8; 32]),
-            created_at: NaiveDateTime::from_timestamp_opt(1234567890, 0).unwrap(),
+            created_at: DateTime::from_timestamp(1234567890, 0)
+                .unwrap()
+                .naive_utc(),
         }
     }
 

--- a/tycho-indexer/src/extractor/models.rs
+++ b/tycho-indexer/src/extractor/models.rs
@@ -408,7 +408,7 @@ impl From<BlockEntityChanges> for BlockChanges {
 pub mod fixtures {
     use std::str::FromStr;
 
-    use chrono::NaiveDateTime;
+    use chrono::DateTime;
     use prost::Message;
     use tycho_common::models::{
         blockchain::Transaction, contract::AccountDelta, protocol::ProtocolComponentStateDelta,
@@ -519,7 +519,9 @@ pub mod fixtures {
             ]),
             change: ChangeType::Creation,
             creation_tx: tx_hash,
-            created_at: NaiveDateTime::from_timestamp_opt(1000, 0).unwrap(),
+            created_at: DateTime::from_timestamp(1000, 0)
+                .unwrap()
+                .naive_utc(),
         }
     }
 
@@ -549,7 +551,7 @@ pub mod fixtures {
                 Chain::Ethereum,
                 Bytes::from_str("0x0000000000000000000000000000000000000000000000000000000031323334").unwrap(),
                 Bytes::from_str("0x0000000000000000000000000000000000000000000000000000000021222324").unwrap(),
-                NaiveDateTime::from_timestamp_opt(1000, 0).unwrap(),
+                DateTime::from_timestamp(1000, 0).unwrap().naive_utc(),
             ),
             0,
             false,

--- a/tycho-indexer/src/extractor/protobuf_deserialisation.rs
+++ b/tycho-indexer/src/extractor/protobuf_deserialisation.rs
@@ -1,7 +1,7 @@
 #![allow(deprecated)]
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 
-use chrono::NaiveDateTime;
+use chrono::{DateTime, NaiveDateTime};
 use tracing::warn;
 use tycho_common::{
     models::{
@@ -79,12 +79,14 @@ impl TryFromMessage for Block {
             number: msg.number,
             hash: msg.hash.into(),
             parent_hash: msg.parent_hash.into(),
-            ts: NaiveDateTime::from_timestamp_opt(msg.ts as i64, 0).ok_or_else(|| {
-                ExtractionError::DecodeError(format!(
-                    "Failed to convert timestamp {} to datetime!",
-                    msg.ts
-                ))
-            })?,
+            ts: DateTime::from_timestamp(msg.ts as i64, 0)
+                .ok_or_else(|| {
+                    ExtractionError::DecodeError(format!(
+                        "Failed to convert timestamp {} to datetime!",
+                        msg.ts
+                    ))
+                })?
+                .naive_utc(),
         })
     }
 }

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -697,7 +697,12 @@ where
             if let Some(post_process_f) = self.post_processor { post_process_f(msg) } else { msg };
 
         if let Some(last_processed_block) = self.get_last_processed_block().await {
-            if msg.block.ts.timestamp() == last_processed_block.ts.timestamp() {
+            if msg.block.ts.and_utc().timestamp() ==
+                last_processed_block
+                    .ts
+                    .and_utc()
+                    .timestamp()
+            {
                 debug!("Block with identical timestamp detected. Prev block ts: {:?} - New block ts: {:?}", last_processed_block.ts, msg.block.ts);
                 // Blockchains with fast block times (e.g., Arbitrum) may produce blocks with
                 // identical timestamps (measured in seconds). To ensure accurate ordering, we
@@ -1901,6 +1906,7 @@ mod test {
                 .await
                 .unwrap()
                 .ts
+                .and_utc()
                 .timestamp_subsec_micros(),
             1
         );
@@ -1923,6 +1929,7 @@ mod test {
                 .await
                 .unwrap()
                 .ts
+                .and_utc()
                 .timestamp_subsec_micros(),
             2
         );
@@ -2876,7 +2883,7 @@ mod test_serial_db {
                 .unwrap();
 
 
-            let base_ts = db_fixtures::yesterday_midnight().timestamp();
+            let base_ts = db_fixtures::yesterday_midnight().and_utc().timestamp();
             let block_entity_changes_result = BlockAggregatedChanges {
                 extractor: "native_name".to_string(),
                 chain: Chain::Ethereum,
@@ -2885,7 +2892,7 @@ mod test_serial_db {
                     Chain::Ethereum,
                     Bytes::from_str("0x0000000000000000000000000000000000000000000000000000000000000003").unwrap(),
                     Bytes::from_str("0x0000000000000000000000000000000000000000000000000000000000000002").unwrap(),
-                    NaiveDateTime::from_timestamp_opt(base_ts + 3000, 0).unwrap(),
+                    chrono::DateTime::from_timestamp(base_ts + 3000, 0).unwrap().naive_utc(),
                 ),
                 finalized_block_height: 1,
                 revert: true,
@@ -2913,7 +2920,7 @@ mod test_serial_db {
                         static_attributes: HashMap::new(),
                         change: ChangeType::Creation,
                         creation_tx: Bytes::from_str("0x000000000000000000000000000000000000000000000000000000000000c351").unwrap(),
-                        created_at: NaiveDateTime::from_timestamp_opt(base_ts + 5000, 0).unwrap(),
+                        created_at: chrono::DateTime::from_timestamp(base_ts + 5000, 0).unwrap().naive_utc(),
                     }),
                 ]),
                 deleted_protocol_components: HashMap::from([
@@ -2930,7 +2937,7 @@ mod test_serial_db {
                         static_attributes: HashMap::new(),
                         change: ChangeType::Deletion,
                         creation_tx: Bytes::from_str("0x0000000000000000000000000000000000000000000000000000000000009c41").unwrap(),
-                        created_at: NaiveDateTime::from_timestamp_opt(base_ts + 4000, 0).unwrap(),
+                        created_at: chrono::DateTime::from_timestamp(base_ts + 4000, 0).unwrap().naive_utc(),
                     }),
                 ]),
                 component_balances: HashMap::from([
@@ -3054,7 +3061,7 @@ mod test_serial_db {
                 .unwrap();
 
 
-            let base_ts = db_fixtures::yesterday_midnight().timestamp();
+            let base_ts = db_fixtures::yesterday_midnight().and_utc().timestamp();
             let account1 = Bytes::from_str("0000000000000000000000000000000000000001").unwrap();
             let account2 = Bytes::from_str("0000000000000000000000000000000000000002").unwrap();
             let block_account_expected = BlockAggregatedChanges {
@@ -3065,7 +3072,7 @@ mod test_serial_db {
                     Chain::Ethereum,
                     Bytes::from_str("0x0000000000000000000000000000000000000000000000000000000000000003").unwrap(),
                     Bytes::from_str("0x0000000000000000000000000000000000000000000000000000000000000002").unwrap(),
-                    NaiveDateTime::from_timestamp_opt(base_ts + 3000, 0).unwrap(),
+                    chrono::DateTime::from_timestamp(base_ts + 3000, 0).unwrap().naive_utc(),
                 ),
                 finalized_block_height: 1,
                 revert: true,
@@ -3108,7 +3115,7 @@ mod test_serial_db {
                         static_attributes: HashMap::new(),
                         change: ChangeType::Deletion,
                         creation_tx: Bytes::from_str("0x0000000000000000000000000000000000000000000000000000000000009c41").unwrap(),
-                        created_at: NaiveDateTime::from_timestamp_opt(base_ts + 4000, 0).unwrap(),
+                        created_at: chrono::DateTime::from_timestamp(base_ts + 4000, 0).unwrap().naive_utc(),
                     }),
                 ]),
                 component_balances: HashMap::from([
@@ -3231,7 +3238,9 @@ mod test_serial_db {
             .expect("Failed to create extractor");
 
             // Send a sequence of block scoped data with the same timestamp.
-            let base_ts = db_fixtures::yesterday_midnight().timestamp() as u64;
+            let base_ts = db_fixtures::yesterday_midnight()
+                .and_utc()
+                .timestamp() as u64;
             let versions = [1, 2, 3, 4];
 
             let inp_sequence = versions
@@ -3312,6 +3321,7 @@ mod test_serial_db {
                     .await
                     .unwrap()
                     .ts
+                    .and_utc()
                     .timestamp_subsec_micros(),
                 3
             );

--- a/tycho-indexer/src/services/ws.rs
+++ b/tycho-indexer/src/services/ws.rs
@@ -466,7 +466,7 @@ mod tests {
     use actix_web::App;
     use actix_web_opentelemetry::RequestTracing;
     use async_trait::async_trait;
-    use chrono::NaiveDateTime;
+    use chrono::DateTime;
     use futures03::SinkExt;
     use serde::Deserialize;
     use tokio::{
@@ -525,7 +525,9 @@ mod tests {
                                 Chain::Ethereum,
                                 Bytes::zero(32),
                                 Bytes::zero(32),
-                                NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                                DateTime::from_timestamp(0, 0)
+                                    .unwrap()
+                                    .naive_utc(),
                             ),
                             finalized_block_height: 1,
                             revert: false,
@@ -886,7 +888,9 @@ mod tests {
                                 Chain::Ethereum,
                                 Bytes::zero(32),
                                 Bytes::zero(32),
-                                NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                                DateTime::from_timestamp(0, 0)
+                                    .unwrap()
+                                    .naive_utc(),
                             ),
                             finalized_block_height: 1,
                             revert: false,

--- a/tycho-indexer/src/testing.rs
+++ b/tycho-indexer/src/testing.rs
@@ -766,7 +766,9 @@ pub mod fixtures {
         if version == 0 {
             panic!("Block version 0 doesn't exist. It starts at 1");
         }
-        let base_ts = yesterday_midnight().timestamp() as u64;
+        let base_ts = yesterday_midnight()
+            .and_utc()
+            .timestamp() as u64;
 
         Block {
             number: version,
@@ -1282,7 +1284,9 @@ pub mod fixtures {
                         .lpad(32, 0)
                         .to_vec(),
                     number: 1,
-                    ts: yesterday_midnight().timestamp() as u64,
+                    ts: yesterday_midnight()
+                        .and_utc()
+                        .timestamp() as u64,
                 }),
                 changes: vec![
                     TransactionEntityChanges {
@@ -2153,7 +2157,9 @@ pub mod fixtures {
                     hash: vec![0x0, 0x0, 0x0, 0x0],
                     parent_hash: vec![0x21, 0x22, 0x23, 0x24],
                     number: 1,
-                    ts: yesterday_midnight().timestamp() as u64,
+                    ts: yesterday_midnight()
+                        .and_utc()
+                        .timestamp() as u64,
                 }),
                 changes: vec![
                     TransactionChanges {

--- a/tycho-storage/src/postgres/protocol.rs
+++ b/tycho-storage/src/postgres/protocol.rs
@@ -3368,7 +3368,9 @@ mod test {
             HashMap::new(),
             ChangeType::Creation,
             Bytes::from("0x0000000000000000000000000000000000000000000000000000000011121314"),
-            NaiveDateTime::from_timestamp_opt(1000, 0).unwrap(),
+            chrono::DateTime::from_timestamp(1000, 0)
+                .unwrap()
+                .naive_utc(),
         )
     }
 

--- a/tycho-storage/src/postgres/versioning.rs
+++ b/tycho-storage/src/postgres/versioning.rs
@@ -521,7 +521,6 @@ pub async fn apply_partitioned_versioning<T: PartitionedVersionedRow>(
 mod test {
     use std::vec;
 
-    use chrono::NaiveDateTime;
     use diesel::prelude::*;
     use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
     use tycho_common::{models, Bytes};
@@ -620,8 +619,12 @@ mod test {
             attribute_value: Bytes::from(1u8),
             previous_value: None,
             modify_tx: 1,
-            valid_from: NaiveDateTime::from_timestamp_micros(1).unwrap(),
-            valid_to: NaiveDateTime::from_timestamp_micros(999).unwrap(),
+            valid_from: chrono::DateTime::from_timestamp_micros(1)
+                .unwrap()
+                .naive_utc(),
+            valid_to: chrono::DateTime::from_timestamp_micros(999)
+                .unwrap()
+                .naive_utc(),
         });
         let row2 = VersioningEntry::Update(NewProtocolState {
             protocol_component_id: 0,
@@ -629,8 +632,12 @@ mod test {
             attribute_value: Bytes::from(2u8),
             previous_value: None,
             modify_tx: 2,
-            valid_from: NaiveDateTime::from_timestamp_micros(1).unwrap(),
-            valid_to: NaiveDateTime::from_timestamp_micros(999).unwrap(),
+            valid_from: chrono::DateTime::from_timestamp_micros(1)
+                .unwrap()
+                .naive_utc(),
+            valid_to: chrono::DateTime::from_timestamp_micros(999)
+                .unwrap()
+                .naive_utc(),
         });
         let row3 = VersioningEntry::Update(NewProtocolState {
             protocol_component_id: 0,
@@ -638,8 +645,12 @@ mod test {
             attribute_value: Bytes::from(3u8),
             previous_value: None,
             modify_tx: 3,
-            valid_from: NaiveDateTime::from_timestamp_micros(1).unwrap(),
-            valid_to: NaiveDateTime::from_timestamp_micros(999).unwrap(),
+            valid_from: chrono::DateTime::from_timestamp_micros(1)
+                .unwrap()
+                .naive_utc(),
+            valid_to: chrono::DateTime::from_timestamp_micros(999)
+                .unwrap()
+                .naive_utc(),
         });
         // outdated row - should get filtered out and not be part of the returned versioning
         let outdated_row = VersioningEntry::Update(NewProtocolState {
@@ -648,8 +659,12 @@ mod test {
             attribute_value: Bytes::from(4u8),
             previous_value: None,
             modify_tx: 4,
-            valid_from: NaiveDateTime::from_timestamp_micros(1).unwrap(),
-            valid_to: NaiveDateTime::from_timestamp_micros(999).unwrap(),
+            valid_from: chrono::DateTime::from_timestamp_micros(1)
+                .unwrap()
+                .naive_utc(),
+            valid_to: chrono::DateTime::from_timestamp_micros(999)
+                .unwrap()
+                .naive_utc(),
         });
         // outdated row for same attribute - should get filtered out and not be part of the returned
         // versioning
@@ -659,18 +674,26 @@ mod test {
             attribute_value: Bytes::from(4u8),
             previous_value: None,
             modify_tx: 5,
-            valid_from: NaiveDateTime::from_timestamp_micros(1).unwrap(),
-            valid_to: NaiveDateTime::from_timestamp_micros(999).unwrap(),
+            valid_from: chrono::DateTime::from_timestamp_micros(1)
+                .unwrap()
+                .naive_utc(),
+            valid_to: chrono::DateTime::from_timestamp_micros(999)
+                .unwrap()
+                .naive_utc(),
         });
 
         let delete_row1 = VersioningEntry::Deletion((
             (0i64, "tick".to_string()),
-            NaiveDateTime::from_timestamp_micros(1).unwrap(),
+            chrono::DateTime::from_timestamp_micros(1)
+                .unwrap()
+                .naive_utc(),
         ));
 
         let (latest, to_archive, to_delete) = apply_partitioned_versioning(
             &[row1, delete_row1, row2, row3, outdated_row, outdated_row_repeat],
-            NaiveDateTime::from_timestamp_micros(0).unwrap(),
+            chrono::DateTime::from_timestamp_micros(0)
+                .unwrap()
+                .naive_utc(),
             &mut conn,
         )
         .await
@@ -684,8 +707,12 @@ mod test {
                 attribute_value: Bytes::from(3u8),
                 previous_value: Some(Bytes::from(2u8)),
                 modify_tx: 3,
-                valid_from: NaiveDateTime::from_timestamp_micros(1).unwrap(),
-                valid_to: NaiveDateTime::from_timestamp_micros(999).unwrap(),
+                valid_from: chrono::DateTime::from_timestamp_micros(1)
+                    .unwrap()
+                    .naive_utc(),
+                valid_to: chrono::DateTime::from_timestamp_micros(999)
+                    .unwrap()
+                    .naive_utc(),
             }]
         );
         assert_eq!(
@@ -697,8 +724,12 @@ mod test {
                     attribute_value: Bytes::from(1u8),
                     previous_value: None,
                     modify_tx: 1,
-                    valid_from: NaiveDateTime::from_timestamp_micros(1).unwrap(),
-                    valid_to: NaiveDateTime::from_timestamp_micros(1).unwrap(),
+                    valid_from: chrono::DateTime::from_timestamp_micros(1)
+                        .unwrap()
+                        .naive_utc(),
+                    valid_to: chrono::DateTime::from_timestamp_micros(1)
+                        .unwrap()
+                        .naive_utc(),
                 },
                 NewProtocolState {
                     protocol_component_id: 0,
@@ -706,8 +737,12 @@ mod test {
                     attribute_value: Bytes::from(2u8),
                     previous_value: None, // None because row 1 has been deleted in the meantime
                     modify_tx: 2,
-                    valid_from: NaiveDateTime::from_timestamp_micros(1).unwrap(),
-                    valid_to: NaiveDateTime::from_timestamp_micros(1).unwrap(),
+                    valid_from: chrono::DateTime::from_timestamp_micros(1)
+                        .unwrap()
+                        .naive_utc(),
+                    valid_to: chrono::DateTime::from_timestamp_micros(1)
+                        .unwrap()
+                        .naive_utc(),
                 }
             ]
         );
@@ -775,7 +810,9 @@ mod test {
             token_id: token1,
             balance: Bytes::from(150u64),
             modify_tx: 2,
-            valid_from: NaiveDateTime::from_timestamp_micros(1).unwrap(),
+            valid_from: chrono::DateTime::from_timestamp_micros(1)
+                .unwrap()
+                .naive_utc(),
             valid_to: None,
         };
         // repeated outdated row - should get filtered out and not be part of the returned
@@ -785,7 +822,9 @@ mod test {
             token_id: token1,
             balance: Bytes::from(150u64),
             modify_tx: 3,
-            valid_from: NaiveDateTime::from_timestamp_micros(1).unwrap(),
+            valid_from: chrono::DateTime::from_timestamp_micros(1)
+                .unwrap()
+                .naive_utc(),
             valid_to: None,
         };
 


### PR DESCRIPTION
When updating the dependencies to fix broken environment on https://github.com/propeller-heads/tycho-indexer/pull/679/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L71
Chrono started reporting deprecation warnings. This PR fixes them