### PR TITLE
fix: Add protocol_system to RunSpkgArgs

### DIFF
--- a/tycho-indexer/src/cli.rs
+++ b/tycho-indexer/src/cli.rs
@@ -122,6 +122,10 @@ pub struct RunSpkgArgs {
     #[clap(long, value_delimiter = ',')]
     pub protocol_type_names: Vec<String>,
 
+    // Protocol system to index
+    #[clap(long)]
+    pub protocol_system: String,
+
     /// Substreams start block
     #[clap(long)]
     pub start_block: i64,
@@ -214,6 +218,8 @@ mod cli_tests {
             "17361664",
             "--protocol-type-names",
             "pt1,pt2",
+            "--protocol-system",
+            "test_protocol",
         ])
         .expect("parse errored");
 
@@ -232,6 +238,7 @@ mod cli_tests {
                 spkg: "package.spkg".to_string(),
                 module: "module_name".to_string(),
                 protocol_type_names: vec!["pt1".to_string(), "pt2".to_string()],
+                protocol_system: "test_protocol".to_string(),
                 start_block: 17361664,
                 stop_block: None,
                 substreams_args: SubstreamsArgs {

--- a/tycho-indexer/src/main.rs
+++ b/tycho-indexer/src/main.rs
@@ -268,9 +268,9 @@ async fn run_spkg(global_args: GlobalArgs, run_args: RunSpkgArgs) -> Result<(), 
         })?;
 
     let config = ExtractorConfigs::new(HashMap::from([(
-        "test_protocol".to_string(),
+        run_args.protocol_system.clone(),
         ExtractorConfig::new(
-            "test_protocol".to_string(),
+            run_args.protocol_system.clone(),
             Chain::from_str(&run_args.chain).unwrap(),
             ImplementationType::Vm,
             1, /* TODO: if we want to increase this, we need to commit the cache when we reached


### PR DESCRIPTION
This way we don't need to hardcode it to "test_protocol" in run_spkg
