### PR TITLE
feat: communicate websocket server errors correctly

### DIFF
--- a/tycho-common/src/models/error.rs
+++ b/tycho-common/src/models/error.rs
@@ -1,0 +1,19 @@
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::models::ExtractorIdentity;
+
+#[derive(Error, Debug)]
+pub enum WebsocketError {
+    #[error("Extractor not found: {0}")]
+    ExtractorNotFound(ExtractorIdentity),
+
+    #[error("Subscription not found: {0}")]
+    SubscriptionNotFound(Uuid),
+
+    #[error("Failed to parse JSON: {1}, msg: {0}")]
+    ParseError(String, #[source] serde_json::Error),
+
+    #[error("Failed to subscribe to extractor: {0}")]
+    SubscribeError(ExtractorIdentity),
+}

--- a/tycho-common/src/models/mod.rs
+++ b/tycho-common/src/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod blockchain;
 pub mod contract;
+pub mod error;
 pub mod protocol;
 pub mod token;
 


### PR DESCRIPTION
Previously we would send error messages as simple text which would fail to deserialize as JSON on the client, crashing the whole websocket client with confusing message to the user.

Websocket errors are now part of the communication protocol and the client handles them gracefully.