### PR TITLE
feat: Retry on transient rpc error.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,6 +2453,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.16",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9541,6 +9555,7 @@ version = "0.85.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "backoff",
  "chrono",
  "clap",
  "futures 0.3.31",
@@ -9557,6 +9572,7 @@ dependencies = [
  "serde_json",
  "test-log",
  "thiserror 1.0.69",
+ "time",
  "tokio",
  "tokio-tungstenite",
  "tracing",

--- a/tycho-client/Cargo.toml
+++ b/tycho-client/Cargo.toml
@@ -41,7 +41,8 @@ tracing-subscriber = { version = "0.3.17", default-features = false, features = 
     "json",
 ] }
 hyper = "0.14.27"
-
+backoff = { version = "0.4.0", features = ["tokio", "futures"] }
+time = "0.3.43"
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/tycho-client/src/feed/synchronizer.rs
+++ b/tycho-client/src/feed/synchronizer.rs
@@ -1908,7 +1908,7 @@ mod test {
         rpc_client
             .expect_get_protocol_states()
             .returning(|_| {
-                Err(RPCError::HttpClient("Test error during snapshot retrieval".to_string()))
+                Err(RPCError::ParseResponse("Test error during snapshot retrieval".to_string()))
             });
 
         // Set up deltas client to send one message that will trigger snapshot retrieval


### PR DESCRIPTION
This avoids crashing if one rpc requests fails or gets rate limited. Once we correctly return a retry-after header from the server, the client will respect it and requests will wait until then.