### PR TITLE
fix: Fix TLS not working after bumping Alloy version

### DIFF
--- a/tycho-ethereum/Cargo.toml
+++ b/tycho-ethereum/Cargo.toml
@@ -30,7 +30,7 @@ futures = "0.3"
 # Required dependencies
 ethers = "^2.0.2"
 web3 = { version = "0.19", default-features = false }
-alloy = { version = "1.0.30", default-features = true }
+alloy = { version = "1.0.30", default-features = true, features = ["reqwest-default-tls"] }
 alloy-rpc-types-trace = "1.0.24"
 
 # Optional dependencies

--- a/tycho-ethereum/src/account_extractor/contract.rs
+++ b/tycho-ethereum/src/account_extractor/contract.rs
@@ -228,19 +228,14 @@ impl EVMBatchAccountExtractor {
     where
         Self: Sized,
     {
-        let url = url::Url::parse(node_url)
-            .map_err(|e| {
-                RPCError::SetupError(format!(
-                    "Invalid URL '{}': {}. Make sure the URL includes the scheme (http:// or https://)",
-                    node_url, e
-                ))
-            })?;
+        let url = url::Url::parse(node_url).map_err(|e| {
+            RPCError::SetupError(format!(
+                "Invalid URL '{}': {}. Make sure the URL includes the scheme (http:// or https://)",
+                node_url, e
+            ))
+        })?;
 
-        debug!(
-            scheme = url.scheme(),
-            host = url.host_str(),
-            "Parsed URL successfully"
-        );
+        debug!(scheme = url.scheme(), host = url.host_str(), "Parsed URL successfully");
 
         // Create the RPC client using ReqwestClient for proper HTTPS support
         debug!(url = %url, "Creating ReqwestClient for RPC with HTTPS support");


### PR DESCRIPTION
We were getting `invalid URL, scheme is not http` errors after bumping alloy on this commit: https://github.com/propeller-heads/tycho-indexer/pull/698/commits/847177d80e45c512820128d7590e58085b10b9bd

Culprit was that alloy removed the reqwest-default-tls from the default features on this commit: https://github.com/alloy-rs/alloy/pull/2865/files#diff-680e1376f52cad37f180f99cac82995eb05e5c3401aa4ff9a7d899ec534afa0f
