### PR TITLE
feat: add configurable batch commit threshold for extractors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.91.1](https://github.com/propeller-heads/tycho-indexer/compare/0.91.0...0.91.1) (2025-09-30)
+
+
+### Bug Fixes
+
+* correctly parse token balances in token-analyzer ([7ebb91d](https://github.com/propeller-heads/tycho-indexer/commit/7ebb91dad827fe72780ad83d22284cbae061b560))
+* correctly parse token balances in token-analyzer ([#715](https://github.com/propeller-heads/tycho-indexer/issues/715)) ([c31f74e](https://github.com/propeller-heads/tycho-indexer/commit/c31f74e28d61c4bb95ee271e8eb0db68b8835a25))
+
 ## [0.91.0](https://github.com/propeller-heads/tycho-indexer/compare/0.90.0...0.91.0) (2025-09-30)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.91.2](https://github.com/propeller-heads/tycho-indexer/compare/0.91.1...0.91.2) (2025-10-01)
+
+
+### Bug Fixes
+
+* support configuring `substreams_api_token` via CLI and instead of only env variables ([f8b1ece](https://github.com/propeller-heads/tycho-indexer/commit/f8b1ece18db7ce710ebd3c27e9e88ae33576e480))
+* support configuring `substreams_api_token` via CLI and instead of only env variables ([#716](https://github.com/propeller-heads/tycho-indexer/issues/716)) ([f7dfb24](https://github.com/propeller-heads/tycho-indexer/commit/f7dfb2408746d9ce3808e7926f96eaf91c033182))
+
 ## [0.91.1](https://github.com/propeller-heads/tycho-indexer/compare/0.91.0...0.91.1) (2025-09-30)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7282,7 +7282,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7323,7 +7323,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-common"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7353,7 +7353,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-ethereum"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "alloy",
  "alloy-rpc-types-trace",
@@ -7381,7 +7381,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-indexer"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "actix",
  "actix-cors",
@@ -7447,7 +7447,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-storage"
-version = "0.91.1"
+version = "0.91.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7282,7 +7282,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.91.0"
+version = "0.91.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7323,7 +7323,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-common"
-version = "0.91.0"
+version = "0.91.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7353,7 +7353,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-ethereum"
-version = "0.91.0"
+version = "0.91.1"
 dependencies = [
  "alloy",
  "alloy-rpc-types-trace",
@@ -7381,7 +7381,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-indexer"
-version = "0.91.0"
+version = "0.91.1"
 dependencies = [
  "actix",
  "actix-cors",
@@ -7447,7 +7447,7 @@ dependencies = [
 
 [[package]]
 name = "tycho-storage"
-version = "0.91.0"
+version = "0.91.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.91.1"
+version = "0.91.2"
 repository = "https://github.com/propeller-heads/tycho-indexer"
 homepage = "https://www.propellerheads.xyz/tycho"
 documentation = "https://docs.propellerheads.xyz/tycho"
@@ -45,10 +45,10 @@ uuid = { version = "1.4.1", features = [
     "macro-diagnostics",
 ] }
 hex = "0.4.3"
-tycho-common = { path = "./tycho-common", version = "0.91.1" }
-tycho-storage = { path = "./tycho-storage", version = "0.91.1" }
-tycho-ethereum = { path = "./tycho-ethereum", features = ["onchain_data"], version = "0.91.1" }
-tycho-client = { path = "./tycho-client", version = "0.91.1" }
+tycho-common = { path = "./tycho-common", version = "0.91.2" }
+tycho-storage = { path = "./tycho-storage", version = "0.91.2" }
+tycho-ethereum = { path = "./tycho-ethereum", features = ["onchain_data"], version = "0.91.2" }
+tycho-client = { path = "./tycho-client", version = "0.91.2" }
 futures03 = { version = "0.3.1", package = "futures", features = ["compat"] }
 thiserror = "1"
 tracing = "0.1.37"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.91.0"
+version = "0.91.1"
 repository = "https://github.com/propeller-heads/tycho-indexer"
 homepage = "https://www.propellerheads.xyz/tycho"
 documentation = "https://docs.propellerheads.xyz/tycho"
@@ -45,10 +45,10 @@ uuid = { version = "1.4.1", features = [
     "macro-diagnostics",
 ] }
 hex = "0.4.3"
-tycho-common = { path = "./tycho-common", version = "0.91.0" }
-tycho-storage = { path = "./tycho-storage", version = "0.91.0" }
-tycho-ethereum = { path = "./tycho-ethereum", features = ["onchain_data"], version = "0.91.0" }
-tycho-client = { path = "./tycho-client", version = "0.91.0" }
+tycho-common = { path = "./tycho-common", version = "0.91.1" }
+tycho-storage = { path = "./tycho-storage", version = "0.91.1" }
+tycho-ethereum = { path = "./tycho-ethereum", features = ["onchain_data"], version = "0.91.1" }
+tycho-client = { path = "./tycho-client", version = "0.91.1" }
 futures03 = { version = "0.3.1", package = "futures", features = ["compat"] }
 thiserror = "1"
 tracing = "0.1.37"

--- a/docs/for-solvers/execution/README.md
+++ b/docs/for-solvers/execution/README.md
@@ -41,6 +41,6 @@ It is possible to bypass approvals altogether by directly transferring the input
 
 ## Security and Audits
 
-The Tycho Router has been audited. We continuously work to improve security and welcome feedback from the community. The current audits are [here](https://github.com/propeller-heads/tycho-execution/tree/main/docs/audits).
+The Tycho Router has been audited by [Maximilian Krüger](https://snd.github.io/). We continuously work to improve security and welcome feedback from the community. The current audits are [here](https://github.com/propeller-heads/tycho-execution/tree/main/docs/audits).
 
 If you discover potential security issues or have suggestions for improvements, please reach out through our official channels.

--- a/tycho-client-py/pyproject.toml
+++ b/tycho-client-py/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "tycho-indexer-client"
 # this is versioned in lockstep with all other tycho packages
-version = "0.91.0"
+version = "0.91.1"
 description = "A package for interacting with the Tycho API."
 readme = "README.md"
 authors = [

--- a/tycho-client-py/pyproject.toml
+++ b/tycho-client-py/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "tycho-indexer-client"
 # this is versioned in lockstep with all other tycho packages
-version = "0.91.1"
+version = "0.91.2"
 description = "A package for interacting with the Tycho API."
 readme = "README.md"
 authors = [

--- a/tycho-indexer/src/cli.rs
+++ b/tycho-indexer/src/cli.rs
@@ -48,6 +48,11 @@ pub struct GlobalArgs {
     )]
     pub database_url: String,
 
+    /// Batch size for the database inserts
+    /// Defaults to Ethereum finality of 128 blocks
+    #[clap(long, default_value = "128")]
+    pub database_insert_batch_size: u64,
+
     /// Name of the s3 bucket used to retrieve spkgs
     #[clap(env = "TYCHO_S3_BUCKET", long, default_value = "repo.propellerheads-propellerheads")]
     //Default is for backward compatibility but needs to be removed later
@@ -205,6 +210,8 @@ mod cli_tests {
             "http://example.com",
             "--database-url",
             "my_db",
+            "--database-insert-batch-size",
+            "256",
             "--rpc-url",
             "http://example.com",
             "run",
@@ -227,6 +234,7 @@ mod cli_tests {
             global_args: GlobalArgs {
                 endpoint_url: "http://example.com".to_string(),
                 database_url: "my_db".to_string(),
+                database_insert_batch_size: 256,
                 rpc_url: "http://example.com".to_string(),
                 s3_bucket: Some("repo.propellerheads-propellerheads".to_string()),
                 server_ip: "0.0.0.0".to_string(),
@@ -275,6 +283,7 @@ mod cli_tests {
             global_args: GlobalArgs {
                 endpoint_url: "http://example.com".to_string(),
                 database_url: "my_db".to_string(),
+                database_insert_batch_size: 128,
                 rpc_url: "http://example.com".to_string(),
                 s3_bucket: Some("repo.propellerheads-propellerheads".to_string()),
                 server_ip: "0.0.0.0".to_string(),

--- a/tycho-indexer/src/cli.rs
+++ b/tycho-indexer/src/cli.rs
@@ -49,8 +49,8 @@ pub struct GlobalArgs {
     pub database_url: String,
 
     /// Batch size for the database inserts
-    /// Defaults to Ethereum finality of 128 blocks
-    #[clap(long, default_value = "128")]
+    /// Defaults to Ethereum finality of 64 blocks
+    #[clap(long, default_value = "64")]
     pub database_insert_batch_size: usize,
 
     /// Name of the s3 bucket used to retrieve spkgs
@@ -283,7 +283,7 @@ mod cli_tests {
             global_args: GlobalArgs {
                 endpoint_url: "http://example.com".to_string(),
                 database_url: "my_db".to_string(),
-                database_insert_batch_size: 128,
+                database_insert_batch_size: 64,
                 rpc_url: "http://example.com".to_string(),
                 s3_bucket: Some("repo.propellerheads-propellerheads".to_string()),
                 server_ip: "0.0.0.0".to_string(),

--- a/tycho-indexer/src/cli.rs
+++ b/tycho-indexer/src/cli.rs
@@ -51,7 +51,7 @@ pub struct GlobalArgs {
     /// Batch size for the database inserts
     /// Defaults to Ethereum finality of 128 blocks
     #[clap(long, default_value = "128")]
-    pub database_insert_batch_size: u64,
+    pub database_insert_batch_size: usize,
 
     /// Name of the s3 bucket used to retrieve spkgs
     #[clap(env = "TYCHO_S3_BUCKET", long, default_value = "repo.propellerheads-propellerheads")]

--- a/tycho-indexer/src/cli.rs
+++ b/tycho-indexer/src/cli.rs
@@ -49,8 +49,7 @@ pub struct GlobalArgs {
     pub database_url: String,
 
     /// Batch size for the database inserts
-    /// Defaults to Ethereum finality of 64 blocks
-    #[clap(long, default_value = "64")]
+    #[clap(long, default_value = "0")]
     pub database_insert_batch_size: usize,
 
     /// Name of the s3 bucket used to retrieve spkgs
@@ -283,7 +282,7 @@ mod cli_tests {
             global_args: GlobalArgs {
                 endpoint_url: "http://example.com".to_string(),
                 database_url: "my_db".to_string(),
-                database_insert_batch_size: 64,
+                database_insert_batch_size: 0,
                 rpc_url: "http://example.com".to_string(),
                 s3_bucket: Some("repo.propellerheads-propellerheads".to_string()),
                 server_ip: "0.0.0.0".to_string(),

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/hook_dci.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/hook_dci.rs
@@ -597,17 +597,6 @@ where
 
         Ok((components_needing_full_processing, components_needing_balance_only))
     }
-
-    fn update_component_balances(
-        &self,
-        component: &ProtocolComponent,
-        block_changes: &mut BlockChanges,
-    ) -> Result<(), ExtractionError> {
-        // This method should not be needed anymore as the HookOrchestrator
-        // already handles balance updates in prepare_components method.
-        // The balances are injected into block_changes.txs_with_update by the orchestrator.
-        Ok(())
-    }
 }
 
 // Component state tracking
@@ -658,7 +647,7 @@ where
                 ExtractionError::Unknown(format!("Failed to ensure block layer: {e:?}"))
             })?;
 
-        // 1. Filter components with swap hooks (beforeSwap/afterSwap only)
+        // 1. Filter-out components with no swap hooks (keep beforeSwap or afterSwap only)
         let swap_hook_components = {
             let _span = span!(Level::INFO, "extract_swap_hook_components").entered();
 

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/hook_dci.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/hook_dci.rs
@@ -597,6 +597,17 @@ where
 
         Ok((components_needing_full_processing, components_needing_balance_only))
     }
+
+    fn update_component_balances(
+        &self,
+        component: &ProtocolComponent,
+        block_changes: &mut BlockChanges,
+    ) -> Result<(), ExtractionError> {
+        // This method should not be needed anymore as the HookOrchestrator
+        // already handles balance updates in prepare_components method.
+        // The balances are injected into block_changes.txs_with_update by the orchestrator.
+        Ok(())
+    }
 }
 
 // Component state tracking
@@ -647,7 +658,7 @@ where
                 ExtractionError::Unknown(format!("Failed to ensure block layer: {e:?}"))
             })?;
 
-        // 1. Filter-out components with no swap hooks (keep beforeSwap or afterSwap only)
+        // 1. Filter components with swap hooks (beforeSwap/afterSwap only)
         let swap_hook_components = {
             let _span = span!(Level::INFO, "extract_swap_hook_components").entered();
 

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/hooks_dci_setup.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/hooks_dci_setup.rs
@@ -52,7 +52,7 @@ pub fn setup_metadata_registries(
 
     // Register RPC provider with default routing key and retry configuration
     let retry_config =
-        RPCRetryConfig { max_retries: 3, initial_backoff_ms: 100, max_backoff_ms: 5000 };
+        RPCRetryConfig { max_retries: 5, initial_backoff_ms: 150, max_backoff_ms: 5000 };
     provider_registry.register_provider(
         "rpc_default".to_string(),
         Arc::new(RPCMetadataProvider::new_with_retry_config(50, retry_config)), // batch size limit with retry config

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/hooks_dci_setup.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/hooks_dci_setup.rs
@@ -52,7 +52,7 @@ pub fn setup_metadata_registries(
 
     // Register RPC provider with default routing key and retry configuration
     let retry_config =
-        RPCRetryConfig { max_retries: 5, initial_backoff_ms: 150, max_backoff_ms: 5000 };
+        RPCRetryConfig { max_retries: 3, initial_backoff_ms: 100, max_backoff_ms: 5000 };
     provider_registry.register_provider(
         "rpc_default".to_string(),
         Arc::new(RPCMetadataProvider::new_with_retry_config(50, retry_config)), // batch size limit with retry config

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/rpc_metadata_provider.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/rpc_metadata_provider.rs
@@ -554,9 +554,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_batch_with_mock_batch_size_1() {
-        let retry_config =
-            RPCRetryConfig { max_retries: 3, initial_backoff_ms: 100, max_backoff_ms: 5000 };
-        let provider = RPCMetadataProvider::new_with_retry_config(1, retry_config);
+        let provider = RPCMetadataProvider::new(1);
         let mut server = Server::new_async().await;
         let endpoint = server.url();
 

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/rpc_metadata_provider.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/rpc_metadata_provider.rs
@@ -554,7 +554,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_batch_with_mock_batch_size_1() {
-        let provider = RPCMetadataProvider::new(1);
+        let retry_config =
+            RPCRetryConfig { max_retries: 3, initial_backoff_ms: 100, max_backoff_ms: 5000 };
+        let provider = RPCMetadataProvider::new_with_retry_config(1, retry_config);
         let mut server = Server::new_async().await;
         let endpoint = server.url();
 

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -60,6 +60,8 @@ pub struct Inner {
 
 pub struct ProtocolExtractor<G, T, E> {
     gateway: G,
+    #[allow(dead_code)]
+    database_insert_batch_size: u64,
     name: String,
     chain: Chain,
     chain_state: ChainState,
@@ -83,6 +85,7 @@ where
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         gateway: G,
+        database_insert_batch_size: u64,
         name: &str,
         chain: Chain,
         chain_state: ChainState,
@@ -101,6 +104,7 @@ where
                 warn!(?name, ?chain, "No cursor found, starting from the beginning");
                 ProtocolExtractor {
                     gateway,
+                    database_insert_batch_size,
                     name: name.to_string(),
                     chain,
                     chain_state,
@@ -137,6 +141,7 @@ where
                 );
                 ProtocolExtractor {
                     gateway,
+                    database_insert_batch_size,
                     name: name.to_string(),
                     chain,
                     chain_state,
@@ -1633,6 +1638,7 @@ mod test {
 
     const EXTRACTOR_NAME: &str = "TestExtractor";
     const TEST_PROTOCOL: &str = "TestProtocol";
+    const DATABASE_INSERT_BATCH_SIZE: u64 = 128;
     async fn create_extractor(
         gw: MockExtractorGateway,
     ) -> ProtocolExtractor<MockExtractorGateway, MockTokenPreProcessor, MockExtractorExtension>
@@ -1649,6 +1655,7 @@ mod test {
             .returning(|_, _, _| Vec::new());
         ProtocolExtractor::new(
             gw,
+            DATABASE_INSERT_BATCH_SIZE,
             EXTRACTOR_NAME,
             Chain::Ethereum,
             ChainState::default(),
@@ -2136,6 +2143,7 @@ mod test {
             MockExtractorExtension,
         >::new(
             extractor_gw,
+            DATABASE_INSERT_BATCH_SIZE,
             EXTRACTOR_NAME,
             Chain::Ethereum,
             ChainState::default(),
@@ -2269,6 +2277,7 @@ mod test {
             MockExtractorExtension,
         >::new(
             extractor_gw,
+            DATABASE_INSERT_BATCH_SIZE,
             "vm_name",
             Chain::Ethereum,
             ChainState::default(),
@@ -2361,6 +2370,8 @@ mod test_serial_db {
         0xaa, 0xaa, 0xaa, 0xaa, 0xa2, 0x4e, 0xee, 0xb8, 0xd5, 0x7d, 0x43, 0x12, 0x24, 0xf7, 0x38,
         0x32, 0xbc, 0x34, 0xf6, 0x88,
     ]; // 0xaaaaaaaaa24eeeb8d57d431224f73832bc34f688
+
+    const DATABASE_INSERT_BATCH_SIZE: u64 = 128;
 
     // SETUP
     fn get_mocked_token_pre_processor() -> MockTokenPreProcessor {
@@ -2879,6 +2890,7 @@ mod test_serial_db {
                 MockExtractorExtension,
             >::new(
                 gw,
+                DATABASE_INSERT_BATCH_SIZE,
                 "native_name",
                 Chain::Ethereum,
                 ChainState::default(),
@@ -3058,6 +3070,7 @@ mod test_serial_db {
                 MockExtractorExtension,
             >::new(
                 gw,
+                DATABASE_INSERT_BATCH_SIZE,
                 "vm_name",
                 Chain::Ethereum,
                 ChainState::default(),
@@ -3256,6 +3269,7 @@ mod test_serial_db {
                 MockExtractorExtension,
             >::new(
                 gw,
+                DATABASE_INSERT_BATCH_SIZE,
                 "vm_name",
                 Chain::Ethereum,
                 ChainState::default(),

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -760,7 +760,7 @@ where
                 self.database_insert_batch_size
             {
                 let mut msgs = reorg_buffer
-                    .drain_blocks(inp.final_block_height)
+                    .drain_blocks_until(inp.final_block_height)
                     .map_err(ExtractionError::Storage)?
                     .into_iter()
                     .peekable();

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -597,11 +597,11 @@ where
     ) -> Result<u64, ExtractionError> {
         let mut reorg_buffer = self.reorg_buffer.lock().await;
 
-        let committed_height_from_buffer =
+        let committed_upto_height_from_buffer =
             |buffer: &ReorgBuffer<_>| -> Result<u64, ExtractionError> {
                 buffer
                     .get_oldest_block()
-                    .map(|block| block.number.saturating_sub(1))
+                    .map(|block| block.number)
                     .ok_or_else(|| {
                         ExtractionError::ReorgBufferError("Reorg buffer is empty".into())
                     })
@@ -614,7 +614,7 @@ where
         if reorg_buffer.finalized_block_count(inp.final_block_height) <
             self.database_insert_batch_size
         {
-            return committed_height_from_buffer(&reorg_buffer);
+            return committed_upto_height_from_buffer(&reorg_buffer);
         }
 
         let mut msgs = reorg_buffer
@@ -634,7 +634,7 @@ where
                 .await?;
         }
 
-        committed_height_from_buffer(&reorg_buffer)
+        committed_upto_height_from_buffer(&reorg_buffer)
     }
 }
 

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -611,7 +611,7 @@ where
             .insert_block(BlockUpdateWithCursor::new(msg.clone(), inp.cursor.clone()))
             .map_err(ExtractionError::Storage)?;
 
-        if reorg_buffer.finalized_block_count(inp.final_block_height) <
+        if reorg_buffer.count_blocks_before(inp.final_block_height) <
             self.database_insert_batch_size
         {
             return committed_upto_height_from_buffer(&reorg_buffer);

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -61,7 +61,7 @@ pub struct Inner {
 pub struct ProtocolExtractor<G, T, E> {
     gateway: G,
     #[allow(dead_code)]
-    database_insert_batch_size: u64,
+    database_insert_batch_size: usize,
     name: String,
     chain: Chain,
     chain_state: ChainState,
@@ -85,7 +85,7 @@ where
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         gateway: G,
-        database_insert_batch_size: u64,
+        database_insert_batch_size: usize,
         name: &str,
         chain: Chain,
         chain_state: ChainState,
@@ -1638,7 +1638,7 @@ mod test {
 
     const EXTRACTOR_NAME: &str = "TestExtractor";
     const TEST_PROTOCOL: &str = "TestProtocol";
-    const DATABASE_INSERT_BATCH_SIZE: u64 = 128;
+    const DATABASE_INSERT_BATCH_SIZE: usize = 128;
     async fn create_extractor(
         gw: MockExtractorGateway,
     ) -> ProtocolExtractor<MockExtractorGateway, MockTokenPreProcessor, MockExtractorExtension>
@@ -2371,7 +2371,7 @@ mod test_serial_db {
         0x32, 0xbc, 0x34, 0xf6, 0x88,
     ]; // 0xaaaaaaaaa24eeeb8d57d431224f73832bc34f688
 
-    const DATABASE_INSERT_BATCH_SIZE: u64 = 128;
+    const DATABASE_INSERT_BATCH_SIZE: usize = 128;
 
     // SETUP
     fn get_mocked_token_pre_processor() -> MockTokenPreProcessor {

--- a/tycho-indexer/src/extractor/reorg_buffer.rs
+++ b/tycho-indexer/src/extractor/reorg_buffer.rs
@@ -873,6 +873,25 @@ mod test {
     }
 
     #[test]
+    fn test_count_blocks_before() {
+        let mut reorg_buffer = ReorgBuffer::new();
+        reorg_buffer
+            .insert_block(get_block_changes(1))
+            .unwrap();
+        reorg_buffer
+            .insert_block(get_block_changes(2))
+            .unwrap();
+        reorg_buffer
+            .insert_block(get_block_changes(3))
+            .unwrap();
+
+        assert_eq!(reorg_buffer.count_blocks_before(1), 0);
+        assert_eq!(reorg_buffer.count_blocks_before(2), 1);
+        assert_eq!(reorg_buffer.count_blocks_before(3), 2);
+        assert_eq!(reorg_buffer.count_blocks_before(4), 3);
+    }
+
+    #[test]
     fn test_drain_committed_blocks() {
         let mut reorg_buffer = ReorgBuffer::new();
         reorg_buffer.strict = true;

--- a/tycho-indexer/src/extractor/reorg_buffer.rs
+++ b/tycho-indexer/src/extractor/reorg_buffer.rs
@@ -187,6 +187,11 @@ where
         None
     }
 
+    /// Returns the number of blocks currently in the buffer.
+    pub fn len(&self) -> usize {
+        self.block_messages.len()
+    }
+
     /// Retrieves a range of blocks from the buffer.
     ///
     /// The retrieved iterator will include both the start and end block of specified range. In case

--- a/tycho-indexer/src/extractor/reorg_buffer.rs
+++ b/tycho-indexer/src/extractor/reorg_buffer.rs
@@ -187,12 +187,12 @@ where
         None
     }
 
-    /// Returns the number of finalized blocks currently in the buffer.
-    /// Assumes the blocks in `block_messages` are ordered by ascending block number.
-    pub fn finalized_block_count(&self, finalized_height: u64) -> usize {
+    /// Returns the number of blocks in the buffer with a block number less than the specified
+    /// target block number. Assumes blocks are stored in ascending order.
+    pub fn count_blocks_before(&self, target_block: u64) -> usize {
         self.block_messages
             .iter()
-            .take_while(|msg| msg.block().number <= finalized_height)
+            .take_while(|msg| msg.block().number < target_block)
             .count()
     }
 

--- a/tycho-indexer/src/extractor/reorg_buffer.rs
+++ b/tycho-indexer/src/extractor/reorg_buffer.rs
@@ -187,9 +187,13 @@ where
         None
     }
 
-    /// Returns the number of blocks currently in the buffer.
-    pub fn len(&self) -> usize {
-        self.block_messages.len()
+    /// Returns the number of finalized blocks currently in the buffer.
+    /// Assumes the blocks in `block_messages` are ordered by ascending block number.
+    pub fn finalized_block_count(&self, finalized_height: u64) -> usize {
+        self.block_messages
+            .iter()
+            .take_while(|msg| msg.block().number < finalized_height)
+            .count()
     }
 
     /// Retrieves a range of blocks from the buffer.

--- a/tycho-indexer/src/extractor/reorg_buffer.rs
+++ b/tycho-indexer/src/extractor/reorg_buffer.rs
@@ -97,10 +97,13 @@ where
         Ok(())
     }
 
-    /// Drains blocks up to the specified block height from the buffer. Returns the
+    /// Drains blocks up to the specified block height (non-inclusive) from the buffer. Returns the
     /// drained blocks ordered by ascending number or an error if the target height is not found
     /// in the buffer and strict mode is enabled.
-    pub fn drain_blocks(&mut self, drain_upto_block_height: u64) -> Result<Vec<B>, StorageError> {
+    pub fn drain_blocks_until(
+        &mut self,
+        drain_upto_block_height: u64,
+    ) -> Result<Vec<B>, StorageError> {
         let target_index = self.find_index(|b| b.block().number == drain_upto_block_height);
         let first = self
             .get_block_range(None, None)?
@@ -905,12 +908,14 @@ mod test {
             .insert_block(get_block_changes(3))
             .unwrap();
 
-        let committed = reorg_buffer.drain_blocks(3).unwrap();
+        let committed = reorg_buffer
+            .drain_blocks_until(3)
+            .unwrap();
 
         assert_eq!(reorg_buffer.block_messages.len(), 1);
         assert_eq!(committed, vec![get_block_changes(1), get_block_changes(2)]);
 
-        let unknown = reorg_buffer.drain_blocks(999);
+        let unknown = reorg_buffer.drain_blocks_until(999);
 
         assert!(unknown.is_err());
     }

--- a/tycho-indexer/src/extractor/reorg_buffer.rs
+++ b/tycho-indexer/src/extractor/reorg_buffer.rs
@@ -192,7 +192,7 @@ where
     pub fn finalized_block_count(&self, finalized_height: u64) -> usize {
         self.block_messages
             .iter()
-            .take_while(|msg| msg.block().number < finalized_height)
+            .take_while(|msg| msg.block().number <= finalized_height)
             .count()
     }
 

--- a/tycho-indexer/src/extractor/runner.rs
+++ b/tycho-indexer/src/extractor/runner.rs
@@ -429,6 +429,7 @@ pub struct ExtractorBuilder {
     s3_bucket: Option<String>,
     token: String,
     extractor: Option<Arc<dyn Extractor>>,
+    database_insert_batch_size: Option<u64>,
     final_block_only: bool,
     /// Handle of the tokio runtime on which the extraction tasks will be run.
     /// If 'None' the default runtime will be used.
@@ -450,6 +451,7 @@ impl ExtractorBuilder {
             s3_bucket: s3_bucket.map(ToString::to_string),
             token: substreams_api_token.to_string(),
             extractor: None,
+            database_insert_batch_size: None,
             final_block_only: false,
             runtime_handle: None,
             rpc_url: None,
@@ -490,6 +492,12 @@ impl ExtractorBuilder {
     /// Set the global RPC URL to use for DCI plugins
     pub fn rpc_url(mut self, rpc_url: &str) -> Self {
         self.rpc_url = Some(rpc_url.to_string());
+        self
+    }
+
+    /// Set the global database insert batch size
+    pub fn database_insert_batch_size(mut self, database_insert_batch_size: u64) -> Self {
+        self.database_insert_batch_size = Some(database_insert_batch_size);
         self
     }
 
@@ -660,9 +668,14 @@ impl ExtractorBuilder {
             None
         };
 
+        let database_insert_batch_size = self
+            .database_insert_batch_size
+            .ok_or(ExtractionError::Setup("Database insert batch size not set".to_string()))?;
+
         self.extractor = Some(Arc::new(
             ProtocolExtractor::<ExtractorPgGateway, EthereumTokenPreProcessor, DCIPlugin>::new(
                 gw,
+                database_insert_batch_size,
                 &self.config.name,
                 self.config.chain,
                 chain_state,

--- a/tycho-indexer/src/extractor/runner.rs
+++ b/tycho-indexer/src/extractor/runner.rs
@@ -429,7 +429,7 @@ pub struct ExtractorBuilder {
     s3_bucket: Option<String>,
     token: String,
     extractor: Option<Arc<dyn Extractor>>,
-    database_insert_batch_size: Option<u64>,
+    database_insert_batch_size: Option<usize>,
     final_block_only: bool,
     /// Handle of the tokio runtime on which the extraction tasks will be run.
     /// If 'None' the default runtime will be used.
@@ -496,7 +496,7 @@ impl ExtractorBuilder {
     }
 
     /// Set the global database insert batch size
-    pub fn database_insert_batch_size(mut self, database_insert_batch_size: u64) -> Self {
+    pub fn database_insert_batch_size(mut self, database_insert_batch_size: usize) -> Self {
         self.database_insert_batch_size = Some(database_insert_batch_size);
         self
     }

--- a/tycho-indexer/src/extractor/runner.rs
+++ b/tycho-indexer/src/extractor/runner.rs
@@ -670,7 +670,7 @@ impl ExtractorBuilder {
 
         let database_insert_batch_size = self
             .database_insert_batch_size
-            .ok_or(ExtractionError::Setup("Database insert batch size not set".to_string()))?;
+            .unwrap_or_default();
 
         self.extractor = Some(Arc::new(
             ProtocolExtractor::<ExtractorPgGateway, EthereumTokenPreProcessor, DCIPlugin>::new(

--- a/tycho-indexer/src/main.rs
+++ b/tycho-indexer/src/main.rs
@@ -382,7 +382,7 @@ async fn create_indexing_tasks(
 
     let (runners, extractor_handles): (Vec<_>, Vec<_>) =
         // TODO: accept substreams configuration from cli.
-        build_all_extractors(&extractors_config, chain_state, chains, &global_args.endpoint_url, global_args.s3_bucket.as_deref(), &substreams_args.substreams_api_token, &cached_gw, &token_processor, &global_args.rpc_url.clone(), extraction_runtime)
+        build_all_extractors(&extractors_config, chain_state, chains, &global_args.endpoint_url, global_args.s3_bucket.as_deref(), &substreams_args.substreams_api_token, &cached_gw, global_args.database_insert_batch_size, &token_processor, &global_args.rpc_url.clone(), extraction_runtime)
             .await
             .map_err(|e| ExtractionError::Setup(format!("Failed to create extractors: {e}")))?
             .into_iter()
@@ -421,6 +421,7 @@ async fn build_all_extractors(
     s3_bucket: Option<&str>,
     substreams_api_token: &str,
     cached_gw: &CachedGateway,
+    database_insert_batch_size: u64,
     token_pre_processor: &EthereumTokenPreProcessor,
     rpc_url: &str,
     runtime: Option<&tokio::runtime::Handle>,
@@ -456,6 +457,7 @@ async fn build_all_extractors(
         let (runner, handle) =
             ExtractorBuilder::new(extractor_config, endpoint_url, s3_bucket, substreams_api_token)
                 .rpc_url(rpc_url)
+                .database_insert_batch_size(database_insert_batch_size)
                 .build(chain_state, cached_gw, token_pre_processor, &protocol_cache)
                 .await?
                 .set_runtime(runtime)

--- a/tycho-indexer/src/main.rs
+++ b/tycho-indexer/src/main.rs
@@ -421,7 +421,7 @@ async fn build_all_extractors(
     s3_bucket: Option<&str>,
     substreams_api_token: &str,
     cached_gw: &CachedGateway,
-    database_insert_batch_size: u64,
+    database_insert_batch_size: usize,
     token_pre_processor: &EthereumTokenPreProcessor,
     rpc_url: &str,
     runtime: Option<&tokio::runtime::Handle>,

--- a/tycho-indexer/src/services/deltas_buffer.rs
+++ b/tycho-indexer/src/services/deltas_buffer.rs
@@ -126,7 +126,7 @@ impl PendingDeltas {
                         "DeltaBufferInsertion"
                     );
                     guard.insert_block((*message).clone())?;
-                    guard.drain_blocks(message.db_committed_upto_block_height)?;
+                    guard.drain_blocks_until(message.db_committed_upto_block_height)?;
                 }
             }
             _ => return Err(PendingDeltasError::UnknownExtractor(message.extractor.clone())),


### PR DESCRIPTION
- add a CLI config controlling how many finalized blocks must accumulate before we flush to Postgres (default 128, matching Ethereum finality)
  - refactor `ProtocolExtractor` to buffer messages via a helper that drains/commits only once the batch size is met, and capture the committed watermark consistently
  - extend the reorg buffer with count helpers plus targeted unit tests to cover the new batching
  behaviour
