### PR TITLE
fix: make new component tokens available to blacklist

### DIFF
--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/cache.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/cache.rs
@@ -178,6 +178,10 @@ impl DCICache {
             .validate_and_ensure_block_layer_internal(block)?;
         self.ep_id_to_component_id
             .validate_and_ensure_block_layer_internal(block)?;
+        self.erc20_addresses
+            .validate_and_ensure_block_layer_internal(block)?;
+        self.blacklisted_addresses
+            .validate_and_ensure_block_layer_internal(block)?;
 
         Ok(())
     }

--- a/tycho-indexer/src/extractor/dynamic_contract_indexer/dci.rs
+++ b/tycho-indexer/src/extractor/dynamic_contract_indexer/dci.rs
@@ -73,15 +73,17 @@ where
         self.cache
             .try_insert_block_layer(&block_changes.block)?;
 
-        // Process new tokens from BlockChanges
-        for (address, _token) in block_changes.new_tokens.iter() {
-            // Add new tokens to the ERC-20 cache
-            self.cache
-                .erc20_addresses
-                .pending_entry(&block_changes.block, address)?
-                .or_insert(true);
-
-            debug!("Added new ERC-20 token to skip list: {}", address);
+        for c in block_changes
+            .txs_with_update
+            .iter()
+            .flat_map(|tx| tx.protocol_components.values())
+        {
+            for t in c.tokens.iter() {
+                self.cache
+                    .erc20_addresses
+                    .pending_entry(&block_changes.block, t)?
+                    .or_insert(true);
+            }
         }
 
         for (component_id, ep) in block_changes


### PR DESCRIPTION
Previously, we would try to do this using `block.new_tokens`, but that only gets populated after the DCI finished processing.

Also had to add some missing initialisations calls in the DCICache.

Tested by syncing a spkg locally.