### PR TITLE
feat(storage): snapshot sink abstraction — FileSink and S3Sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,6 +1898,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-named-pipe",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "rustls 0.23.31",
+ "rustls-native-certs 0.8.1",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.47.1-rc.27.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,6 +2710,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker_credential"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,6 +2886,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ethabi"
 version = "17.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2964,6 +3036,17 @@ checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -3514,6 +3597,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.7.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3598,6 +3696,21 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -3997,7 +4110,7 @@ checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.4",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.17",
 ]
 
 [[package]]
@@ -4675,9 +4788,34 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.17",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5300,6 +5438,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
@@ -5646,6 +5793,7 @@ checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.4",
  "subtle",
@@ -5659,7 +5807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "schannel",
  "security-framework 2.11.1",
 ]
@@ -5683,6 +5831,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5965,6 +6122,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6241,6 +6409,29 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "strum"
@@ -6521,6 +6712,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "testcontainers"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+dependencies = [
+ "async-trait",
+ "bollard",
+ "bollard-stubs",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera",
+ "futures 0.3.31",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-stream",
+ "tokio-tar",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d43ed4e8f58424c3a2c6c56dbea6643c3c23e8666a34df13c54f0a184e6c707"
+dependencies = [
+ "testcontainers",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6764,6 +6993,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tar"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall 0.3.5",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6858,7 +7102,7 @@ dependencies = [
  "pin-project",
  "prost 0.11.9",
  "rustls-native-certs 0.6.3",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-stream",
@@ -7288,6 +7532,8 @@ name = "tycho-storage"
 version = "0.144.1"
 dependencies = [
  "async-trait",
+ "aws-config",
+ "aws-sdk-s3",
  "chrono",
  "diesel",
  "diesel-async",
@@ -7297,10 +7543,16 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "lru 0.12.5",
+ "mockall",
  "pretty_assertions",
  "rstest",
  "serde_json",
+ "sha2",
+ "tempfile",
  "test-log",
+ "testcontainers",
+ "testcontainers-modules",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tycho-common",
@@ -7852,6 +8104,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -7875,6 +8136,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -7912,6 +8188,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7924,6 +8206,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7933,6 +8221,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7960,6 +8254,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7969,6 +8269,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7984,6 +8290,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7993,6 +8305,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8043,6 +8361,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.0.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,10 @@ tokio = { version = "1.27", features = [
     "rt-multi-thread",
     "parking_lot",
     "tracing",
+    "fs",
+    "io-util",
 ] }
+sha2 = "0.10"
 console-subscriber = "0.2.0"
 tokio-tungstenite = { version = "0.20.0", features = ["native-tls"] }
 utoipa = { version = "4.2.0", features = ["chrono"] }

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -619,7 +619,7 @@ where
             .await;
         let (unknown_tokens, known_tokens) = new_token_addresses
             .into_iter()
-            .zip(is_token_known.into_iter())
+            .zip(is_token_known)
             .partition::<Vec<_>, _>(|(_, known)| !*known);
         let known_tokens = known_tokens
             .into_iter()
@@ -1727,8 +1727,8 @@ impl ExtractorGateway for ExtractorPgGateway {
                 tx_update
                     .balance_changes
                     .clone()
-                    .into_iter()
-                    .flat_map(|(_, tokens_balances)| tokens_balances.into_values()),
+                    .into_values()
+                    .flatten(),
             );
 
             // Map account balance changes
@@ -1736,8 +1736,8 @@ impl ExtractorGateway for ExtractorPgGateway {
                 tx_update
                     .account_balance_changes
                     .clone()
-                    .into_iter()
-                    .flat_map(|(_, tokens_balances)| tokens_balances.into_values()),
+                    .into_values()
+                    .flatten(),
             );
 
             // Map new entrypoints

--- a/tycho-indexer/src/extractor/protocol_extractor.rs
+++ b/tycho-indexer/src/extractor/protocol_extractor.rs
@@ -1728,7 +1728,7 @@ impl ExtractorGateway for ExtractorPgGateway {
                     .balance_changes
                     .clone()
                     .into_values()
-                    .flatten(),
+                    .flat_map(|m| m.into_values()),
             );
 
             // Map account balance changes
@@ -1737,7 +1737,7 @@ impl ExtractorGateway for ExtractorPgGateway {
                     .account_balance_changes
                     .clone()
                     .into_values()
-                    .flatten(),
+                    .flat_map(|m| m.into_values()),
             );
 
             // Map new entrypoints

--- a/tycho-storage/Cargo.toml
+++ b/tycho-storage/Cargo.toml
@@ -38,6 +38,9 @@ testcontainers-modules = { version = "0.11", features = ["minio"], optional = tr
 s3 = [
     "dep:aws-sdk-s3",
     "dep:aws-config",
+]
+s3-integration-tests = [
+    "s3",
     "dep:testcontainers",
     "dep:testcontainers-modules",
 ]

--- a/tycho-storage/Cargo.toml
+++ b/tycho-storage/Cargo.toml
@@ -31,9 +31,16 @@ thiserror.workspace = true
 sha2.workspace = true
 aws-sdk-s3 = { version = "1.77", optional = true }
 aws-config = { version = "1.1.8", features = ["behavior-version-latest"], optional = true }
+testcontainers = { version = "0.23", optional = true }
+testcontainers-modules = { version = "0.11", features = ["minio"], optional = true }
 
 [features]
-s3 = ["dep:aws-sdk-s3", "dep:aws-config"]
+s3 = [
+    "dep:aws-sdk-s3",
+    "dep:aws-config",
+    "dep:testcontainers",
+    "dep:testcontainers-modules",
+]
 
 [dev-dependencies]
 pretty_assertions.workspace = true
@@ -41,6 +48,4 @@ rstest.workspace = true
 test-log = { version = "0.2.14", features = ["trace"] }
 mockall.workspace = true
 tempfile = "3"
-testcontainers = "0.23"
-testcontainers-modules = { version = "0.11", features = ["minio"] }
 tokio = { workspace = true, features = ["fs", "io-util"] }

--- a/tycho-storage/Cargo.toml
+++ b/tycho-storage/Cargo.toml
@@ -27,9 +27,13 @@ diesel-derive-enum = { version = "2.1.0", features = ["postgres"] }
 diesel_migrations = "2.1.0"
 itertools = "0.12.1"
 lazy_static = "1.4.0"
-
+thiserror.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
 rstest.workspace = true
 test-log = { version = "0.2.14", features = ["trace"] }
+mockall.workspace = true
+tempfile = "3"
+tokio = { workspace = true, features = ["fs", "io-util"] }

--- a/tycho-storage/Cargo.toml
+++ b/tycho-storage/Cargo.toml
@@ -29,6 +29,11 @@ itertools = "0.12.1"
 lazy_static = "1.4.0"
 thiserror.workspace = true
 sha2.workspace = true
+aws-sdk-s3 = { version = "1.77", optional = true }
+aws-config = { version = "1.1.8", features = ["behavior-version-latest"], optional = true }
+
+[features]
+s3 = ["dep:aws-sdk-s3", "dep:aws-config"]
 
 [dev-dependencies]
 pretty_assertions.workspace = true
@@ -36,4 +41,6 @@ rstest.workspace = true
 test-log = { version = "0.2.14", features = ["trace"] }
 mockall.workspace = true
 tempfile = "3"
+testcontainers = "0.23"
+testcontainers-modules = { version = "0.11", features = ["minio"] }
 tokio = { workspace = true, features = ["fs", "io-util"] }

--- a/tycho-storage/src/lib.rs
+++ b/tycho-storage/src/lib.rs
@@ -4,3 +4,4 @@ extern crate pretty_assertions;
 #[macro_use]
 extern crate lazy_static;
 pub mod postgres;
+pub mod snapshot;

--- a/tycho-storage/src/postgres/contract.rs
+++ b/tycho-storage/src/postgres/contract.rs
@@ -514,8 +514,8 @@ impl PostgresGateway {
             .collect();
         #[allow(clippy::mutable_key_type)]
         let accounts: HashSet<_> = slots
-            .iter()
-            .flat_map(|(_, contract_slots)| contract_slots.keys())
+            .values()
+            .flat_map(|contract_slots| contract_slots.keys())
             .collect();
         let account_ids: HashMap<Bytes, i64> = schema::account::table
             .filter(schema::account::address.eq_any(accounts))

--- a/tycho-storage/src/postgres/entry_point.rs
+++ b/tycho-storage/src/postgres/entry_point.rs
@@ -78,7 +78,10 @@ impl PostgresGateway {
         // because it doesn't return the ids on conflicts.
         let input_external_ids: Vec<EntryPointId> = new_data
             .values()
-            .flat_map(|ep| ep.iter().map(|ep| ep.external_id.clone()))
+            .flat_map(|ep| {
+                ep.iter()
+                    .map(|ep| ep.external_id.clone())
+            })
             .collect();
 
         let entry_point_ids =

--- a/tycho-storage/src/postgres/entry_point.rs
+++ b/tycho-storage/src/postgres/entry_point.rs
@@ -53,8 +53,8 @@ impl PostgresGateway {
         .collect::<HashMap<_, _>>();
 
         let new_entry_points = new_data
-            .iter()
-            .flat_map(|(_, ep)| {
+            .values()
+            .flat_map(|ep| {
                 ep.iter()
                     .map(|ep| NewEntryPoint {
                         external_id: ep.external_id.clone(),
@@ -77,11 +77,8 @@ impl PostgresGateway {
         // Fetch entry points by their external_ids, we can't use .returning() on the insert above
         // because it doesn't return the ids on conflicts.
         let input_external_ids: Vec<EntryPointId> = new_data
-            .iter()
-            .flat_map(|(_, ep)| {
-                ep.iter()
-                    .map(|ep| ep.external_id.clone())
-            })
+            .values()
+            .flat_map(|ep| ep.iter().map(|ep| ep.external_id.clone()))
             .collect();
 
         let entry_point_ids =

--- a/tycho-storage/src/snapshot/mod.rs
+++ b/tycho-storage/src/snapshot/mod.rs
@@ -1,0 +1,3 @@
+pub mod sink;
+
+pub use sink::{FileSink, FileSinkFactory, SinkError, SinkFactory, SinkResult, SnapshotSink};

--- a/tycho-storage/src/snapshot/mod.rs
+++ b/tycho-storage/src/snapshot/mod.rs
@@ -1,3 +1,5 @@
 pub mod sink;
 
 pub use sink::{FileSink, FileSinkFactory, SinkError, SinkFactory, SinkResult, SnapshotSink};
+#[cfg(feature = "s3")]
+pub use sink::{S3Sink, S3SinkFactory, DEFAULT_PART_THRESHOLD};

--- a/tycho-storage/src/snapshot/sink.rs
+++ b/tycho-storage/src/snapshot/sink.rs
@@ -1,6 +1,11 @@
 use std::path::PathBuf;
 
 use async_trait::async_trait;
+#[cfg(feature = "s3")]
+use aws_sdk_s3::{
+    types::{CompletedMultipartUpload, CompletedPart},
+    Client,
+};
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncWriteExt, BufWriter};
 
@@ -14,6 +19,18 @@ pub struct SinkResult {
 pub enum SinkError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
+    #[cfg(feature = "s3")]
+    #[error("Failed to create multipart upload: {0}")]
+    UploadCreateFailed(String),
+    #[cfg(feature = "s3")]
+    #[error("Part {part} upload failed: {reason}")]
+    PartFailed { part: i32, reason: String },
+    #[cfg(feature = "s3")]
+    #[error("Failed to complete multipart upload: {0}")]
+    CompleteFailed(String),
+    #[cfg(feature = "s3")]
+    #[error("Failed to abort multipart upload: {0}")]
+    AbortFailed(String),
 }
 
 /// Async write-only byte sink that tracks position and accumulates SHA-256.
@@ -91,6 +108,297 @@ impl SinkFactory for FileSinkFactory {
     }
 }
 
+// ─────────────────────────── S3Ops (internal trait) ──────────────────────────
+
+#[cfg(feature = "s3")]
+pub const DEFAULT_PART_THRESHOLD: usize = 64 * 1024 * 1024;
+
+#[cfg(feature = "s3")]
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub(crate) trait S3Ops: Send + Sync {
+    async fn create_multipart_upload(&self, bucket: &str, key: &str) -> Result<String, SinkError>;
+
+    async fn upload_part(
+        &self,
+        bucket: &str,
+        key: &str,
+        upload_id: &str,
+        part_number: i32,
+        data: Vec<u8>,
+    ) -> Result<CompletedPart, SinkError>;
+
+    async fn complete_multipart_upload(
+        &self,
+        bucket: &str,
+        key: &str,
+        upload_id: &str,
+        parts: Vec<CompletedPart>,
+    ) -> Result<(), SinkError>;
+
+    async fn abort_multipart_upload(
+        &self,
+        bucket: &str,
+        key: &str,
+        upload_id: &str,
+    ) -> Result<(), SinkError>;
+}
+
+// ─────────────────────────── AwsS3Ops ────────────────────────────────────────
+
+#[cfg(feature = "s3")]
+pub(crate) struct AwsS3Ops {
+    client: Client,
+}
+
+#[cfg(feature = "s3")]
+impl AwsS3Ops {
+    pub(crate) fn new(client: Client) -> Self {
+        Self { client }
+    }
+}
+
+#[cfg(feature = "s3")]
+#[async_trait]
+impl S3Ops for AwsS3Ops {
+    async fn create_multipart_upload(&self, bucket: &str, key: &str) -> Result<String, SinkError> {
+        let resp = self
+            .client
+            .create_multipart_upload()
+            .bucket(bucket)
+            .key(key)
+            .send()
+            .await
+            .map_err(|e| SinkError::UploadCreateFailed(e.to_string()))?;
+        resp.upload_id()
+            .map(str::to_string)
+            .ok_or_else(|| SinkError::UploadCreateFailed("missing upload_id in response".into()))
+    }
+
+    async fn upload_part(
+        &self,
+        bucket: &str,
+        key: &str,
+        upload_id: &str,
+        part_number: i32,
+        data: Vec<u8>,
+    ) -> Result<CompletedPart, SinkError> {
+        let body = aws_sdk_s3::primitives::ByteStream::from(data);
+        let resp = self
+            .client
+            .upload_part()
+            .bucket(bucket)
+            .key(key)
+            .upload_id(upload_id)
+            .part_number(part_number)
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| SinkError::PartFailed { part: part_number, reason: e.to_string() })?;
+        let e_tag = resp.e_tag().map(str::to_string);
+        Ok(CompletedPart::builder()
+            .set_e_tag(e_tag)
+            .part_number(part_number)
+            .build())
+    }
+
+    async fn complete_multipart_upload(
+        &self,
+        bucket: &str,
+        key: &str,
+        upload_id: &str,
+        parts: Vec<CompletedPart>,
+    ) -> Result<(), SinkError> {
+        let upload = CompletedMultipartUpload::builder()
+            .set_parts(Some(parts))
+            .build();
+        self.client
+            .complete_multipart_upload()
+            .bucket(bucket)
+            .key(key)
+            .upload_id(upload_id)
+            .multipart_upload(upload)
+            .send()
+            .await
+            .map_err(|e| SinkError::CompleteFailed(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn abort_multipart_upload(
+        &self,
+        bucket: &str,
+        key: &str,
+        upload_id: &str,
+    ) -> Result<(), SinkError> {
+        self.client
+            .abort_multipart_upload()
+            .bucket(bucket)
+            .key(key)
+            .upload_id(upload_id)
+            .send()
+            .await
+            .map_err(|e| SinkError::AbortFailed(e.to_string()))?;
+        Ok(())
+    }
+}
+
+// ─────────────────────────── S3Sink ──────────────────────────────────────────
+
+#[cfg(feature = "s3")]
+pub struct S3Sink {
+    ops: Box<dyn S3Ops>,
+    bucket: String,
+    key: String,
+    upload_id: String,
+    part_threshold: usize,
+    buffer: Vec<u8>,
+    completed_parts: Vec<CompletedPart>,
+    part_number: i32,
+    hasher: Sha256,
+    position: u64,
+}
+
+#[cfg(feature = "s3")]
+impl S3Sink {
+    pub async fn create(
+        client: Client,
+        bucket: String,
+        key: String,
+        part_threshold: usize,
+    ) -> Result<Self, SinkError> {
+        Self::create_with_ops(Box::new(AwsS3Ops::new(client)), bucket, key, part_threshold).await
+    }
+
+    pub(crate) async fn create_with_ops(
+        ops: Box<dyn S3Ops>,
+        bucket: String,
+        key: String,
+        part_threshold: usize,
+    ) -> Result<Self, SinkError> {
+        let upload_id = ops
+            .create_multipart_upload(&bucket, &key)
+            .await?;
+        Ok(Self {
+            ops,
+            bucket,
+            key,
+            upload_id,
+            part_threshold,
+            buffer: Vec::new(),
+            completed_parts: Vec::new(),
+            part_number: 0,
+            hasher: Sha256::new(),
+            position: 0,
+        })
+    }
+
+    async fn flush_part(&mut self) -> Result<(), SinkError> {
+        if self.buffer.is_empty() {
+            return Ok(());
+        }
+        self.part_number += 1;
+        let data = std::mem::take(&mut self.buffer);
+        match self
+            .ops
+            .upload_part(&self.bucket, &self.key, &self.upload_id, self.part_number, data)
+            .await
+        {
+            Ok(part) => {
+                self.completed_parts.push(part);
+                Ok(())
+            }
+            Err(e) => {
+                if let Err(abort_err) = self
+                    .ops
+                    .abort_multipart_upload(&self.bucket, &self.key, &self.upload_id)
+                    .await
+                {
+                    tracing::warn!(error = %abort_err, "failed to abort multipart upload");
+                }
+                Err(e)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "s3")]
+#[async_trait]
+impl SnapshotSink for S3Sink {
+    async fn write_all(&mut self, buf: &[u8]) -> Result<(), SinkError> {
+        self.hasher.update(buf);
+        self.position += buf.len() as u64;
+        self.buffer.extend_from_slice(buf);
+        if self.buffer.len() >= self.part_threshold {
+            self.flush_part().await?;
+        }
+        Ok(())
+    }
+
+    fn position(&self) -> u64 {
+        self.position
+    }
+
+    async fn finalize(mut self: Box<Self>) -> Result<SinkResult, SinkError> {
+        self.flush_part().await?;
+        let sha256: [u8; 32] = self.hasher.finalize().into();
+        let size_bytes = self.position;
+        let parts = std::mem::take(&mut self.completed_parts);
+        let complete_result = self
+            .ops
+            .complete_multipart_upload(&self.bucket, &self.key, &self.upload_id, parts)
+            .await;
+        if let Err(e) = complete_result {
+            if let Err(abort_err) = self
+                .ops
+                .abort_multipart_upload(&self.bucket, &self.key, &self.upload_id)
+                .await
+            {
+                tracing::warn!(error = %abort_err, "failed to abort multipart upload");
+            }
+            return Err(e);
+        }
+        Ok(SinkResult { size_bytes, sha256 })
+    }
+}
+
+// ─────────────────────────── S3SinkFactory ───────────────────────────────────
+
+#[cfg(feature = "s3")]
+pub struct S3SinkFactory {
+    client: Client,
+    bucket: String,
+    part_threshold: usize,
+}
+
+#[cfg(feature = "s3")]
+impl S3SinkFactory {
+    pub async fn from_env(bucket: String) -> Self {
+        let config = aws_config::from_env().load().await;
+        let client = Client::new(&config);
+        Self { client, bucket, part_threshold: DEFAULT_PART_THRESHOLD }
+    }
+
+    pub fn with_client(client: Client, bucket: String, part_threshold: usize) -> Self {
+        Self { client, bucket, part_threshold }
+    }
+}
+
+#[cfg(feature = "s3")]
+#[async_trait]
+impl SinkFactory for S3SinkFactory {
+    async fn create_sink(&self, key: &str) -> Result<Box<dyn SnapshotSink>, SinkError> {
+        Ok(Box::new(
+            S3Sink::create(
+                self.client.clone(),
+                self.bucket.clone(),
+                key.to_string(),
+                self.part_threshold,
+            )
+            .await?,
+        ))
+    }
+}
+
 // ─────────────────────────── Tests ───────────────────────────────────────────
 
 #[cfg(test)]
@@ -126,5 +434,137 @@ mod tests {
         let result = sink.finalize().await.unwrap();
 
         assert_eq!(result.size_bytes, data.len() as u64);
+    }
+
+    #[cfg(all(test, feature = "s3"))]
+    mod s3_tests {
+        use aws_sdk_s3::config::{BehaviorVersion, Credentials, Region};
+        use testcontainers::runners::AsyncRunner;
+        use testcontainers_modules::minio::MinIO;
+
+        use super::*;
+
+        fn make_s3_client(endpoint: &str) -> Client {
+            let creds = Credentials::new("minioadmin", "minioadmin", None, None, "test");
+            let config = aws_sdk_s3::Config::builder()
+                .behavior_version(BehaviorVersion::latest())
+                .endpoint_url(endpoint)
+                .credentials_provider(creds)
+                .region(Region::new("us-east-1"))
+                .force_path_style(true)
+                .build();
+            Client::from_conf(config)
+        }
+
+        async fn create_bucket(client: &Client, bucket: &str) {
+            client
+                .create_bucket()
+                .bucket(bucket)
+                .send()
+                .await
+                .unwrap();
+        }
+
+        #[tokio::test]
+        async fn s3_sink_upload_part_failure_calls_abort_and_returns_part_failed() {
+            let mut mock = MockS3Ops::new();
+            mock.expect_create_multipart_upload()
+                .returning(|_, _| Ok("test-upload-id".to_string()));
+            mock.expect_upload_part()
+                .returning(|_, _, _, part_num, _| {
+                    Err(SinkError::PartFailed {
+                        part: part_num,
+                        reason: "network error".to_string(),
+                    })
+                });
+            mock.expect_abort_multipart_upload()
+                .times(1)
+                .returning(|_, _, _| Ok(()));
+
+            let mut sink = S3Sink::create_with_ops(
+                Box::new(mock),
+                "test-bucket".to_string(),
+                "test-key".to_string(),
+                5, // small threshold to trigger flush
+            )
+            .await
+            .unwrap();
+
+            let result = sink.write_all(b"hello world!").await;
+            assert!(matches!(result, Err(SinkError::PartFailed { part: 1, .. })));
+        }
+
+        #[tokio::test]
+        async fn s3_sink_multipart_upload_completes_and_data_matches() {
+            let minio = MinIO::default().start().await.unwrap();
+            let port = minio
+                .get_host_port_ipv4(9000)
+                .await
+                .unwrap();
+            let endpoint = format!("http://127.0.0.1:{port}");
+            let client = make_s3_client(&endpoint);
+
+            let bucket = "test-bucket";
+            let key = "test/snapshot.bin";
+            create_bucket(&client, bucket).await;
+
+            let data: Vec<u8> = (0u8..=255).cycle().take(1024).collect();
+            let expected_sha256: [u8; 32] = Sha256::digest(&data).into();
+
+            let mut sink = S3Sink::create(
+                client.clone(),
+                bucket.to_string(),
+                key.to_string(),
+                DEFAULT_PART_THRESHOLD,
+            )
+            .await
+            .unwrap();
+            sink.write_all(&data).await.unwrap();
+            let result = Box::new(sink).finalize().await.unwrap();
+
+            assert_eq!(result.size_bytes, data.len() as u64);
+            assert_eq!(result.sha256, expected_sha256);
+
+            let resp = client
+                .get_object()
+                .bucket(bucket)
+                .key(key)
+                .send()
+                .await
+                .unwrap();
+            let stored = resp
+                .body
+                .collect()
+                .await
+                .unwrap()
+                .into_bytes();
+            assert_eq!(stored.as_ref(), data.as_slice());
+        }
+
+        #[tokio::test]
+        async fn s3_sink_satisfies_boxed_dyn_snapshot_sink() {
+            let minio = MinIO::default().start().await.unwrap();
+            let port = minio
+                .get_host_port_ipv4(9000)
+                .await
+                .unwrap();
+            let endpoint = format!("http://127.0.0.1:{port}");
+            let client = make_s3_client(&endpoint);
+
+            let bucket = "test-bucket-dyn";
+            let key = "dyn-test.bin";
+            create_bucket(&client, bucket).await;
+
+            let data = b"boxed s3 sink test";
+            let sink =
+                S3Sink::create(client, bucket.to_string(), key.to_string(), DEFAULT_PART_THRESHOLD)
+                    .await
+                    .unwrap();
+            let mut sink: Box<dyn SnapshotSink> = Box::new(sink);
+            sink.write_all(data).await.unwrap();
+            let result = sink.finalize().await.unwrap();
+
+            assert_eq!(result.size_bytes, data.len() as u64);
+        }
     }
 }

--- a/tycho-storage/src/snapshot/sink.rs
+++ b/tycho-storage/src/snapshot/sink.rs
@@ -1,0 +1,130 @@
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncWriteExt, BufWriter};
+
+/// Returned by a successfully finalized sink.
+pub struct SinkResult {
+    pub size_bytes: u64,
+    pub sha256: [u8; 32],
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SinkError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Async write-only byte sink that tracks position and accumulates SHA-256.
+#[async_trait]
+pub trait SnapshotSink: Send {
+    async fn write_all(&mut self, buf: &[u8]) -> Result<(), SinkError>;
+    fn position(&self) -> u64;
+    /// Seals the sink and returns size + digest. Consumes via `Box<Self>` for object-safety.
+    async fn finalize(self: Box<Self>) -> Result<SinkResult, SinkError>;
+}
+
+/// Creates sinks by key without exposing raw config to callers.
+#[async_trait]
+pub trait SinkFactory: Send + Sync {
+    async fn create_sink(&self, key: &str) -> Result<Box<dyn SnapshotSink>, SinkError>;
+}
+
+// ─────────────────────────── FileSink ────────────────────────────────────────
+
+pub struct FileSink {
+    writer: BufWriter<tokio::fs::File>,
+    hasher: Sha256,
+    position: u64,
+}
+
+impl FileSink {
+    pub async fn create(path: PathBuf) -> Result<Self, SinkError> {
+        let file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&path)
+            .await?;
+        Ok(Self { writer: BufWriter::new(file), hasher: Sha256::new(), position: 0 })
+    }
+}
+
+#[async_trait]
+impl SnapshotSink for FileSink {
+    async fn write_all(&mut self, buf: &[u8]) -> Result<(), SinkError> {
+        self.hasher.update(buf);
+        self.position += buf.len() as u64;
+        self.writer.write_all(buf).await?;
+        Ok(())
+    }
+
+    fn position(&self) -> u64 {
+        self.position
+    }
+
+    async fn finalize(mut self: Box<Self>) -> Result<SinkResult, SinkError> {
+        self.writer.flush().await?;
+        let sha256 = self.hasher.finalize().into();
+        Ok(SinkResult { size_bytes: self.position, sha256 })
+    }
+}
+
+// ─────────────────────────── FileSinkFactory ─────────────────────────────────
+
+pub struct FileSinkFactory {
+    base_dir: PathBuf,
+}
+
+impl FileSinkFactory {
+    pub fn new(base_dir: PathBuf) -> Self {
+        Self { base_dir }
+    }
+}
+
+#[async_trait]
+impl SinkFactory for FileSinkFactory {
+    async fn create_sink(&self, key: &str) -> Result<Box<dyn SnapshotSink>, SinkError> {
+        let path = self.base_dir.join(key);
+        Ok(Box::new(FileSink::create(path).await?))
+    }
+}
+
+// ─────────────────────────── Tests ───────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use sha2::{Digest, Sha256};
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn file_sink_write_finalize_verifies_size_and_sha256() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("snapshot.bin");
+        let data = b"hello, snapshot!";
+        let expected_sha256: [u8; 32] = Sha256::digest(data).into();
+
+        let mut sink = FileSink::create(path).await.unwrap();
+        sink.write_all(data).await.unwrap();
+        let result = Box::new(sink).finalize().await.unwrap();
+
+        assert_eq!(result.size_bytes, data.len() as u64);
+        assert_eq!(result.sha256, expected_sha256);
+    }
+
+    #[tokio::test]
+    async fn file_sink_satisfies_boxed_dyn_snapshot_sink() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("snapshot_dyn.bin");
+        let data = b"boxed sink test";
+
+        let mut sink: Box<dyn SnapshotSink> = Box::new(FileSink::create(path).await.unwrap());
+        sink.write_all(data).await.unwrap();
+        let result = sink.finalize().await.unwrap();
+
+        assert_eq!(result.size_bytes, data.len() as u64);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `tycho-storage/src/snapshot` module with `SnapshotSink` and `SinkFactory` traits
- `FileSink`: writes to a local file via `BufWriter`, accumulates SHA-256 on the fly
- `S3Sink`: streams data into S3 via multipart upload; flushes parts at a configurable threshold (default 64 MiB, supporting objects up to 640 GiB within S3's 10k-part limit); aborts the upload on part or complete failure
- `FileSinkFactory` / `S3SinkFactory` let callers create sinks by key without touching raw config
- S3 code is behind an optional `s3` feature flag; `S3Ops` is `pub(crate)` and `automock`-ed for unit testing without Docker

## Test plan

- [ ] `cargo nextest run --package tycho-storage --locked --all-features -E 'not test(serial_db)'` — all 5 new tests pass (2 file unit, 1 mock, 2 Minio integration)
- [ ] `cargo +nightly clippy --locked --package tycho-storage --all-features --all-targets -- -D warnings` — zero warnings
- [ ] `cargo +nightly fmt --package tycho-storage -- --check` — no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)