### PR TITLE
fix: update cli and python clients

### DIFF
--- a/crates/tycho-client-py/python/tests/assets/rpc/contract_state.json
+++ b/crates/tycho-client-py/python/tests/assets/rpc/contract_state.json
@@ -68,7 +68,13 @@
       "code_hash": "0x2b62e1037bf02c3617c0a8598318b9ca0d958fc7861377ee5912d56065234076",
       "balance_modify_tx": "0xa63c671046ad2075ec8ea83ac21199cf3e3a5f433e72ec4c117cbabfb9b18de2",
       "code_modify_tx": "0xa63c671046ad2075ec8ea83ac21199cf3e3a5f433e72ec4c117cbabfb9b18de2",
-      "creation_tx": "0xa63c671046ad2075ec8ea83ac21199cf3e3a5f433e72ec4c117cbabfb9b18de2"
+      "creation_tx": "0xa63c671046ad2075ec8ea83ac21199cf3e3a5f433e72ec4c117cbabfb9b18de2",
+      "token_balances": {}
     }
-  ]
+  ],
+  "pagination": {
+    "page": 0,
+    "page_size": 20,
+    "total": 2
+  }
 }

--- a/crates/tycho-client-py/python/tests/assets/rpc/protocol_components.json
+++ b/crates/tycho-client-py/python/tests/assets/rpc/protocol_components.json
@@ -36,5 +36,10 @@
       "creation_tx": "0x9d5fedf3dd9e1784f8e3a1b5c0fcbfb45d420efa2f8166227f0141120e60a246",
       "created_at": "2020-05-26T18:54:56"
     }
-  ]
+  ],
+  "pagination": {
+    "page": 0,
+    "page_size": 20,
+    "total": 2
+  }
 }

--- a/crates/tycho-client-py/python/tests/assets/rpc/protocol_state.json
+++ b/crates/tycho-client-py/python/tests/assets/rpc/protocol_state.json
@@ -10,5 +10,10 @@
         "0x38c2a4a7330b22788374b8ff70bba513c8d848ca": "0x056bc75e2d63100000"
       }
     }
-  ]
+  ],
+  "pagination": {
+    "page": 0,
+    "page_size": 20,
+    "total": 1
+  }
 }

--- a/crates/tycho-client-py/python/tests/assets/rpc/tokens.json
+++ b/crates/tycho-client-py/python/tests/assets/rpc/tokens.json
@@ -223,6 +223,7 @@
   ],
   "pagination": {
     "page": 0,
-    "page_size": 20
+    "page_size": 20,
+    "total": 20
   }
 }

--- a/crates/tycho-client-py/python/tycho_indexer_client/dto.py
+++ b/crates/tycho-client-py/python/tycho_indexer_client/dto.py
@@ -45,6 +45,7 @@ class Chain(str, Enum):
     bsc = "bsc"
     zksync = "zksync"
     unichain = "unichain"
+    polygon = "polygon"
 
 
 class ChangeType(str, Enum):

--- a/crates/tycho-client-py/python/tycho_indexer_client/stream.py
+++ b/crates/tycho-client-py/python/tycho_indexer_client/stream.py
@@ -76,7 +76,11 @@ class TychoStream:
         # stdout=PIPE means that the output is piped directly to this Python process
         # stderr=STDOUT combines the stderr and stdout streams
 
-        cmd = ["--log-folder", self._logs_directory, "--tycho-url", self.tycho_url]
+        cmd = [
+            "--log-folder", self._logs_directory,
+            "--tycho-url", self.tycho_url,
+            "--chain", self._blockchain.value,
+        ]
 
         if self.min_tvl is not None:
             cmd.extend(["--min-tvl", str(self.min_tvl)])

--- a/crates/tycho-client/src/cli.rs
+++ b/crates/tycho-client/src/cli.rs
@@ -1,20 +1,11 @@
-use std::{collections::HashSet, path::Path, str::FromStr, time::Duration};
+use std::{path::Path, str::FromStr};
 
 use clap::Parser;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info};
 use tracing_appender::rolling;
-use tycho_common::dto::{Chain, ExtractorIdentity};
+use tycho_common::dto::Chain;
 
-use crate::{
-    deltas::DeltasClient,
-    feed::{
-        component_tracker::ComponentFilter, synchronizer::ProtocolStateSynchronizer,
-        BlockSynchronizer,
-    },
-    rpc::HttpRPCClientOptions,
-    stream::ProtocolSystemsInfo,
-    HttpRPCClient, WsDeltasClient,
-};
+use crate::{feed::component_tracker::ComponentFilter, stream::TychoStreamBuilder};
 
 /// Tycho Client CLI - A tool for indexing and tracking blockchain protocol data
 ///
@@ -60,19 +51,20 @@ struct CliArgs {
     #[clap(long)]
     add_tvl_threshold: Option<f64>,
 
-    /// Expected block time in seconds. For blockchains with consistent intervals,
-    /// set to the average block time (e.g., "600" for a 10-minute interval).
+    /// Expected block time in seconds. Defaults to the canonical block time for the selected
+    /// chain (e.g. 12s for Ethereum, 2s for Base).
     ///
     /// Adjusting `block_time` helps balance efficiency and responsiveness:
     /// - **Low values**: Increase sync frequency but may waste resources on retries.
     /// - **High values**: Reduce sync frequency but may delay updates on faster chains.
-    #[clap(long, default_value = "600")]
-    block_time: u64,
+    #[clap(long)]
+    block_time: Option<u64>,
 
     /// Maximum wait time in seconds beyond the block time. Useful for handling
-    /// chains with variable block intervals or network delays.
-    #[clap(long, default_value = "1")]
-    timeout: u64,
+    /// chains with variable block intervals or network delays. Defaults to a chain-appropriate
+    /// value.
+    #[clap(long)]
+    timeout: Option<u64>,
 
     /// Logging folder path.
     #[clap(long, default_value = "logs")]
@@ -95,8 +87,9 @@ struct CliArgs {
 
     /// Maximum blocks an exchange can be absent for before it is marked as stale. Used
     /// in conjunction with block_time to calculate a timeout: block_time * max_missed_blocks.
-    #[clap(long, default_value = "10")]
-    max_missed_blocks: u64,
+    /// Defaults to a chain-appropriate value.
+    #[clap(long)]
+    max_missed_blocks: Option<u64>,
 
     /// If set, the synchronizer will include TVL in the messages.
     /// Enabling this option will increase the number of network requests made during start-up,
@@ -209,7 +202,7 @@ pub async fn run_cli() -> Result<(), String> {
                     if parts.len() == 2 {
                         Some((parts[0].to_string(), Some(parts[1].to_string())))
                     } else {
-                        warn!("Ignoring invalid exchange format: {}", e);
+                        tracing::warn!("Ignoring invalid exchange format: {}", e);
                         None
                     }
                 } else {
@@ -231,91 +224,66 @@ async fn run(exchanges: Vec<(String, Option<String>)>, args: CliArgs) -> Result<
         None => Vec::new(),
     };
 
-    info!("Running with version: {}", option_env!("CARGO_PKG_VERSION").unwrap_or("unknown"));
-    //TODO: remove "or args.auth_key.is_none()" when our internal client use the no_tls flag
-    let (tycho_ws_url, tycho_rpc_url) = if args.no_tls || args.auth_key.is_none() {
-        info!("Using non-secure connection: ws:// and http://");
-        let tycho_ws_url = format!("ws://{url}", url = &args.tycho_url);
-        let tycho_rpc_url = format!("http://{url}", url = &args.tycho_url);
-        (tycho_ws_url, tycho_rpc_url)
-    } else {
-        info!("Using secure connection: wss:// and https://");
-        let tycho_ws_url = format!("wss://{url}", url = &args.tycho_url);
-        let tycho_rpc_url = format!("https://{url}", url = &args.tycho_url);
-        (tycho_ws_url, tycho_rpc_url)
-    };
-
-    let ws_client = WsDeltasClient::new(&tycho_ws_url, args.auth_key.as_deref())
-        .map_err(|e| format!("Failed to create WebSocket client: {e}"))?;
-    let rpc_client = HttpRPCClient::new(
-        &tycho_rpc_url,
-        HttpRPCClientOptions::new()
-            .with_auth_key(args.auth_key.clone())
-            .with_compression(!args.disable_compression),
-    )
-    .map_err(|e| format!("Failed to create RPC client: {e}"))?;
     let chain = Chain::from_str(&args.chain)
         .map_err(|_| format!("Unknown chain: {chain}", chain = &args.chain))?;
-    let ws_jh = ws_client
-        .connect()
+
+    // Start with chain-appropriate defaults; override only what the user explicitly provided.
+    let builder = TychoStreamBuilder::new(&args.tycho_url, chain);
+
+    // Auth key is optional; TLS is on by default and disabled only via --no-tls.
+    let builder = match args.auth_key {
+        Some(key) => builder.auth_key(Some(key)),
+        None => builder,
+    };
+    let builder = builder.no_tls(args.no_tls);
+
+    // Timing: use CLI overrides when provided, otherwise the builder keeps chain defaults.
+    let builder = match args.block_time {
+        Some(bt) => builder.block_time(bt),
+        None => builder,
+    };
+    let builder = match args.timeout {
+        Some(to) => builder.timeout(to),
+        None => builder,
+    };
+    let builder = match args.max_missed_blocks {
+        Some(mmb) => builder.max_missed_blocks(mmb),
+        None => builder,
+    };
+
+    // Feature flags
+    let builder = builder
+        .no_state(args.no_state)
+        .include_tvl(args.include_tvl)
+        .max_retries(args.max_retries)
+        .blocklisted_ids(blocklist);
+    let builder = if args.disable_compression { builder.disable_compression() } else { builder };
+    let builder = if args.partial_blocks { builder.enable_partial_blocks() } else { builder };
+    let builder = match args.max_messages {
+        Some(n) => builder.max_messages(n),
+        None => builder,
+    };
+
+    // Register exchanges
+    let builder = exchanges
+        .into_iter()
+        .fold(builder, |b, (name, address)| {
+            let filter = if let Some(addr) = address {
+                ComponentFilter::Ids(vec![addr])
+            } else if let (Some(remove_tvl), Some(add_tvl)) =
+                (args.remove_tvl_threshold, args.add_tvl_threshold)
+            {
+                ComponentFilter::with_tvl_range(remove_tvl, add_tvl)
+            } else {
+                ComponentFilter::with_tvl_range(args.min_tvl, args.min_tvl)
+            };
+            b.exchange(&name, filter)
+        });
+
+    let (handle, mut rx) = builder
+        .build()
         .await
-        .map_err(|e| format!("WebSocket client connection error: {e}"))?;
-
-    let mut block_sync = BlockSynchronizer::new(
-        Duration::from_secs(args.block_time),
-        Duration::from_secs(args.timeout),
-        args.max_missed_blocks,
-    );
-
-    if let Some(mm) = &args.max_messages {
-        block_sync.max_messages(*mm);
-    }
-
-    let requested_protocol_set: HashSet<_> = exchanges
-        .iter()
-        .map(|(name, _)| name.clone())
-        .collect();
-    let protocol_info =
-        ProtocolSystemsInfo::fetch(&rpc_client, chain, &requested_protocol_set).await;
-    protocol_info.log_other_available();
-    let dci_protocols = protocol_info.dci_protocols;
-
-    for (name, address) in exchanges {
-        debug!("Registering exchange: {}", name);
-        let id = ExtractorIdentity { chain, name: name.clone() };
-        let filter = if let Some(address) = address {
-            ComponentFilter::Ids(vec![address])
-        } else if let (Some(remove_tvl), Some(add_tvl)) =
-            (args.remove_tvl_threshold, args.add_tvl_threshold)
-        {
-            ComponentFilter::with_tvl_range(remove_tvl, add_tvl)
-        } else {
-            ComponentFilter::with_tvl_range(args.min_tvl, args.min_tvl)
-        }
-        .blocklist(blocklist.clone());
-        let uses_dci = dci_protocols.contains(&name);
-        let sync = ProtocolStateSynchronizer::new(
-            id.clone(),
-            true,
-            filter,
-            args.max_retries,
-            Duration::from_secs(args.block_time / 2),
-            !args.no_state,
-            args.include_tvl,
-            !args.disable_compression,
-            rpc_client.clone(),
-            ws_client.clone(),
-            args.block_time + args.timeout,
-        )
-        .with_dci(uses_dci)
-        .with_partial_blocks(args.partial_blocks);
-        block_sync = block_sync.register_synchronizer(id, sync);
-    }
-
-    let (sync_jh, mut rx) = block_sync
-        .run()
-        .await
-        .map_err(|e| format!("Failed to start block synchronizer: {e}"))?;
+        .map_err(|e| e.to_string())?;
 
     let msg_printer = tokio::spawn(async move {
         while let Some(result) = rx.recv().await {
@@ -333,23 +301,18 @@ async fn run(exchanges: Vec<(String, Option<String>)>, args: CliArgs) -> Result<
         Ok::<(), String>(())
     });
 
-    // Monitor the WebSocket, BlockSynchronizer and message printer futures.
+    // Monitor the stream handle and message printer futures.
     let (failed_task, shutdown_reason) = tokio::select! {
-        res = ws_jh => (
-            "WebSocket",
-            extract_nested_error(res)
+        res = handle => (
+            "Stream",
+            res.err().map(|e| e.to_string())
         ),
-        res = sync_jh => (
-            "BlockSynchronizer",
-            extract_nested_error::<_, _, String>(Ok(res))
-            ),
         res = msg_printer => (
             "MessagePrinter",
             extract_nested_error(res)
-        )
+        ),
     };
 
-    debug!("RX closed");
     Err(format!(
         "{failed_task} task terminated: {}",
         shutdown_reason.unwrap_or("unknown reason".to_string())
@@ -397,8 +360,8 @@ mod cli_tests {
         assert_eq!(args.tycho_url, "localhost:5000");
         assert_eq!(args.exchange, exchanges);
         assert_eq!(args.min_tvl, 3000.0);
-        assert_eq!(args.block_time, 50);
-        assert_eq!(args.timeout, 5);
+        assert_eq!(args.block_time, Some(50));
+        assert_eq!(args.timeout, Some(5));
         assert_eq!(args.log_folder, "test_logs");
         assert_eq!(args.max_messages, Some(1));
         assert!(args.example);

--- a/crates/tycho-client/src/cli.rs
+++ b/crates/tycho-client/src/cli.rs
@@ -227,18 +227,14 @@ async fn run(exchanges: Vec<(String, Option<String>)>, args: CliArgs) -> Result<
     let chain = Chain::from_str(&args.chain)
         .map_err(|_| format!("Unknown chain: {chain}", chain = &args.chain))?;
 
-    // Start with chain-appropriate defaults; override only what the user explicitly provided.
-    let builder = TychoStreamBuilder::new(&args.tycho_url, chain);
+    let mut builder = TychoStreamBuilder::new(&args.tycho_url, chain)
+        .auth_key(args.auth_key)
+        .no_tls(args.no_tls)
+        .no_state(args.no_state)
+        .include_tvl(args.include_tvl)
+        .max_retries(args.max_retries)
+        .blocklisted_ids(blocklist);
 
-    // Auth key is optional; TLS is on by default and disabled only via --no-tls.
-    let builder = match args.auth_key {
-        Some(key) => builder.auth_key(Some(key)),
-        None => builder,
-    };
-    let builder = builder.no_tls(args.no_tls);
-
-    // Timing: use CLI overrides when provided, otherwise the builder keeps chain defaults.
-    let mut builder = builder;
     if let Some(bt) = args.block_time {
         builder = builder.block_time(bt);
     }
@@ -248,19 +244,15 @@ async fn run(exchanges: Vec<(String, Option<String>)>, args: CliArgs) -> Result<
     if let Some(mmb) = args.max_missed_blocks {
         builder = builder.max_missed_blocks(mmb);
     }
-
-    // Feature flags
-    let builder = builder
-        .no_state(args.no_state)
-        .include_tvl(args.include_tvl)
-        .max_retries(args.max_retries)
-        .blocklisted_ids(blocklist);
-    let builder = if args.disable_compression { builder.disable_compression() } else { builder };
-    let builder = if args.partial_blocks { builder.enable_partial_blocks() } else { builder };
-    let builder = match args.max_messages {
-        Some(n) => builder.max_messages(n),
-        None => builder,
-    };
+    if args.disable_compression {
+        builder = builder.disable_compression();
+    }
+    if args.partial_blocks {
+        builder = builder.enable_partial_blocks();
+    }
+    if let Some(n) = args.max_messages {
+        builder = builder.max_messages(n);
+    }
 
     // Register exchanges
     let builder = exchanges

--- a/crates/tycho-client/src/cli.rs
+++ b/crates/tycho-client/src/cli.rs
@@ -238,18 +238,16 @@ async fn run(exchanges: Vec<(String, Option<String>)>, args: CliArgs) -> Result<
     let builder = builder.no_tls(args.no_tls);
 
     // Timing: use CLI overrides when provided, otherwise the builder keeps chain defaults.
-    let builder = match args.block_time {
-        Some(bt) => builder.block_time(bt),
-        None => builder,
-    };
-    let builder = match args.timeout {
-        Some(to) => builder.timeout(to),
-        None => builder,
-    };
-    let builder = match args.max_missed_blocks {
-        Some(mmb) => builder.max_missed_blocks(mmb),
-        None => builder,
-    };
+    let mut builder = builder;
+    if let Some(bt) = args.block_time {
+        builder = builder.block_time(bt);
+    }
+    if let Some(to) = args.timeout {
+        builder = builder.timeout(to);
+    }
+    if let Some(mmb) = args.max_missed_blocks {
+        builder = builder.max_missed_blocks(mmb);
+    }
 
     // Feature flags
     let builder = builder

--- a/crates/tycho-client/src/stream.rs
+++ b/crates/tycho-client/src/stream.rs
@@ -69,6 +69,7 @@ pub struct TychoStreamBuilder {
     include_tvl: bool,
     compression: bool,
     partial_blocks: bool,
+    max_messages: Option<usize>,
 }
 
 impl TychoStreamBuilder {
@@ -99,6 +100,7 @@ impl TychoStreamBuilder {
             include_tvl: false,
             compression: true,
             partial_blocks: false,
+            max_messages: None,
         }
     }
 
@@ -213,6 +215,23 @@ impl TychoStreamBuilder {
         self
     }
 
+    /// Stops the stream after emitting this many messages. Useful for testing or
+    /// triggering a periodic restart after a fixed number of blocks.
+    pub fn max_messages(mut self, n: usize) -> Self {
+        self.max_messages = Some(n);
+        self
+    }
+
+    /// Overrides the maximum number of retry attempts for state synchronizer startup.
+    /// The retry cooldown is derived from the chain's block time and is not affected.
+    pub fn max_retries(mut self, max_retries: u64) -> Self {
+        let cooldown = match &self.state_sync_retry_config {
+            RetryConfiguration::Constant(c) => c.cooldown,
+        };
+        self.state_sync_retry_config = RetryConfiguration::constant(max_retries, cooldown);
+        self
+    }
+
     /// Blocklist specific component IDs across all registered exchanges.
     ///
     /// Blocklisted components are never tracked, regardless of TVL or other
@@ -285,6 +304,9 @@ impl TychoStreamBuilder {
             Duration::from_secs(self.timeout),
             self.max_missed_blocks,
         );
+        if let Some(n) = self.max_messages {
+            block_sync.max_messages(n);
+        }
 
         let requested: HashSet<_> = self.exchanges.keys().cloned().collect();
         let info = ProtocolSystemsInfo::fetch(&rpc_client, self.chain, &requested).await;


### PR DESCRIPTION
The CLI and python clients were outdated and did not reflect recent fixes or changes. This PR includes:
- refactoring the CLI client to use the (actually maintained) stream builder internally
- updating the python client