### PR TITLE
fix(ci): correct substreams package detection path prefix

### DIFF
--- a/.github/actions/substreams-check/action.yml
+++ b/.github/actions/substreams-check/action.yml
@@ -19,7 +19,7 @@ runs:
       shell: bash
       run: |
         # Convert space-separated list to newline-separated list and process
-        echo '${{ inputs.changed-files }}' | tr ' ' '\n' | grep '^substreams/' | grep -v 'Cargo.lock$' > changed_files.txt
+        echo '${{ inputs.changed-files }}' | tr ' ' '\n' | grep '^protocols/substreams/' | grep -v 'Cargo.lock$' > changed_files.txt
 
         # Initialize empty array for package names
         PACKAGE_NAMES=()
@@ -36,7 +36,7 @@ runs:
           ENCOUNTERED_WORKSPACE=""
 
           # Find the nearest parent directory containing Cargo.toml
-          while [ "$dir" != "substreams" ] && [ "$dir" != "." ]; do
+          while [ "$dir" != "protocols/substreams" ] && [ "$dir" != "." ]; do
             if [ -f "$dir/Cargo.toml" ]; then
               # Check if this Cargo.toml is a workspace (has [workspace] section)
               if grep -q '^\[workspace\]' "$dir/Cargo.toml" 2>/dev/null; then


### PR DESCRIPTION
## Summary

- Fixes `substreams-check` action grep pattern from `^substreams/` to `^protocols/substreams/` — `tj-actions/changed-files` returns repo-root-relative paths, so the old pattern never matched anything
- Fixes the directory-walk loop termination condition from `"$dir" != "substreams"` to `"$dir" != "protocols/substreams"` for the same reason

This bug caused the Substreams CI (lint + test) to silently output "No packages to check" / "No packages to test" on every PR, including #919 which added `ethereum-fluid`.

## Test plan

- [ ] Push a change under `protocols/substreams/<any-package>/` and confirm the Substreams CI lint and test steps detect it and run against the correct package name

🤖 Generated with [Claude Code](https://claude.com/claude-code)