### PR TITLE
fix(protocol-testing): bump tycho-indexer Docker tag

### DIFF
--- a/protocols/testing/run.Dockerfile
+++ b/protocols/testing/run.Dockerfile
@@ -13,7 +13,7 @@ RUN /root/.foundry/bin/foundryup
 FROM rust:1.89-bookworm AS tycho-indexer-builder
 WORKDIR /build
 RUN apt-get update && apt-get install -y git
-RUN git clone --depth 1 --branch "0.83.4" https://github.com/propeller-heads/tycho-indexer.git
+RUN git clone --depth 1 --branch "0.153.0" https://github.com/propeller-heads/tycho-indexer.git
 WORKDIR /build/tycho-indexer
 RUN cargo build --release --bin tycho-indexer
 


### PR DESCRIPTION
The integration test Dockerfile clones tycho-indexer at a pinned tag to build the binary. Tag 0.83.4 depends on metrics v0.24.1 which contains a lifetime soundness issue (rust-lang/rust#141402) now rejected by Rust 1.89. Tag 0.153.0 uses metrics v0.24.2 which includes the fix.

This must land on main before PR #918 can pass CI, because the ci-substreams-integration workflow uses pull_request_target and checks out the base branch Dockerfile, not the PR branch.