### PR TITLE
feat: add pipeline to run cargo update periodically

### DIFF
--- a/.github/scripts/check-crate-ages.sh
+++ b/.github/scripts/check-crate-ages.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Compares old and new Cargo.lock files, extracts updated crates,
+# and checks each was published at least MIN_AGE_DAYS ago on crates.io.
+#
+# Outputs too-recent crates as "crate old_version" lines to a file so the
+# caller can pin them back with `cargo update -p <crate> --precise <old_version>`.
+#
+# Usage: check-crate-ages.sh <old-lockfile> <new-lockfile> <output-file> [min-age-days]
+#
+# Exit codes:
+#   0 — all crates are old enough (output file empty)
+#   2 — some crates are too recent (output file has entries)
+
+OLD_LOCK="${1:?Usage: check-crate-ages.sh <old-lock> <new-lock> <output-file> [min-age-days]}"
+NEW_LOCK="${2:?Usage: check-crate-ages.sh <old-lock> <new-lock> <output-file> [min-age-days]}"
+OUTPUT_FILE="${3:?Usage: check-crate-ages.sh <old-lock> <new-lock> <output-file> [min-age-days]}"
+MIN_AGE_DAYS="${4:-3}"
+
+if ! command -v jq &>/dev/null; then
+    echo "ERROR: jq is required but not found" >&2
+    exit 1
+fi
+
+# Extract name+version pairs from a Cargo.lock as "name version" lines.
+extract_packages() {
+    awk '/^\[\[package\]\]/{name=""; ver=""} /^name = /{gsub(/"/, "", $3); name=$3} /^version = /{gsub(/"/, "", $3); ver=$3; if(name!="") print name, ver}' "$1"
+}
+
+OLD_PKGS=$(extract_packages "$OLD_LOCK" | sort)
+NEW_PKGS=$(extract_packages "$NEW_LOCK" | sort)
+
+# Packages added or whose version changed (present in new but not old).
+CHANGED=$(diff <(echo "$OLD_PKGS") <(echo "$NEW_PKGS") | grep '^>' | sed 's/^> //' || true)
+
+if [[ -z "$CHANGED" ]]; then
+    echo "No package changes detected."
+    : > "$OUTPUT_FILE"
+    exit 0
+fi
+
+echo "Updated packages:"
+echo "$CHANGED"
+echo ""
+
+# Build a lookup of old versions: old_versions[crate]=version
+declare -A OLD_VERSIONS
+while IFS=' ' read -r name ver; do
+    OLD_VERSIONS["$name"]="$ver"
+done <<< "$OLD_PKGS"
+
+NOW=$(date +%s)
+TOO_RECENT=()
+
+while IFS=' ' read -r crate version; do
+    RESPONSE=$(curl -sf -H "User-Agent: tycho-indexer-ci (cargo-update)" \
+        "https://crates.io/api/v1/crates/${crate}/${version}" 2>/dev/null) || {
+        echo "WARNING: Could not fetch info for ${crate}@${version} (may be a path/git dep), skipping"
+        continue
+    }
+
+    CREATED_AT=$(echo "$RESPONSE" | jq -r '.version.created_at // empty')
+    if [[ -z "$CREATED_AT" ]]; then
+        echo "WARNING: No created_at for ${crate}@${version}, skipping"
+        continue
+    fi
+
+    # Parse ISO 8601 timestamp to epoch (Linux date -d handles ISO 8601 natively)
+    CREATED_EPOCH=$(date -d "${CREATED_AT}" +%s 2>/dev/null) || \
+    CREATED_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${CREATED_AT%%.*}" +%s 2>/dev/null) || {
+        echo "WARNING: Could not parse date '${CREATED_AT}' for ${crate}@${version}, skipping"
+        continue
+    }
+
+    AGE_DAYS=$(( (NOW - CREATED_EPOCH) / 86400 ))
+
+    if (( AGE_DAYS < MIN_AGE_DAYS )); then
+        old_ver="${OLD_VERSIONS[$crate]:-}"
+        if [[ -n "$old_ver" ]]; then
+            echo "TOO RECENT: ${crate}@${version} (${AGE_DAYS}d old) -> reverting to ${old_ver}"
+            TOO_RECENT+=("${crate} ${old_ver}")
+        else
+            echo "TOO RECENT: ${crate}@${version} (${AGE_DAYS}d old) — new dep, no old version to pin"
+        fi
+    else
+        echo "OK:   ${crate}@${version} published ${AGE_DAYS}d ago"
+    fi
+
+    # Rate-limit: crates.io allows 1 req/sec for unauthenticated clients
+    sleep 1
+done <<< "$CHANGED"
+
+: > "$OUTPUT_FILE"
+if (( ${#TOO_RECENT[@]} > 0 )); then
+    echo ""
+    echo "========================================="
+    echo "${#TOO_RECENT[@]} crate(s) more recent than ${MIN_AGE_DAYS} days will be pinned back:"
+    for entry in "${TOO_RECENT[@]}"; do
+        echo "  - $entry"
+        echo "$entry" >> "$OUTPUT_FILE"
+    done
+    echo "========================================="
+    exit 2
+fi
+
+echo ""
+echo "All updated crates are at least ${MIN_AGE_DAYS} days old."

--- a/.github/scripts/check-crate-ages.sh
+++ b/.github/scripts/check-crate-ages.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 # Compares old and new Cargo.lock files, extracts updated crates,
 # and checks each was published at least MIN_AGE_DAYS ago on crates.io.
 #
-# Outputs too-recent crates as "crate old_version" lines to a file so the
-# caller can pin them back with `cargo update -p <crate> --precise <old_version>`.
+# Outputs too-recent crates as "crate safe_version" lines to a file so the
+# caller can pin them back with `cargo update -p <crate> --precise <safe_version>`.
+# The safe version is the latest release published at least MIN_AGE_DAYS ago.
 #
 # Usage: check-crate-ages.sh <old-lockfile> <new-lockfile> <output-file> [min-age-days]
 #
@@ -44,14 +45,33 @@ echo "Updated packages:"
 echo "$CHANGED"
 echo ""
 
-# Build a lookup of old versions: old_versions[crate]=version
-declare -A OLD_VERSIONS
-while IFS=' ' read -r name ver; do
-    OLD_VERSIONS["$name"]="$ver"
-done <<< "$OLD_PKGS"
+# Find the latest version of a crate published at least MIN_AGE_DAYS ago.
+# Queries the crates.io versions list and returns the first match.
+latest_safe_version() {
+    local crate="$1"
+    local min_age="$2"
+    local now="$3"
+    local threshold=$((min_age * 86400))
+
+    local resp
+    resp=$(curl -sf -H "User-Agent: tycho-indexer-ci (cargo-update)" \
+        "https://crates.io/api/v1/crates/${crate}/versions" 2>/dev/null) || return 1
+
+    # Versions are returned newest-first. Find the first non-yanked
+    # version published at least min_age days ago.
+    echo "$resp" | jq -r --argjson now "$now" --argjson threshold "$threshold" '
+        [.versions[] | select(.yanked == false)] |
+        map(select(
+            (.created_at | sub("\\.[0-9]+.*"; "") | strptime("%Y-%m-%dT%H:%M:%S") | mktime) as $t |
+            ($now - $t) >= $threshold
+        )) |
+        first | .num // empty
+    '
+}
 
 NOW=$(date +%s)
-TOO_RECENT=()
+: > "$OUTPUT_FILE"
+too_recent_count=0
 
 while IFS=' ' read -r crate version; do
     RESPONSE=$(curl -sf -H "User-Agent: tycho-indexer-ci (cargo-update)" \
@@ -66,7 +86,7 @@ while IFS=' ' read -r crate version; do
         continue
     fi
 
-    # Parse ISO 8601 timestamp to epoch (Linux date -d handles ISO 8601 natively)
+    # Parse ISO 8601 timestamp to epoch (Linux date -d, macOS date -j fallback)
     CREATED_EPOCH=$(date -d "${CREATED_AT}" +%s 2>/dev/null) || \
     CREATED_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${CREATED_AT%%.*}" +%s 2>/dev/null) || {
         echo "WARNING: Could not parse date '${CREATED_AT}' for ${crate}@${version}, skipping"
@@ -76,12 +96,14 @@ while IFS=' ' read -r crate version; do
     AGE_DAYS=$(( (NOW - CREATED_EPOCH) / 86400 ))
 
     if (( AGE_DAYS < MIN_AGE_DAYS )); then
-        old_ver="${OLD_VERSIONS[$crate]:-}"
-        if [[ -n "$old_ver" ]]; then
-            echo "TOO RECENT: ${crate}@${version} (${AGE_DAYS}d old) -> reverting to ${old_ver}"
-            TOO_RECENT+=("${crate} ${old_ver}")
+        safe_ver=$(latest_safe_version "$crate" "$MIN_AGE_DAYS" "$NOW")
+        sleep 1  # rate-limit the extra API call
+        if [[ -n "$safe_ver" ]]; then
+            echo "TOO RECENT: ${crate}@${version} (${AGE_DAYS}d old) -> pinning to ${safe_ver}"
+            echo "${crate} ${safe_ver}" >> "$OUTPUT_FILE"
+            too_recent_count=$((too_recent_count + 1))
         else
-            echo "TOO RECENT: ${crate}@${version} (${AGE_DAYS}d old) — new dep, no old version to pin"
+            echo "TOO RECENT: ${crate}@${version} (${AGE_DAYS}d old) — no safe version found, skipping"
         fi
     else
         echo "OK:   ${crate}@${version} published ${AGE_DAYS}d ago"
@@ -91,15 +113,13 @@ while IFS=' ' read -r crate version; do
     sleep 1
 done <<< "$CHANGED"
 
-: > "$OUTPUT_FILE"
-if (( ${#TOO_RECENT[@]} > 0 )); then
+if (( too_recent_count > 0 )); then
     echo ""
     echo "========================================="
-    echo "${#TOO_RECENT[@]} crate(s) more recent than ${MIN_AGE_DAYS} days will be pinned back:"
-    for entry in "${TOO_RECENT[@]}"; do
-        echo "  - $entry"
-        echo "$entry" >> "$OUTPUT_FILE"
-    done
+    echo "${too_recent_count} crate(s) more recent than ${MIN_AGE_DAYS} days will be pinned back:"
+    while IFS=' ' read -r c v; do
+        echo "  - ${c} ${v}"
+    done < "$OUTPUT_FILE"
     echo "========================================="
     exit 2
 fi

--- a/.github/workflows/cargo-update.yaml
+++ b/.github/workflows/cargo-update.yaml
@@ -36,24 +36,14 @@ jobs:
             cp "$lock" "/tmp/old-locks/$lock"
           done < <(find . -name Cargo.lock -not -path '*/target/*' -print0)
 
-      - name: Run cargo update in all workspaces
+      - name: Run cargo update in every workspace with a Cargo.lock
         run: |
-          WORKSPACES=(
-            "."
-            "protocols/substreams"
-            "protocols/substreams/ethereum-ambient"
-            "protocols/substreams/ethereum-balancer-v3"
-            "protocols/substreams/ethereum-curve"
-            "protocols/substreams/ethereum-sfrax"
-            "protocols/substreams/ethereum-sfraxeth"
-            "protocols/substreams/ethereum-uniswap-v4"
-            "protocols/testing"
-          )
-          for ws in "${WORKSPACES[@]}"; do
+          while IFS= read -r -d '' lock; do
+            ws=$(dirname "$lock")
             echo "::group::cargo update in $ws"
             (cd "$ws" && cargo update)
             echo "::endgroup::"
-          done
+          done < <(find . -name Cargo.lock -not -path '*/target/*' -print0)
 
       - name: Check for changes
         id: changes
@@ -69,11 +59,11 @@ jobs:
       - name: Check crate ages and collect too-recent crates
         if: steps.changes.outputs.changed == 'true'
         run: |
-          mkdir -p /tmp/young-crates
+          mkdir -p /tmp/recent-crates
           while IFS= read -r -d '' lock; do
             old="/tmp/old-locks/$lock"
             if [[ -f "$old" ]]; then
-              outfile="/tmp/young-crates/$(echo "$lock" | tr '/' '_').txt"
+              outfile="/tmp/recent-crates/$(echo "$lock" | tr '/' '_').txt"
               echo "::group::Checking $lock"
               # Exit code 2 means some crates are too recent (written to outfile)
               .github/scripts/check-crate-ages.sh "$old" "$lock" "$outfile" "$MIN_CRATE_AGE_DAYS" || true
@@ -84,19 +74,8 @@ jobs:
       - name: Pin back too-recent crates
         if: steps.changes.outputs.changed == 'true'
         run: |
-          WORKSPACES=(
-            "."
-            "protocols/substreams"
-            "protocols/substreams/ethereum-ambient"
-            "protocols/substreams/ethereum-balancer-v3"
-            "protocols/substreams/ethereum-curve"
-            "protocols/substreams/ethereum-sfrax"
-            "protocols/substreams/ethereum-sfraxeth"
-            "protocols/substreams/ethereum-uniswap-v4"
-            "protocols/testing"
-          )
           # Collect all unique "crate old_version" pairs across lockfiles
-          pinlist=$(cat /tmp/young-crates/*.txt 2>/dev/null | sort -u || true)
+          pinlist=$(cat /tmp/recent-crates/*.txt 2>/dev/null | sort -u || true)
           if [[ -z "$pinlist" ]]; then
             echo "No too-recent crates to pin back."
             exit 0
@@ -104,11 +83,12 @@ jobs:
           echo "Pinning back too-recent crates:"
           echo "$pinlist"
           while IFS=' ' read -r crate old_version; do
-            for ws in "${WORKSPACES[@]}"; do
+            while IFS= read -r -d '' lock; do
+              ws=$(dirname "$lock")
               echo "::group::Pin ${crate}@${old_version} in $ws"
               (cd "$ws" && cargo update -p "$crate" --precise "$old_version") || true
               echo "::endgroup::"
-            done
+            done < <(find . -name Cargo.lock -not -path '*/target/*' -print0)
           done <<< "$pinlist"
 
       - name: Re-check for changes after pinning
@@ -126,7 +106,7 @@ jobs:
         if: steps.final-changes.outputs.changed == 'true'
         id: pr-body
         run: |
-          pinlist=$(cat /tmp/young-crates/*.txt 2>/dev/null | sort -u || true)
+          pinlist=$(cat /tmp/recent-crates/*.txt 2>/dev/null | sort -u || true)
           body="Automated biweekly \`cargo update\` across all workspace lockfiles."
           body="${body}"$'\n\n'"All updated crates have been verified to be at least ${MIN_CRATE_AGE_DAYS} days old (supply chain safety check)."
           if [[ -n "$pinlist" ]]; then

--- a/.github/workflows/cargo-update.yaml
+++ b/.github/workflows/cargo-update.yaml
@@ -124,6 +124,7 @@ jobs:
         if: steps.final-changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e  # v7.0.8
         with:
+          add-paths: '**/Cargo.lock'
           branch: chore/cargo-update
           commit-message: "chore(deps): run cargo update"
           title: "chore(deps): biweekly cargo update"

--- a/.github/workflows/cargo-update.yaml
+++ b/.github/workflows/cargo-update.yaml
@@ -1,0 +1,150 @@
+name: Cargo Update
+
+on:
+  schedule:
+    # 1st and 15th of each month at 06:00 UTC (biweekly)
+    - cron: '0 6 1,15 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  MIN_CRATE_AGE_DAYS: 3
+
+jobs:
+  cargo-update:
+    name: Update dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: true  # needed to push the branch
+
+      - uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1  # stable
+        with:
+          toolchain: stable
+
+      - name: Save old lockfiles
+        run: |
+          mkdir -p /tmp/old-locks
+          while IFS= read -r -d '' lock; do
+            dir=$(dirname "$lock")
+            mkdir -p "/tmp/old-locks/$dir"
+            cp "$lock" "/tmp/old-locks/$lock"
+          done < <(find . -name Cargo.lock -not -path '*/target/*' -print0)
+
+      - name: Run cargo update in all workspaces
+        run: |
+          WORKSPACES=(
+            "."
+            "protocols/substreams"
+            "protocols/substreams/ethereum-ambient"
+            "protocols/substreams/ethereum-balancer-v3"
+            "protocols/substreams/ethereum-curve"
+            "protocols/substreams/ethereum-sfrax"
+            "protocols/substreams/ethereum-sfraxeth"
+            "protocols/substreams/ethereum-uniswap-v4"
+            "protocols/testing"
+          )
+          for ws in "${WORKSPACES[@]}"; do
+            echo "::group::cargo update in $ws"
+            (cd "$ws" && cargo update)
+            echo "::endgroup::"
+          done
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet -- '**/Cargo.lock'; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No lockfile changes detected."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Lockfile changes detected."
+          fi
+
+      - name: Check crate ages and collect too-recent crates
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          mkdir -p /tmp/young-crates
+          while IFS= read -r -d '' lock; do
+            old="/tmp/old-locks/$lock"
+            if [[ -f "$old" ]]; then
+              outfile="/tmp/young-crates/$(echo "$lock" | tr '/' '_').txt"
+              echo "::group::Checking $lock"
+              # Exit code 2 means some crates are too recent (written to outfile)
+              .github/scripts/check-crate-ages.sh "$old" "$lock" "$outfile" "$MIN_CRATE_AGE_DAYS" || true
+              echo "::endgroup::"
+            fi
+          done < <(find . -name Cargo.lock -not -path '*/target/*' -print0)
+
+      - name: Pin back too-recent crates
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          WORKSPACES=(
+            "."
+            "protocols/substreams"
+            "protocols/substreams/ethereum-ambient"
+            "protocols/substreams/ethereum-balancer-v3"
+            "protocols/substreams/ethereum-curve"
+            "protocols/substreams/ethereum-sfrax"
+            "protocols/substreams/ethereum-sfraxeth"
+            "protocols/substreams/ethereum-uniswap-v4"
+            "protocols/testing"
+          )
+          # Collect all unique "crate old_version" pairs across lockfiles
+          pinlist=$(cat /tmp/young-crates/*.txt 2>/dev/null | sort -u || true)
+          if [[ -z "$pinlist" ]]; then
+            echo "No too-recent crates to pin back."
+            exit 0
+          fi
+          echo "Pinning back too-recent crates:"
+          echo "$pinlist"
+          while IFS=' ' read -r crate old_version; do
+            for ws in "${WORKSPACES[@]}"; do
+              echo "::group::Pin ${crate}@${old_version} in $ws"
+              (cd "$ws" && cargo update -p "$crate" --precise "$old_version") || true
+              echo "::endgroup::"
+            done
+          done <<< "$pinlist"
+
+      - name: Re-check for changes after pinning
+        if: steps.changes.outputs.changed == 'true'
+        id: final-changes
+        run: |
+          if git diff --quiet -- '**/Cargo.lock'; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No lockfile changes remain after pinning."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build PR body
+        if: steps.final-changes.outputs.changed == 'true'
+        id: pr-body
+        run: |
+          pinlist=$(cat /tmp/young-crates/*.txt 2>/dev/null | sort -u || true)
+          body="Automated biweekly \`cargo update\` across all workspace lockfiles."
+          body="${body}"$'\n\n'"All updated crates have been verified to be at least ${MIN_CRATE_AGE_DAYS} days old (supply chain safety check)."
+          if [[ -n "$pinlist" ]]; then
+            body="${body}"$'\n\n'"**Skipped (published <${MIN_CRATE_AGE_DAYS} days ago, pinned to previous version):**"
+            while IFS=' ' read -r crate old_version; do
+              body="${body}"$'\n'"- \`${crate}\` pinned at \`${old_version}\`"
+            done <<< "$pinlist"
+          fi
+          # Write to file to avoid escaping issues
+          echo "$body" > /tmp/pr-body.md
+
+      - name: Create pull request
+        if: steps.final-changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e  # v7.0.8
+        with:
+          branch: chore/cargo-update
+          commit-message: "chore(deps): run cargo update"
+          title: "chore(deps): biweekly cargo update"
+          body-path: /tmp/pr-body.md
+          labels: dependencies
+          delete-branch: true

--- a/.github/workflows/cargo-update.yaml
+++ b/.github/workflows/cargo-update.yaml
@@ -41,7 +41,9 @@ jobs:
           while IFS= read -r -d '' lock; do
             ws=$(dirname "$lock")
             echo "::group::cargo update in $ws"
-            (cd "$ws" && cargo update)
+            if ! (cd "$ws" && cargo update); then
+              echo "::warning::cargo update failed in $ws, skipping"
+            fi
             echo "::endgroup::"
           done < <(find . -name Cargo.lock -not -path '*/target/*' -print0)
 
@@ -110,9 +112,9 @@ jobs:
           body="Automated biweekly \`cargo update\` across all workspace lockfiles."
           body="${body}"$'\n\n'"All updated crates have been verified to be at least ${MIN_CRATE_AGE_DAYS} days old (supply chain safety check)."
           if [[ -n "$pinlist" ]]; then
-            body="${body}"$'\n\n'"**Skipped (published <${MIN_CRATE_AGE_DAYS} days ago, pinned to previous version):**"
-            while IFS=' ' read -r crate old_version; do
-              body="${body}"$'\n'"- \`${crate}\` pinned at \`${old_version}\`"
+            body="${body}"$'\n\n'"**Pinned (latest release <${MIN_CRATE_AGE_DAYS} days old, using latest safe version):**"
+            while IFS=' ' read -r crate safe_version; do
+              body="${body}"$'\n'"- \`${crate}\` pinned at \`${safe_version}\`"
             done <<< "$pinlist"
           fi
           # Write to file to avoid escaping issues

--- a/.github/workflows/ci-substreams.yaml
+++ b/.github/workflows/ci-substreams.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'protocols/substreams/**'
+      - '!**/Cargo.lock'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
  - Add a scheduled GitHub Actions workflow that runs `cargo update` across all workspace lockfiles biweekly (1st and 15th of each month)                                                                    
  - Include a safety check: a script queries crates.io to verify every updated crate was published at least 3 days ago. Too recent crates are pinned to the latest safe version instead of being reverted to the old lockfile version                                                                                                                                                                      
  - The workflow auto-creates a PR scoped to only `Cargo.lock` file changes                                                                                                                                
  - Exclude `Cargo.lock` from the substreams CI trigger path to avoid unnecessary CI runs on dependency-only updates  