### PR TITLE
fix: Don't allow Curve tokens to be zero address

### DIFF
--- a/crates/tycho-execution/contracts/src/executors/CurveExecutor.sol
+++ b/crates/tycho-execution/contracts/src/executors/CurveExecutor.sol
@@ -12,6 +12,7 @@ import {TychoRouter} from "../TychoRouter.sol";
 
 error CurveExecutor__AddressZero();
 error CurveExecutor__InvalidDataLength();
+error CurveExecutor__TokenAddressZero();
 
 interface CryptoPool {
     function exchange(uint256 i, uint256 j, uint256 dx, uint256 minDy)
@@ -121,6 +122,9 @@ contract CurveExecutor is IExecutor {
     {
         tokenIn = address(bytes20(data[0:20]));
         tokenOut = address(bytes20(data[20:40]));
+        if (tokenIn == address(0) || tokenOut == address(0)) {
+            revert CurveExecutor__TokenAddressZero();
+        }
         pool = address(bytes20(data[40:60]));
         poolType = uint8(data[60]);
         i = int128(uint128(uint8(data[61])));
@@ -149,6 +153,9 @@ contract CurveExecutor is IExecutor {
     {
         tokenIn = address(bytes20(data[0:20]));
         tokenOut = address(bytes20(data[20:40]));
+        if (tokenIn == address(0) || tokenOut == address(0)) {
+            revert CurveExecutor__TokenAddressZero();
+        }
         if (tokenIn == nativeToken) {
             // ETH transfers are handled in the Executor, so we need to set the transferType to TransferNativeInExecutor
             // to update the delta accounting accordingly.

--- a/crates/tycho-execution/contracts/test/protocols/Curve.t.sol
+++ b/crates/tycho-execution/contracts/test/protocols/Curve.t.sol
@@ -101,6 +101,24 @@ contract CurveExecutorTest is Test, TestUtils, Constants {
         assertEq(outputToRouter, true);
     }
 
+    function testRevertTokenInAddressZero() public {
+        bytes memory data = abi.encodePacked(
+            address(0), USDC_ADDR, TRICRYPTO_POOL, uint8(3), uint8(2), uint8(0)
+        );
+
+        vm.expectRevert(CurveExecutor__TokenAddressZero.selector);
+        curveExecutorExposed.swap(1 ether, data, ALICE);
+    }
+
+    function testRevertTokenOutAddressZero() public {
+        bytes memory data = abi.encodePacked(
+            WETH_ADDR, address(0), TRICRYPTO_POOL, uint8(3), uint8(2), uint8(0)
+        );
+
+        vm.expectRevert(CurveExecutor__TokenAddressZero.selector);
+        curveExecutorExposed.swap(1 ether, data, ALICE);
+    }
+
     function testTriPool() public {
         // Swapping DAI -> USDC on TriPool 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7
         uint256 amountIn = 1 ether;


### PR DESCRIPTION
In the CurveExecutor , tokenIn is turned into address(0) if it matches nativeToken. Same for tokenOut. However, both tokenIn and tokenOut can also be set to address(0) directly. This could have produced the situation where tokenIn = address(0) and transferType = ProtocolWillDebit.