### PR TITLE
feat: use local workspace deps for substreams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9751,15 +9751,15 @@ dependencies = [
 
 [[package]]
 name = "tycho-substreams"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6381b4b9443e767339412f1fdfc8a2dff208563ba8901d9b5181ac148b6064b"
+version = "0.8.0"
 dependencies = [
+ "base64 0.22.1",
  "ethabi 18.0.0",
  "hex",
  "itertools 0.12.1",
  "num-bigint",
  "prost 0.11.9",
+ "rstest 0.24.0",
  "serde",
  "serde_json",
  "substreams",

--- a/crates/tycho-indexer/Cargo.toml
+++ b/crates/tycho-indexer/Cargo.toml
@@ -78,7 +78,7 @@ mini-moka = "0.10.3"
 num-bigint = "0.4.4"
 num-traits = "0.2.19"
 num_cpus = "1.16.0"
-tycho-substreams = "0.6.0"
+tycho-substreams = { path = "../../protocols/substreams/crates/tycho-substreams" }
 rand.workspace = true
 alloy = { workspace = true, default-features = false, features = [
     "sol-types",

--- a/protocols/substreams/Cargo.toml
+++ b/protocols/substreams/Cargo.toml
@@ -26,6 +26,10 @@ members = [
 ]
 resolver = "2"
 
+[workspace.dependencies]
+substreams-helper = { path = "crates/substreams-helper" }
+tycho-substreams = { path = "crates/tycho-substreams" }
+
 [profile.release]
 lto = true
 opt-level = 's'

--- a/protocols/substreams/base-aerodrome-slipstreams/Cargo.toml
+++ b/protocols/substreams/base-aerodrome-slipstreams/Cargo.toml
@@ -14,8 +14,8 @@ prost = "0.11"
 ethabi = "18.0.0"
 anyhow = "1.0.75"
 hex-literal = "0.4.1"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
+substreams-helper.workspace = true
+tycho-substreams.workspace = true
 num-bigint = "0.4.4"
 hex = "0.4.3"
 tiny-keccak = "2.0"

--- a/protocols/substreams/ethereum-ambient/Cargo.toml
+++ b/protocols/substreams/ethereum-ambient/Cargo.toml
@@ -8,7 +8,7 @@ name = "ethereum_ambient"
 crate-type = ["cdylib"]
 
 [dependencies]
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "52d5021" }
+tycho-substreams.workspace = true
 substreams = "0.5.22"
 substreams-ethereum = "0.9.9"
 prost = "0.11"

--- a/protocols/substreams/ethereum-balancer-v2/Cargo.toml
+++ b/protocols/substreams/ethereum-balancer-v2/Cargo.toml
@@ -15,7 +15,7 @@ hex = "0.4.3"
 anyhow = "1.0.75"
 num-bigint = "0.4.4"
 itertools = "0.12.0"
-tycho-substreams = "0.5.1"
+tycho-substreams.workspace = true
 
 [build-dependencies]
 anyhow = "1"

--- a/protocols/substreams/ethereum-balancer-v3/Cargo.toml
+++ b/protocols/substreams/ethereum-balancer-v3/Cargo.toml
@@ -18,7 +18,7 @@ hex = "0.4.3"
 bytes = "1.5.0"
 anyhow = "1.0.75"
 num-bigint = "0.4.4"
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "51995f9" }
+tycho-substreams.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_qs = "0.13.0"
 itertools = "0.13.0"

--- a/protocols/substreams/ethereum-curve/Cargo.toml
+++ b/protocols/substreams/ethereum-curve/Cargo.toml
@@ -18,7 +18,7 @@ hex = "0.4.3"
 bytes = "1.5.0"
 anyhow = "1.0.75"
 num-bigint = "0.4.4"
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "655fae7" }
+tycho-substreams.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_qs = "0.13.0"
 itertools = "0.13.0"

--- a/protocols/substreams/ethereum-ekubo-v2/Cargo.toml
+++ b/protocols/substreams/ethereum-ekubo-v2/Cargo.toml
@@ -10,8 +10,8 @@ crate-type = ["cdylib"]
 [dependencies]
 substreams = "0.5.22"
 substreams-ethereum = "0.9.9"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
+substreams-helper.workspace = true
+tycho-substreams.workspace = true
 prost = "0.11"
 anyhow = "1.0.95"
 ethabi = "18.0.0"

--- a/protocols/substreams/ethereum-erc4626/Cargo.toml
+++ b/protocols/substreams/ethereum-erc4626/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 substreams = "0.5.22"
 substreams-ethereum = "0.9.9"
 prost = "0.11"
-tycho-substreams = "0.8.0"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.5.0" }
+tycho-substreams.workspace = true
+substreams-helper.workspace = true
 anyhow = "1.0.95"
 ethabi = "18.0.0"
 num-bigint = "0.4.6"

--- a/protocols/substreams/ethereum-fluid/Cargo.toml
+++ b/protocols/substreams/ethereum-fluid/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 substreams = "0.5.22"
 substreams-ethereum = "0.9.9"
 prost = "0.11"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
-tycho-substreams = "0.5.1"
+substreams-helper.workspace = true
+tycho-substreams.workspace = true
 anyhow = "1.0.95"
 ethabi = "18.0.0"
 num-bigint = "0.4.6"

--- a/protocols/substreams/ethereum-lido/Cargo.toml
+++ b/protocols/substreams/ethereum-lido/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 substreams = "0.5.22"
 substreams-ethereum = "0.9.9"
 prost = "0.11"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.5.0" }
-tycho-substreams = "0.6.0"
+substreams-helper.workspace = true
+tycho-substreams.workspace = true
 anyhow = "1.0.95"
 ethabi = "18.0.0"
 num-bigint = "0.4.6"

--- a/protocols/substreams/ethereum-maverick-v2/Cargo.toml
+++ b/protocols/substreams/ethereum-maverick-v2/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 substreams = "0.5.22"
 substreams-ethereum = "0.9.9"
 prost = "0.11"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "52d5021" }
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "52d5021" }
+substreams-helper.workspace = true
+tycho-substreams.workspace = true
 anyhow = "1.0.95"
 ethabi = "18.0.0"
 num-bigint = "0.4.6"

--- a/protocols/substreams/ethereum-pancakeswap-v3/Cargo.toml
+++ b/protocols/substreams/ethereum-pancakeswap-v3/Cargo.toml
@@ -14,8 +14,8 @@ prost = "0.11"
 ethabi = "18.0.0"
 anyhow = "1.0.75"
 hex-literal = "0.4.1"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
+substreams-helper.workspace = true
+tycho-substreams.workspace = true
 num-bigint = "0.4.4"
 hex = "0.4.3"
 tiny-keccak = "2.0"

--- a/protocols/substreams/ethereum-sfrax/Cargo.toml
+++ b/protocols/substreams/ethereum-sfrax/Cargo.toml
@@ -17,7 +17,7 @@ prost-types = "0.11"
 substreams = "0.5.22"
 substreams-ethereum = "0.9.9"
 hex = "0.4.3"
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "52d5021" }
+tycho-substreams.workspace = true
 itertools = "0.12.0"
 anyhow = "1.0.75"
 

--- a/protocols/substreams/ethereum-sfraxeth/Cargo.toml
+++ b/protocols/substreams/ethereum-sfraxeth/Cargo.toml
@@ -17,7 +17,7 @@ prost-types = "0.11"
 substreams = "0.5.22"
 substreams-ethereum = "0.9.9"
 hex = "0.4.3"
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "52d5021" }
+tycho-substreams.workspace = true
 itertools = "0.12.0"
 anyhow = "1.0.75"
 

--- a/protocols/substreams/ethereum-template-factory/Cargo.toml
+++ b/protocols/substreams/ethereum-template-factory/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 substreams = "0.5.22"
 substreams-ethereum = "0.9.9"
 prost = "0.11"
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "52d5021" }
+tycho-substreams.workspace = true
 anyhow = "1.0.95"
 ethabi = "18.0.0"
 num-bigint = "0.4.6"

--- a/protocols/substreams/ethereum-template-singleton/Cargo.toml
+++ b/protocols/substreams/ethereum-template-singleton/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 substreams = "0.5.22"
 substreams-ethereum = "0.9.9"
 prost = "0.11"
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "52d5021" }
+tycho-substreams.workspace = true
 anyhow = "1.0.95"
 ethabi = "18.0.0"
 num-bigint = "0.4.6"

--- a/protocols/substreams/ethereum-uniswap-v2/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v2/Cargo.toml
@@ -14,8 +14,8 @@ prost = "0.11"
 ethabi = "18.0.0"
 anyhow = "1.0.75"
 hex-literal = "0.4.1"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
+substreams-helper.workspace = true
+tycho-substreams.workspace = true
 num-bigint = "0.4.4"
 itertools = "0.12.1"
 serde_qs = "0.13.0"

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/Cargo.toml
@@ -14,8 +14,8 @@ prost = "0.11"
 ethabi = "18.0.0"
 anyhow = "1.0.75"
 hex-literal = "0.4.1"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
+substreams-helper.workspace = true
+tycho-substreams.workspace = true
 num-bigint = "0.4.4"
 hex = "0.4.3"
 tiny-keccak = "2.0"

--- a/protocols/substreams/ethereum-uniswap-v3/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v3/Cargo.toml
@@ -14,8 +14,8 @@ prost = "0.11"
 ethabi = "18.0.0"
 anyhow = "1.0.75"
 hex-literal = "0.4.1"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
+substreams-helper.workspace = true
+tycho-substreams.workspace = true
 num-bigint = "0.4.4"
 hex = "0.4.3"
 tiny-keccak = "2.0"

--- a/protocols/substreams/ethereum-uniswap-v4/no-hooks/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v4/no-hooks/Cargo.toml
@@ -14,8 +14,8 @@ prost = "0.11"
 ethabi = "18.0.0"
 anyhow = "1.0.75"
 hex-literal = "0.4.1"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.5.0" }
-tycho-substreams =  "0.6.0"
+substreams-helper.workspace = true
+tycho-substreams.workspace = true
 num-bigint = "0.4.4"
 hex = "0.4.3"
 tiny-keccak = "2.0"

--- a/protocols/substreams/ethereum-uniswap-v4/shared/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v4/shared/Cargo.toml
@@ -14,8 +14,8 @@ prost = "0.11"
 ethabi = "18.0.0"
 anyhow = "1.0.75"
 hex-literal = "0.4.1"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.5.0" }
-tycho-substreams = "0.6.0"
+substreams-helper.workspace = true
+tycho-substreams.workspace = true
 num-bigint = "0.4.4"
 hex = "0.4.3"
 tiny-keccak = "2.0"

--- a/protocols/substreams/ethereum-uniswap-v4/with-hooks/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v4/with-hooks/Cargo.toml
@@ -14,8 +14,8 @@ prost = "0.11"
 ethabi = "18.0.0"
 anyhow = "1.0.75"
 hex-literal = "0.4.1"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.5.0" }
-tycho-substreams = "0.6.0"
+substreams-helper.workspace = true
+tycho-substreams.workspace = true
 num-bigint = "0.4.4"
 hex = "0.4.3"
 tiny-keccak = "2.0"


### PR DESCRIPTION
# Do not review yet

Replace all git-pinned and crates.io references with workspace path dependencies now that both crates live in the monorepo.