### PR TITLE
docs: update and create claude docs after monorepo merge

### DIFF
--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -1,14 +1,14 @@
-<!-- docs-synced-at: 58d9900b -->
+<!-- docs-synced-at: d7e677248c7d5bc6e340404eb823fac9445c6e0a -->
 # Tycho Codebase Guide
 
-Low-latency, reorg-aware indexer that streams DEX liquidity state from on-chain data to solvers.
+Low-latency, reorg-aware indexer that streams DEX liquidity state from on-chain data to consumers.
 
 ## What is Tycho
 
 Tycho indexes EVM blockchain state for DeFi protocols. It consumes Substreams (blockchain data
 pipelines), processes fork-aware messages through extractors, persists finalized state to Postgres,
 and serves real-time deltas over WebSocket plus snapshots over HTTP RPC. Consumers reconstruct
-protocol component state to simulate swaps.
+protocol component state for simulation, pricing, and execution.
 
 Key properties:
 - **Reorg-aware**: blocks stay in a memory buffer until finalized; reverts never reach the DB
@@ -18,43 +18,60 @@ Key properties:
 
 ## Workspace Module Map
 
-### Shared Domain
+The monorepo is organized into four layers: **Foundation** (shared types), **Indexer** (on-chain data
+pipeline), **Simulation & Execution** (solver tooling), and **Consumer SDK** (connecting to Tycho).
+Protocol Substreams modules live under `protocols/` as a separate WASM workspace.
+
+### Foundation
 
 | Crate | Description |
 |---|---|
-| [`tycho-common`](../tycho-common/CLAUDE.md) | Domain types (`Chain`, `Block`, `ProtocolComponent`, `Token`), DTOs, async gateway/extraction traits, simulation abstractions (`SwapQuoter`) |
+| [`tycho-common`](../crates/tycho-common/CLAUDE.md) | Domain types (`Chain`, `Block`, `ProtocolComponent`, `Token`), DTOs, async gateway/extraction traits, simulation abstractions (`SwapQuoter`) |
+| `tycho` | Meta-crate re-exporting a compatible, versioned set of ecosystem crates for downstream consumers |
 
-**Features**: `diesel` (Diesel derives), `test-utils` (mockall mocks).
+**Features on `tycho-common`**: `diesel` (Diesel derives), `test-utils` (mockall mocks).
 
-### Ingestion & Extraction
+### Indexer
 
 | Crate / Module | Description |
 |---|---|
-| [`tycho-indexer/extractor`](../tycho-indexer/CLAUDE.md) | `ProtocolExtractor` processes Substreams messages, `ReorgBuffer` handles finality, `ProtocolMemoryCache` for in-process state, DCI plugin for VM tracing |
-| [`tycho-ethereum`](../tycho-ethereum/CLAUDE.md) | Ethereum RPC client (alloy), `AccountExtractor`, `TokenPreProcessor`, `TokenAnalyzer`, `EntryPointTracer` |
+| [`tycho-indexer/extractor`](../crates/tycho-indexer/CLAUDE.md) | `ProtocolExtractor` processes Substreams messages, `ReorgBuffer` handles finality, `ProtocolMemoryCache` for in-process state, DCI plugin for VM tracing |
+| [`tycho-indexer/services`](../crates/tycho-indexer/CLAUDE.md) | HTTP RPC endpoints, WebSocket broadcaster, `PendingDeltasBuffer` for RPC consistency, access control, plan restrictions, compression |
+| [`tycho-ethereum`](../crates/tycho-ethereum/CLAUDE.md) | Ethereum RPC client (alloy), `AccountExtractor`, `TokenPreProcessor`, `TokenAnalyzer`, `EntryPointTracer` |
+| [`tycho-storage`](../crates/tycho-storage/CLAUDE.md) | Postgres backend (Diesel): `CachedGateway` (buffered writes), `DirectGateway` (testing), temporal versioning, FK-safe write ordering |
 
-### Services (HTTP + WS)
-
-| Crate / Module | Description |
-|---|---|
-| [`tycho-indexer/services`](../tycho-indexer/CLAUDE.md) | HTTP RPC endpoints, WebSocket broadcaster, `PendingDeltasBuffer` for RPC consistency, access control, plan restrictions, compression |
-
-### Storage
+### Simulation & Execution
 
 | Crate | Description |
 |---|---|
-| [`tycho-storage`](../tycho-storage/CLAUDE.md) | Postgres backend (Diesel): `CachedGateway` (buffered writes), `DirectGateway` (testing), temporal versioning, FK-safe write ordering |
+| `tycho-simulation` | DEX swap simulation library: protocol-specific state machines (`ProtocolSim`) for 20+ DEXs; `evm` module for EVM storage-based protocols, `protocol` module for custom implementations, `rfq` for request-for-quote protocols |
+| `tycho-execution` | Swap encoding and execution: Solidity TychoRouter contract + Rust encoding library; multi-hop swaps with fee-taking, vault-based accounting, delegatecall executor dispatch |
 
-### Consumer
+### Consumer SDK
 
 | Crate | Description |
 |---|---|
-| [`tycho-client`](../tycho-client/CLAUDE.md) | Rust library + CLI: `TychoStreamBuilder`, snapshot+delta sync, block alignment across extractors, TVL/ID filtering |
-| `tycho-client-py` | Python bindings (maturin/PyO3) wrapping tycho-client |
+| [`tycho-client`](../crates/tycho-client/CLAUDE.md) | Rust library + CLI: `TychoStreamBuilder`, snapshot+delta sync, block alignment across extractors, TVL/ID filtering |
+| `tycho-client-py` | Python bindings (maturin/PyO3) wrapping tycho-client (separate workspace, not a `[workspace.members]` entry) |
 
-### End-to-End Data Flow
+### Protocols
 
-#### Ingestion
+| Path | Description |
+|---|---|
+| `protocols/substreams/` | Substreams modules (WASM) producing the protobuf messages consumed by `tycho-indexer`; **separate WASM workspace** with its own toolchain — not in `[workspace.members]` |
+| `protocols/testing/` (`protocol-testing`) | Simulation accuracy test harness: runs protocol state through `tycho-simulation` and compares against on-chain results |
+| `protocols/adapter-integration/` | EVM adapter integration tests |
+
+### Testing Infrastructure
+
+| Crate | Description |
+|---|---|
+| `tycho-test` | Shared test helpers and fixtures used across crates |
+| `tycho-integration-test` | End-to-end integration runner: subscribes to a live Tycho instance, syncs protocol state via `tycho-client`, and validates simulation accuracy against on-chain prices |
+
+## End-to-End Data Flow
+
+### Ingestion
 
 1. Substreams gRPC delivers `BlockScopedData` (protobuf) to `ProtocolExtractor`
 2. `ProtocolExtractor` deserializes into `BlockChanges` (tx-level state/balance/token deltas)
@@ -67,7 +84,7 @@ Key properties:
 5. DB write via `CachedGateway` → Postgres (upsert blocks, tokens, components, state, balances); sets `db_committed_block_height` on outgoing message
 6. Broadcast `BlockAggregatedChanges` on internal channel (all blocks, including pending/non-committed)
 
-#### Server
+### Server
 
 7. WebSocket subscribers (`services/ws.rs`) receive broadcast directly; revert flag signals chain reorg
 8. `PendingDeltasBuffer` (`services/deltas_buffer.rs`) receives broadcast
@@ -75,7 +92,7 @@ Key properties:
    - Auto-drains blocks ≤ `db_committed_block_height` (already in DB, no longer "pending")
    - RPC handlers query DB snapshot + pending deltas = consistent view of latest state
 
-#### Client (tycho-client)
+### Client (tycho-client)
 
 9. `StateSynchronizer` (one per extractor subscription):
    - Subscribes to WebSocket stream via `WsDeltasClient`
@@ -85,6 +102,17 @@ Key properties:
     - Tracks state per synchronizer: `Ready` / `Delayed` / `Stale`
     - Delayed synchronizers consume buffered messages to catch up
     - When all synchronizers reach the same block: emits `FeedMessage` (unified view of all protocol state at that block) to consumer
+
+### Simulation & Execution (tycho-simulation / tycho-execution)
+
+11. Consumer applies `FeedMessage` deltas to in-memory `ProtocolSim` instances (one per component)
+    - Custom protocols: update decoded state fields directly
+    - VM protocols: patch EVM storage slots, code, balances in a local `SimulationDB`
+12. Consumer queries `ProtocolSim::get_amount_out` / `spot_price` to price swap routes
+13. `tycho-execution` encodes a chosen route into calldata for `TychoRouter`
+    - Selects the appropriate executor contract for each DEX hop
+    - Constructs `SwapSequence` with per-hop amounts, tokens, and executor addresses
+14. Consumer submits the encoded transaction to the chain via `TychoRouter.swap()`
 
 ## Key Architectural Patterns
 
@@ -141,7 +169,7 @@ Configurable via `EXTRACTION_WORKER_THREADS` (default 2) and `MAIN_WORKER_THREAD
 |---|---|
 | `index` | Run all extractors from `extractors.yaml` + HTTP/WS server |
 | `run` | Run a single extractor (testing / debugging) |
-| `analyze-tokens` | Token quality analysis cron job |
+| `analyze-tokens` | Token quality analysis cron job; accepts `--settlement-contract <ADDRESS>` (default: CoW Swap settlement `0xc9f2e6ea1637E499406986ac50ddC92401ce1f58`) |
 | `rpc` | HTTP RPC server only (no extractors) |
 
 ### Feature flags
@@ -162,8 +190,3 @@ No other crate-level features. Runtime behavior controlled via CLI args, env var
 - Lint: `cargo clippy --workspace --lib --all-targets --all-features`
 - Format: `cargo +nightly fmt --check`
 
-## Related Repositories
-
-- **tycho-protocol-sdk**: Substreams modules producing the protobuf messages Tycho consumes
-- **tycho-simulation**: Protocol-specific swap simulators (consumed via tycho-client)
-- **tycho-execution**: Swap encoding and execution against Tycho router contracts

--- a/.claude/knowledge/solidity.md
+++ b/.claude/knowledge/solidity.md
@@ -13,7 +13,9 @@ forge fmt --check                # format check (CI)
 forge snapshot                   # update gas snapshots
 ```
 
-Static analysis:
+Static analysis (requires Python env — see
+[contributing guidelines](https://docs.propellerheads.xyz/tycho/for-dexs/protocol-integration/contributing-guidelines#contract-analysis)
+for setup):
 
 ```bash
 slither .                        # run from contracts/
@@ -26,14 +28,18 @@ After a task is done, run the `/run-ci` skill. It runs the Foundry CI checks mat
 
 ### Naming
 
-- Private/internal state variables prefixed with underscore: `_feeCalculator`, `_ALLOWED_DUST`
-- Custom errors are contract-prefixed: `TychoRouter__EmptySwaps`, `Vault__AmountZero`
-- Transient storage slot constants use `keccak256` of a descriptive name string
+- Private/internal state variables: prefixed `_`: `_feeCalculator`, `_ALLOWED_DUST`
+- Input parameters that clash with a state variable: suffixed `_`: `token_`, `amount_`
+- Public variables and non-clashing parameters: no prefix or suffix
+- Custom errors: contract-prefixed with double underscore: `TychoRouter__EmptySwaps`, `Vault__AmountZero`
+- Transient storage slot constants: `keccak256` of a descriptive name string
 
 ### Formatting
 
 - `forge fmt` enforced in CI; line length 80 chars
 - Suppress Slither false positives with `// slither-disable-next-line` and a comment
+- Avoid assembly (`assembly { ... }`) unless there is no viable alternative — prefer high-level
+  Solidity
 
 ### Executor conventions
 
@@ -60,6 +66,5 @@ Rust-encoded calldata end-to-end.
 
 ## Project Config
 
-- EVM target: Cancun; `via_ir` enabled; optimizer 200 runs (default), 1000 runs (production)
 - Solidity dependencies managed as git submodules under `contracts/lib/` — always clone with
   `--recursive`

--- a/.claude/knowledge/solidity.md
+++ b/.claude/knowledge/solidity.md
@@ -1,0 +1,65 @@
+# Coding in Solidity (Foundry)
+
+## Commands
+
+During development, from `crates/tycho-execution/contracts/`:
+
+```bash
+forge build                      # compile
+forge test -vvv                  # run all tests (requires RPC_URL + BASE_RPC_URL)
+forge test -vvv --match-test foo # run a single test
+forge fmt                        # auto-format
+forge fmt --check                # format check (CI)
+forge snapshot                   # update gas snapshots
+```
+
+Static analysis:
+
+```bash
+slither .                        # run from contracts/
+```
+
+After a task is done, run the `/run-ci` skill. It runs the Foundry CI checks matching what
+`.github/workflows/ci-rust.yaml` does.
+
+## Coding Style
+
+### Naming
+
+- Private/internal state variables prefixed with underscore: `_feeCalculator`, `_ALLOWED_DUST`
+- Custom errors are contract-prefixed: `TychoRouter__EmptySwaps`, `Vault__AmountZero`
+- Transient storage slot constants use `keccak256` of a descriptive name string
+
+### Formatting
+
+- `forge fmt` enforced in CI; line length 80 chars
+- Suppress Slither false positives with `// slither-disable-next-line` and a comment
+
+### Executor conventions
+
+When adding an executor, hardcode `TransferType`, `tokenOut`, and `outputToRouter` in
+`getTransferData()` — do not make them encodable. Set `outputToRouter = true` if the protocol
+sends output to `msg.sender` rather than accepting a receiver param.
+
+`swap()` returns void and must not contain balance tracking, output transfers, or amount
+validation — the Dispatcher handles all of this via balance-diff. **Never use pool return
+values or callback arguments to determine transfer amounts.**
+
+## Testing
+
+- All tests inherit from `TychoRouterTestSetup.sol`
+- Test naming: `test<Description>` in Solidity
+- Fork tests require `RPC_URL` (Ethereum mainnet) and `BASE_RPC_URL` env vars
+
+### Cross-language integration tests
+
+Rust encoding tests call `write_calldata_to_file(test_identifier, hex_calldata)`, which appends
+`name:hex` lines to `contracts/test/assets/calldata.txt`. Solidity tests read that file via
+`loadCallDataFromFile(testName)` and execute the calldata against a mainnet fork. This verifies
+Rust-encoded calldata end-to-end.
+
+## Project Config
+
+- EVM target: Cancun; `via_ir` enabled; optimizer 200 runs (default), 1000 runs (production)
+- Solidity dependencies managed as git submodules under `contracts/lib/` — always clone with
+  `--recursive`

--- a/.claude/skills/run-ci/SKILL.md
+++ b/.claude/skills/run-ci/SKILL.md
@@ -7,7 +7,7 @@ user-invocable: true
 # Run CI Locally
 
 Run the same checks that GitHub Actions CI runs, locally, to catch failures before they hit the
-remote pipeline. The canonical commands live in `.github/workflows/ci.yaml`.
+remote pipeline. The canonical commands live in `.github/workflows/ci-rust.yaml`.
 
 ## Environment
 
@@ -23,7 +23,7 @@ Environment variables needed for DB tests can be configured in `.claude/settings
 ```
 
 DB tests require both `DATABASE_URL` set AND a running Postgres instance (see
-`tycho-storage/README.md` for setup). Tests marked `#[ignore]` require `RPC_URL` pointing to an
+`crates/tycho-storage/README.md` for setup). Tests marked `#[ignore]` require `RPC_URL` pointing to an
 Ethereum archive node with **debug APIs enabled** (Erigon, Reth with `--http.api debug`) —
 standard providers like Alchemy/Infura do not support `debug_storageRangeAt` and will cause
 failures. These tests are skipped unless `RPC_URL` is set.
@@ -57,13 +57,13 @@ If `DATABASE_URL` is not set, mark DB as unavailable:
 If `DATABASE_URL` IS set, run migrations to ensure the schema is up to date:
 
 ```bash
-diesel migration run --migration-dir ./tycho-storage/migrations
+diesel migration run --migration-dir ./crates/tycho-storage/migrations
 ```
 
 If migrations fail with "already exists" errors (stale schema), reset the database:
 
 ```bash
-diesel database reset --migration-dir ./tycho-storage/migrations
+diesel database reset --migration-dir ./crates/tycho-storage/migrations
 ```
 
 If the reset fails because other connections are active, terminate them first using `psql` then
@@ -84,8 +84,8 @@ checks run). Otherwise, map changed file patterns to check categories:
 
 | File pattern | Category |
 |---|---|
-| `tycho-*/src/**/*.rs`, `Cargo.toml`, `Cargo.lock` | `rust` |
-| `tycho-client-py/**` | `python` |
+| `crates/tycho-*/src/**/*.rs`, `Cargo.toml`, `Cargo.lock` | `rust` |
+| `crates/tycho-client-py/**` | `python` |
 | `.github/workflows/**` | `ci` (always run full) |
 
 If only `python` files changed, skip Rust format/clippy/tests entirely and only run Python checks.
@@ -190,7 +190,7 @@ To run the full suite including DB tests:
    a) Per-session:    export DATABASE_URL="postgres://postgres:mypassword@localhost:5431/tycho_indexer_0"
    b) Persistent:     Add to .claude/settings.local.json:
                       { "env": { "DATABASE_URL": "postgres://postgres:mypassword@localhost:5431/tycho_indexer_0" } }
-3. Run migrations:  diesel migration run --migration-dir ./tycho-storage/migrations
+3. Run migrations:  diesel migration run --migration-dir ./crates/tycho-storage/migrations
 4. Re-run:          /run-ci
 ```
 

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -61,11 +61,14 @@ This repo's documentation lives in two places:
 
 | File | Crate |
 |------|-------|
-| `tycho-indexer/CLAUDE.md` | Main indexer: extractors, services, RPC endpoints |
-| `tycho-common/CLAUDE.md` | Shared domain types, traits, simulation abstractions |
-| `tycho-storage/CLAUDE.md` | Postgres backend, temporal versioning, gateway structs |
-| `tycho-ethereum/CLAUDE.md` | Ethereum RPC, token analysis, entrypoint tracing |
-| `tycho-client/CLAUDE.md` | Consumer library: snapshot+delta sync, feed alignment |
+| `crates/tycho-indexer/CLAUDE.md` | Main indexer: extractors, services, RPC endpoints |
+| `crates/tycho-common/CLAUDE.md` | Shared domain types, traits, simulation abstractions |
+| `crates/tycho-storage/CLAUDE.md` | Postgres backend, temporal versioning, gateway structs |
+| `crates/tycho-ethereum/CLAUDE.md` | Ethereum RPC, token analysis, entrypoint tracing |
+| `crates/tycho-client/CLAUDE.md` | Consumer library: snapshot+delta sync, feed alignment |
+| `crates/tycho-execution/CLAUDE.md` | TychoRouter contracts + Rust encoding library |
+
+Note: `tycho-simulation` and `protocols/testing` do not yet have `CLAUDE.md` files.
 
 ## Process
 
@@ -92,39 +95,47 @@ it only reports discrepancies.
 > **Workspace entrypoint** (`.claude/CODEBASE.md`):
 > - Compare "Workspace Module Map" against actual crates in `Cargo.toml` `[workspace.members]`
 > - Compare feature flags table against each crate's `Cargo.toml` `[features]`
-> - Compare "End-to-End Data Flow" diagram against `tycho-indexer/src/extractor/protocol_extractor.rs`,
->   `tycho-indexer/src/services/`, and `tycho-client/src/feed/`
-> - Compare CLI commands table against `tycho-indexer/src/cli/`
+> - Compare "End-to-End Data Flow" diagram against `crates/tycho-indexer/src/extractor/protocol_extractor.rs`,
+>   `crates/tycho-indexer/src/services/`, and `crates/tycho-client/src/feed/`
+> - Compare CLI commands table against `crates/tycho-indexer/src/cli/`
 > - Compare env vars table against actual usage (search for `env::var` / `std::env`)
 > - Compare testing section against CI config (`.github/workflows/`)
 >
-> **tycho-indexer** (`tycho-indexer/CLAUDE.md`):
-> - Compare module map against `tycho-indexer/src/` directory tree
-> - Compare ProtocolExtractor description against `tycho-indexer/src/extractor/protocol_extractor.rs`
-> - Compare RPC endpoints table against `tycho-indexer/src/services/rpc.rs`
-> - Compare services/middleware listing against `tycho-indexer/src/services/middleware/`
-> - Compare DCI description against `tycho-indexer/src/extractor/dynamic_contract_indexer/`
+> **tycho-indexer** (`crates/tycho-indexer/CLAUDE.md`):
+> - Compare module map against `crates/tycho-indexer/src/` directory tree
+> - Compare ProtocolExtractor description against `crates/tycho-indexer/src/extractor/protocol_extractor.rs`
+> - Compare RPC endpoints table against `crates/tycho-indexer/src/services/rpc.rs`
+> - Compare services/middleware listing against `crates/tycho-indexer/src/services/middleware/`
+> - Compare DCI description against `crates/tycho-indexer/src/extractor/dynamic_contract_indexer/`
 >
-> **tycho-common** (`tycho-common/CLAUDE.md`):
-> - Compare module organisation against `tycho-common/src/` directory tree
-> - Compare trait abstractions against `tycho-common/src/storage/` and `tycho-common/src/traits/`
-> - Compare simulation module against `tycho-common/src/simulation/`
+> **tycho-common** (`crates/tycho-common/CLAUDE.md`):
+> - Compare module organisation against `crates/tycho-common/src/` directory tree
+> - Compare trait abstractions against `crates/tycho-common/src/storage.rs` and `crates/tycho-common/src/traits.rs`
+> - Compare simulation module against `crates/tycho-common/src/simulation/`
 > - Compare data flow diagram against actual inter-crate dependencies
 >
-> **tycho-storage** (`tycho-storage/CLAUDE.md`):
-> - Compare module map against `tycho-storage/src/postgres/` directory tree
-> - Compare write order against `DBCacheWriteExecutor` in `tycho-storage/src/postgres/cache.rs`
-> - Compare gateway descriptions against `tycho-storage/src/postgres/cache.rs` and `direct.rs`
+> **tycho-storage** (`crates/tycho-storage/CLAUDE.md`):
+> - Compare module map against `crates/tycho-storage/src/postgres/` directory tree
+> - Compare write order against `DBCacheWriteExecutor` in `crates/tycho-storage/src/postgres/cache.rs`
+> - Compare gateway descriptions against `crates/tycho-storage/src/postgres/cache.rs` and `direct.rs`
 >
-> **tycho-ethereum** (`tycho-ethereum/CLAUDE.md`):
-> - Compare module map against `tycho-ethereum/src/` directory tree
+> **tycho-ethereum** (`crates/tycho-ethereum/CLAUDE.md`):
+> - Compare module map against `crates/tycho-ethereum/src/` directory tree
 > - Compare trait implementations table against actual `impl` blocks
-> - Compare entrypoint_tracer contents against `tycho-ethereum/src/services/entrypoint_tracer/`
+> - Compare entrypoint_tracer contents against `crates/tycho-ethereum/src/services/entrypoint_tracer/`
 >
-> **tycho-client** (`tycho-client/CLAUDE.md`):
-> - Compare module map against `tycho-client/src/` directory tree
+> **tycho-client** (`crates/tycho-client/CLAUDE.md`):
+> - Compare module map against `crates/tycho-client/src/` directory tree
 > - Compare connections diagram against actual struct relationships
-> - Compare sync lifecycle against `tycho-client/src/feed/synchronizer.rs`
+> - Compare sync lifecycle against `crates/tycho-client/src/feed/synchronizer.rs`
+>
+> **tycho-execution** (`crates/tycho-execution/CLAUDE.md`):
+> - Compare Solidity architecture against `crates/tycho-execution/contracts/`
+> - Compare Rust encoding module map against `crates/tycho-execution/src/` directory tree
+> - Compare swap flow description against actual contract entry points
+>
+> **tycho-simulation** (no CLAUDE.md yet — skip unless creating one):
+> - Note whether a CLAUDE.md is warranted given the crate's complexity; if so, flag it
 >
 > **Skill file paths**: Verify every source path referenced in `.claude/skills/sync-docs/SKILL.md` and
 > `.claude/skills/run-ci/SKILL.md` still exists.
@@ -145,17 +156,19 @@ that hash and HEAD to find changes that demand documentation updates.
 >
 > 1. Read the first line of `.claude/CODEBASE.md` to extract the commit hash from the `docs-synced-at` HTML comment
 >    (format: `<!-- docs-synced-at: <hash> -->`).
-> 2. Run `git log --oneline <hash>..HEAD -- tycho-indexer/src/ tycho-common/src/ tycho-storage/src/ tycho-ethereum/src/ tycho-client/src/`
+> 2. Run `git log --oneline <hash>..HEAD -- crates/tycho-indexer/src/ crates/tycho-common/src/ crates/tycho-storage/src/ crates/tycho-ethereum/src/ crates/tycho-client/src/ crates/tycho-simulation/src/ crates/tycho-execution/src/ protocols/testing/`
 >    to list all source-code commits since the last doc sync.
 > 3. For each commit (or group of related commits), run `git diff <hash> HEAD` on the relevant paths to understand what
 >    changed. Focus on:
->    - New or removed files/modules under any `tycho-*/src/` directory
->    - Changed trait definitions (added/removed/renamed methods) in `tycho-common/src/storage/` or `tycho-common/src/traits/`
+>    - New or removed files/modules under any `crates/tycho-*/src/` or `protocols/` directory
+>    - Changed trait definitions (added/removed/renamed methods) in `crates/tycho-common/src/storage.rs` or `crates/tycho-common/src/traits.rs`
+>    - Changed `ProtocolSim` trait in `crates/tycho-simulation/src/` or executor interfaces in `crates/tycho-execution/src/`
 >    - Changed struct/enum definitions (added/removed/renamed fields/variants)
->    - Changed RPC endpoints in `tycho-indexer/src/services/rpc.rs`
+>    - Changed RPC endpoints in `crates/tycho-indexer/src/services/rpc.rs`
 >    - Changed feature flags in any crate's `Cargo.toml`
->    - Changed CLI commands in `tycho-indexer/src/cli/`
+>    - Changed CLI commands in `crates/tycho-indexer/src/cli/`
 >    - Changed data flow or extraction pipeline logic
+>    - New DEX integrations added to `crates/tycho-simulation/src/protocol/` or `crates/tycho-execution/src/encoding/`
 > 4. For each change that affects something documented in `.claude/CODEBASE.md` or any `CLAUDE.md`, report:
 >    - The commit(s) that introduced the change
 >    - Which doc file is affected

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -67,8 +67,9 @@ This repo's documentation lives in two places:
 | `crates/tycho-ethereum/CLAUDE.md` | Ethereum RPC, token analysis, entrypoint tracing |
 | `crates/tycho-client/CLAUDE.md` | Consumer library: snapshot+delta sync, feed alignment |
 | `crates/tycho-execution/CLAUDE.md` | TychoRouter contracts + Rust encoding library |
+| `crates/tycho-simulation/CLAUDE.md` | DEX simulation library: native/VM/RFQ approaches, protocol implementations |
 
-Note: `tycho-simulation` and `protocols/testing` do not yet have `CLAUDE.md` files.
+Note: `protocols/testing` does not yet have a `CLAUDE.md` file.
 
 ## Process
 
@@ -134,8 +135,11 @@ it only reports discrepancies.
 > - Compare Rust encoding module map against `crates/tycho-execution/src/` directory tree
 > - Compare swap flow description against actual contract entry points
 >
-> **tycho-simulation** (no CLAUDE.md yet — skip unless creating one):
-> - Note whether a CLAUDE.md is warranted given the crate's complexity; if so, flag it
+> **tycho-simulation** (`crates/tycho-simulation/CLAUDE.md`):
+> - Compare module map against `crates/tycho-simulation/src/` directory tree
+> - Compare native protocol list against `crates/tycho-simulation/src/evm/protocol/` subdirectories
+> - Compare VM adapter description against `crates/tycho-simulation/src/evm/protocol/vm/`
+> - Compare features table against `crates/tycho-simulation/Cargo.toml` `[features]`
 >
 > **Skill file paths**: Verify every source path referenced in `.claude/skills/sync-docs/SKILL.md` and
 > `.claude/skills/run-ci/SKILL.md` still exists.

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -68,8 +68,9 @@ This repo's documentation lives in two places:
 | `crates/tycho-client/CLAUDE.md` | Consumer library: snapshot+delta sync, feed alignment |
 | `crates/tycho-execution/CLAUDE.md` | TychoRouter contracts + Rust encoding library |
 | `crates/tycho-simulation/CLAUDE.md` | DEX simulation library: native/VM/RFQ approaches, protocol implementations |
+| `crates/tycho-integration-test/CLAUDE.md` | Live integration validator: CLI binary, env vars, validation loop |
 
-Note: `protocols/testing` does not yet have a `CLAUDE.md` file.
+Note: `protocols/testing` does not have a `CLAUDE.md` file.
 
 ## Process
 
@@ -134,6 +135,11 @@ it only reports discrepancies.
 > - Compare Solidity architecture against `crates/tycho-execution/contracts/`
 > - Compare Rust encoding module map against `crates/tycho-execution/src/` directory tree
 > - Compare swap flow description against actual contract entry points
+>
+> **tycho-integration-test** (`crates/tycho-integration-test/CLAUDE.md`):
+> - Compare module map against `crates/tycho-integration-test/src/` directory tree
+> - Compare env vars / CLI args against `Cli` struct in `crates/tycho-integration-test/src/main.rs`
+> - Compare validation steps against actual logic in `stream_processor/`
 >
 > **tycho-simulation** (`crates/tycho-simulation/CLAUDE.md`):
 > - Compare module map against `crates/tycho-simulation/src/` directory tree

--- a/.claude/skills/sync-docs/SKILL.md
+++ b/.claude/skills/sync-docs/SKILL.md
@@ -70,7 +70,10 @@ This repo's documentation lives in two places:
 | `crates/tycho-simulation/CLAUDE.md` | DEX simulation library: native/VM/RFQ approaches, protocol implementations |
 | `crates/tycho-integration-test/CLAUDE.md` | Live integration validator: CLI binary, env vars, validation loop |
 
-Note: `protocols/testing` does not have a `CLAUDE.md` file.
+| `protocols/CLAUDE.md` | Index of sub-directories |
+| `protocols/substreams/CLAUDE.md` | WASM Substreams modules: layout, templates, release process |
+| `protocols/testing/CLAUDE.md` | Integration test runner: CLI, env vars |
+| `protocols/adapter-integration/CLAUDE.md` | Foundry VM adapter tests |
 
 ## Process
 
@@ -135,6 +138,12 @@ it only reports discrepancies.
 > - Compare Solidity architecture against `crates/tycho-execution/contracts/`
 > - Compare Rust encoding module map against `crates/tycho-execution/src/` directory tree
 > - Compare swap flow description against actual contract entry points
+>
+> **protocols** (`protocols/CLAUDE.md`, `protocols/substreams/CLAUDE.md`,
+> `protocols/testing/CLAUDE.md`, `protocols/adapter-integration/CLAUDE.md`):
+> - Compare substreams protocol list against `protocols/substreams/` subdirectories
+> - Compare adapter-integration protocol list against `protocols/adapter-integration/evm/src/` and `test/`
+> - Verify release tagging instructions still match `protocols/substreams/Readme.md`
 >
 > **tycho-integration-test** (`crates/tycho-integration-test/CLAUDE.md`):
 > - Compare module map against `crates/tycho-integration-test/src/` directory tree

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 When responding to user input, always log this information to the user which knowledge docs you have read. Only say yes
 if you actually read them. Respond like this:
 
-> Knowledge docs: Rust: [yes/no] , Python [yes/no], Version-control: [yes/no]
+> Knowledge docs: Rust: [yes/no], Python: [yes/no], Version-control: [yes/no], Solidity: [yes/no]
 > Files loaded in context: [list of loaded documents]
 
 By default, don't use the Explore agent as a first step in a conversation. The first step should always be to identify
@@ -24,6 +24,7 @@ you've exhausted the path of documentation.
 | Rust            | Writing, reviewing, or debugging Rust code                              | `.claude/knowledge/rust.md`            |
 | Version control | git, branch, commit, PR, push, rebase, merge, cherry-pick, tag, release | `.claude/knowledge/version_control.md` |
 | Python          | Python code, tycho-client-py, changes to dto.rs or rpc.rs              | `.claude/knowledge/python.md`          |
+| Solidity        | Solidity contracts, Foundry, forge, executors, tycho-execution          | `.claude/knowledge/solidity.md`        |
 
 When spawning subagents, pass the relevant knowledge document contents to them.
 

--- a/crates/tycho-client/CLAUDE.md
+++ b/crates/tycho-client/CLAUDE.md
@@ -31,6 +31,14 @@ TychoStreamBuilder (stream.rs)
 ## Sync Lifecycle
 
 1. `WsDeltasClient` subscribes; first message determines snapshot block
-2. `HttpRPCClient` fetches snapshot at that block; deltas buffer until it arrives
+2. `HttpRPCClient` fetches snapshot at that block; deltas buffer until it arrives.
+   When `partial_blocks` is enabled, components created on a partial block cannot be snapshotted
+   immediately — their snapshots are deferred (`deferred_snapshot_components`) until the first
+   message of the next block arrives, then fetched at the previous block's height.
 3. `BlockSynchronizer` waits for all synchronizers, then emits a `FeedMessage` per block
 4. Synchronizers classified as `Started | Ready | Delayed | Stale | Advanced | Ended`; stale ones are kept but skipped
+
+## CLI
+
+The `tycho-client` binary accepts `--blocklist-config <PATH>` pointing to a TOML file of the
+form `ids = ["0x...", ...]`. Components in that list are excluded from tracking.

--- a/crates/tycho-ethereum/CLAUDE.md
+++ b/crates/tycho-ethereum/CLAUDE.md
@@ -16,7 +16,12 @@ gas.rs                  BlockGasPrice / GasPrice (Legacy + EIP-1559) data types
 services/
   ├─ account_extractor.rs     Fetches code, balance, storage for accounts at a block height
   ├─ token_pre_processor.rs   Fetches symbol + decimals; gracefully handles non-standard tokens
-  ├─ token_analyzer.rs        Simulates token transfers via trace_callMany; classifies token quality
+  ├─ token_analyzer/
+  │    ├─ mod.rs              Public API; re-exports EthCallDetector (primary) and TraceCallDetector (deprecated)
+  │    ├─ ethcall_detector.rs EthCallDetector — simulates token transfers via eth_call with bytecode state overrides; works on all EVM chains
+  │    ├─ trace_detector.rs   TraceCallDetector — legacy trace_callMany approach; deprecated, use EthCallDetector
+  │    ├─ common.rs           Shared helpers (token quality classification, transfer cost parsing)
+  │    └─ bytecode.rs         Compiled bytecode + ABI for Analyzer and Forwarder Solidity contracts
   └─ entrypoint_tracer/
        ├─ tracer.rs                   Traces contract execution; returns access lists + state diffs
        ├─ slot_detector.rs            Detects ERC-20 storage slot layout via trace simulation

--- a/crates/tycho-integration-test/CLAUDE.md
+++ b/crates/tycho-integration-test/CLAUDE.md
@@ -1,0 +1,46 @@
+# tycho-integration-test
+
+Long-running binary (not a `cargo test` suite) that connects to a live Tycho instance, syncs
+protocol state via `tycho-client`, and continuously validates simulation accuracy against on-chain
+results. Exits after `--max-blocks` blocks, or runs indefinitely.
+
+## Running
+
+Requires three env vars (can be set in `.claude/settings.local.json`):
+
+| Variable | Purpose |
+|---|---|
+| `TYCHO_URL` | WebSocket endpoint of the Tycho server |
+| `TYCHO_API_KEY` | Auth key (`sampletoken` works against local dev instances) |
+| `RPC_URL` | Ethereum-compatible JSON-RPC endpoint for on-chain validation |
+
+```bash
+cargo run -p tycho-integration-test -- \
+  --chain ethereum \
+  --tycho-url ws://localhost:4242 \
+  --tvl-threshold 100
+```
+
+Key optional flags: `--disable-onchain`, `--disable-rfq`, `--protocols uniswap_v2,curve`,
+`--max-blocks 100`, `--parallel-simulations 5`, `--always-test-components <id,...>`.
+
+## Module Structure
+
+- **`main.rs`**: CLI (`Cli` struct), top-level orchestration loop — subscribes to Tycho,
+  dispatches blocks to stream processors, calls `poll_rpc_for_block` for on-chain comparison
+- **`stream_processor/`**:
+  - `protocol_stream_processor.rs`: Handles on-chain protocol updates — applies deltas to
+    `ProtocolSim` instances, runs `get_amount_out` simulations, validates via Tenderly execution
+  - `rfq_stream_processor.rs`: Handles RFQ protocol updates — fetches live quotes, compares
+    against simulation
+- **`statistics.rs`**: `TestStatistics` + `ProtocolStatistics` — per-protocol counters for
+  simulation success/failure, execution reverts, slippage, `get_limits` / `get_amount_out` calls
+- **`metrics.rs`**: Prometheus metrics (served on `--metrics-port`, default 9898)
+
+## What it validates
+
+For each block update, for a random sample of components (up to `--max-simulations`):
+1. `ProtocolSim::get_amount_out` — checks the simulation returns a non-zero output
+2. `ProtocolSim::get_limits` — checks token limits are non-zero
+3. Encodes a swap via `tycho-execution` and simulates it via Tenderly — checks it doesn't revert
+   and that on-chain output is within slippage tolerance of simulated output

--- a/crates/tycho-simulation/CLAUDE.md
+++ b/crates/tycho-simulation/CLAUDE.md
@@ -20,11 +20,16 @@ for any protocol indexed by Tycho.
 
 ## Simulation Approaches
 
-Order of preference when integrating a new protocol:
+**Always prefer native.** If a protocol's behaviour can be ported to Rust, it should be. VM is a
+fallback for protocols too complex to port, not a default.
 
-1. **Native** — pure Rust math; fastest, preferred for simple AMMs (Uniswap V2/V3 forks)
-2. **VM** — Solidity adapter in `revm`; works for any EVM protocol, slower
-3. **RFQ** — off-chain quotes via API; for protocols that can't be simulated on-chain
+1. **Native** — pure Rust math; fastest. Use whenever the protocol logic can be expressed in Rust.
+2. **Hybrid** — native Rust math for swap calculation, but reads/updates pool state via the local
+   VM (`SimulationDB`). Use when the swap logic can be ported but state is complex to track
+   independently. Example: Fluid V1.
+3. **VM** — Solidity adapter in `revm`; works for any EVM protocol but is slower and requires an
+   adapter contract in `protocols/adapter-integration/`. Use only when native is not feasible.
+4. **RFQ** — off-chain quotes via API; for protocols that cannot be simulated on-chain at all.
 
 ## Features
 

--- a/crates/tycho-simulation/CLAUDE.md
+++ b/crates/tycho-simulation/CLAUDE.md
@@ -1,0 +1,42 @@
+# tycho-simulation
+
+Off-chain DeFi protocol simulation library. Computes swap outputs, spot prices, and price impact
+for any protocol indexed by Tycho.
+
+## Key Modules (`src/`)
+
+- **`protocol/`**: Core traits and models — `ProtocolSim`, `ProtocolComponent`, `Update`
+- **`evm/simulation.rs`**: `SimulationEngine` — runs EVM transactions via `revm`
+- **`evm/engine_db/`**: Database backends (`SimulationDB` in-memory, `TychoDB` RPC-backed)
+- **`evm/stream.rs`**: Tycho feed integration — decodes live `FeedMessage` state into protocol
+  instances ready for simulation
+- **`evm/protocol/`**: Protocol implementations
+  - **Native** (`uniswap_v2/`, `uniswap_v3/`, `uniswap_v4/`, `ekubo/`, `cowamm/`, `fluid/`,
+    `aerodrome_v1/`, `aerodrome_slipstreams/`, `pancakeswap_v2/`, `etherfi/`, `erc4626/`,
+    `rocketpool/`, `cpmm/`, `clmm/`): Pure Rust math, no EVM execution
+  - **VM** (`vm/`): Generic Solidity adapter (`TychoSimulationContract`) executed in `revm` for
+    protocols without a native implementation
+- **`rfq/`**: RFQ client for off-chain market makers (WebSocket-based quote streaming)
+
+## Simulation Approaches
+
+Order of preference when integrating a new protocol:
+
+1. **Native** — pure Rust math; fastest, preferred for simple AMMs (Uniswap V2/V3 forks)
+2. **VM** — Solidity adapter in `revm`; works for any EVM protocol, slower
+3. **RFQ** — off-chain quotes via API; for protocols that can't be simulated on-chain
+
+## Features
+
+| Feature | Default | Contents |
+|---------|---------|----------|
+| `evm` | yes | `revm`, `SimulationEngine`, all EVM protocol impls |
+| `rfq` | yes | RFQ WebSocket client and protocol adapters |
+| `network_tests` | no | Gates tests that require live network access |
+
+## Conventions
+
+- `cargo +nightly fmt` for formatting; stable toolchain for everything else
+- `rstest`: name each parametrised case with `#[case::descriptive_name(...)]`
+- `network_tests` feature gates any test that hits external services — do not leave network calls
+  in tests without this gate

--- a/protocols/CLAUDE.md
+++ b/protocols/CLAUDE.md
@@ -1,0 +1,11 @@
+# protocols/
+
+On-chain protocol indexing: Substreams modules that extract state from the chain, and the
+tooling to test and validate those integrations. Each sub-directory has its own toolchain
+and workspace — see the relevant `CLAUDE.md` for details.
+
+| Directory | Description |
+|---|---|
+| [`substreams/`](substreams/CLAUDE.md) | WASM modules extracting on-chain state → protobuf for `tycho-indexer` |
+| [`testing/`](testing/CLAUDE.md) | End-to-end integration test runner for Substreams implementations |
+| [`adapter-integration/`](adapter-integration/CLAUDE.md) | Foundry fork tests for `tycho-execution` VM adapter contracts |

--- a/protocols/adapter-integration/CLAUDE.md
+++ b/protocols/adapter-integration/CLAUDE.md
@@ -1,0 +1,16 @@
+# protocols/adapter-integration/
+
+Foundry project containing Solidity integration tests for VM adapter contracts. Adapters are only
+needed for **VM protocol integrations** — they implement the on-chain interface used by
+`tycho-simulation` to execute swaps inside `revm`. Native protocol implementations do not require
+an adapter. 
+
+**Not a Rust workspace member** — run with `forge test` from `protocols/adapter-integration/evm/`.
+
+## Layout
+
+Organised by protocol under `evm/src/` and `evm/test/`:
+
+- `src/{protocol}/` — adapter contract source (angle, balancer-v2, balancer-v3, curve, etherfi,
+  integral, maverick-v2, sfrax, sfraxeth, uniswap-v2, template)
+- `test/{Protocol}Adapter.t.sol` — fork tests validating swap encoding and on-chain execution

--- a/protocols/substreams/CLAUDE.md
+++ b/protocols/substreams/CLAUDE.md
@@ -1,0 +1,27 @@
+# protocols/substreams/
+
+Substreams modules compiled to WASM that extract on-chain protocol state and emit protobuf
+messages consumed by `tycho-indexer`. **Separate WASM workspace** — not in root
+`[workspace.members]`. Build target: `wasm32-unknown-unknown`.
+
+## Layout
+
+One directory per protocol: `{chain}-{protocol}` (e.g. `ethereum-uniswap-v2`). Each contains:
+
+- `{name}.yaml` — manifest: package metadata, protobuf imports, module graph, initial block
+- `src/` — Rust map/store modules emitting `BlockChanges` / `EntityChanges` protobufs
+- `integration_test.tycho.yaml` — block range + assertions for `protocols/testing`
+
+## Adding a new protocol
+
+Copy `ethereum-template-factory` (pool-factory pattern) or `ethereum-template-singleton` (single
+contract) as a starting point. Implement the map modules, update the manifest, add an
+`integration_test.tycho.yaml`.
+
+## Versioning
+
+Every PR that touches a package **must** bump that package's version in its `Cargo.toml` before
+merging to main — never merge changes without a version bump.
+
+- **Minor bump** (e.g. `0.3.2` → `0.3.3`): bug fixes, small adjustments
+- **Major bump** (e.g. `0.3.2` → `0.4.0`): significant changes, breaking output format

--- a/protocols/testing/CLAUDE.md
+++ b/protocols/testing/CLAUDE.md
@@ -1,0 +1,20 @@
+# protocols/testing/
+
+Rust binary (`protocol-testing`) that runs end-to-end integration tests for Substreams protocol
+implementations. Spins up a full indexer stack, indexes a block range from each protocol's
+`integration_test.tycho.yaml`, then validates resulting state via `tycho-simulation`.
+
+IS in the monorepo `[workspace.members]` (unlike `protocols/substreams/`).
+
+## Running
+
+Requires: `RPC_URL`, `SUBSTREAMS_API_TOKEN`, Postgres (`DATABASE_URL`, default
+`postgres://postgres:mypassword@localhost:5431/tycho_indexer_0`).
+
+```bash
+cargo run -- range --package "ethereum-balancer-v2"          # block range from yaml
+cargo run -- full  --package "ethereum-balancer-v2"          # creation block to latest
+cargo run -- range --package "base-aerodrome-slipstreams" --chain base
+```
+
+Docker Compose is available for isolated runs — see `README.md`.


### PR DESCRIPTION
- updated existing claude docs to reflect the new monorepo structure and recent code changes
- port missing simulation claude docs from the old repo
- add integration test claude docs 
- create minor protocol integration claude docs