### PR TITLE
fix(integration-test): fix flashblock execution simulations

### DIFF
--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -483,7 +483,7 @@ async fn run(cli: Cli) -> miette::Result<()> {
 
 enum BlockPollResult {
     /// Block numbers match; simulation can proceed.
-    Ready(Block),
+    Ready(Box<Block>),
     /// Tycho is behind the RPC. Carries the target block's timestamp (if fetchable) so latency
     /// can still be recorded before the update is skipped.
     Stale { target_block_timestamp: Option<u64> },
@@ -491,31 +491,39 @@ enum BlockPollResult {
     Timeout,
 }
 
-/// Polls the RPC until it reaches the target block number.
+/// Polls the RPC until the queried block (`Latest` or `Pending`) matches `target_block`.
 ///
-/// Returns [`BlockPollResult::Ready`] when the RPC block matches `target_block`,
+/// Returns [`BlockPollResult::Ready`] when the block number matches,
 /// [`BlockPollResult::Stale`] if the update is already behind the RPC (includes the target
 /// block's timestamp for latency recording), or [`BlockPollResult::Timeout`] if the RPC never
 /// caught up within `max_attempts`.
+///
+/// Pass `BlockNumberOrTag::Latest` for confirmed-block mode and `BlockNumberOrTag::Pending`
+/// for flashblock mode (requires a flashblocks-capable RPC endpoint).
 async fn poll_rpc_for_block(
     rpc_tools: &tycho_test::RPCTools,
     target_block: u64,
+    block_tag: BlockNumberOrTag,
     max_attempts: u32,
     poll_interval: Duration,
 ) -> miette::Result<BlockPollResult> {
     for attempt in 0..max_attempts {
         let block = match rpc_tools
             .provider
-            .get_block_by_number(BlockNumberOrTag::Latest)
+            .get_block_by_number(block_tag)
             .await
             .into_diagnostic()
-            .wrap_err("Failed to fetch latest block")
+            .wrap_err("Failed to fetch block")
             .ok()
             .flatten()
         {
             Some(b) => b,
             None => {
-                warn!("Failed to retrieve latest block (attempt {}/{})", attempt + 1, max_attempts);
+                warn!(
+                    "Failed to retrieve {block_tag} block (attempt {}/{})",
+                    attempt + 1,
+                    max_attempts
+                );
                 if attempt < max_attempts - 1 {
                     tokio::time::sleep(poll_interval).await;
                 }
@@ -528,7 +536,7 @@ async fn poll_rpc_for_block(
         if rpc_block > target_block {
             let delay = rpc_block - target_block;
             warn!(
-                "Update block ({target_block}) is behind RPC block ({rpc_block}), \
+                "Update block ({target_block}) is behind {block_tag} block ({rpc_block}), \
                  skipping to catch up."
             );
             metrics::record_protocol_update_block_delay(delay);
@@ -549,14 +557,13 @@ async fn poll_rpc_for_block(
 
         if rpc_block == target_block {
             if attempt > 0 {
-                debug!("RPC caught up to block {target_block} after {} poll(s)", attempt);
+                debug!("{block_tag} block caught up to {target_block} after {} poll(s)", attempt);
             }
-            return Ok(BlockPollResult::Ready(block));
+            return Ok(BlockPollResult::Ready(Box::new(block)));
         }
 
-        // RPC is behind — wait and retry
         debug!(
-            "RPC block ({rpc_block}) behind update block ({target_block}), \
+            "{block_tag} block ({rpc_block}) behind update block ({target_block}), \
              polling... (attempt {}/{})",
             attempt + 1,
             max_attempts
@@ -615,43 +622,50 @@ async fn process_update(
             }
         }
 
-        // Poll RPC until it reaches the update's block number
         let update_block_number = update.update.block_number_or_timestamp;
+
+        // Flashblocks-capable endpoints expose sequencer pre-confirmed state under `pending`;
+        // standard endpoints use `latest` (confirmed blocks only).
+        let block_tag = if cli.partial_blocks {
+            BlockNumberOrTag::Pending
+        } else {
+            BlockNumberOrTag::Latest
+        };
         let poll_interval = Duration::from_millis(cli.rpc_poll_interval_ms);
 
         let poll_result = poll_rpc_for_block(
             &rpc_tools,
             update_block_number,
+            block_tag,
             cli.rpc_poll_attempts,
             poll_interval,
         )
         .await?;
 
+        let block_type = if block_tag == BlockNumberOrTag::Pending { "partial" } else { "full" };
         let block = match poll_result {
             BlockPollResult::Ready(b) => {
                 let latency_seconds =
                     update.received_at.as_secs_f64() - b.header.timestamp as f64;
-                metrics::record_block_processing_duration(latency_seconds);
-                Arc::new(b)
+                metrics::record_block_processing_duration(latency_seconds, block_type);
+                Arc::new(*b)
             }
             BlockPollResult::Stale { target_block_timestamp } => {
                 if let Some(ts) = target_block_timestamp {
                     let latency_seconds = update.received_at.as_secs_f64() - ts as f64;
-                    metrics::record_block_processing_duration(latency_seconds);
+                    metrics::record_block_processing_duration(latency_seconds, block_type);
                 }
                 metrics::record_protocol_update_skipped();
                 return Ok(());
             }
             BlockPollResult::Timeout => {
                 warn!(
-                    "Timed out waiting for RPC to reach update block {update_block_number}, \
-                     skipping."
+                    "RPC ({block_tag}) did not reach update block {update_block_number}, skipping."
                 );
                 metrics::record_protocol_update_skipped();
                 return Ok(());
             }
         };
-
         if update.is_first_update {
             info!("Skipping simulation on first protocol update...");
             return Ok(());

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -481,16 +481,28 @@ async fn run(cli: Cli) -> miette::Result<()> {
     Ok(())
 }
 
+enum BlockPollResult {
+    /// Block numbers match; simulation can proceed.
+    Ready(Block),
+    /// Tycho is behind the RPC. Carries the target block's timestamp (if fetchable) so latency
+    /// can still be recorded before the update is skipped.
+    Stale { target_block_timestamp: Option<u64> },
+    /// RPC never reached the target block within the allowed attempts.
+    Timeout,
+}
+
 /// Polls the RPC until it reaches the target block number.
 ///
-/// Returns `Some(block)` when the RPC block matches `target_block`, or `None` if the update
-/// is behind the RPC (stale) or we exhaust all polling attempts (RPC too slow).
+/// Returns [`BlockPollResult::Ready`] when the RPC block matches `target_block`,
+/// [`BlockPollResult::Stale`] if the update is already behind the RPC (includes the target
+/// block's timestamp for latency recording), or [`BlockPollResult::Timeout`] if the RPC never
+/// caught up within `max_attempts`.
 async fn poll_rpc_for_block(
     rpc_tools: &tycho_test::RPCTools,
     target_block: u64,
     max_attempts: u32,
     poll_interval: Duration,
-) -> miette::Result<Option<Block>> {
+) -> miette::Result<BlockPollResult> {
     for attempt in 0..max_attempts {
         let block = match rpc_tools
             .provider
@@ -520,15 +532,26 @@ async fn poll_rpc_for_block(
                  skipping to catch up."
             );
             metrics::record_protocol_update_block_delay(delay);
-            metrics::record_protocol_update_skipped();
-            return Ok(None);
+
+            // Fetch the target block so we can record accurate latency even though simulation
+            // will be skipped — excluding stale blocks would bias the histogram toward
+            // fast updates only.
+            let target_block_timestamp = rpc_tools
+                .provider
+                .get_block_by_number(BlockNumberOrTag::Number(target_block))
+                .await
+                .ok()
+                .flatten()
+                .map(|b| b.header.timestamp);
+
+            return Ok(BlockPollResult::Stale { target_block_timestamp });
         }
 
         if rpc_block == target_block {
             if attempt > 0 {
                 debug!("RPC caught up to block {target_block} after {} poll(s)", attempt);
             }
-            return Ok(Some(block));
+            return Ok(BlockPollResult::Ready(block));
         }
 
         // RPC is behind — wait and retry
@@ -541,7 +564,7 @@ async fn poll_rpc_for_block(
         tokio::time::sleep(poll_interval).await;
     }
 
-    Ok(None)
+    Ok(BlockPollResult::Timeout)
 }
 
 async fn process_update(
@@ -596,7 +619,7 @@ async fn process_update(
         let update_block_number = update.update.block_number_or_timestamp;
         let poll_interval = Duration::from_millis(cli.rpc_poll_interval_ms);
 
-        let block = poll_rpc_for_block(
+        let poll_result = poll_rpc_for_block(
             &rpc_tools,
             update_block_number,
             cli.rpc_poll_attempts,
@@ -604,9 +627,22 @@ async fn process_update(
         )
         .await?;
 
-        let block = match block {
-            Some(b) => Arc::new(b),
-            None => {
+        let block = match poll_result {
+            BlockPollResult::Ready(b) => {
+                let latency_seconds =
+                    update.received_at.as_secs_f64() - b.header.timestamp as f64;
+                metrics::record_block_processing_duration(latency_seconds);
+                Arc::new(b)
+            }
+            BlockPollResult::Stale { target_block_timestamp } => {
+                if let Some(ts) = target_block_timestamp {
+                    let latency_seconds = update.received_at.as_secs_f64() - ts as f64;
+                    metrics::record_block_processing_duration(latency_seconds);
+                }
+                metrics::record_protocol_update_skipped();
+                return Ok(());
+            }
+            BlockPollResult::Timeout => {
                 warn!(
                     "Timed out waiting for RPC to reach update block {update_block_number}, \
                      skipping."
@@ -615,11 +651,6 @@ async fn process_update(
                 return Ok(());
             }
         };
-
-        // Block numbers match — record latency against the correct block
-        let latency_seconds =
-            (update.received_at.as_secs_f64() - block.header.timestamp as f64).abs();
-        metrics::record_block_processing_duration(latency_seconds);
 
         if update.is_first_update {
             info!("Skipping simulation on first protocol update...");

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -626,11 +626,8 @@ async fn process_update(
 
         // Flashblocks-capable endpoints expose sequencer pre-confirmed state under `pending`;
         // standard endpoints use `latest` (confirmed blocks only).
-        let block_tag = if cli.partial_blocks {
-            BlockNumberOrTag::Pending
-        } else {
-            BlockNumberOrTag::Latest
-        };
+        let block_tag =
+            if cli.partial_blocks { BlockNumberOrTag::Pending } else { BlockNumberOrTag::Latest };
         let poll_interval = Duration::from_millis(cli.rpc_poll_interval_ms);
 
         let poll_result = poll_rpc_for_block(
@@ -645,8 +642,7 @@ async fn process_update(
         let block_type = if block_tag == BlockNumberOrTag::Pending { "partial" } else { "full" };
         let block = match poll_result {
             BlockPollResult::Ready(b) => {
-                let latency_seconds =
-                    update.received_at.as_secs_f64() - b.header.timestamp as f64;
+                let latency_seconds = update.received_at.as_secs_f64() - b.header.timestamp as f64;
                 metrics::record_block_processing_duration(latency_seconds, block_type);
                 Arc::new(*b)
             }

--- a/crates/tycho-integration-test/src/metrics.rs
+++ b/crates/tycho-integration-test/src/metrics.rs
@@ -66,9 +66,14 @@ pub fn initialize_metrics() {
     );
 }
 
-/// Record the duration between block timestamp and component receipt
-pub fn record_block_processing_duration(duration_seconds: f64) {
-    histogram!("tycho_integration_block_processing_duration_seconds").record(duration_seconds);
+/// Record the duration between block timestamp and component receipt.
+/// `block_type` is `"full"` for confirmed blocks and `"partial"` for flashblock updates.
+pub fn record_block_processing_duration(duration_seconds: f64, block_type: &str) {
+    histogram!(
+        "tycho_integration_block_processing_duration_seconds",
+        "block_type" => block_type.to_string()
+    )
+    .record(duration_seconds);
 }
 
 /// Record a failed get_limits operation

--- a/crates/tycho-integration-test/src/metrics.rs
+++ b/crates/tycho-integration-test/src/metrics.rs
@@ -201,7 +201,10 @@ pub async fn create_metrics_exporter(port: u16) -> Result<tokio::task::JoinHandl
     let exporter_builder = PrometheusBuilder::new()
         .set_buckets_for_metric(
             Matcher::Full("tycho_integration_block_processing_duration_seconds".to_string()),
-            &[-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0, 12.0, 15.0, 20.0],
+            &[
+                -2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0, 12.0, 15.0,
+                20.0,
+            ],
         )
         .map_err(|e| miette::miette!("Failed to set buckets: {}", e))?
         .set_buckets_for_metric(

--- a/crates/tycho-integration-test/src/metrics.rs
+++ b/crates/tycho-integration-test/src/metrics.rs
@@ -9,7 +9,8 @@ use tycho_client::feed::SynchronizerState;
 pub fn initialize_metrics() {
     describe_histogram!(
         "tycho_integration_block_processing_duration_seconds",
-        "Time between block timestamp and when protocol components are received"
+        "Latency from block timestamp to protocol component receipt: positive = Tycho was slower \
+         than the block, negative = Tycho was faster (clock skew or pre-delivery)"
     );
     describe_counter!(
         "tycho_integration_simulation_get_limits_failures_total",
@@ -195,7 +196,7 @@ pub async fn create_metrics_exporter(port: u16) -> Result<tokio::task::JoinHandl
     let exporter_builder = PrometheusBuilder::new()
         .set_buckets_for_metric(
             Matcher::Full("tycho_integration_block_processing_duration_seconds".to_string()),
-            &[0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0, 12.0, 15.0, 20.0],
+            &[-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0, 12.0, 15.0, 20.0],
         )
         .map_err(|e| miette::miette!("Failed to set buckets: {}", e))?
         .set_buckets_for_metric(

--- a/crates/tycho-test/src/execution/encoding.rs
+++ b/crates/tycho-test/src/execution/encoding.rs
@@ -1,7 +1,9 @@
 use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use alloy::{
-    primitives::{keccak256, map::AddressHashMap, Address, FixedBytes, Keccak256, U256},
+    eips::BlockNumberOrTag,
+    primitives::{keccak256, map::AddressHashMap, Address, FixedBytes, Keccak256, B256, U256},
+    providers::Provider,
     rpc::types::{state::AccountOverride, Block, TransactionRequest},
     sol_types::SolValue,
 };
@@ -210,9 +212,26 @@ pub(crate) async fn detect_token_slots(
         return token_slots;
     }
 
+    // Pending (flashblock) blocks have a zero hash — slot layouts are immutable so any
+    // valid confirmed block hash works for detection.
+    let detection_hash = if block.header.hash == B256::ZERO {
+        let latest = rpc_tools
+            .provider
+            .get_block_by_number(BlockNumberOrTag::Latest)
+            .await
+            .ok()
+            .flatten();
+        match latest {
+            Some(b) => b.header.hash,
+            None => return HashMap::new(),
+        }
+    } else {
+        block.header.hash
+    };
+
     let balance_results = rpc_tools
         .evm_balance_slot_detector
-        .detect_balance_slots(&erc20_tokens, (**user_address).into(), (*block.header.hash).into())
+        .detect_balance_slots(&erc20_tokens, (**user_address).into(), (*detection_hash).into())
         .await;
 
     let allowance_results = rpc_tools
@@ -221,7 +240,7 @@ pub(crate) async fn detect_token_slots(
             &erc20_tokens,
             (**user_address).into(),
             to_address.clone(),
-            (*block.header.hash).into(),
+            (*detection_hash).into(),
         )
         .await;
 

--- a/crates/tycho-test/src/execution/execution_simulator.rs
+++ b/crates/tycho-test/src/execution/execution_simulator.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
 use alloy::{
+    eips::BlockNumberOrTag,
     hex,
-    primitives::{keccak256, Bytes},
+    primitives::{keccak256, Bytes, B256},
     rpc::{
         client::ClientBuilder,
         types::{Block, BlockId},
@@ -198,7 +199,13 @@ impl ExecutionSimulator {
         let (simulation_ids, simulation_inputs): (Vec<String>, Vec<SimulationInput>) =
             inputs.into_iter().unzip();
 
-        let block_id = BlockId::from(block.number());
+        // Pending (flashblock) blocks have a zero hash — simulate against the pending state
+        // so the RPC uses the sequencer's pre-confirmed block rather than a specific number.
+        let block_id = if block.header.hash == B256::ZERO {
+            BlockId::from(BlockNumberOrTag::Pending)
+        } else {
+            BlockId::from(block.number())
+        };
 
         let client = ClientBuilder::default().http(self.rpc_url.parse()?);
 


### PR DESCRIPTION
To simulate on a flashblock we should use the 'pending' block label, not the 'latest' label. 

Also improved latency metric handling:
- if tycho message is behind, fetch the timestamp of the older block the tycho message corresponded to and calculate actual latency instead of just skipping
- if tycho is ahead, report negative latency 