### PR TITLE
refactor: change getCallbackTransferData from delegatecall to staticcall

### DIFF
--- a/crates/tycho-execution/contracts/interfaces/ICallback.sol
+++ b/crates/tycho-execution/contracts/interfaces/ICallback.sol
@@ -16,7 +16,6 @@ interface ICallback {
         bytes calldata data
     ) external returns (bytes memory result);
 
-
     /**
      * @notice Gets transfer data for callback-based token transfers.
      * @dev Used by the Dispatcher during protocol callbacks to determine
@@ -29,14 +28,20 @@ interface ICallback {
      *
      * @param data The encoded callback data.
      * @param tokenIn The address of the input token to transfer.
-     * @return transferType The transfer type for this executor (None, ProtocolWillDebit, or Transfer).
-     * @return receiver The address that should receive the pre swap tokens (usually a pool or the TychoRouter - depending on the protocol)
+     * @param caller The address that triggered the callback (msg.sender
+     *     in the fallback).
+     * @return transferType The transfer type for this executor (None,
+     *     ProtocolWillDebit, or Transfer).
+     * @return receiver The address that should receive the pre swap
+     *     tokens (usually a pool or the TychoRouter - depending on the
+     *     protocol)
      */
-    function getCallbackTransferData(bytes calldata data, address tokenIn)
+    function getCallbackTransferData(
+        bytes calldata data,
+        address tokenIn,
+        address caller
+    )
         external
-        payable
-        returns (
-            TransferManager.TransferType transferType,
-            address receiver
-        );
+        view
+        returns (TransferManager.TransferType transferType, address receiver);
 }

--- a/crates/tycho-execution/contracts/src/Dispatcher.sol
+++ b/crates/tycho-execution/contracts/src/Dispatcher.sol
@@ -209,7 +209,7 @@ contract Dispatcher is TransferManager {
     }
 
     // slither-disable-next-line assembly
-    function _callHandleCallbackOnExecutor(bytes calldata data)
+    function _callHandleCallbackOnExecutor(bytes calldata data, address caller)
         internal
         returns (bytes memory)
     {
@@ -228,9 +228,12 @@ contract Dispatcher is TransferManager {
 
         _validateExecutor(executor);
 
-        (bool transferDataSuccess, bytes memory transferData) = executor.delegatecall(
+        (bool transferDataSuccess, bytes memory transferData) = executor.staticcall(
             abi.encodeWithSelector(
-                ICallback.getCallbackTransferData.selector, data, tokenIn
+                ICallback.getCallbackTransferData.selector,
+                data,
+                tokenIn,
+                caller
             )
         );
 

--- a/crates/tycho-execution/contracts/src/TychoRouter.sol
+++ b/crates/tycho-execution/contracts/src/TychoRouter.sol
@@ -1035,7 +1035,7 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
         whenNotPaused
         returns (bytes memory)
     {
-        return _callHandleCallbackOnExecutor(data);
+        return _callHandleCallbackOnExecutor(data, msg.sender);
     }
 
     /**

--- a/crates/tycho-execution/contracts/src/executors/BalancerV3Executor.sol
+++ b/crates/tycho-execution/contracts/src/executors/BalancerV3Executor.sol
@@ -147,10 +147,11 @@ contract BalancerV3Executor is IExecutor, ICallback {
 
     function getCallbackTransferData(
         bytes calldata, /* data */
-        address /* tokenIn */
+        address, /* tokenIn */
+        address /* caller */
     )
         external
-        payable
+        view
         returns (TransferManager.TransferType transferType, address receiver)
     {
         transferType = TransferManager.TransferType.Transfer;

--- a/crates/tycho-execution/contracts/src/executors/EkuboExecutor.sol
+++ b/crates/tycho-execution/contracts/src/executors/EkuboExecutor.sol
@@ -272,9 +272,13 @@ contract EkuboExecutor is IExecutor, ILocker, IPayer, ICallback {
         );
     }
 
-    function getCallbackTransferData(bytes calldata data, address tokenIn)
+    function getCallbackTransferData(
+        bytes calldata data,
+        address tokenIn,
+        address /* caller */
+    )
         external
-        payable
+        view
         returns (TransferManager.TransferType transferType, address receiver)
     {
         bytes4 selector = bytes4(data[:4]);

--- a/crates/tycho-execution/contracts/src/executors/EkuboV3Executor.sol
+++ b/crates/tycho-execution/contracts/src/executors/EkuboV3Executor.sol
@@ -146,10 +146,11 @@ contract EkuboV3Executor is IExecutor, ICallback {
 
     function getCallbackTransferData(
         bytes calldata, /* data */
-        address tokenIn
+        address tokenIn,
+        address /* caller */
     )
         external
-        payable
+        view
         returns (TransferManager.TransferType transferType, address receiver)
     {
         receiver = CORE_ADDRESS;

--- a/crates/tycho-execution/contracts/src/executors/FluidV1Executor.sol
+++ b/crates/tycho-execution/contracts/src/executors/FluidV1Executor.sol
@@ -157,10 +157,11 @@ contract FluidV1Executor is IExecutor, ICallback {
 
     function getCallbackTransferData(
         bytes calldata, /* data */
-        address /* tokenIn */
+        address, /* tokenIn */
+        address /* caller */
     )
         external
-        payable
+        view
         returns (TransferManager.TransferType transferType, address receiver)
     {
         // This is only called for ERC20 swaps. Native sells use swapIn() (no

--- a/crates/tycho-execution/contracts/src/executors/SlipstreamsExecutor.sol
+++ b/crates/tycho-execution/contracts/src/executors/SlipstreamsExecutor.sol
@@ -106,13 +106,14 @@ contract SlipstreamsExecutor is IExecutor, ICallback {
 
     function getCallbackTransferData(
         bytes calldata, /* data */
-        address /* tokenIn */
+        address, /* tokenIn */
+        address caller
     )
         external
-        payable
+        pure
         returns (TransferManager.TransferType transferType, address receiver)
     {
         transferType = TransferManager.TransferType.Transfer;
-        receiver = msg.sender;
+        receiver = caller;
     }
 }

--- a/crates/tycho-execution/contracts/src/executors/UniswapV3Executor.sol
+++ b/crates/tycho-execution/contracts/src/executors/UniswapV3Executor.sol
@@ -104,13 +104,14 @@ contract UniswapV3Executor is IExecutor, ICallback {
 
     function getCallbackTransferData(
         bytes calldata, /* data */
-        address /* tokenIn */
+        address, /* tokenIn */
+        address caller
     )
         external
-        payable
+        pure
         returns (TransferManager.TransferType transferType, address receiver)
     {
         transferType = TransferManager.TransferType.Transfer;
-        receiver = msg.sender;
+        receiver = caller;
     }
 }

--- a/crates/tycho-execution/contracts/src/executors/UniswapV4Executor.sol
+++ b/crates/tycho-execution/contracts/src/executors/UniswapV4Executor.sol
@@ -542,10 +542,11 @@ contract UniswapV4Executor is IExecutor, ICallback {
 
     function getCallbackTransferData(
         bytes calldata, /* data */
-        address tokenIn
+        address tokenIn,
+        address /* caller */
     )
         external
-        payable
+        view
         returns (TransferManager.TransferType transferType, address receiver)
     {
         receiver = address(poolManager);

--- a/crates/tycho-execution/contracts/test/protocols/BalancerV3.t.sol
+++ b/crates/tycho-execution/contracts/test/protocols/BalancerV3.t.sol
@@ -26,7 +26,8 @@ contract BalancerV3ExecutorExposed is BalancerV3Executor {
         // tokenIn is at bytes [32:52] in the Balancer V3 callback data:
         // amountGiven(32) | tokenIn(20) | tokenOut(20) | poolId(20) | receiver(20)
         address tokenIn = address(bytes20(data[32:52]));
-        (, address receiver) = this.getCallbackTransferData(data, tokenIn);
+        (, address receiver) =
+            this.getCallbackTransferData(data, tokenIn, msg.sender);
         uint256 amount = uint256(bytes32(data[0:32]));
         IERC20(tokenIn).transfer(receiver, amount);
         return abi.encode(_swapCallback(data));
@@ -91,8 +92,9 @@ contract BalancerV3ExecutorTest is Constants, TestUtils {
         uint256 amountOwed = 1 ether;
         bytes memory params =
             abi.encodePacked(amountOwed, WBTC_ADDR, address(0), address(0));
-        (TransferManager.TransferType transferType, address receiver) =
-            balancerV3Exposed.getCallbackTransferData(params, WBTC_ADDR);
+        (TransferManager.TransferType transferType, address receiver) = balancerV3Exposed.getCallbackTransferData(
+            params, WBTC_ADDR, address(this)
+        );
         assertEq(
             uint8(transferType), uint8(TransferManager.TransferType.Transfer)
         );

--- a/crates/tycho-execution/contracts/test/protocols/BalancerV3.t.sol
+++ b/crates/tycho-execution/contracts/test/protocols/BalancerV3.t.sol
@@ -26,8 +26,9 @@ contract BalancerV3ExecutorExposed is BalancerV3Executor {
         // tokenIn is at bytes [32:52] in the Balancer V3 callback data:
         // amountGiven(32) | tokenIn(20) | tokenOut(20) | poolId(20) | receiver(20)
         address tokenIn = address(bytes20(data[32:52]));
-        (, address receiver) =
+        (TransferManager.TransferType transferType, address receiver) =
             this.getCallbackTransferData(data, tokenIn, msg.sender);
+        assert(transferType == TransferManager.TransferType.Transfer);
         uint256 amount = uint256(bytes32(data[0:32]));
         IERC20(tokenIn).transfer(receiver, amount);
         return abi.encode(_swapCallback(data));

--- a/crates/tycho-execution/contracts/test/protocols/Ekubo.t.sol
+++ b/crates/tycho-execution/contracts/test/protocols/Ekubo.t.sol
@@ -105,7 +105,7 @@ contract EkuboExecutorTest is Constants, TestUtils {
         bytes memory data = abi.encodePacked(PAY_CALLBACK_SELECTOR);
 
         (TransferManager.TransferType transferType, address receiver) =
-            executor.getCallbackTransferData(data, USDC_ADDR);
+            executor.getCallbackTransferData(data, USDC_ADDR, address(this));
 
         assertEq(
             uint8(transferType), uint8(TransferManager.TransferType.Transfer)
@@ -117,7 +117,7 @@ contract EkuboExecutorTest is Constants, TestUtils {
         bytes memory data = abi.encodePacked(LOCKED_SELECTOR);
 
         (TransferManager.TransferType transferType, address receiver) =
-            executor.getCallbackTransferData(data, USDC_ADDR);
+            executor.getCallbackTransferData(data, USDC_ADDR, address(this));
 
         assertEq(uint8(transferType), uint8(TransferManager.TransferType.None));
         assertEq(receiver, address(0));
@@ -127,7 +127,7 @@ contract EkuboExecutorTest is Constants, TestUtils {
         bytes memory data = abi.encodePacked(LOCKED_SELECTOR);
 
         (TransferManager.TransferType transferType, address receiver) =
-            executor.getCallbackTransferData(data, address(0));
+            executor.getCallbackTransferData(data, address(0), address(this));
 
         assertEq(
             uint8(transferType),

--- a/crates/tycho-execution/contracts/test/protocols/EkuboV3.t.sol
+++ b/crates/tycho-execution/contracts/test/protocols/EkuboV3.t.sol
@@ -21,14 +21,8 @@ contract EkuboV3ExecutorStandalone is EkuboV3Executor, ILocker {
         // tokenIn starts at byte 72 (4 + 32 + 16 + 20 = 72)
         address tokenIn = address(bytes20(msg.data[72:92]));
 
-        bytes memory callData = abi.encodeWithSignature(
-            "getCallbackTransferData(bytes,address)", msg.data, tokenIn
-        );
-        (bool success, bytes memory result) =
-            address(this).delegatecall(callData);
-        require(success, "Delegatecall failed");
-
-        (, address receiver) = abi.decode(result, (uint8, address));
+        (, address receiver) =
+            this.getCallbackTransferData(msg.data, tokenIn, msg.sender);
         uint256 amount = uint128(bytes16(msg.data[36:52]));
 
         if (tokenIn != address(0)) {

--- a/crates/tycho-execution/contracts/test/protocols/EkuboV3.t.sol
+++ b/crates/tycho-execution/contracts/test/protocols/EkuboV3.t.sol
@@ -21,8 +21,16 @@ contract EkuboV3ExecutorStandalone is EkuboV3Executor, ILocker {
         // tokenIn starts at byte 72 (4 + 32 + 16 + 20 = 72)
         address tokenIn = address(bytes20(msg.data[72:92]));
 
-        (, address receiver) =
+        (TransferManager.TransferType transferType, address receiver) =
             this.getCallbackTransferData(msg.data, tokenIn, msg.sender);
+        if (tokenIn == address(0)) {
+            assert(
+                transferType
+                    == TransferManager.TransferType.TransferNativeInExecutor
+            );
+        } else {
+            assert(transferType == TransferManager.TransferType.Transfer);
+        }
         uint256 amount = uint128(bytes16(msg.data[36:52]));
 
         if (tokenIn != address(0)) {

--- a/crates/tycho-execution/contracts/test/protocols/FluidV1.t.sol
+++ b/crates/tycho-execution/contracts/test/protocols/FluidV1.t.sol
@@ -28,7 +28,7 @@ contract FluidV1ExecutorExposed is FluidV1Executor {
     // The first argument is the token that must be transferred to liquidity.
     function dexCallback(address tokenIn, uint256) public {
         (TransferManager.TransferType transferType, address receiver) =
-            this.getCallbackTransferData(msg.data, tokenIn);
+            this.getCallbackTransferData(msg.data, tokenIn, msg.sender);
         if (transferType == TransferManager.TransferType.Transfer) {
             uint256 amount = abi.decode(msg.data[36:68], (uint256));
             IERC20(tokenIn).transfer(receiver, amount);
@@ -94,7 +94,7 @@ contract FluidV1ExecutorTest is Test, Constants {
         executor.setCurrentDex(IFluidV1Dex(dexAddress));
 
         (TransferManager.TransferType transferType, address receiver) =
-            executor.getCallbackTransferData(data, DAI_ADDR);
+            executor.getCallbackTransferData(data, DAI_ADDR, address(this));
 
         assertEq(
             uint8(transferType), uint8(TransferManager.TransferType.Transfer)
@@ -110,7 +110,7 @@ contract FluidV1ExecutorTest is Test, Constants {
         executor.setCurrentDex(IFluidV1Dex(dexAddress));
 
         (TransferManager.TransferType transferType, address receiver) =
-            executor.getCallbackTransferData(data, address(0));
+            executor.getCallbackTransferData(data, address(0), address(this));
 
         assertEq(
             uint8(transferType), uint8(TransferManager.TransferType.Transfer)

--- a/crates/tycho-execution/contracts/test/protocols/Slipstreams.t.sol
+++ b/crates/tycho-execution/contracts/test/protocols/Slipstreams.t.sol
@@ -29,15 +29,8 @@ contract SlipstreamsExecutorExposed is SlipstreamsExecutor {
             ? IUniswapV3Pool(msg.sender).token0()
             : IUniswapV3Pool(msg.sender).token1();
 
-        // Use delegatecall to preserve msg.sender
-        bytes memory callData = abi.encodeWithSignature(
-            "getCallbackTransferData(bytes,address)", msg.data, tokenIn
-        );
-        (bool success, bytes memory result) =
-            address(this).delegatecall(callData);
-        require(success, "Delegatecall failed");
-
-        (, address receiver) = abi.decode(result, (uint8, address));
+        (, address receiver) =
+            this.getCallbackTransferData(msg.data, tokenIn, msg.sender);
 
         uint256 amount =
             amount0Delta > 0 ? uint256(amount0Delta) : uint256(amount1Delta);
@@ -106,8 +99,9 @@ contract SlipstreamsExecutorTest is Test, TestUtils, Constants {
             dataLength,
             protocolData
         );
-        (TransferManager.TransferType transferType, address receiver) =
-            slipstreamsExposed.getCallbackTransferData(callbackData, BASE_WETH);
+        (TransferManager.TransferType transferType, address receiver) = slipstreamsExposed.getCallbackTransferData(
+            callbackData, BASE_WETH, address(this)
+        );
 
         assertEq(
             uint8(transferType), uint8(TransferManager.TransferType.Transfer)

--- a/crates/tycho-execution/contracts/test/protocols/Slipstreams.t.sol
+++ b/crates/tycho-execution/contracts/test/protocols/Slipstreams.t.sol
@@ -29,8 +29,9 @@ contract SlipstreamsExecutorExposed is SlipstreamsExecutor {
             ? IUniswapV3Pool(msg.sender).token0()
             : IUniswapV3Pool(msg.sender).token1();
 
-        (, address receiver) =
+        (TransferManager.TransferType transferType, address receiver) =
             this.getCallbackTransferData(msg.data, tokenIn, msg.sender);
+        assert(transferType == TransferManager.TransferType.Transfer);
 
         uint256 amount =
             amount0Delta > 0 ? uint256(amount0Delta) : uint256(amount1Delta);

--- a/crates/tycho-execution/contracts/test/protocols/UniswapV3.t.sol
+++ b/crates/tycho-execution/contracts/test/protocols/UniswapV3.t.sol
@@ -29,15 +29,8 @@ contract UniswapV3ExecutorExposed is UniswapV3Executor {
             ? IUniswapV3Pool(msg.sender).token0()
             : IUniswapV3Pool(msg.sender).token1();
 
-        // Use delegatecall to preserve msg.sender
-        bytes memory callData = abi.encodeWithSignature(
-            "getCallbackTransferData(bytes,address)", msg.data, tokenIn
-        );
-        (bool success, bytes memory result) =
-            address(this).delegatecall(callData);
-        require(success, "Delegatecall failed");
-
-        (, address receiver) = abi.decode(result, (uint8, address));
+        (, address receiver) =
+            this.getCallbackTransferData(msg.data, tokenIn, msg.sender);
 
         uint256 amount =
             amount0Delta > 0 ? uint256(amount0Delta) : uint256(amount1Delta);
@@ -108,8 +101,9 @@ contract UniswapV3ExecutorTest is Test, TestUtils, Constants {
             dataLength,
             protocolData
         );
-        (TransferManager.TransferType transferType, address receiver) =
-            uniswapV3Exposed.getCallbackTransferData(callbackData, WETH_ADDR);
+        (TransferManager.TransferType transferType, address receiver) = uniswapV3Exposed.getCallbackTransferData(
+            callbackData, WETH_ADDR, address(this)
+        );
 
         assertEq(
             uint8(transferType), uint8(TransferManager.TransferType.Transfer)

--- a/crates/tycho-execution/contracts/test/protocols/UniswapV3.t.sol
+++ b/crates/tycho-execution/contracts/test/protocols/UniswapV3.t.sol
@@ -29,8 +29,9 @@ contract UniswapV3ExecutorExposed is UniswapV3Executor {
             ? IUniswapV3Pool(msg.sender).token0()
             : IUniswapV3Pool(msg.sender).token1();
 
-        (, address receiver) =
+        (TransferManager.TransferType transferType, address receiver) =
             this.getCallbackTransferData(msg.data, tokenIn, msg.sender);
+        assert(transferType == TransferManager.TransferType.Transfer);
 
         uint256 amount =
             amount0Delta > 0 ? uint256(amount0Delta) : uint256(amount1Delta);

--- a/crates/tycho-execution/contracts/test/protocols/UniswapV4.t.sol
+++ b/crates/tycho-execution/contracts/test/protocols/UniswapV4.t.sol
@@ -55,7 +55,7 @@ contract UniswapV4ExecutorExposed is UniswapV4Executor {
         }
 
         (TransferManager.TransferType transferType, address receiver) =
-            this.getCallbackTransferData(msg.data, tokenIn);
+            this.getCallbackTransferData(msg.data, tokenIn, msg.sender);
         if (transferType == TransferManager.TransferType.Transfer) {
             uint256 amount;
             if (sel == this.swapExactInputSingle.selector) {

--- a/crates/tycho-execution/contracts/test/protocols/UniswapV4Angstrom.t.sol
+++ b/crates/tycho-execution/contracts/test/protocols/UniswapV4Angstrom.t.sol
@@ -40,7 +40,8 @@ contract UniswapV4ExecutorExposed is UniswapV4Executor {
             tokenIn = zeroForOne ? currency0 : currency1;
         }
 
-        (, address receiver) = this.getCallbackTransferData(msg.data, tokenIn);
+        (, address receiver) =
+            this.getCallbackTransferData(msg.data, tokenIn, msg.sender);
         uint256 amount;
         if (sel == this.swapExactInputSingle.selector) {
             amount = uint128(bytes16(stripped[212:228]));

--- a/crates/tycho-execution/contracts/test/protocols/UniswapV4Angstrom.t.sol
+++ b/crates/tycho-execution/contracts/test/protocols/UniswapV4Angstrom.t.sol
@@ -40,8 +40,16 @@ contract UniswapV4ExecutorExposed is UniswapV4Executor {
             tokenIn = zeroForOne ? currency0 : currency1;
         }
 
-        (, address receiver) =
+        (TransferManager.TransferType transferType, address receiver) =
             this.getCallbackTransferData(msg.data, tokenIn, msg.sender);
+        if (tokenIn == address(0)) {
+            assert(
+                transferType
+                    == TransferManager.TransferType.TransferNativeInExecutor
+            );
+        } else {
+            assert(transferType == TransferManager.TransferType.Transfer);
+        }
         uint256 amount;
         if (sel == this.swapExactInputSingle.selector) {
             amount = uint128(bytes16(stripped[212:228]));


### PR DESCRIPTION
Switches getCallbackTransferData from delegatecall to staticcall to increase safety.
[Task](https://propeller-heads.atlassian.net/browse/ENG-5925)
