### PR TITLE
fix(RouterV3 model): Curve executor token decoding

### DIFF
--- a/crates/tycho-execution/model/src/model/executors.rs
+++ b/crates/tycho-execution/model/src/model/executors.rs
@@ -88,15 +88,15 @@ impl Executor {
                     Address::CURVE_TOKENS,
                 )?;
 
-                if token_in == Address::CurveNative {
-                    token_in = Address::Zero;
-                }
-
                 let transfer_type = if token_in == Address::CurveNative {
                     TransferType::TransferNativeInExecutor
                 } else {
                     TransferType::ProtocolWillDebit
                 };
+
+                if token_in == Address::CurveNative {
+                    token_in = Address::Zero;
+                }
 
                 if token_out == Address::CurveNative {
                     token_out = Address::Zero;


### PR DESCRIPTION
We were reassigning token_in from CurveNative to Zero, then in the next line checking the already-overwritten value - so TransferNativeInExecutor was never selected.

The warning is gone, and no new suspicious states found.