### PR TITLE
fix(tycho-client): improve WS connection handling

### DIFF
--- a/crates/tycho-client/src/deltas.rs
+++ b/crates/tycho-client/src/deltas.rs
@@ -914,16 +914,31 @@ impl DeltasClient for WsDeltasClient {
                 this.conn_notify.notify_waiters();
                 result = Ok(());
 
+                // If no WS frame arrives within this window the TCP connection is
+                // considered stalled (e.g. network cut without a TCP RST/FIN). The OS
+                // default keepalive fires after ~2 hours; this gives us an
+                // application-level detection that is orders of magnitude faster.
+                const IDLE_TIMEOUT: Duration = Duration::from_secs(60);
                 loop {
                     let res = tokio::select! {
-                        msg = msg_rx.next() => match msg {
-                            Some(msg) => this.handle_msg(msg).await,
-                            None => {
-                                // This code should not be reachable since the stream
-                                // should return ConnectionClosed in the case above
-                                // before it returns None here.
-                                warn!("Websocket connection silently closed, giving up!");
-                                break 'retry
+                        msg_result = tokio::time::timeout(IDLE_TIMEOUT, msg_rx.next()) => {
+                            match msg_result {
+                                Err(_elapsed) => {
+                                    warn!("No WS frame received for {IDLE_TIMEOUT:?}, \
+                                           treating connection as stalled; Reconnecting...");
+                                    retry_count += 1;
+                                    let mut guard = this.inner.as_ref().lock().await;
+                                    *guard = None;
+                                    break; // break inner loop → reconnect
+                                }
+                                Ok(Some(msg)) => this.handle_msg(msg).await,
+                                Ok(None) => {
+                                    // This code should not be reachable since the stream
+                                    // should return ConnectionClosed in the case above
+                                    // before it returns None here.
+                                    warn!("Websocket connection silently closed, giving up!");
+                                    break 'retry
+                                }
                             }
                         },
                         _ = cmd_rx.recv() => {break 'retry},

--- a/crates/tycho-client/src/deltas.rs
+++ b/crates/tycho-client/src/deltas.rs
@@ -504,6 +504,9 @@ impl WsDeltasClient {
         if self.dead.load(Ordering::SeqCst) {
             return Err(DeltasError::NotConnected);
         }
+        if !self.is_connected().await {
+            return Err(DeltasError::NotConnected);
+        }
         Ok(())
     }
 

--- a/crates/tycho-client/src/deltas.rs
+++ b/crates/tycho-client/src/deltas.rs
@@ -899,7 +899,8 @@ impl DeltasClient for WsDeltasClient {
                         *guard = None;
 
                         if let tungstenite::Error::Http(response) = &e {
-                            if response.status() == tungstenite::http::StatusCode::TOO_MANY_REQUESTS {
+                            if response.status() == tungstenite::http::StatusCode::TOO_MANY_REQUESTS
+                            {
                                 let reason = response
                                     .body()
                                     .as_deref()

--- a/crates/tycho-client/src/deltas.rs
+++ b/crates/tycho-client/src/deltas.rs
@@ -800,9 +800,7 @@ impl DeltasClient for WsDeltasClient {
                 )
             })?
             .map_err(|_| {
-                DeltasError::TransportError(
-                    "Subscription channel closed unexpectedly".to_string(),
-                )
+                DeltasError::TransportError("Subscription channel closed unexpectedly".to_string())
             })??;
         trace!("Subscription successful");
         Ok(res)
@@ -829,9 +827,7 @@ impl DeltasClient for WsDeltasClient {
                 )
             })?
             .map_err(|_| {
-                DeltasError::TransportError(
-                    "Unsubscribe channel closed unexpectedly".to_string(),
-                )
+                DeltasError::TransportError("Unsubscribe channel closed unexpectedly".to_string())
             })?;
 
         Ok(())

--- a/crates/tycho-client/src/deltas.rs
+++ b/crates/tycho-client/src/deltas.rs
@@ -486,11 +486,24 @@ impl WsDeltasClient {
     /// connection is established if not already connected.
     async fn ensure_connection(&self) -> Result<(), DeltasError> {
         if self.dead.load(Ordering::SeqCst) {
-            return Err(DeltasError::NotConnected)
-        };
+            return Err(DeltasError::NotConnected);
+        }
+        if self.is_connected().await {
+            return Ok(());
+        }
+        // Enable the future BEFORE re-checking is_connected to close the race window where
+        // the reconnect task calls notify_waiters() between is_connected() returning false and
+        // notified().await — without enable(), that notification would be lost and this call
+        // would block until the next reconnect.
+        let notified = self.conn_notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
         if !self.is_connected().await {
-            self.conn_notify.notified().await;
-        };
+            notified.await;
+        }
+        if self.dead.load(Ordering::SeqCst) {
+            return Err(DeltasError::NotConnected);
+        }
         Ok(())
     }
 

--- a/crates/tycho-client/src/deltas.rs
+++ b/crates/tycho-client/src/deltas.rs
@@ -655,7 +655,11 @@ impl WsDeltasClient {
             Ok(tungstenite::protocol::Message::Pong(_)) => {
                 // Do nothing.
             }
-            Ok(tungstenite::protocol::Message::Close(_)) => {
+            Ok(tungstenite::protocol::Message::Close(frame)) => {
+                match &frame {
+                    Some(f) => warn!(code = ?f.code, reason = %f.reason, "WebSocket closed by server"),
+                    None => warn!("WebSocket closed by server (no close frame)"),
+                }
                 return Err(DeltasError::ConnectionClosed);
             }
             Ok(unknown_msg) => {
@@ -893,6 +897,19 @@ impl DeltasClient for WsDeltasClient {
                         retry_count += 1;
                         let mut guard = this.inner.as_ref().lock().await;
                         *guard = None;
+
+                        if let tungstenite::Error::Http(response) = &e {
+                            if response.status() == tungstenite::http::StatusCode::TOO_MANY_REQUESTS {
+                                let reason = response
+                                    .body()
+                                    .as_deref()
+                                    .and_then(|b| std::str::from_utf8(b).ok())
+                                    .unwrap_or("")
+                                    .to_string();
+                                warn!(reason, "WebSocket connection rejected: rate limited");
+                                continue 'retry;
+                            }
+                        }
 
                         warn!(
                             e = e.to_string(),

--- a/crates/tycho-client/src/deltas.rs
+++ b/crates/tycho-client/src/deltas.rs
@@ -482,7 +482,7 @@ impl WsDeltasClient {
 
     /// Waits for the client to be connected
     ///
-    /// This method acquires the lock for inner for a short period, then waits until the  
+    /// This method acquires the lock for inner for a short period, then waits until the
     /// connection is established if not already connected.
     async fn ensure_connection(&self) -> Result<(), DeltasError> {
         if self.dead.load(Ordering::SeqCst) {
@@ -776,9 +776,18 @@ impl DeltasClient for WsDeltasClient {
                 .await?;
         }
         trace!("Waiting for subscription response");
-        let res = ready_rx.await.map_err(|_| {
-            DeltasError::TransportError("Subscription channel closed unexpectedly".to_string())
-        })??;
+        let res = tokio::time::timeout(Duration::from_secs(30), ready_rx)
+            .await
+            .map_err(|_| {
+                DeltasError::TransportError(
+                    "Subscribe confirmation timed out after 30s".to_string(),
+                )
+            })?
+            .map_err(|_| {
+                DeltasError::TransportError(
+                    "Subscription channel closed unexpectedly".to_string(),
+                )
+            })??;
         trace!("Subscription successful");
         Ok(res)
     }
@@ -795,9 +804,19 @@ impl DeltasClient for WsDeltasClient {
 
             WsDeltasClient::unsubscribe_inner(inner, subscription_id, ready_tx).await?;
         }
-        ready_rx.await.map_err(|_| {
-            DeltasError::TransportError("Unsubscribe channel closed unexpectedly".to_string())
-        })?;
+        tokio::time::timeout(Duration::from_secs(5), ready_rx)
+            .await
+            .map_err(|_| {
+                warn!(?subscription_id, "Unsubscribe confirmation timed out after 5s");
+                DeltasError::TransportError(
+                    "Unsubscribe confirmation timed out after 5s".to_string(),
+                )
+            })?
+            .map_err(|_| {
+                DeltasError::TransportError(
+                    "Unsubscribe channel closed unexpectedly".to_string(),
+                )
+            })?;
 
         Ok(())
     }

--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -982,9 +982,7 @@ where
         }
         let reason: Vec<String> = sync_streams
             .iter()
-            .map(|s| {
-                format!("{} reported as {} at {}", s.extractor_id, s.state, s.modify_ts)
-            })
+            .map(|s| format!("{} reported as {} at {}", s.extractor_id, s.state, s.modify_ts))
             .collect();
         Err(BlockSynchronizerError::NoReadySynchronizers(reason.join(", ")))
     }
@@ -993,8 +991,8 @@ where
     ///
     /// Returns `Ok` if:
     /// - At least one synchronizer is active (Ready, Delayed, or Advanced), OR
-    /// - All synchronizers are stale but none have ended — temporary disconnect
-    ///   (e.g. WS reconnect) where recovery is still possible.
+    /// - All synchronizers are stale but none have ended — temporary disconnect (e.g. WS reconnect)
+    ///   where recovery is still possible.
     ///
     /// Returns `Err` if at least one synchronizer has permanently ended while all
     /// remaining ones are stale — no recovery path exists.
@@ -1740,19 +1738,16 @@ mod tests {
         // and send an advanced block. The main loop should rebase block history and resume.
         let v2_sync = MockStateSync::new();
         let v3_sync = MockStateSync::new();
-        let block_sync = BlockSynchronizer::new(
-            Duration::from_millis(20),
-            Duration::from_millis(10),
-            3,
-        )
-        .register_synchronizer(
-            ExtractorIdentity { chain: Chain::Ethereum, name: "uniswap-v2".to_string() },
-            v2_sync.clone(),
-        )
-        .register_synchronizer(
-            ExtractorIdentity { chain: Chain::Ethereum, name: "uniswap-v3".to_string() },
-            v3_sync.clone(),
-        );
+        let block_sync =
+            BlockSynchronizer::new(Duration::from_millis(20), Duration::from_millis(10), 3)
+                .register_synchronizer(
+                    ExtractorIdentity { chain: Chain::Ethereum, name: "uniswap-v2".to_string() },
+                    v2_sync.clone(),
+                )
+                .register_synchronizer(
+                    ExtractorIdentity { chain: Chain::Ethereum, name: "uniswap-v3".to_string() },
+                    v3_sync.clone(),
+                );
 
         v2_sync
             .send_header(header_message(1))
@@ -1784,8 +1779,14 @@ mod tests {
         while let Ok(Some(Ok(msg))) =
             tokio::time::timeout(Duration::from_millis(50), rx.recv()).await
         {
-            let v2 = msg.sync_states.get("uniswap-v2").unwrap();
-            let v3 = msg.sync_states.get("uniswap-v3").unwrap();
+            let v2 = msg
+                .sync_states
+                .get("uniswap-v2")
+                .unwrap();
+            let v3 = msg
+                .sync_states
+                .get("uniswap-v3")
+                .unwrap();
             if matches!(v2, SynchronizerState::Stale(_)) &&
                 matches!(v3, SynchronizerState::Stale(_))
             {
@@ -1817,8 +1818,14 @@ mod tests {
         let mut recovered = false;
         for _ in 0..20 {
             let msg = receive_message(&mut rx).await;
-            let v2 = msg.sync_states.get("uniswap-v2").unwrap();
-            let v3 = msg.sync_states.get("uniswap-v3").unwrap();
+            let v2 = msg
+                .sync_states
+                .get("uniswap-v2")
+                .unwrap();
+            let v3 = msg
+                .sync_states
+                .get("uniswap-v3")
+                .unwrap();
             if matches!(v2, SynchronizerState::Ready(h) if h.number == 5) &&
                 matches!(v3, SynchronizerState::Ready(h) if h.number == 5)
             {

--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -5,11 +5,7 @@ use std::{
 };
 
 use chrono::{Duration as ChronoDuration, Local, NaiveDateTime};
-use futures03::{
-    future::join_all,
-    stream::FuturesUnordered,
-    FutureExt, StreamExt,
-};
+use futures03::{future::join_all, stream::FuturesUnordered, FutureExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::{
@@ -673,11 +669,10 @@ where
             .ok_or(BlockSynchronizerError::NoSynchronizers)?;
         // init synchronizers; unknown extractors are warned about and skipped rather than
         // crashing the whole client, so a misconfigured protocol doesn't take down valid ones.
-        let init_results = join_all(
-            synchronizers
-                .iter_mut()
-                .map(|(id, s)| s.initialize().map(|res| (id.clone(), res))),
-        )
+        let init_results = join_all(synchronizers.iter_mut().map(|(id, s)| {
+            s.initialize()
+                .map(|res| (id.clone(), res))
+        }))
         .await;
         let mut to_skip = Vec::new();
         for (extractor_id, result) in init_results {

--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -8,7 +8,7 @@ use chrono::{Duration as ChronoDuration, Local, NaiveDateTime};
 use futures03::{
     future::join_all,
     stream::FuturesUnordered,
-    StreamExt,
+    FutureExt, StreamExt,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -673,17 +673,21 @@ where
             .ok_or(BlockSynchronizerError::NoSynchronizers)?;
         // init synchronizers; unknown extractors are warned about and skipped rather than
         // crashing the whole client, so a misconfigured protocol doesn't take down valid ones.
-        let extractor_ids: Vec<ExtractorIdentity> = synchronizers.keys().cloned().collect();
-        let init_results = join_all(synchronizers.values_mut().map(|s| s.initialize())).await;
+        let init_results = join_all(
+            synchronizers
+                .iter_mut()
+                .map(|(id, s)| s.initialize().map(|res| (id.clone(), res))),
+        )
+        .await;
         let mut to_skip = Vec::new();
-        for (extractor_id, result) in extractor_ids.iter().zip(init_results) {
+        for (extractor_id, result) in init_results {
             match result {
                 Ok(()) => {}
                 Err(SynchronizerError::RPCError(crate::rpc::RPCError::UnknownExtractor(
                     reason,
                 ))) => {
                     warn!(%extractor_id, %reason, "Extractor not recognised by server, skipping");
-                    to_skip.push(extractor_id.clone());
+                    to_skip.push(extractor_id);
                 }
                 Err(e) => return Err(BlockSynchronizerError::InitializationError(e)),
             }

--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -757,13 +757,14 @@ where
             .into_iter()
             .collect::<Vec<_>>();
 
-        // Ensures we have at least one ready stream
-        Self::check_streams(&sync_streams)?;
+        // Fail fast if no synchronizer produced a ready first message.
+        Self::require_active_stream(&sync_streams)?;
         let mut block_history = BlockHistory::new(initial_headers, 15)?;
-        // Determine the starting header for synchronization
+        // Determine the starting header for synchronization.
+        // Safe: require_active_stream above guarantees at least one Ready stream,
+        // so initial_headers is non-empty and block_history.latest() is Some.
         let start_header = block_history
             .latest()
-            // Safe, as we have checked this invariant with `check_streams`
             .ok_or(BlockHistoryError::EmptyHistory)?;
         info!(
             start_block=%start_header,
@@ -909,18 +910,15 @@ where
             .any(SynchronizerStream::is_advanced)
         {
             *block_history = Self::reinit_block_history(sync_streams, block_history)?;
-        } else {
-            let header = sync_streams
-                .iter()
-                .filter_map(SynchronizerStream::get_current_header)
-                .max_by_key(|b| b.number)
-                // Safe, as we have checked this invariant with `check_streams`
-                .ok_or(BlockSynchronizerError::NoReadySynchronizers(
-                    "Expected to have at least one synchronizer that is not stale or ended"
-                        .to_string(),
-                ))?;
+        } else if let Some(header) = sync_streams
+            .iter()
+            .filter_map(SynchronizerStream::get_current_header)
+            .max_by_key(|b| b.number)
+        {
             block_history.push(header.clone())?;
         }
+        // If all synchronizers are stale (e.g. WS reconnect in progress), skip block
+        // history update and continue waiting for recovery.
         Ok(())
     }
 
@@ -971,32 +969,67 @@ where
         Ok(new_block_history)
     }
 
-    /// Checks if we still have at least one active stream else errors.
+    /// Startup check: fails if no synchronizer is active (all Stale or Ended at init time).
     ///
-    /// If there are no active streams meaning all are ended or stale, it returns a
-    /// summary error message for the state of all synchronizers.
+    /// Used once before entering the main loop, where all-Stale is a fatal configuration
+    /// problem (nothing to sync from), not a temporary disconnect.
+    fn require_active_stream(sync_streams: &[SynchronizerStream]) -> BlockSyncResult<()> {
+        if sync_streams
+            .iter()
+            .any(|s| !s.has_ended() && !s.is_stale())
+        {
+            return Ok(());
+        }
+        let reason: Vec<String> = sync_streams
+            .iter()
+            .map(|s| {
+                format!("{} reported as {} at {}", s.extractor_id, s.state, s.modify_ts)
+            })
+            .collect();
+        Err(BlockSynchronizerError::NoReadySynchronizers(reason.join(", ")))
+    }
+
+    /// Checks if the main loop should continue or exit.
+    ///
+    /// Returns `Ok` if:
+    /// - At least one synchronizer is active (Ready, Delayed, or Advanced), OR
+    /// - All synchronizers are stale but none have ended — temporary disconnect
+    ///   (e.g. WS reconnect) where recovery is still possible.
+    ///
+    /// Returns `Err` if at least one synchronizer has permanently ended while all
+    /// remaining ones are stale — no recovery path exists.
     fn check_streams(sync_streams: &[SynchronizerStream]) -> BlockSyncResult<()> {
-        let mut latest_errored_stream: Option<&SynchronizerStream> = None;
+        let mut has_any_ended = false;
+        let mut latest_ended_stream: Option<&SynchronizerStream> = None;
 
         for stream in sync_streams.iter() {
-            // If we have at least one active stream, we can return early
+            // If we have at least one active stream (ready, delayed, or advanced), continue.
             if !stream.has_ended() && !stream.is_stale() {
                 return Ok(());
             }
 
-            // Otherwise, we track the latest errored stream for reporting
-            if latest_errored_stream.is_none() ||
-                stream.modify_ts >
-                    latest_errored_stream
-                        .as_ref()
-                        .unwrap()
-                        .modify_ts
-            {
-                latest_errored_stream = Some(stream);
+            if stream.has_ended() {
+                has_any_ended = true;
+                if latest_ended_stream.is_none() ||
+                    stream.modify_ts >
+                        latest_ended_stream
+                            .as_ref()
+                            .unwrap()
+                            .modify_ts
+                {
+                    latest_ended_stream = Some(stream);
+                }
             }
         }
 
-        let last_error_reason = if let Some(stream) = latest_errored_stream {
+        // All streams are stale or ended. If none have ended, all synchronizers are
+        // temporarily disconnected — wait for recovery without exiting the main loop.
+        if !has_any_ended {
+            return Ok(());
+        }
+
+        // At least one synchronizer has permanently ended while all others are stale.
+        let last_error_reason = if let Some(stream) = latest_ended_stream {
             if let Some(err) = &stream.error {
                 format!("Synchronizer for {} errored with: {err}", stream.extractor_id)
             } else {
@@ -1276,14 +1309,14 @@ mod tests {
     }
 
     async fn shutdown_block_synchronizer(
-        v2_sync: &MockStateSync,
-        v3_sync: &MockStateSync,
         nanny_handle: JoinHandle<()>,
+        rx: Receiver<BlockSyncResult<FeedMessage>>,
     ) {
-        v3_sync.trigger_close().await;
-        v2_sync.trigger_close().await;
-
-        timeout(Duration::from_millis(100), nanny_handle)
+        // Dropping the receiver causes the main loop's next send to fail, which exits
+        // the loop. The nanny then calls cleanup_synchronizers, which sends close signals
+        // to the synchronizer tasks via their handle-side channels.
+        drop(rx);
+        timeout(Duration::from_secs(2), nanny_handle)
             .await
             .expect("Nanny failed to exit within time")
             .expect("Nanny panicked");
@@ -1346,7 +1379,7 @@ mod tests {
         };
         assert_eq!(second_feed_msg, exp2);
 
-        shutdown_block_synchronizer(&v2_sync, &v3_sync, nanny_handle).await;
+        shutdown_block_synchronizer(nanny_handle, rx).await;
     }
 
     #[test(tokio::test)]
@@ -1427,7 +1460,7 @@ mod tests {
             SynchronizerState::Ready(header) if header.number == 3
         ));
 
-        shutdown_block_synchronizer(&v2_sync, &v3_sync, nanny_handle).await;
+        shutdown_block_synchronizer(nanny_handle, rx).await;
     }
 
     #[test(tokio::test)]
@@ -1501,7 +1534,7 @@ mod tests {
             SynchronizerState::Ready(header) if header.number == 3
         ));
 
-        shutdown_block_synchronizer(&v2_sync, &v3_sync, jh).await;
+        shutdown_block_synchronizer(jh, rx).await;
     }
 
     #[test(tokio::test)]
@@ -1570,7 +1603,7 @@ mod tests {
     #[test(tokio::test)]
     async fn test_one_synchronizer_goes_stale_while_other_works() {
         // Test Case 1: One protocol goes stale and is removed while another protocol works normally
-        let (v2_sync, v3_sync, nanny_handle, mut rx) = setup_block_sync().await;
+        let (_v2_sync, v3_sync, nanny_handle, mut rx) = setup_block_sync().await;
 
         // Send block 2 only to v3, v2 will timeout and become delayed
         let block2_msg = header_message(2);
@@ -1629,81 +1662,178 @@ mod tests {
         }
         assert!(stale_found, "v2 synchronizer should be stale");
 
-        shutdown_block_synchronizer(&v2_sync, &v3_sync, nanny_handle).await;
+        shutdown_block_synchronizer(nanny_handle, rx).await;
     }
 
     #[test(tokio::test)]
-    async fn test_all_synchronizers_go_stale_main_loop_exits() {
-        // Test Case 2: All protocols go stale and main loop exits gracefully
+    async fn test_all_synchronizers_stale_loop_continues() {
+        // When all synchronizers go stale simultaneously (simulating a WS reconnect), the
+        // main loop must NOT exit — it should keep running and wait for recovery.
         let (v2_sync, v3_sync, nanny_handle, mut rx) = setup_block_sync().await;
 
-        // Stop sending messages to both synchronizers - they should both timeout and go stale
-        // Don't send any more messages, let them timeout and become delayed, then stale
-
-        // Monitor the state transitions to ensure proper delayed -> stale progression
+        // Stop sending messages — both should timeout, go Delayed, then Stale.
         let mut seen_delayed = false;
-
-        // Consume messages and track state transitions
-        // Give enough time for the synchronizers to transition through states
-        let timeout_duration = Duration::from_millis(500); // Generous timeout
+        let mut seen_stale = false;
         let start_time = tokio::time::Instant::now();
 
         while let Ok(Some(Ok(msg))) =
             tokio::time::timeout(Duration::from_millis(50), rx.recv()).await
         {
-            // Track when synchronizers transition to delayed
-            if !seen_delayed {
-                let v2_state = msg.sync_states.get("uniswap-v2");
-                let v3_state = msg.sync_states.get("uniswap-v3");
+            let v2_state = msg.sync_states.get("uniswap-v2");
+            let v3_state = msg.sync_states.get("uniswap-v3");
 
-                if matches!(v2_state, Some(SynchronizerState::Delayed(_))) ||
-                    matches!(v3_state, Some(SynchronizerState::Delayed(_)))
-                {
-                    seen_delayed = true;
-                    // Verify nanny is still running when synchronizers are just delayed
-                    assert!(!nanny_handle.is_finished(),
-                        "Nanny should still be running when synchronizers are delayed (not stale yet)");
-                    // Once we've seen delayed and verified nanny is running, we can break
-                    break;
-                }
+            if !seen_delayed &&
+                (matches!(v2_state, Some(SynchronizerState::Delayed(_))) ||
+                    matches!(v3_state, Some(SynchronizerState::Delayed(_))))
+            {
+                seen_delayed = true;
+                assert!(
+                    !nanny_handle.is_finished(),
+                    "Nanny must still run when synchronizers are Delayed"
+                );
             }
 
-            // Safety timeout to avoid infinite loop
-            if start_time.elapsed() > timeout_duration {
+            if matches!(v2_state, Some(SynchronizerState::Stale(_))) &&
+                matches!(v3_state, Some(SynchronizerState::Stale(_)))
+            {
+                seen_stale = true;
+                assert!(
+                    !nanny_handle.is_finished(),
+                    "Main loop must not exit when all synchronizers are Stale (awaiting recovery)"
+                );
+                break;
+            }
+
+            if start_time.elapsed() > Duration::from_millis(500) {
                 break;
             }
         }
-        // Verify that synchronizers went through proper state transitions
-        assert!(seen_delayed, "Synchronizers should transition to Delayed state first");
 
+        assert!(seen_delayed, "Synchronizers should transition through Delayed first");
+        assert!(seen_stale, "Both synchronizers should reach Stale state");
+
+        // Simulate the underlying synchronizer tasks permanently dying:
+        // trigger_close makes the mock tasks exit (dropping their tx clones), and
+        // dropping the MockStateSyncs closes the original sender side.
+        // This causes SynchronizerStream.rx to return None → Ended → check_streams error.
+        v2_sync.trigger_close().await;
+        v3_sync.trigger_close().await;
+        drop(v2_sync);
+        drop(v3_sync);
+
+        // Now the main loop should detect all-ended and report an error.
         let mut error_reported = false;
-        // Consume any remaining messages until channel closes
         while let Some(msg) = rx.recv().await {
-            if let Err(e) = msg {
-                assert!(e
-                    .to_string()
-                    .contains("became: Stale(1)"));
-                assert!(e
-                    .to_string()
-                    .contains("reported as Stale(1)"));
+            if msg.is_err() {
                 error_reported = true;
             }
         }
-        assert!(error_reported, "Expected the channel to report an error before closing");
+        assert!(error_reported, "Expected an error after all synchronizers ended");
 
-        // The nanny should complete when the main loop exits due to no ready synchronizers
         let nanny_result = timeout(Duration::from_secs(2), nanny_handle).await;
-        assert!(nanny_result.is_ok(), "Nanny should complete when main loop exits");
+        assert!(nanny_result.is_ok(), "Nanny should complete after all synchronizers ended");
+    }
 
-        // Verify cleanup was triggered for both synchronizers
-        assert!(
-            v2_sync.was_close_received().await,
-            "v2_sync should have received close signal during cleanup"
+    #[test(tokio::test)]
+    async fn test_all_synchronizers_recover_after_going_stale() {
+        // Simulates a full WS reconnect: both synchronizers go stale, then reconnect
+        // and send an advanced block. The main loop should rebase block history and resume.
+        let v2_sync = MockStateSync::new();
+        let v3_sync = MockStateSync::new();
+        let block_sync = BlockSynchronizer::new(
+            Duration::from_millis(20),
+            Duration::from_millis(10),
+            3,
+        )
+        .register_synchronizer(
+            ExtractorIdentity { chain: Chain::Ethereum, name: "uniswap-v2".to_string() },
+            v2_sync.clone(),
+        )
+        .register_synchronizer(
+            ExtractorIdentity { chain: Chain::Ethereum, name: "uniswap-v3".to_string() },
+            v3_sync.clone(),
         );
-        assert!(
-            v3_sync.was_close_received().await,
-            "v3_sync should have received close signal during cleanup"
-        );
+
+        v2_sync
+            .send_header(header_message(1))
+            .await
+            .unwrap();
+        v3_sync
+            .send_header(header_message(1))
+            .await
+            .unwrap();
+
+        let (nanny_handle, mut rx) = block_sync
+            .run()
+            .await
+            .expect("BlockSynchronizer start failed");
+
+        let first_msg = receive_message(&mut rx).await;
+        assert!(matches!(
+            first_msg.sync_states.get("uniswap-v2").unwrap(),
+            SynchronizerState::Ready(h) if h.number == 1
+        ));
+        assert!(matches!(
+            first_msg.sync_states.get("uniswap-v3").unwrap(),
+            SynchronizerState::Ready(h) if h.number == 1
+        ));
+
+        // Stop sending messages — both should go Stale.
+        let mut seen_stale = false;
+        let start_time = tokio::time::Instant::now();
+        while let Ok(Some(Ok(msg))) =
+            tokio::time::timeout(Duration::from_millis(50), rx.recv()).await
+        {
+            let v2 = msg.sync_states.get("uniswap-v2").unwrap();
+            let v3 = msg.sync_states.get("uniswap-v3").unwrap();
+            if matches!(v2, SynchronizerState::Stale(_)) &&
+                matches!(v3, SynchronizerState::Stale(_))
+            {
+                seen_stale = true;
+                assert!(
+                    !nanny_handle.is_finished(),
+                    "Main loop must not exit while synchronizers are Stale"
+                );
+                break;
+            }
+            if start_time.elapsed() > Duration::from_millis(500) {
+                break;
+            }
+        }
+        assert!(seen_stale, "Both synchronizers should go Stale");
+
+        // Simulate reconnect: send block 5 (advanced — not connected to block 1).
+        v2_sync
+            .send_header(header_message(5))
+            .await
+            .unwrap();
+        v3_sync
+            .send_header(header_message(5))
+            .await
+            .unwrap();
+
+        // The main loop should detect the advanced blocks, rebase block history, and
+        // reclassify both synchronizers as Ready at block 5.
+        let mut recovered = false;
+        for _ in 0..20 {
+            let msg = receive_message(&mut rx).await;
+            let v2 = msg.sync_states.get("uniswap-v2").unwrap();
+            let v3 = msg.sync_states.get("uniswap-v3").unwrap();
+            if matches!(v2, SynchronizerState::Ready(h) if h.number == 5) &&
+                matches!(v3, SynchronizerState::Ready(h) if h.number == 5)
+            {
+                recovered = true;
+                break;
+            }
+        }
+        assert!(recovered, "Both synchronizers should recover to Ready at block 5");
+
+        // Drop rx to signal the main loop to stop, then await nanny cleanup.
+        drop(rx);
+        timeout(Duration::from_secs(2), nanny_handle)
+            .await
+            .expect("Nanny timed out")
+            .expect("Nanny panicked");
     }
 
     #[test(tokio::test)]
@@ -1794,7 +1924,7 @@ mod tests {
             SynchronizerState::Ready(_)
         ));
 
-        shutdown_block_synchronizer(&v2_sync, &v3_sync, nanny_handle).await;
+        shutdown_block_synchronizer(nanny_handle, rx).await;
 
         // Verify cleanup was triggered for both synchronizers
         assert!(
@@ -1838,7 +1968,7 @@ mod tests {
             SynchronizerState::Ready(_)
         );
 
-        shutdown_block_synchronizer(&v2_sync, &v3_sync, nanny_handle).await;
+        shutdown_block_synchronizer(nanny_handle, rx).await;
     }
 
     #[test(tokio::test)]
@@ -1870,14 +2000,14 @@ mod tests {
             SynchronizerState::Delayed(_)
         );
 
-        shutdown_block_synchronizer(&v2_sync, &v3_sync, nanny_handle).await;
+        shutdown_block_synchronizer(nanny_handle, rx).await;
     }
 
     #[test(tokio::test)]
     async fn test_partial_blocks_normal_operation() {
         // Normal operation: partials with arbitrary index increments, then advance to next block
         // Scenario: block 1 → partials 0,3,7 for block 2 → partials 0,2 for block 3
-        let (v2_sync, v3_sync, nanny_handle, mut rx) = setup_block_sync().await;
+        let (v2_sync, _v3_sync, nanny_handle, mut rx) = setup_block_sync().await;
 
         // Partials for block 2 with arbitrary increments (only v2, v3 ignored)
         send_and_assert_ready(
@@ -1928,14 +2058,14 @@ mod tests {
         )
         .await;
 
-        shutdown_block_synchronizer(&v2_sync, &v3_sync, nanny_handle).await;
+        shutdown_block_synchronizer(nanny_handle, rx).await;
     }
 
     #[test(tokio::test)]
     async fn test_partial_blocks_handles_reverts() {
         // Revert resets state and allows continuation on new fork with full blocks
         // Scenario: block 1 → block 2 → partials for block 3 → revert to 2 → full block 3
-        let (v2_sync, v3_sync, nanny_handle, mut rx) = setup_block_sync().await;
+        let (v2_sync, _v3_sync, nanny_handle, mut rx) = setup_block_sync().await;
 
         // Advance to full block 2 (only v2, v3 ignored)
         send_and_assert_ready(&v2_sync, "uniswap-v2", &mut rx, header_message(2), 2, None).await;
@@ -1967,7 +2097,7 @@ mod tests {
         // New fork: full block 3
         send_and_assert_ready(&v2_sync, "uniswap-v2", &mut rx, header_message(3), 3, None).await;
 
-        shutdown_block_synchronizer(&v2_sync, &v3_sync, nanny_handle).await;
+        shutdown_block_synchronizer(nanny_handle, rx).await;
     }
 
     #[test(tokio::test)]
@@ -2031,6 +2161,6 @@ mod tests {
         }
         assert!(v3_ready, "v3 caught up to partial 2");
 
-        shutdown_block_synchronizer(&v2_sync, &v3_sync, nanny_handle).await;
+        shutdown_block_synchronizer(nanny_handle, rx).await;
     }
 }

--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -6,7 +6,7 @@ use std::{
 
 use chrono::{Duration as ChronoDuration, Local, NaiveDateTime};
 use futures03::{
-    future::{join_all, try_join_all},
+    future::join_all,
     stream::FuturesUnordered,
     StreamExt,
 };
@@ -671,12 +671,29 @@ where
             .synchronizers
             .take()
             .ok_or(BlockSynchronizerError::NoSynchronizers)?;
-        // init synchronizers
-        let init_tasks = synchronizers
-            .values_mut()
-            .map(|s| s.initialize())
-            .collect::<Vec<_>>();
-        try_join_all(init_tasks).await?;
+        // init synchronizers; unknown extractors are warned about and skipped rather than
+        // crashing the whole client, so a misconfigured protocol doesn't take down valid ones.
+        let extractor_ids: Vec<ExtractorIdentity> = synchronizers.keys().cloned().collect();
+        let init_results = join_all(synchronizers.values_mut().map(|s| s.initialize())).await;
+        let mut to_skip = Vec::new();
+        for (extractor_id, result) in extractor_ids.iter().zip(init_results) {
+            match result {
+                Ok(()) => {}
+                Err(SynchronizerError::RPCError(crate::rpc::RPCError::UnknownExtractor(
+                    reason,
+                ))) => {
+                    warn!(%extractor_id, %reason, "Extractor not recognised by server, skipping");
+                    to_skip.push(extractor_id.clone());
+                }
+                Err(e) => return Err(BlockSynchronizerError::InitializationError(e)),
+            }
+        }
+        for id in &to_skip {
+            synchronizers.remove(id);
+        }
+        if synchronizers.is_empty() {
+            return Err(BlockSynchronizerError::NoSynchronizers);
+        }
 
         let mut sync_streams = Vec::with_capacity(synchronizers.len());
         let mut sync_close_senders = Vec::new();

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -757,9 +757,12 @@ where
             while retry_count < self.max_retries {
                 info!(extractor_id=%&self.extractor_id, retry_count, "(Re)starting synchronization loop");
 
+                let prev_block = self.last_synced_block.as_ref().map(|h| h.number);
                 let res = self
                     .state_sync(&mut tx, current_end_rx)
                     .await;
+                let made_progress =
+                    self.last_synced_block.as_ref().map(|h| h.number) > prev_block;
                 match res {
                     Ok(()) => {
                         info!(
@@ -800,7 +803,13 @@ where
                     }
                 }
                 sleep(self.retry_cooldown).await;
-                retry_count += 1;
+                // A run that processed blocks is a healthy run — reset the counter so
+                // transient failures after a long successful period get a fresh retry budget.
+                if made_progress {
+                    retry_count = 0;
+                } else {
+                    retry_count += 1;
+                }
             }
             if let Some(e) = final_error {
                 warn!(extractor_id=%&self.extractor_id, retry_count, error=%e, "Max retries exceeded");

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -422,8 +422,6 @@ where
 
         let result = async {
             info!("Waiting for deltas...");
-            let mut warned_waiting_for_new_block = false;
-            let mut warned_skipping_synced = false;
             // Track the last seen block number such that we know when we get the first partial
             let mut last_block_number: Option<u64> = None;
 
@@ -435,6 +433,8 @@ where
             const MAX_STALE_RETRIES: u32 = 5;
             let mut stale_retries: u32 = 0;
             let (msg, header) = 'init: loop {
+                let mut warned_waiting_for_new_block = false;
+                let mut warned_skipping_synced = false;
                 let mut first_msg = loop {
                     let msg = select! {
                         deltas_result = timeout(Duration::from_secs(self.timeout), msg_rx.recv()) => {

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -757,12 +757,18 @@ where
             while retry_count < self.max_retries {
                 info!(extractor_id=%&self.extractor_id, retry_count, "(Re)starting synchronization loop");
 
-                let prev_block = self.last_synced_block.as_ref().map(|h| h.number);
+                let prev_block = self
+                    .last_synced_block
+                    .as_ref()
+                    .map(|h| h.number);
                 let res = self
                     .state_sync(&mut tx, current_end_rx)
                     .await;
-                let made_progress =
-                    self.last_synced_block.as_ref().map(|h| h.number) > prev_block;
+                let made_progress = self
+                    .last_synced_block
+                    .as_ref()
+                    .map(|h| h.number) >
+                    prev_block;
                 match res {
                     Ok(()) => {
                         info!(

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -426,118 +426,154 @@ where
             let mut warned_skipping_synced = false;
             // Track the last seen block number such that we know when we get the first partial
             let mut last_block_number: Option<u64> = None;
-            let mut first_msg = loop {
-                let msg = select! {
-                    deltas_result = timeout(Duration::from_secs(self.timeout), msg_rx.recv()) => {
-                        deltas_result
-                            .map_err(|_| {
-                                SynchronizerError::Timeout(format!(
-                                    "First deltas took longer than {t}s to arrive",
-                                    t = self.timeout
-                                ))
-                            })?
-                            .ok_or_else(|| {
-                                SynchronizerError::ConnectionError(
-                                    "Deltas channel closed before first message".to_string(),
-                                )
-                            })?
-                    },
-                    _ = &mut end_rx => {
-                        info!("Received close signal while waiting for first deltas");
-                        return Ok(());
-                    }
-                };
 
-                let incoming: BlockHeader = (&msg).into();
-
-                // Determine if this message is a candidate for starting synchronization.
-                // In partial mode, we wait for a new block to start (block number increases).
-                // In non-partial mode, all messages are candidates.
-                let is_new_block_candidate = if self.partial_blocks {
-                    match msg.partial_block_index {
-                        None => {
-                            // If we get a full block, it is a candidate
-                            last_block_number = Some(incoming.number);
-                            true
+            // Outer loop: find a suitable first block and fetch its snapshot. Retries within the
+            // same subscription when the snapshot endpoint rejects the block as too old — this
+            // happens after a server restart whose persisted state is outside the plan retention
+            // window. Consuming the stale delta and waiting for the next one lets the server catch
+            // up without tearing down the WS subscription and rebuilding state from scratch.
+            const MAX_STALE_RETRIES: u32 = 5;
+            let mut stale_retries: u32 = 0;
+            let (msg, header) = 'init: loop {
+                let mut first_msg = loop {
+                    let msg = select! {
+                        deltas_result = timeout(Duration::from_secs(self.timeout), msg_rx.recv()) => {
+                            deltas_result
+                                .map_err(|_| {
+                                    SynchronizerError::Timeout(format!(
+                                        "First deltas took longer than {t}s to arrive",
+                                        t = self.timeout
+                                    ))
+                                })?
+                                .ok_or_else(|| {
+                                    SynchronizerError::ConnectionError(
+                                        "Deltas channel closed before first message".to_string(),
+                                    )
+                                })?
+                        },
+                        _ = &mut end_rx => {
+                            info!("Received close signal while waiting for first deltas");
+                            return Ok(());
                         }
-                        Some(current_partial_idx) => {
-                            let is_new_block = last_block_number
-                                .map(|prev_block| incoming.number > prev_block)
-                                .unwrap_or(false);
+                    };
 
-                            if !warned_waiting_for_new_block {
-                                info!(
-                                    extractor=%self.extractor_id,
-                                    block=incoming.number,
-                                    partial_idx=current_partial_idx,
-                                    "Syncing. Waiting for new block to start"
-                                );
-                                warned_waiting_for_new_block = true;
+                    let incoming: BlockHeader = (&msg).into();
+
+                    // Determine if this message is a candidate for starting synchronization.
+                    // In partial mode, we wait for a new block to start (block number increases).
+                    // In non-partial mode, all messages are candidates.
+                    let is_new_block_candidate = if self.partial_blocks {
+                        match msg.partial_block_index {
+                            None => {
+                                // If we get a full block, it is a candidate
+                                last_block_number = Some(incoming.number);
+                                true
                             }
-                            last_block_number = Some(incoming.number);
-                            is_new_block
-                        }
-                    }
-                } else {
-                    true // Non-partial mode: all messages are candidates
-                };
+                            Some(current_partial_idx) => {
+                                let is_new_block = last_block_number
+                                    .map(|prev_block| incoming.number > prev_block)
+                                    .unwrap_or(false);
 
-                if !is_new_block_candidate {
-                    continue;
-                }
-
-                // Check if we've already synced this block (applies to both modes)
-                if let Some(current) = &self.last_synced_block {
-                    if current.number >= incoming.number && !self.is_next_expected(&incoming) {
-                        if !warned_skipping_synced {
-                            info!(extractor=%self.extractor_id, from=incoming.number, to=current.number, "Syncing. Skipping already synced block");
-                            warned_skipping_synced = true;
+                                if !warned_waiting_for_new_block {
+                                    info!(
+                                        extractor=%self.extractor_id,
+                                        block=incoming.number,
+                                        partial_idx=current_partial_idx,
+                                        "Syncing. Waiting for new block to start"
+                                    );
+                                    warned_waiting_for_new_block = true;
+                                }
+                                last_block_number = Some(incoming.number);
+                                is_new_block
+                            }
                         }
+                    } else {
+                        true // Non-partial mode: all messages are candidates
+                    };
+
+                    if !is_new_block_candidate {
                         continue;
                     }
-                }
-                break msg;
-            };
 
-            self.filter_deltas(&mut first_msg);
+                    // Check if we've already synced this block (applies to both modes)
+                    if let Some(current) = &self.last_synced_block {
+                        if current.number >= incoming.number && !self.is_next_expected(&incoming) {
+                            if !warned_skipping_synced {
+                                info!(extractor=%self.extractor_id, from=incoming.number, to=current.number, "Syncing. Skipping already synced block");
+                                warned_skipping_synced = true;
+                            }
+                            continue;
+                        }
+                    }
+                    break msg;
+                };
 
-            // initial snapshot
-            info!(height = first_msg.get_block().number, "First deltas received");
-            let header: BlockHeader = (&first_msg).into();
-            let deltas_msg = StateSyncMessage {
-                header: header.clone(),
-                snapshots: Default::default(),
-                deltas: Some(first_msg),
-                removed_components: Default::default(),
-            };
+                self.filter_deltas(&mut first_msg);
 
-            // If possible skip retrieving snapshots
-            let msg = if !self.is_next_expected(&header) {
-                info!("Retrieving snapshot");
-                // With partial blocks, the server only has full blocks in its buffer; pass the
-                // previous block's header so we request state at N-1, then merge with deltas.
-                let snapshot_header = if self.partial_blocks && header.number > 0 {
-                    BlockHeader {
-                        number: header.number - 1,
-                        hash: header.parent_hash.clone(),
-                        ..Default::default()
+                // initial snapshot
+                info!(height = first_msg.get_block().number, "First deltas received");
+                let header: BlockHeader = (&first_msg).into();
+                let deltas_msg = StateSyncMessage {
+                    header: header.clone(),
+                    snapshots: Default::default(),
+                    deltas: Some(first_msg),
+                    removed_components: Default::default(),
+                };
+
+                // If possible skip retrieving snapshots
+                if !self.is_next_expected(&header) {
+                    info!("Retrieving snapshot");
+                    // With partial blocks, the server only has full blocks in its buffer; pass the
+                    // previous block's header so we request state at N-1, then merge with deltas.
+                    let snapshot_header = if self.partial_blocks && header.number > 0 {
+                        BlockHeader {
+                            number: header.number - 1,
+                            hash: header.parent_hash.clone(),
+                            ..Default::default()
+                        }
+                    } else {
+                        BlockHeader { revert: false, ..header.clone() }
+                    };
+                    match self
+                        .get_snapshots::<Vec<&String>>(snapshot_header, None)
+                        .await
+                    {
+                        Ok(snapshot) => {
+                            let n_components = self.component_tracker.components.len();
+                            let n_snapshots = snapshot.snapshots.states.len();
+                            info!(n_components, n_snapshots, "Initial snapshot retrieved, starting delta message feed");
+                            break 'init (snapshot.merge(deltas_msg), header);
+                        }
+                        Err(SynchronizerError::RPCError(crate::rpc::RPCError::StaleBlock(
+                            reason,
+                        ))) => {
+                            stale_retries += 1;
+                            if stale_retries > MAX_STALE_RETRIES {
+                                return Err(SynchronizerError::RPCError(
+                                    crate::rpc::RPCError::StaleBlock(reason),
+                                ));
+                            }
+                            // The server's persisted state for this block is outside the plan
+                            // retention window. Discard this delta and wait for a fresher block
+                            // from the same subscription rather than restarting from scratch.
+                            warn!(
+                                block = header.number,
+                                stale_retries,
+                                %reason,
+                                "Snapshot block is outside server retention window; \
+                                 waiting for a more recent block"
+                            );
+                            continue 'init;
+                        }
+                        Err(e) => return Err(e),
                     }
                 } else {
-                    BlockHeader { revert: false, ..header.clone() }
-                };
-                let snapshot = self
-                    .get_snapshots::<Vec<&String>>(snapshot_header, None)
-                    .await?
-                    .merge(deltas_msg);
-                let n_components = self.component_tracker.components.len();
-                let n_snapshots = snapshot.snapshots.states.len();
-                info!(n_components, n_snapshots, "Initial snapshot retrieved, starting delta message feed");
-                snapshot
-            } else {
-                deltas_msg
+                    break 'init (deltas_msg, header);
+                }
             };
+
             block_tx.send(Ok(msg)).await?;
-            self.last_synced_block = Some(header.clone());
+            self.last_synced_block = Some(header);
             loop {
                 select! {
                     deltas_opt = msg_rx.recv() => {

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -318,8 +318,7 @@ pub trait RPCClient: Send + Sync {
                 };
                 let first_response = self
                     .get_protocol_components(&initial_request)
-                    .await
-                    .map_err(|err| RPCError::Fatal(err.to_string()))?;
+                    .await?;
 
                 let total_items = first_response.pagination.total;
                 let total_pages = (total_items as f64 / chunk_size as f64).ceil() as i64;

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -1159,7 +1159,7 @@ impl RPCClient for HttpRPCClient {
             .await
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
         let tokens = serde_json::from_str::<TokensRequestResponse>(&body)
-            .map_err(|err| parse_error(err, &body))?;
+            .map_err(|err| RPCError::ParseResponse(format!("Error: {err}, Body: {body}")))?;
 
         Ok(tokens)
     }
@@ -1186,7 +1186,7 @@ impl RPCClient for HttpRPCClient {
             .await
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
         let protocol_systems = serde_json::from_str::<ProtocolSystemsRequestResponse>(&body)
-            .map_err(|err| parse_error(err, &body))?;
+            .map_err(|err| RPCError::ParseResponse(format!("Error: {err}, Body: {body}")))?;
         trace!(?protocol_systems, "Received protocol_systems response from Tycho server");
         Ok(protocol_systems)
     }
@@ -1215,7 +1215,7 @@ impl RPCClient for HttpRPCClient {
         let component_tvl =
             serde_json::from_str::<ComponentTvlRequestResponse>(&body).map_err(|err| {
                 error!("Failed to parse component_tvl response: {:?}", &body);
-                parse_error(err, &body)
+                RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
             })?;
         trace!(?component_tvl, "Received component_tvl response from Tycho server");
         Ok(component_tvl)
@@ -1247,7 +1247,7 @@ impl RPCClient for HttpRPCClient {
         let entrypoints =
             serde_json::from_str::<TracedEntryPointRequestResponse>(&body).map_err(|err| {
                 error!("Failed to parse traced_entry_points response: {:?}", &body);
-                parse_error(err, &body)
+                RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
             })?;
         trace!(?entrypoints, "Received traced_entry_points response from Tycho server");
         Ok(entrypoints)

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -132,6 +132,10 @@ pub enum RPCError {
     #[error("Snapshot block is stale: {0}")]
     StaleBlock(String),
 
+    /// The requested extractor does not exist on the server.
+    #[error("Unknown extractor: {0}")]
+    UnknownExtractor(String),
+
     /// Other fatal errors.
     #[error("Fatal error: {0}")]
     Fatal(String),
@@ -155,6 +159,8 @@ pub enum RPCError {
 fn parse_error(err: serde_json::Error, body: &str) -> RPCError {
     if body.contains("version is older than") || body.contains("Could not find Block") {
         RPCError::StaleBlock(body.to_string())
+    } else if body.starts_with("Unknown extractor:") {
+        RPCError::UnknownExtractor(body.to_string())
     } else {
         RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
     }

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -898,6 +898,12 @@ impl HttpRPCClient {
                     .and_then(|h| h.to_str().ok())
                     .and_then(parse_retry_value);
 
+                let reason = response
+                    .text()
+                    .await
+                    .unwrap_or_default();
+                warn!(reason, retry_after = ?retry_after_raw, "Rate limited by server");
+
                 Err(RPCError::RateLimited(retry_after_raw))
             }
             StatusCode::BAD_GATEWAY |

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -128,6 +128,10 @@ pub enum RPCError {
     #[error("Failed to parse response: {0}")]
     ParseResponse(String),
 
+    /// The requested block is outside the server's retention window.
+    #[error("Snapshot block is stale: {0}")]
+    StaleBlock(String),
+
     /// Other fatal errors.
     #[error("Fatal error: {0}")]
     Fatal(String),
@@ -137,6 +141,23 @@ pub enum RPCError {
 
     #[error("Server unreachable: {0}")]
     ServerUnreachable(String),
+}
+
+/// Converts an HTTP response body parse failure into the correct `RPCError`.
+///
+/// The tycho server returns plain-text error messages (not JSON) when a requested block falls
+/// outside its retention window. Detecting these here gives callers a typed signal to retry
+/// with a more recent block rather than treating it as an unrecoverable parse failure.
+///
+/// NOTE: The string matching below is coupled to the server's error message text. If those
+/// messages change server-side this silently regresses to `ParseResponse`. Replace with a
+/// structured error code if the server ever returns typed error responses.
+fn parse_error(err: serde_json::Error, body: &str) -> RPCError {
+    if body.contains("version is older than") || body.contains("Could not find Block") {
+        RPCError::StaleBlock(body.to_string())
+    } else {
+        RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
+    }
 }
 
 #[cfg_attr(test, automock)]
@@ -1021,7 +1042,7 @@ impl RPCClient for HttpRPCClient {
         }
 
         let accounts = serde_json::from_str::<StateRequestResponse>(&body)
-            .map_err(|err| RPCError::ParseResponse(format!("Error: {err}, Body: {body}")))?;
+            .map_err(|err| parse_error(err, &body))?;
         trace!(?accounts, "Received contract_state response from Tycho server");
 
         Ok(accounts)
@@ -1052,7 +1073,7 @@ impl RPCClient for HttpRPCClient {
             .await
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
         let components = serde_json::from_str::<ProtocolComponentRequestResponse>(&body)
-            .map_err(|err| RPCError::ParseResponse(format!("Error: {err}, Body: {body}")))?;
+            .map_err(|err| parse_error(err, &body))?;
         trace!(?components, "Received protocol_components response from Tycho server");
 
         Ok(components)
@@ -1104,7 +1125,7 @@ impl RPCClient for HttpRPCClient {
         }
 
         let states = serde_json::from_str::<ProtocolStateRequestResponse>(&body)
-            .map_err(|err| RPCError::ParseResponse(format!("Error: {err}, Body: {body}")))?;
+            .map_err(|err| parse_error(err, &body))?;
         trace!(?states, "Received protocol_states response from Tycho server");
 
         Ok(states)
@@ -1132,7 +1153,7 @@ impl RPCClient for HttpRPCClient {
             .await
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
         let tokens = serde_json::from_str::<TokensRequestResponse>(&body)
-            .map_err(|err| RPCError::ParseResponse(format!("Error: {err}, Body: {body}")))?;
+            .map_err(|err| parse_error(err, &body))?;
 
         Ok(tokens)
     }
@@ -1159,7 +1180,7 @@ impl RPCClient for HttpRPCClient {
             .await
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
         let protocol_systems = serde_json::from_str::<ProtocolSystemsRequestResponse>(&body)
-            .map_err(|err| RPCError::ParseResponse(format!("Error: {err}, Body: {body}")))?;
+            .map_err(|err| parse_error(err, &body))?;
         trace!(?protocol_systems, "Received protocol_systems response from Tycho server");
         Ok(protocol_systems)
     }
@@ -1188,7 +1209,7 @@ impl RPCClient for HttpRPCClient {
         let component_tvl =
             serde_json::from_str::<ComponentTvlRequestResponse>(&body).map_err(|err| {
                 error!("Failed to parse component_tvl response: {:?}", &body);
-                RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
+                parse_error(err, &body)
             })?;
         trace!(?component_tvl, "Received component_tvl response from Tycho server");
         Ok(component_tvl)
@@ -1220,7 +1241,7 @@ impl RPCClient for HttpRPCClient {
         let entrypoints =
             serde_json::from_str::<TracedEntryPointRequestResponse>(&body).map_err(|err| {
                 error!("Failed to parse traced_entry_points response: {:?}", &body);
-                RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
+                parse_error(err, &body)
             })?;
         trace!(?entrypoints, "Received traced_entry_points response from Tycho server");
         Ok(entrypoints)

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -147,22 +147,24 @@ pub enum RPCError {
     ServerUnreachable(String),
 }
 
-/// Converts an HTTP response body parse failure into the correct `RPCError`.
-///
-/// The tycho server returns plain-text error messages (not JSON) when a requested block falls
-/// outside its retention window. Detecting these here gives callers a typed signal to retry
-/// with a more recent block rather than treating it as an unrecoverable parse failure.
-///
-/// NOTE: The string matching below is coupled to the server's error message text. If those
-/// messages change server-side this silently regresses to `ParseResponse`. Replace with a
-/// structured error code if the server ever returns typed error responses.
-fn parse_error(err: serde_json::Error, body: &str) -> RPCError {
-    if body.contains("version is older than") || body.contains("Could not find Block") {
-        RPCError::StaleBlock(body.to_string())
-    } else if body.starts_with("Unknown extractor:") {
-        RPCError::UnknownExtractor(body.to_string())
-    } else {
-        RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
+impl RPCError {
+    /// Converts an HTTP response body parse failure into the correct `RPCError`.
+    ///
+    /// The tycho server returns plain-text error messages (not JSON) when a requested block falls
+    /// outside its retention window. Detecting these here gives callers a typed signal to retry
+    /// with a more recent block rather than treating it as an unrecoverable parse failure.
+    ///
+    /// NOTE: The string matching below is coupled to the server's error message text. If those
+    /// messages change server-side this silently regresses to `ParseResponse`. Replace with a
+    /// structured error code if the server ever returns typed error responses.
+    fn from_parse_error(err: serde_json::Error, body: &str) -> Self {
+        if body.contains("version is older than") || body.contains("Could not find Block") {
+            RPCError::StaleBlock(body.to_string())
+        } else if body.starts_with("Unknown extractor:") {
+            RPCError::UnknownExtractor(body.to_string())
+        } else {
+            RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
+        }
     }
 }
 
@@ -1047,7 +1049,7 @@ impl RPCClient for HttpRPCClient {
         }
 
         let accounts = serde_json::from_str::<StateRequestResponse>(&body)
-            .map_err(|err| parse_error(err, &body))?;
+            .map_err(|err| RPCError::from_parse_error(err, &body))?;
         trace!(?accounts, "Received contract_state response from Tycho server");
 
         Ok(accounts)
@@ -1078,7 +1080,7 @@ impl RPCClient for HttpRPCClient {
             .await
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
         let components = serde_json::from_str::<ProtocolComponentRequestResponse>(&body)
-            .map_err(|err| parse_error(err, &body))?;
+            .map_err(|err| RPCError::from_parse_error(err, &body))?;
         trace!(?components, "Received protocol_components response from Tycho server");
 
         Ok(components)
@@ -1130,7 +1132,7 @@ impl RPCClient for HttpRPCClient {
         }
 
         let states = serde_json::from_str::<ProtocolStateRequestResponse>(&body)
-            .map_err(|err| parse_error(err, &body))?;
+            .map_err(|err| RPCError::from_parse_error(err, &body))?;
         trace!(?states, "Received protocol_states response from Tycho server");
 
         Ok(states)

--- a/crates/tycho-indexer/src/services/ws.rs
+++ b/crates/tycho-indexer/src/services/ws.rs
@@ -23,7 +23,7 @@ use crate::extractor::runner::MessageSender;
 /// How often heartbeat pings are sent
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 /// How long before lack of client response causes a timeout
-const CLIENT_TIMEOUT: Duration = Duration::from_secs(300);
+const CLIENT_TIMEOUT: Duration = Duration::from_secs(90);
 
 pub type MessageSenderMap = HashMap<ExtractorIdentity, Arc<dyn MessageSender + Send + Sync>>;
 


### PR DESCRIPTION
Improvements include:
  - **WS subscribe/unsubscribe timeouts**: Without timeouts, a server that stops confirming WS commands caused cleanup to block forever, leaving stale processes alive and accumulating WS connections.                                                                                                                                                                                                        
  - **ensure_connection TOCTOU race**: Used Notify::enable() to close the window where a reconnect notification could fire before notified().await, and added a post-wake is_connected() check against spurious wakes.
  - **Stale snapshot blocks**: Added RPCError::StaleBlock so the 'init loop can discard a too-old delta and wait for a fresher block on the same subscription rather than tearing it down and retrying from scratch.      
  - **Unknown extractor no longer crashes**: A misconfigured protocol name now logs a warning and skips that extractor, leaving valid protocols running.                                                                  
  - **Retry count resets after a healthy run**: After processing at least one block, a subsequent failure resets the retry counter so transient errors don't consume quota earned by prior failures.  
  - **Detect stalled connections**: trigger reconnect attempts after a period of silence on the ws connection.