### PR TITLE
feat: add gas_error_ratio metric histogram for integration tests

### DIFF
--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -1200,6 +1200,7 @@ async fn process_state(
             }
         };
         let duration_seconds = start_time.elapsed().as_secs_f64();
+        let estimated_gas = amount_out_result.gas;
         let expected_amount_out = amount_out_result.amount;
         debug!(
             event_type = "get_amount_out_duration",
@@ -1249,6 +1250,7 @@ async fn process_state(
                 component_id: component.id.to_string(),
                 token_in: token_in.address.to_string(),
                 token_out: token_out.address.to_string(),
+                estimated_gas,
             },
         );
     }
@@ -1362,6 +1364,14 @@ fn process_execution_result(
             }
 
             metrics::record_execution_slippage(&execution_info.protocol_system, slippage);
+
+            if let Some(estimated) = execution_info.estimated_gas.to_f64() {
+                metrics::record_gas_error_ratio(
+                    &execution_info.protocol_system,
+                    estimated,
+                    *gas_used as f64,
+                );
+            }
 
             // Record slippage in statistics
             if let Some(ref stats) = statistics {

--- a/crates/tycho-integration-test/src/metrics.rs
+++ b/crates/tycho-integration-test/src/metrics.rs
@@ -64,6 +64,10 @@ pub fn initialize_metrics() {
         "tycho_integration_validation_failures_total",
         "Total number of failed state validations"
     );
+    describe_histogram!(
+        "tycho_integration_simulation_gas_error_ratio",
+        "Absolute gas estimation error as a fraction of actual gas: |estimated - actual| / actual"
+    );
 }
 
 /// Record the duration between block timestamp and component receipt.
@@ -186,6 +190,18 @@ pub fn record_protocol_update_block_delay(block_delay: u64) {
     histogram!("tycho_integration_protocol_update_block_delay_blocks").record(block_delay as f64);
 }
 
+/// Record gas estimation error as |estimated - actual| / actual
+pub fn record_gas_error_ratio(protocol: &str, estimated_gas: f64, actual_gas: f64) {
+    if actual_gas > 0.0 {
+        let ratio = (estimated_gas - actual_gas).abs() / actual_gas;
+        histogram!(
+            "tycho_integration_simulation_gas_error_ratio",
+            "protocol" => protocol.to_string(),
+        )
+        .record(ratio);
+    }
+}
+
 /// Record a failed validation
 pub fn record_validation_failure(protocol: &str) {
     counter!(
@@ -225,6 +241,11 @@ pub async fn create_metrics_exporter(port: u16) -> Result<tokio::task::JoinHandl
         .set_buckets_for_metric(
             Matcher::Full("tycho_integration_protocol_update_block_delay_blocks".to_string()),
             &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 7.0, 10.0, 15.0, 20.0, 25.0],
+        )
+        .map_err(|e| miette::miette!("Failed to set buckets: {}", e))?
+        .set_buckets_for_metric(
+            Matcher::Full("tycho_integration_simulation_gas_error_ratio".to_string()),
+            &[0.0, 0.02, 0.04, 0.06, 0.08, 0.1, 0.25, 0.5, 1.0],
         )
         .map_err(|e| miette::miette!("Failed to set buckets: {}", e))?;
     let handle = exporter_builder

--- a/crates/tycho-test/src/execution/models.rs
+++ b/crates/tycho-test/src/execution/models.rs
@@ -20,6 +20,7 @@ pub struct TychoExecutionInput {
     pub component_id: String,
     pub token_in: String,
     pub token_out: String,
+    pub estimated_gas: BigUint,
 }
 
 /// Result of executing a Tycho transaction simulation.

--- a/protocols/testing/src/test_runner.rs
+++ b/protocols/testing/src/test_runner.rs
@@ -1136,6 +1136,7 @@ impl TestRunner {
                             component_id: component.id.to_string(),
                             token_in: token_in.symbol.clone(),
                             token_out: token_out.symbol.clone(),
+                            estimated_gas: amount_out_result.gas.clone(),
                         },
                     );
                 }


### PR DESCRIPTION
- add gas_error_ratio prometheus hist to tycho integration tests, measuring `|estimated_gas - actual_gas| / actual_gas` per protocol
- emit the gas_error_ratio metric
- buckets: dense up to 10% threshold (2% steps), then a few for outliers [0.0, 0.02, 0.04, 0.06, 0.08, 0.1, 0.25, 0.5, 1.0]