### PR TITLE
feat(router v3 model): Consider wasted router funds

### DIFF
--- a/crates/tycho-execution/model/src/model/tycho_router.rs
+++ b/crates/tycho-execution/model/src/model/tycho_router.rs
@@ -29,7 +29,7 @@ pub fn split_swap(
     n_tokens: i64,
     receiver: Address,
 ) -> Result<(), Error> {
-    _update_native_delta_accounting(params, vault, log, amount_in)?;
+    _update_native_delta_accounting(params, state, vault, log, amount_in)?;
     _tstore_transfer_from_info(state, token_in, amount_in, false, false);
 
     _split_swap_checked(
@@ -119,7 +119,7 @@ pub fn sequential_swap(
     min_amount_out: i64,
     receiver: Address,
 ) -> Result<(), Error> {
-    _update_native_delta_accounting(params, vault, log, amount_in)?;
+    _update_native_delta_accounting(params, state, vault, log, amount_in)?;
     _tstore_transfer_from_info(state, token_in, amount_in, false, false);
 
     _sequential_swap_checked(
@@ -204,7 +204,7 @@ pub fn single_swap(
     min_amount_out: i64,
     receiver: Address,
 ) -> Result<(), Error> {
-    _update_native_delta_accounting(params, vault, log, amount_in)?;
+    _update_native_delta_accounting(params, state, vault, log, amount_in)?;
     _tstore_transfer_from_info(state, token_in, amount_in, false, false);
 
     if crate::config::INTRODUCE_FAULT {
@@ -686,6 +686,7 @@ fn _take_fees(
 /// <https://github.com/propeller-heads/tycho-execution/blob/0454514f4f6ccff55dcaa8e3abbb4ac494d89eba/foundry/src/TychoRouter.sol#L1063>
 fn _update_native_delta_accounting(
     params: &Params,
+    state: &mut State,
     vault: &mut Vault,
     log: &mut impl Log,
     amount_in: i64,
@@ -696,6 +697,7 @@ fn _update_native_delta_accounting(
         if msg_value != amount_in {
             return Err(Error::revert("update_native_delta_accounting: msg_value != amount_in"));
         }
+        state.eth_send_value(Address::Sender, Address::Router, msg_value)?;
         vault._update_delta_accounting(Address::Zero, msg_value);
         log.append(Event::UpdateDeltaAccounting {
             token: Address::Zero,

--- a/crates/tycho-execution/model/src/outcome.rs
+++ b/crates/tycho-execution/model/src/outcome.rs
@@ -33,25 +33,53 @@ impl<T: Log> Outcome<T> {
         Self { params, state, vault, log }
     }
 
-    /// Right now the [Outcome] is considered suspicious if the
-    /// caller ends up with more ETH or WETH on the addresses they
-    /// control ([Address::is_sender_controlled]) than they had before
-    /// the transaction.
-    ///
-    /// TODO should be extended to detect more suspicious scenarios.
-    /// only looks at situations where the user can steal assets.
-    /// TODO also detect situations where the user can waste assets.
+    /// The [Outcome] is considered suspicious if:
+    /// 1. The caller ends up with more ETH or WETH on the addresses they control
+    ///    ([Address::is_sender_controlled]) than they had before the transaction (stealing assets).
+    /// 2. The router's on-chain ETH/WETH loss exceeds the reduction in vault balances. A client
+    ///    contribution that debits a vault balance to cover the router's outflow is not suspicious
+    ///    — the client paid for it.
     pub fn is_suspicious(&self) -> bool {
         let msg_value: i64 = self
             .params
             .get("msg_value")
             .unwrap_or(0);
-        self.final_caller_eth_balance() > msg_value
+        self.final_caller_eth_balance() > msg_value ||
+            self.final_router_eth_balance() < self.sender_vault_eth_change()
+    }
+
+    /// ETH/WETH vault balance change for sender-controlled addresses.
+    /// These parties consented: msg.sender by calling the function,
+    /// ClientFeeReceiver by signing the client fee params.
+    fn sender_vault_eth_change(&self) -> i64 {
+        let mut total = 0;
+        for ((owner, token), balance) in &self.vault.owner_and_token_to_balance {
+            if owner.is_sender_controlled() && (*token == Address::Zero || *token == Address::WETH)
+            {
+                total += balance;
+            }
+        }
+        total
+    }
+
+    /// On-chain ETH and WETH balance delta of [Address::Router].
+    /// A negative value means the router lost tokens.
+    pub fn final_router_eth_balance(&self) -> i64 {
+        self.state
+            .owner_to_eth_balance
+            .get(&Address::Router)
+            .copied()
+            .unwrap_or(0) +
+            self.state
+                .owner_and_token_to_balance
+                .get(&(Address::Router, Address::WETH))
+                .copied()
+                .unwrap_or(0)
     }
 
     /// Return the positive or negative ETH and WETH balance the caller
     /// has at the end of the simulated transaction
-    /// accross all addresses they control ([Address::is_sender_controlled]).
+    /// across all addresses they control ([Address::is_sender_controlled]).
     pub fn final_caller_eth_balance(&self) -> i64 {
         let mut total_eth = 0;
         for (owner, balance) in &self.state.owner_to_eth_balance {
@@ -106,6 +134,10 @@ impl<T: Log + Serialize> Serialize for Outcome<T> {
         let final_caller_eth_balance = self.final_caller_eth_balance();
         if final_caller_eth_balance > 0 {
             s.serialize_entry("final_caller_eth_balance", &final_caller_eth_balance)?;
+        }
+        let final_router_eth_balance = self.final_router_eth_balance();
+        if final_router_eth_balance < 0 {
+            s.serialize_entry("final_router_eth_balance", &final_router_eth_balance)?;
         }
 
         if !self


### PR DESCRIPTION
We were only considering if the sender controlled accounts managed to steal funds. Now, we also consider if the router loses any vault balances that do not belong to the sender, even if the sender does not receive these funds (fund wastage).

Related fix:
We weren't actually making the router the balance owner of the eth that was sent. This was affecting our is_suspicious calculation for a nonzero msg.value.