### PR TITLE
fix: calibrate protocol specific gas costs

### DIFF
--- a/crates/tycho-execution/src/encoding/evm/gas_estimator.rs
+++ b/crates/tycho-execution/src/encoding/evm/gas_estimator.rs
@@ -4,10 +4,10 @@ use crate::encoding::models::{Solution, Strategy};
 
 /// Default gas cost for an ERC-20 `transferFrom` or `transfer`. Used as fallback when the token
 /// has no measured gas cost.
-pub const DEFAULT_TOKEN_TRANSFER_GAS: u64 = 60_000;
+pub const DEFAULT_TOKEN_TRANSFER_GAS: u64 = 40_000;
 
 /// Gas cost for an ERC-20 `approve`.
-pub const TOKEN_APPROVAL_GAS: u64 = 45_000;
+pub const TOKEN_APPROVAL_GAS: u64 = 25_000;
 
 /// Callback-based protocols: the input `transferFrom` happens inside the callback, which is
 /// inside `swap()`. The gas is thus already included in `get_amount_out`.

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -1398,12 +1398,13 @@ fn process_execution_result(
 
             metrics::record_execution_slippage(&execution_info.protocol_system, slippage);
 
-            if let Some(estimated) = execution_info.estimated_gas.to_f64() {
-                let actual = *gas_used as f64;
+            let estimated_gas = execution_info.estimated_gas.clone();
+
+            if let Some(estimated) = estimated_gas.to_f64() {
                 metrics::record_gas_signed_error_ratio(
                     &execution_info.protocol_system,
                     estimated,
-                    actual,
+                    *gas_used as f64,
                 );
             }
 

--- a/crates/tycho-simulation/src/evm/protocol/aerodrome_slipstreams/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/aerodrome_slipstreams/state.rs
@@ -38,6 +38,11 @@ use crate::evm::protocol::{
     },
 };
 
+// The names of the constants reflect the exact method from the tenderly log.
+const TICK_CROSSING_GAS_COST: i32 = 25_000;
+// nextInitializedTickWithinOneWord +  computeSwapStep + calculateFees
+const LOOP_GAS_COST: i32 = 10_000;
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AerodromeSlipstreamsState {
     id: String,
@@ -234,12 +239,13 @@ impl AerodromeSlipstreamsState {
                     let liquidity_net = if zero_for_one { -liquidity_raw } else { liquidity_raw };
                     state.liquidity =
                         liquidity_math::add_liquidity_delta(state.liquidity, liquidity_net)?;
+                    gas_used = safe_add_u256(gas_used, U256::from(TICK_CROSSING_GAS_COST))?;
                 }
                 state.tick = if zero_for_one { step.tick_next - 1 } else { step.tick_next };
             } else if state.sqrt_price != step.sqrt_price_start {
                 state.tick = get_tick_at_sqrt_ratio(state.sqrt_price)?;
             }
-            gas_used = safe_add_u256(gas_used, U256::from(2000))?;
+            gas_used = safe_add_u256(gas_used, U256::from(LOOP_GAS_COST))?;
         }
         Ok(SwapResults {
             amount_calculated: state.amount_calculated,

--- a/crates/tycho-simulation/src/evm/protocol/ekubo/pool/base.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ekubo/pool/base.rs
@@ -49,7 +49,10 @@ pub(super) fn impl_from_state(
 }
 
 impl BasePool {
-    const BASE_GAS_COST: u64 = 24_000;
+    // The names of the constants reflect the exact method from the tenderly log.
+    const BASE_SWAP_GAS_COST: u64 = 24_000;
+    const PAY_METHOD_GAS_COST: u64 = 46_000;
+    const WITHDRAW_METHOD_GAS_COST: u64 = 20_000;
     const GAS_COST_OF_ONE_TICK_SPACING_CROSSED: u64 = 4_000;
     const GAS_COST_OF_ONE_INITIALIZED_TICK_CROSSED: u64 = 20_000;
 
@@ -118,7 +121,10 @@ impl EkuboPool for BasePool {
         Ok(EkuboPoolQuote {
             consumed_amount: quote.consumed_amount,
             calculated_amount: quote.calculated_amount,
-            gas: Self::BASE_GAS_COST + Self::gas_costs(quote.execution_resources),
+            gas: Self::BASE_SWAP_GAS_COST +
+                Self::PAY_METHOD_GAS_COST +
+                Self::WITHDRAW_METHOD_GAS_COST +
+                Self::gas_costs(quote.execution_resources),
             new_state,
         })
     }

--- a/crates/tycho-simulation/src/evm/protocol/ekubo_v3/pool/concentrated.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ekubo_v3/pool/concentrated.rs
@@ -33,7 +33,13 @@ use crate::{
 // Factor to account for computation inaccuracies due to not using tick bitmaps
 const WEI_UNDERESTIMATION_FACTOR: i128 = 2;
 
-const BASE_GAS_COST: u64 = 19_665;
+// The names of the constants reflect the exact method from the tenderly log.
+const TRANSFER_FROM_USER_GAS_COST: u64 = 40_000;
+const START_PAYMENT_GAS_COST: u64 = 6_000;
+const BASE_SWAP_GAS_COST: u64 = 19_665;
+const WITHDRAW_GAS_COST: u64 = 37_500;
+const COMPLETE_PAYMENT_GAS_COST: u64 = 2_000;
+
 const GAS_COST_OF_ONE_INITIALIZED_TICK_CROSSED: u64 = 14_259;
 const GAS_COST_OF_ONE_EXTRA_TICK_BITMAP_SLOAD: u64 = 2_000;
 const GAS_COST_OF_ONE_EXTRA_MATH_ROUND: u64 = 4_076;
@@ -173,7 +179,11 @@ pub(super) fn gas_costs(
     let (extra_distinct_bitmap_lookups, initialized_ticks_crossed) =
         (u64::from(extra_distinct_bitmap_lookups), u64::from(initialized_ticks_crossed));
 
-    BASE_GAS_COST +
+    START_PAYMENT_GAS_COST +
+        BASE_SWAP_GAS_COST +
+        WITHDRAW_GAS_COST +
+        COMPLETE_PAYMENT_GAS_COST +
+        TRANSFER_FROM_USER_GAS_COST +
         extra_distinct_bitmap_lookups * GAS_COST_OF_ONE_EXTRA_TICK_BITMAP_SLOAD +
         initialized_ticks_crossed * GAS_COST_OF_ONE_INITIALIZED_TICK_CROSSED +
         (initialized_ticks_crossed + extra_distinct_bitmap_lookups) *

--- a/crates/tycho-simulation/src/evm/protocol/ekubo_v3/pool/stableswap.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ekubo_v3/pool/stableswap.rs
@@ -17,8 +17,12 @@ use tycho_common::{
 use super::{EkuboPool, EkuboPoolQuote};
 use crate::protocol::errors::InvalidSnapshotError;
 
-const BASE_GAS_COST: u64 = 17_400;
-
+// The names of the constants reflect the exact method from the tenderly log.
+const START_PAYMENT_GAS_COST: u64 = 6_000;
+const BASE_SWAP_GAS_COST: u64 = 17_400;
+const WITHDRAW_GAS_COST: u64 = 16_500;
+const COMPLETE_PAYMENT_GAS_COST: u64 = 2_000;
+const TRANSFER_FROM_USER_GAS_COST: u64 = 20_000;
 #[derive(Debug, Clone, Eq, Serialize, Deserialize)]
 pub struct StableswapPool {
     imp: EvmStableswapPool,
@@ -43,7 +47,11 @@ impl StableswapPool {
     }
 
     pub(super) fn gas_costs() -> u64 {
-        BASE_GAS_COST
+        START_PAYMENT_GAS_COST +
+            BASE_SWAP_GAS_COST +
+            WITHDRAW_GAS_COST +
+            COMPLETE_PAYMENT_GAS_COST +
+            TRANSFER_FROM_USER_GAS_COST
     }
 }
 

--- a/crates/tycho-simulation/src/evm/protocol/erc4626/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/erc4626/state.rs
@@ -96,7 +96,7 @@ impl ProtocolSim for ERC4626State {
                     amount_in * self.asset_price /
                         U256::from(10).pow(U256::from(self.asset_token.decimals)),
                 ),
-                gas: 86107.to_biguint().expect("infallible"),
+                gas: 297000.to_biguint().expect("infallible"),
                 new_state: self.clone_box(),
             })
         } else if token_in.address == self.share_token.address &&
@@ -109,7 +109,7 @@ impl ProtocolSim for ERC4626State {
                     amount_in * self.share_price /
                         U256::from(10).pow(U256::from(self.share_token.decimals)),
                 ),
-                gas: 74977.to_biguint().expect("infallible"),
+                gas: 287000.to_biguint().expect("infallible"),
                 new_state: self.clone_box(),
             })
         } else {

--- a/crates/tycho-simulation/src/evm/protocol/pancakeswap_v2/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/pancakeswap_v2/state.rs
@@ -83,7 +83,7 @@ impl ProtocolSim for PancakeswapV2State {
         };
         Ok(GetAmountOutResult::new(
             u256_to_biguint(amount_out),
-            BigUint::from(120_000u32),
+            BigUint::from(70_000u32),
             Box::new(new_state),
         ))
     }

--- a/crates/tycho-simulation/src/evm/protocol/rocketpool/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/rocketpool/state.rs
@@ -26,6 +26,15 @@ const DEPOSIT_FEE_BASE: u128 = 1_000_000_000_000_000_000; // 1e18
 /// 32 ETH — the hardcoded amount every megapool queue entry requests.
 const FULL_DEPOSIT_VALUE: u128 = 32_000_000_000_000_000_000u128;
 
+// The names of the constants reflect the exact method from the tenderly log.
+const BASE_DEPOSIT_GAS: u64 = 209_000;
+const RETH_MINT_GAS: u64 = 50_000;
+const VAULT_DEPOSIT_OR_EXCESS_GAS: u64 = 20_000;
+const ASSIGN_DEPOSITS_BASE_GAS: u64 = 20_000;
+// peekItem + withdrawEther + assignFunds + dequeueItem
+const GAS_PER_MEGAPOOL_ASSIGNMENT: u64 = 120_000;
+const BASE_WITHDRAWAL_GAS: u64 = 134_000;
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RocketpoolState {
     pub reth_supply: U256,
@@ -179,12 +188,12 @@ impl RocketpoolState {
     ///
     /// The minimum of these three gives the number of entries assigned.
     /// Total ETH assigned = entries × 32 ETH.
-    fn calculate_assign_deposits(&self, deposit_amount: U256) -> U256 {
+    fn calculate_assign_deposits(&self, deposit_amount: U256) -> (U256, u64) {
         if !self.deposit_assigning_enabled ||
             self.megapool_queue_requested_total
                 .is_zero()
         {
-            return U256::ZERO;
+            return (U256::ZERO, 0);
         }
 
         let full_deposit_value = U256::from(FULL_DEPOSIT_VALUE);
@@ -205,7 +214,7 @@ impl RocketpoolState {
             .min(vault_cap)
             .min(queue_entries);
 
-        entries * full_deposit_value
+        (entries * full_deposit_value, entries.try_into().unwrap_or(u64::MAX))
     }
 }
 
@@ -287,18 +296,35 @@ impl ProtocolSim for RocketpoolState {
         };
 
         let mut new_state = self.clone();
+        let mut gas_used = 0;
+
         // Note: total_eth and reth_supply are not updated as they are managed by an oracle.
         if is_depositing_eth {
+            gas_used += BASE_DEPOSIT_GAS;
+
             // route ETH between rETH collateral buffer and vault.
             let (to_reth, to_vault) = new_state.compute_deposit_routing(amount_in)?;
             new_state.reth_contract_liquidity =
                 safe_add_u256(new_state.reth_contract_liquidity, to_reth)?;
             new_state.deposit_contract_balance =
                 safe_add_u256(new_state.deposit_contract_balance, to_vault)?;
+            if to_reth > U256::ZERO {
+                gas_used += RETH_MINT_GAS;
+            }
+
+            if to_vault > U256::ZERO {
+                gas_used += VAULT_DEPOSIT_OR_EXCESS_GAS;
+            }
 
             // Assign deposits: dequeue megapool entries and send ETH from vault to validators.
             // Both the vault balance and the queue requested are reduced by the same amount.
-            let eth_assigned = new_state.calculate_assign_deposits(amount_in);
+            let (eth_assigned, entries) = new_state.calculate_assign_deposits(amount_in);
+
+            if entries > 0 {
+                gas_used += ASSIGN_DEPOSITS_BASE_GAS;
+                gas_used += entries * GAS_PER_MEGAPOOL_ASSIGNMENT;
+            }
+
             if eth_assigned > U256::ZERO {
                 new_state.deposit_contract_balance =
                     safe_sub_u256(new_state.deposit_contract_balance, eth_assigned)?;
@@ -306,6 +332,7 @@ impl ProtocolSim for RocketpoolState {
                     safe_sub_u256(new_state.megapool_queue_requested_total, eth_assigned)?;
             }
         } else {
+            gas_used = BASE_WITHDRAWAL_GAS;
             // Withdraw from rETH contract first, spill remainder into deposit pool.
             let needed_from_deposit_pool =
                 amount_out.saturating_sub(new_state.reth_contract_liquidity);
@@ -319,7 +346,6 @@ impl ProtocolSim for RocketpoolState {
         // The ETH withdrawal gas estimation assumes a best case scenario when there is sufficient
         // liquidity in the rETH contract. Note that there has never been a situation during a
         // withdrawal when this was not the case, hence the simplified gas estimation.
-        let gas_used = if is_depositing_eth { 209_000u32 } else { 134_000u32 };
 
         Ok(GetAmountOutResult::new(
             u256_to_biguint(amount_out),
@@ -1166,7 +1192,7 @@ mod tests {
             U256::from(max),
             U256::from(socialised),
         );
-        let assigned = state.calculate_assign_deposits(U256::from(deposit));
+        let (assigned, _gas_used) = state.calculate_assign_deposits(U256::from(deposit));
         assert_eq!(assigned, U256::from(expected_assigned));
     }
 

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v2/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v2/state.rs
@@ -83,7 +83,7 @@ impl ProtocolSim for UniswapV2State {
         };
         Ok(GetAmountOutResult::new(
             u256_to_biguint(amount_out),
-            BigUint::from(120_000u32),
+            BigUint::from(70_000u32),
             Box::new(new_state),
         ))
     }

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
@@ -41,12 +41,19 @@ use crate::evm::protocol::{
 
 // Gas limit constants for capping get_limits calculations
 // These prevent simulations from exceeding Ethereum's block gas limit
+// The names of the constants reflect the exact method from the tenderly log.
 const SWAP_BASE_GAS: u64 = 130_000;
-// This gas is estimated from UniswapV3Pool cross() calls on Tenderly
-const GAS_PER_TICK: u64 = 17_540;
+// Bitmap word scan
+const GAS_PER_BITMAP_WORD: u64 = 2_100;
+// swap math step: getSqrtRatioAtTick + computeSwapStep + amount accounting
+const GAS_PER_SWAP_MATH_STEP: u64 = 4_000;
+// Initialized tick crossing
+const GAS_PER_INITIALIZED_TICK_CROSS: u64 = 17_540;
+// Output transfer + balanceBefore + callback + balanceAfter.
+const V3_CALLBACK_SETTLEMENT_GAS: u64 = 70_000;
 // Conservative max gas budget for a single swap (Ethereum transaction gas limit)
 const MAX_SWAP_GAS: u64 = 16_700_000;
-const MAX_TICKS_CROSSED: u64 = (MAX_SWAP_GAS - SWAP_BASE_GAS) / GAS_PER_TICK;
+const MAX_TICKS_CROSSED: u64 = (MAX_SWAP_GAS - SWAP_BASE_GAS) / GAS_PER_INITIALIZED_TICK_CROSS;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UniswapV3State {
@@ -127,7 +134,7 @@ impl UniswapV3State {
             tick: self.tick,
             liquidity: self.liquidity,
         };
-        let mut gas_used = U256::from(130_000);
+        let mut gas_used = U256::from(0);
 
         while state.amount_remaining != I256::from_raw(U256::from(0u64)) &&
             state.sqrt_price != price_limit
@@ -136,7 +143,10 @@ impl UniswapV3State {
                 .ticks
                 .next_initialized_tick_within_one_word(state.tick, zero_for_one)
             {
-                Ok((tick, init)) => (tick, init),
+                Ok((tick, init)) => {
+                    gas_used = safe_add_u256(gas_used, U256::from(GAS_PER_BITMAP_WORD))?;
+                    (tick, init)
+                }
                 Err(tick_err) => match tick_err.kind {
                     TickListErrorKind::TicksExeeded => {
                         let mut new_state = self.clone();
@@ -178,6 +188,9 @@ impl UniswapV3State {
                 amount_out,
                 fee_amount,
             };
+
+            gas_used = safe_add_u256(gas_used, U256::from(GAS_PER_SWAP_MATH_STEP))?;
+
             if exact_input {
                 state.amount_remaining -= I256::checked_from_sign_and_abs(
                     Sign::Positive,
@@ -205,12 +218,12 @@ impl UniswapV3State {
                     let liquidity_net = if zero_for_one { -liquidity_raw } else { liquidity_raw };
                     state.liquidity =
                         liquidity_math::add_liquidity_delta(state.liquidity, liquidity_net)?;
+                    gas_used = safe_add_u256(gas_used, U256::from(GAS_PER_INITIALIZED_TICK_CROSS))?;
                 }
                 state.tick = if zero_for_one { step.tick_next - 1 } else { step.tick_next };
             } else if state.sqrt_price != step.sqrt_price_start {
                 state.tick = get_tick_at_sqrt_ratio(state.sqrt_price)?;
             }
-            gas_used = safe_add_u256(gas_used, U256::from(2000))?;
         }
         Ok(SwapResults {
             amount_calculated: state.amount_calculated,
@@ -219,7 +232,7 @@ impl UniswapV3State {
             sqrt_price: state.sqrt_price,
             liquidity: state.liquidity,
             tick: state.tick,
-            gas_used,
+            gas_used: safe_add_u256(gas_used, U256::from(V3_CALLBACK_SETTLEMENT_GAS))?,
         })
     }
 

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
@@ -53,9 +53,13 @@ use crate::{
 
 // Gas limit constants for capping get_limits calculations
 // These prevent simulations from exceeding Ethereum's block gas limit
+// The names of the constants reflect the exact method from the tenderly log.
 const SWAP_BASE_GAS: u64 = 130_000;
-// This gas is estimated from UniswapV3Pool cross() calls on Tenderly
 const GAS_PER_TICK: u64 = 17_540;
+const GAS_PER_BITMAP_LOOKUP: u64 = 4_000;
+// Cost of taking the output amount from the Uniswap V4 PoolManager, corresponds to
+// PoolManager.take()
+const V4_CALLBACK_SETTLEMENT_GAS: u64 = 30_000;
 // Conservative max gas budget for a single swap (Ethereum transaction gas limit)
 const MAX_SWAP_GAS: u64 = 16_700_000;
 const MAX_TICKS_CROSSED: u64 = (MAX_SWAP_GAS - SWAP_BASE_GAS) / GAS_PER_TICK;
@@ -209,14 +213,17 @@ impl UniswapV4State {
             tick: self.tick,
             liquidity: self.liquidity,
         };
-        let mut gas_used = U256::from(130_000);
+        let mut gas_used = U256::from(0);
 
         while state.amount_remaining != I256::ZERO && state.sqrt_price != price_limit {
             let (mut next_tick, initialized) = match self
                 .ticks
                 .next_initialized_tick_within_one_word(state.tick, zero_for_one)
             {
-                Ok((tick, init)) => (tick, init),
+                Ok((tick, init)) => {
+                    gas_used = safe_add_u256(gas_used, U256::from(GAS_PER_BITMAP_LOOKUP))?;
+                    (tick, init)
+                }
                 Err(tick_err) => match tick_err.kind {
                     TickListErrorKind::TicksExeeded => {
                         let mut new_state = self.clone();
@@ -292,13 +299,14 @@ impl UniswapV4State {
                     let liquidity_net = if zero_for_one { -liquidity_raw } else { liquidity_raw };
                     state.liquidity =
                         liquidity_math::add_liquidity_delta(state.liquidity, liquidity_net)?;
+                    gas_used = safe_add_u256(gas_used, U256::from(GAS_PER_TICK))?;
                 }
                 state.tick = if zero_for_one { step.tick_next - 1 } else { step.tick_next };
             } else if state.sqrt_price != step.sqrt_price_start {
                 state.tick = get_tick_at_sqrt_ratio(state.sqrt_price)?;
             }
-            gas_used = safe_add_u256(gas_used, U256::from(2000))?;
         }
+
         Ok(SwapResults {
             amount_calculated: state.amount_calculated,
             amount_specified,
@@ -306,7 +314,7 @@ impl UniswapV4State {
             sqrt_price: state.sqrt_price,
             liquidity: state.liquidity,
             tick: state.tick,
-            gas_used,
+            gas_used: safe_add_u256(gas_used, U256::from(V4_CALLBACK_SETTLEMENT_GAS))?,
         })
     }
 

--- a/crates/tycho-simulation/src/evm/protocol/velodrome_slipstreams/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/velodrome_slipstreams/state.rs
@@ -31,6 +31,11 @@ use crate::evm::protocol::{
     },
 };
 
+// The names of the constants reflect the exact method from the tenderly log.
+const GAS_PER_TICK: u64 = 25_000;
+// nextInitializedTickWithinOneWord +  computeSwapStep + calculateFees
+const GAS_PER_LOOP: u64 = 10_000;
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VelodromeSlipstreamsState {
     liquidity: u128,
@@ -201,12 +206,13 @@ impl VelodromeSlipstreamsState {
                     let liquidity_net = if zero_for_one { -liquidity_raw } else { liquidity_raw };
                     state.liquidity =
                         liquidity_math::add_liquidity_delta(state.liquidity, liquidity_net)?;
+                    gas_used = safe_add_u256(gas_used, U256::from(GAS_PER_TICK))?;
                 }
                 state.tick = if zero_for_one { step.tick_next - 1 } else { step.tick_next };
             } else if state.sqrt_price != step.sqrt_price_start {
                 state.tick = get_tick_at_sqrt_ratio(state.sqrt_price)?;
             }
-            gas_used = safe_add_u256(gas_used, U256::from(2000))?;
+            gas_used = safe_add_u256(gas_used, U256::from(GAS_PER_LOOP))?;
         }
         Ok(SwapResults {
             amount_calculated: state.amount_calculated,

--- a/crates/tycho-test/src/execution/execution_simulator.rs
+++ b/crates/tycho-test/src/execution/execution_simulator.rs
@@ -289,7 +289,14 @@ impl ExecutionSimulator {
 
                         let gas_used = trace_value
                             .get("gasUsed")
-                            .and_then(|g| g.as_u64())
+                            .and_then(|g| {
+                                g.as_u64().or_else(|| {
+                                    g.as_str().and_then(|s| {
+                                        u64::from_str_radix(s.strip_prefix("0x").unwrap_or(s), 16)
+                                            .ok()
+                                    })
+                                })
+                            })
                             .unwrap_or(0);
 
                         results.insert(


### PR DESCRIPTION
Note:
Before merging, feel free to squash all commits, since only the final state matters.

Also, could you please remove this [debug print](https://github.com/propeller-heads/tycho-indexer/pull/977/changes#diff-26e2e8378ea4a8cf3761d062001b0af30e6be9c975653df2faf9cd8a7ba4ffaaR1369)
 before merging? It’s no longer needed.

**UniswapV2 / SushiSwapV2 / PancakeSwapV2**

Reduced the gas estimates to exclude token transfer costs.
Based on the tenderly simulations, the previous estimates included both the swap cost and token transfer cost. The updated values now only represent the swap itself.
This increases the gas error rate, but once token transfer gas is added explicitly as a separate cost, the overall error rate should decrease.

Tenderly references:
[UniswapV2](https://www.tdly.co/shared/simulation/cd042fcd-e956-4c34-b390-fd4d662adb52)
[PancakeSwapV2](https://www.tdly.co/shared/simulation/711f4f75-9e25-4c79-be06-4e02cffe7833)

**ERC4626**

Updated gas estimates based on Tenderly simulation data.

Tenderly references:
[ERC4626](https://www.tdly.co/shared/simulation/66081c01-5edb-4dd1-886b-28c48b6d7ff7)

**UniswapV3 / UniswapV4 / PancakeSwapV3 / Aerodrome Slipstreams / Velodrome Slipstreams**

Added missing cross-tick gas cost and increased the per iteration gas cost based on tenderly.

Tenderly references:
[UniswapV3](https://www.tdly.co/shared/simulation/09a3d46b-6b73-4528-9fa0-ee91db683ec2)
[UniswapV3](https://www.tdly.co/shared/simulation/6b2eb513-09e5-47ae-9833-fe45156bbf1b)
[UniswapV3](https://www.tdly.co/shared/simulation/09a3d46b-6b73-4528-9fa0-ee91db683ec2)
[UniswapV4](https://www.tdly.co/shared/simulation/8eb7c1d0-e6a7-4323-a43a-0b11d3609d83)
[UniswapV4](https://www.tdly.co/shared/simulation/8eb7c1d0-e6a7-4323-a43a-0b11d3609d83)
[UniswapV4](https://www.tdly.co/shared/simulation/4bf188d9-6e9f-4b39-94ce-9577356eaa9c)
[Aerodrome Slipstreams](https://www.tdly.co/shared/simulation/4d8b1cd1-9ff6-40e2-8e6a-8224d4cc6e27)
[Velodrome Slipstreams](https://www.tdly.co/shared/simulation/2b913851-99bb-45ec-9fb9-b103ac15c585)


**Rocketpool**

Added missing component costs based on the tenderly simulation.

Tenderly references:
[Rocketpool](https://www.tdly.co/shared/simulation/9fe7bb68-e296-4ba2-a686-d73466c53818)

**Ekubo v2** 

Added missing component costs based on the tenderly simulation.
 
Tenderly references:
[Ekubo v2](https://www.tdly.co/shared/simulation/336dbf17-71ad-4d0a-9693-9bc6989d6c5b)

**Ekubo v3** 

Updated gas estimates to include the full swap lifecycle cost, instead of only the pool swap cost.

For concentrated pools, the previous estimate only included the base swap gas. The updated estimate now also includes transfer/payment lifecycle costs: transfer from user, start payment, withdraw, and complete payment.

For stableswap pools, the same lifecycle cost pattern was added, with a different withdraw cost based on Tenderly simulation data.

This adds the missing fixed costs on top of the existing base swap gas and should make Ekubo v3 estimates closer to actual execution gas.

Tenderly references:
[Ekubo v3 stable pool](https://www.tdly.co/shared/simulation/072ae7bb-32d2-4597-a9be-9d93f597f48b)
[Ekubo v3 concentrated pool](https://www.tdly.co/shared/simulation/e581c38e-6973-4170-b597-24cb18b9b451)