### PR TITLE
fix(integration-test): add staleness watchdog for protocol sync metrics

### DIFF
--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -7,7 +7,7 @@ use std::{
     fmt::Debug,
     str::FromStr,
     sync::{Arc, RwLock},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use alloy::{
@@ -155,6 +155,12 @@ struct Cli {
     /// Enable partial block updates (flashblocks) on the tycho stream for lower latency
     #[arg(long, default_value_t = false)]
     partial_blocks: bool,
+
+    /// Seconds without a protocol update before marking all known protocols as stale in metrics.
+    /// Should be at least 2× the chain's expected block time (e.g. 30 for Ethereum at ~12s
+    /// blocks).
+    #[arg(long, default_value_t = 30)]
+    stale_threshold_secs: u64,
 }
 
 impl Debug for Cli {
@@ -329,6 +335,36 @@ async fn run(cli: Cli) -> miette::Result<()> {
     let mut protocol_stream_open = true;
     let mut rfq_stream_open = !cli.disable_rfq;
 
+    // Staleness watchdog: if no protocol update arrives within stale_threshold_secs, mark all
+    // known protocols as Stale in metrics. This catches stream disconnections where the
+    // SynchronizerState gauge would otherwise remain frozen at its last known value.
+    let known_protocols: Arc<RwLock<HashSet<String>>> = Arc::new(RwLock::new(HashSet::new()));
+    let last_protocol_update: Arc<RwLock<Instant>> = Arc::new(RwLock::new(Instant::now()));
+    if !cli.disable_onchain && cli.stale_threshold_secs > 0 {
+        let checker_known = known_protocols.clone();
+        let checker_last = last_protocol_update.clone();
+        let threshold = Duration::from_secs(cli.stale_threshold_secs);
+        tokio::spawn(async move {
+            let interval = threshold / 2;
+            loop {
+                tokio::time::sleep(interval).await;
+                if checker_last
+                    .read()
+                    .expect("Failed to acquire read lock on last_protocol_update")
+                    .elapsed() >
+                    threshold
+                {
+                    let protocols = checker_known
+                        .read()
+                        .expect("Failed to acquire read lock on known_protocols");
+                    for protocol in protocols.iter() {
+                        metrics::mark_protocol_stale(protocol);
+                    }
+                }
+            }
+        });
+    }
+
     loop {
         if !protocol_stream_open && !rfq_stream_open {
             info!("All streams closed, exiting");
@@ -387,6 +423,22 @@ async fn run(cli: Cli) -> miette::Result<()> {
                                 continue;
                             }
                         };
+
+                        // Reset the staleness watchdog: record this moment as the last time we saw
+                        // a live update, and register any newly-seen protocol names.
+                        {
+                            let now = Instant::now();
+                            *last_protocol_update
+                                .write()
+                                .expect("Failed to acquire write lock on last_protocol_update") =
+                                now;
+                            let mut protocols = known_protocols
+                                .write()
+                                .expect("Failed to acquire write lock on known_protocols");
+                            for protocol in update.update.sync_states.keys() {
+                                protocols.insert(protocol.clone());
+                            }
+                        }
 
                         if cli.max_blocks > 0 {
                             if let Some(stats) = statistics.as_ref() {

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -152,13 +152,13 @@ struct Cli {
     #[arg(long)]
     max_days_since_last_trade: Option<u64>,
 
-    /// Enable partial block updates (flashblocks) on the tycho stream for lower latency
+    /// Enable partial block updates (flashblocks) on the tycho stream.
+    /// Be aware this significantly increases the frequency of simulations. You may need to
+    /// consider adjusting the max-simulations and max-simulations-stale values.
     #[arg(long, default_value_t = false)]
     partial_blocks: bool,
 
     /// Seconds without a protocol update before marking all known protocols as stale in metrics.
-    /// Should be at least 2× the chain's expected block time (e.g. 30 for Ethereum at ~12s
-    /// blocks).
     #[arg(long, default_value_t = 30)]
     stale_threshold_secs: u64,
 }

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -7,7 +7,7 @@ use std::{
     fmt::Debug,
     str::FromStr,
     sync::{Arc, RwLock},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use alloy::{
@@ -338,32 +338,11 @@ async fn run(cli: Cli) -> miette::Result<()> {
     // Staleness watchdog: if no protocol update arrives within stale_threshold_secs, mark all
     // known protocols as Stale in metrics. This catches stream disconnections where the
     // SynchronizerState gauge would otherwise remain frozen at its last known value.
-    let known_protocols: Arc<RwLock<HashSet<String>>> = Arc::new(RwLock::new(HashSet::new()));
-    let last_protocol_update: Arc<RwLock<Instant>> = Arc::new(RwLock::new(Instant::now()));
-    if !cli.disable_onchain && cli.stale_threshold_secs > 0 {
-        let checker_known = known_protocols.clone();
-        let checker_last = last_protocol_update.clone();
-        let threshold = Duration::from_secs(cli.stale_threshold_secs);
-        tokio::spawn(async move {
-            let interval = threshold / 2;
-            loop {
-                tokio::time::sleep(interval).await;
-                if checker_last
-                    .read()
-                    .expect("Failed to acquire read lock on last_protocol_update")
-                    .elapsed() >
-                    threshold
-                {
-                    let protocols = checker_known
-                        .read()
-                        .expect("Failed to acquire read lock on known_protocols");
-                    for protocol in protocols.iter() {
-                        metrics::mark_protocol_stale(protocol);
-                    }
-                }
-            }
-        });
-    }
+    let stale_threshold = Duration::from_secs(cli.stale_threshold_secs);
+    let stale_enabled = !cli.disable_onchain && cli.stale_threshold_secs > 0;
+    let mut known_protocols: HashSet<String> = HashSet::new();
+    let stale_sleep = tokio::time::sleep(stale_threshold);
+    tokio::pin!(stale_sleep);
 
     loop {
         if !protocol_stream_open && !rfq_stream_open {
@@ -412,6 +391,16 @@ async fn run(cli: Cli) -> miette::Result<()> {
                 }
             }
 
+            // Staleness watchdog fires when no protocol update arrives within the threshold
+            _ = &mut stale_sleep, if stale_enabled => {
+                for protocol in &known_protocols {
+                    metrics::mark_protocol_stale(protocol);
+                }
+                stale_sleep
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + stale_threshold);
+            }
+
             // Process protocol updates
             update = protocol_rx.recv(), if protocol_stream_open => {
                 match update {
@@ -424,21 +413,13 @@ async fn run(cli: Cli) -> miette::Result<()> {
                             }
                         };
 
-                        // Reset the staleness watchdog: record this moment as the last time we saw
-                        // a live update, and register any newly-seen protocol names.
-                        {
-                            let now = Instant::now();
-                            *last_protocol_update
-                                .write()
-                                .expect("Failed to acquire write lock on last_protocol_update") =
-                                now;
-                            let mut protocols = known_protocols
-                                .write()
-                                .expect("Failed to acquire write lock on known_protocols");
-                            for protocol in update.update.sync_states.keys() {
-                                protocols.insert(protocol.clone());
-                            }
+                        // Reset the staleness watchdog and register any newly-seen protocols.
+                        for protocol in update.update.sync_states.keys() {
+                            known_protocols.insert(protocol.clone());
                         }
+                        stale_sleep
+                            .as_mut()
+                            .reset(tokio::time::Instant::now() + stale_threshold);
 
                         if cli.max_blocks > 0 {
                             if let Some(stats) = statistics.as_ref() {

--- a/crates/tycho-integration-test/src/metrics.rs
+++ b/crates/tycho-integration-test/src/metrics.rs
@@ -181,6 +181,18 @@ pub fn record_protocol_sync_state(protocol: &str, sync_state: &SynchronizerState
     .set(state_value);
 }
 
+/// Explicitly mark a protocol as stale when no update has been received within the expected window.
+///
+/// Unlike `record_protocol_sync_state`, this is called by the staleness watchdog when the stream
+/// has gone silent — the SynchronizerState itself cannot be queried in that case.
+pub fn mark_protocol_stale(protocol: &str) {
+    gauge!(
+        "tycho_integration_protocol_sync_state",
+        "protocol" => protocol.to_string()
+    )
+    .set(4.0); // 4 = Stale
+}
+
 /// Record when a protocol update is skipped because it's behind the current block
 pub fn record_protocol_update_skipped() {
     counter!("tycho_integration_protocol_updates_skipped_total").increment(1);


### PR DESCRIPTION
Adds a background task that marks all known protocols as Stale in the tycho_integration_protocol_sync_state gauge when no protocol update arrives within --stale-threshold-secs (default 30s). Prevents the gauge from freezing at its last value during a silent stream disconnection, ensuring alerting remains accurate during WS reconnects.