### PR TITLE
feat(uniswap-v3-core): add shared indexing crate with TxDeltaIndexer trait

### DIFF
--- a/.claude/skills/migrate-substreams-to-native/SKILL.md
+++ b/.claude/skills/migrate-substreams-to-native/SKILL.md
@@ -52,8 +52,10 @@ consumed by an event must reflect all prior Initialize/Swap-type events in the s
   **clamped to zero** (mirrors `tycho_substreams::balances`)
 - Tick net-liquidity change type, checked in this order: Creation if the previous running
   value was missing **or zero**; Deletion if the new value is zero; else Update
-- Component ids: registry keys and emitted ids are lowercase hex without `0x`
-  (`hex::encode`); trim `0x` before `hex::decode` of ids from `apply_block`
+- Component ids: normalize incoming ids at the `apply_block` boundary (trim `0x`,
+  lowercase) for internal registry keys, but emit ids from `generate_deltas` exactly as
+  the substreams do (`0x`-prefixed lower-case hex) so they match decoder state keys —
+  copy `normalize_id`/`emitted_id` from uniswap-v4's `processor.rs`
 - `apply_block` must reconstruct ALL state the transforms consume (e.g. uniswap-v4 tracks
   `sqrt_price_x96` because ModifyLiquidity balance math depends on it)
 - Pools created in block N are invisible to `generate_deltas` until `apply_block(N)` ran —

--- a/.claude/skills/migrate-substreams-to-native/SKILL.md
+++ b/.claude/skills/migrate-substreams-to-native/SKILL.md
@@ -1,0 +1,113 @@
+---
+description: "Use when migrating or refactoring a substreams package into a native Rust processor crate — e.g. the user says 'migrate <protocol> to native', 'create a native processor', 'port the substreams to a core crate', or 'migrate <protocol> the same way uniswap-v3/v4 was migrated'. Covers the core crate, TxDeltaIndexer parity semantics, and the substreams parity integration test."
+user-invocable: true
+---
+
+# Migrate a Substreams Package to a Native Processor Crate
+
+Extract a protocol's substreams transform logic into a native crate at
+`protocols/crates/<protocol>` whose processor implements `TxDeltaIndexer`
+(`tycho_common::traits`), so pending-block simulation can decode raw EVM logs without a
+Substreams runtime. The existing substreams package stays untouched and serves as ground
+truth for a parity integration test.
+
+**Reference implementations — mirror these, do not redesign:**
+- `protocols/crates/uniswap-v4` (canonical: pool registry keyed by id, sqrt-price tracking,
+  spkg-from-main test, `scripts/build_main_spkg.sh`)
+- `protocols/crates/uniswap-v3` (factory-pattern pools keyed by contract address)
+
+## Step 1: Understand the substreams package
+
+Read every module under `protocols/substreams/<package>/src/modules/` (and `shared/` if the
+package has variants). For each map/store module note: handled events, store update policies
+(`add`, `set`, `set_sum`, `set_if_not_exists`), attribute names emitted, balance-delta
+semantics, and any math helpers. The native crate must reproduce these byte-for-byte.
+
+## Step 2: Create the crate
+
+Copy the structure of `protocols/crates/uniswap-v4`:
+
+| File | Content |
+|---|---|
+| `Cargo.toml` | Copy from uniswap-v4, rename. Crate name `<protocol>-core` |
+| `src/abi/` | Copy the generated ABI file(s) from the substreams package verbatim; `mod.rs` gets `#![allow(clippy::all, clippy::pedantic, clippy::nursery)]` |
+| `src/events.rs` | `Pool`, `TxRef`, `PoolEventKind`, decode fn using `match_and_decode` |
+| `src/balance.rs`, `src/ticks.rs`, `src/liquidity.rs`, `src/output.rs` | Pure `event → delta` transforms ported 1:1 from the substreams modules |
+| `src/math.rs` | Port math helpers (they already use `num_bigint`) including their unit tests; add `rstest` to dev-deps if the tests use it |
+| `src/processor.rs` | `<Protocol>Processor` implementing `TxDeltaIndexer` — copy uniswap-v4's and adapt the tracked state |
+| `tests/integration.rs` | Copy uniswap-v4's parity test and adapt |
+| `scripts/build_main_spkg.sh` | Copy from uniswap-v4, swap package paths |
+
+Add the crate to root `Cargo.toml` `[workspace.members]`, then run
+`cargo check --workspace` to update `Cargo.lock` (never `cargo generate-lockfile`).
+
+## Step 3: Parity semantics (where mismatches come from)
+
+The substreams pipeline reads stores with `get_at(log_ordinal)`. The native equivalent is
+**applying events sequentially in log order and mutating running state as you go** — state
+consumed by an event must reflect all prior Initialize/Swap-type events in the same block.
+
+- Ordinal: `tx.index() * 100_000 + log_index` (matches cross-tx event ordering)
+- Balances: running `BigInt` accumulators per `(pool, token)`; emit the absolute value,
+  **clamped to zero** (mirrors `tycho_substreams::balances`)
+- Tick net-liquidity change type, checked in this order: Creation if the previous running
+  value was missing **or zero**; Deletion if the new value is zero; else Update
+- Component ids: registry keys and emitted ids are lowercase hex without `0x`
+  (`hex::encode`); trim `0x` before `hex::decode` of ids from `apply_block`
+- `apply_block` must reconstruct ALL state the transforms consume (e.g. uniswap-v4 tracks
+  `sqrt_price_x96` because ModifyLiquidity balance math depends on it)
+- Pools created in block N are invisible to `generate_deltas` until `apply_block(N)` ran —
+  production semantics; the test accounts for this via known-pools filtering
+
+## Step 4: Parity integration test
+
+The test streams `map_protocol_changes` from the spkg as ground truth and asserts
+byte-identical attributes/balances per block. The per-block flow (copy it from
+uniswap-v4's test, do not reinvent):
+
+1. `generate_deltas(rpc_txs)` — pending deltas from raw `eth_getLogs`/block data
+2. Compare against the aggregated substreams output, restricted to known pools
+3. `apply_block(substreams ground truth)` — advance state and register new pools
+
+Two non-obvious setup points:
+
+1. **Build the spkg from `origin/main`, not the working tree** (a branch that refactors the
+   substreams to use the core crate would otherwise test the code against itself). Use the
+   `scripts/build_main_spkg.sh` pattern: temp `git worktree` of origin/main → wasm build →
+   `substreams pack` → `target/spkg/<package>-main.spkg`. The test defaults
+   `*_SPKG_PATH` to that output.
+2. **Pick an active block window.** Scan candidate 2000-block windows with `eth_getLogs`
+   (count creation + activity events) and hard-code a default window that contains pool
+   creations *followed by* swaps/liquidity changes — only pools created inside the window
+   get compared. The default must be a full ~2000-block window; never reuse the tiny range
+   from `integration_test.tycho.yaml`. Keep `*_START_BLOCK`/`*_STOP_BLOCK` env overrides.
+
+Credentials (from repo-root `.env`): `ETH_RPC_URL` (archive node) and `STREAMINGFAST_KEY`.
+The endpoint is `https://mainnet.eth.streamingfast.io:443` and `SubstreamsEndpoint` sends
+the token raw — a `server_…` API key must first be exchanged for a JWT:
+
+```bash
+TOKEN=$(curl -s https://auth.streamingfast.io/v1/auth/issue \
+  -d "{\"api_key\":\"$STREAMINGFAST_KEY\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
+STREAMINGFAST_KEY="$TOKEN" cargo test -p <protocol>-core --test integration -- --ignored --nocapture
+```
+
+## Step 5: Done criteria
+
+- Parity test summary shows **0 attr and 0 balance mismatches** with meaningful coverage
+  (tens of pools, hundreds of comparisons — widen the window if coverage is thin)
+- `cargo test -p <protocol>-core --lib` green; `cargo clippy -p <protocol>-core
+  --all-targets` warning-free; `cargo +nightly fmt`
+- Do not modify the substreams package itself in this migration; if it must later consume
+  the core crate (like `ethereum-uniswap-v3-logs-only`), that is a separate change with a
+  version bump per `protocols/substreams/CLAUDE.md`
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Testing against a working-tree spkg | Build from origin/main via the worktree script |
+| Inventing env vars (`SUBSTREAMS_API_KEY` etc.) | Use `.env`'s `ETH_RPC_URL` + `STREAMINGFAST_KEY` (JWT-exchanged) |
+| Default window at protocol genesis with no activity | Scan for an active window first (uniswap-v4 launch had ~0 events for 60k blocks) |
+| Reading state "as of block start" for in-block events | Apply events sequentially; update running state between events |
+| Deriving static attributes (fee→tick_spacing maps) | Take them from the creation event exactly as the substreams does |

--- a/.claude/skills/migrate-substreams-to-native/SKILL.md
+++ b/.claude/skills/migrate-substreams-to-native/SKILL.md
@@ -15,6 +15,8 @@ truth for a parity integration test.
 - `protocols/crates/uniswap-v4` (canonical: pool registry keyed by id, sqrt-price tracking,
   spkg-from-main test, `scripts/build_main_spkg.sh`)
 - `protocols/crates/uniswap-v3` (factory-pattern pools keyed by contract address)
+- `protocols/crates/uniswap-v2` (simplest: one `Sync` event carrying absolute reserves —
+  no ticks/liquidity, no running accumulators, processor state is just the pool registry)
 
 ## Step 1: Understand the substreams package
 
@@ -48,8 +50,12 @@ The substreams pipeline reads stores with `get_at(log_ordinal)`. The native equi
 consumed by an event must reflect all prior Initialize/Swap-type events in the same block.
 
 - Ordinal: `tx.index() * 100_000 + log_index` (matches cross-tx event ordering)
-- Balances: running `BigInt` accumulators per `(pool, token)`; emit the absolute value,
-  **clamped to zero** (mirrors `tycho_substreams::balances`)
+- Balances: usually running `BigInt` accumulators per `(pool, token)`, emitting the
+  absolute value **clamped to zero** (mirrors `tycho_substreams::balances`). But some
+  protocols report absolute balances directly — uniswap-v2's `Sync` carries the reserves,
+  so there is no accumulation and the balance is emitted as `reserve.to_signed_bytes_be()`
+  (match the substreams' exact encoding: signed vs unsigned magnitude differs by a leading
+  zero byte). Check what the substreams module actually emits.
 - Tick net-liquidity change type, checked in this order: Creation if the previous running
   value was missing **or zero**; Deletion if the new value is zero; else Update
 - Component ids: normalize incoming ids at the `apply_block` boundary (trim `0x`,
@@ -63,13 +69,22 @@ consumed by an event must reflect all prior Initialize/Swap-type events in the s
 
 ## Step 4: Parity integration test
 
-The test streams `map_protocol_changes` from the spkg as ground truth and asserts
-byte-identical attributes/balances per block. The per-block flow (copy it from
-uniswap-v4's test, do not reinvent):
+The test streams the package's final map module from the spkg as ground truth and asserts
+byte-identical attributes/balances per block. The module name varies — `map_protocol_changes`
+for uniswap-v3/v4, `map_pool_events` for uniswap-v2; check the manifest. The per-block flow
+(copy it from uniswap-v4's test, do not reinvent):
 
 1. `generate_deltas(rpc_txs)` — pending deltas from raw `eth_getLogs`/block data
 2. Compare against the aggregated substreams output, restricted to known pools
 3. `apply_block(substreams ground truth)` — advance state and register new pools
+
+**Aggregate the substreams side in ascending transaction-index order.** When a pool changes
+in several transactions within one block, the block-final value is the highest-index
+transaction's — which is what the processor produces (it orders by `tx.index()`). Some
+substreams emit per-transaction changes in non-deterministic order (uniswap-v2's
+`merge_block` collects via `into_values()`), so sort `proto.changes` by `tx.index` before
+the last-write-wins aggregation, or the comparison flaps on multi-tx pools. (uniswap-v3/v4
+already sort upstream, so their tests didn't need it.)
 
 Two non-obvious setup points:
 
@@ -113,3 +128,5 @@ STREAMINGFAST_KEY="$TOKEN" cargo test -p <protocol>-core --test integration -- -
 | Default window at protocol genesis with no activity | Scan for an active window first (uniswap-v4 launch had ~0 events for 60k blocks) |
 | Reading state "as of block start" for in-block events | Apply events sequentially; update running state between events |
 | Deriving static attributes (fee→tick_spacing maps) | Take them from the creation event exactly as the substreams does |
+| Test flaps on pools that change in multiple txs per block | Sort the substreams `proto.changes` by `tx.index` before aggregating (last write = highest index, matching the processor) |
+| Emitting unsigned-magnitude balances when substreams emit signed | Match the substreams encoding exactly (`to_signed_bytes_be` vs `to_bytes_be().1`) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,3 +44,6 @@ When spawning subagents, pass the relevant knowledge document contents to them.
   test files. Use after adding, removing, or renaming tests. Trigger words: "update test metadata", "sync test metadata".
 - `migrate-pr`: Migrate an open PR from a related repository (tycho-protocol-sdk, tycho-simulation, tycho-execution)
   into this monorepo. Rewrites paths, strips unmapped diffs, handles conflicts. Trigger words: "migrate PR", "port PR".
+- `migrate-substreams-to-native`: Migrate a substreams package into a native processor crate
+  (`protocols/crates/<protocol>`) implementing `TxDeltaIndexer`, with a parity integration test against the spkg built
+  from main. Trigger words: "migrate to native", "native processor", "port substreams to core crate".

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,10 +2702,8 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link 0.1.3",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9916,7 +9916,7 @@ dependencies = [
  "tycho-common",
  "tycho-ethereum",
  "tycho-storage",
- "tycho-substreams",
+ "tycho-substreams 0.6.0",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
@@ -10051,6 +10051,23 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint",
  "prost 0.11.9",
+ "serde",
+ "serde_json",
+ "substreams",
+ "substreams-ethereum",
+]
+
+[[package]]
+name = "tycho-substreams"
+version = "0.8.0"
+dependencies = [
+ "base64 0.22.1",
+ "ethabi 18.0.0",
+ "hex",
+ "itertools 0.12.1",
+ "num-bigint",
+ "prost 0.11.9",
+ "rstest 0.24.0",
  "serde",
  "serde_json",
  "substreams",
@@ -10237,6 +10254,27 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "uniswap-v3-core"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "dotenv",
+ "ethabi 18.0.0",
+ "getrandom 0.2.16",
+ "hex",
+ "num-bigint",
+ "num-traits",
+ "prost 0.11.9",
+ "substreams",
+ "substreams-ethereum",
+ "tokio",
+ "tokio-stream",
+ "tycho-common",
+ "tycho-indexer",
+ "tycho-substreams 0.8.0",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10256,6 +10256,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "uniswap-v2-core"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "dotenv",
+ "ethabi 18.0.0",
+ "getrandom 0.2.16",
+ "hex",
+ "num-bigint",
+ "num-traits",
+ "prost 0.11.9",
+ "substreams",
+ "substreams-ethereum",
+ "tokio",
+ "tokio-stream",
+ "tycho-common",
+ "tycho-indexer",
+ "tycho-substreams 0.8.0",
+]
+
+[[package]]
 name = "uniswap-v3-core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10277,6 +10277,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniswap-v4-core"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "dotenv",
+ "ethabi 18.0.0",
+ "getrandom 0.2.16",
+ "hex",
+ "num-bigint",
+ "num-traits",
+ "prost 0.11.9",
+ "rstest 0.24.0",
+ "substreams",
+ "substreams-ethereum",
+ "tokio",
+ "tokio-stream",
+ "tycho-common",
+ "tycho-indexer",
+ "tycho-substreams 0.8.0",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,12 +45,7 @@ serde = { version = "1.0.204", features = ["rc", "derive"] }
 serde_json = "1.0.120"
 toml = "0.8"
 typetag = "0.2.21"
-uuid = { version = "1.4.1", features = [
-    "serde",
-    "v4",
-    "fast-rng",
-    "macro-diagnostics",
-] }
+uuid = { version = "1.4.1", features = ["serde", "macro-diagnostics"] }
 
 # --- Async & concurrency ---
 tokio = { version = "1.47.1", features = ["full"] }
@@ -77,7 +72,7 @@ alloy = { version = "1.1.0", default-features = false }
 ethabi = "18.0.0"
 
 # --- Utility ---
-chrono = { version = "0.4.26", features = ["serde"] }
+chrono = { version = "0.4.26", default-features = false, features = ["serde", "clock", "std"] }
 hex = "0.4.3"
 hex-literal = "0.4.1"
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/tycho-execution",
     "crates/tycho-execution/model",
     "protocols/testing",
+    "protocols/crates/uniswap-v3",
 ]
 # protocols/substreams/ is intentionally excluded — separate WASM workspace, different toolchain
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/tycho-execution/model",
     "protocols/testing",
     "protocols/crates/uniswap-v3",
+    "protocols/crates/uniswap-v4",
 ]
 # protocols/substreams/ is intentionally excluded — separate WASM workspace, different toolchain
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/tycho-execution",
     "crates/tycho-execution/model",
     "protocols/testing",
+    "protocols/crates/uniswap-v2",
     "protocols/crates/uniswap-v3",
     "protocols/crates/uniswap-v4",
 ]

--- a/crates/tycho-common/Cargo.toml
+++ b/crates/tycho-common/Cargo.toml
@@ -24,7 +24,6 @@ chrono.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
-uuid.workspace = true
 utoipa.workspace = true
 async-trait.workspace = true
 anyhow.workspace = true
@@ -35,8 +34,9 @@ tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 bytes = "1.5.0"
 mockall = { workspace = true, optional = true }
 num-bigint = "0.4"
-deepsize.workspace = true# perf: make optional, as used only by the indexer for memory profiling
+deepsize.workspace = true # perf: make optional, as used only by the indexer for memory profiling
 itertools = "0.10.5"
+uuid.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
@@ -45,6 +45,7 @@ diesel-async.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true
 maplit = "1.0.2"
+uuid = { workspace = true, features = ["v4", "fast-rng"] }
 
 [features]
 diesel = ["dep:diesel"]

--- a/crates/tycho-common/src/models/blockchain.rs
+++ b/crates/tycho-common/src/models/blockchain.rs
@@ -64,6 +64,92 @@ impl Transaction {
     }
 }
 
+/// Raw EVM log emitted by a contract during transaction execution.
+///
+/// Used as the primary input to [`TxDeltaIndexer`] implementations.
+///
+/// [`TxDeltaIndexer`]: crate::traits::TxDeltaIndexer
+#[derive(Debug, Clone)]
+pub struct LogInput {
+    address: Bytes,
+    topics: Vec<Bytes>,
+    data: Bytes,
+    log_index: u32,
+}
+
+impl LogInput {
+    pub fn new(address: Bytes, topics: Vec<Bytes>, data: Bytes, log_index: u32) -> Self {
+        Self { address, topics, data, log_index }
+    }
+
+    pub fn address(&self) -> &Bytes {
+        &self.address
+    }
+
+    pub fn topics(&self) -> &[Bytes] {
+        &self.topics
+    }
+
+    pub fn data(&self) -> &Bytes {
+        &self.data
+    }
+
+    pub fn log_index(&self) -> u32 {
+        self.log_index
+    }
+}
+
+/// Raw EVM transaction with its associated logs.
+///
+/// The `succeeded` flag allows callers to pass all transactions in a block and
+/// have the processor skip reverted ones, avoiding a separate pre-filter.
+#[derive(Debug, Clone)]
+pub struct TxInput {
+    hash: Bytes,
+    from: Bytes,
+    to: Bytes,
+    index: u64,
+    logs: Vec<LogInput>,
+    succeeded: bool,
+}
+
+impl TxInput {
+    pub fn new(
+        hash: Bytes,
+        from: Bytes,
+        to: Bytes,
+        index: u64,
+        logs: Vec<LogInput>,
+        succeeded: bool,
+    ) -> Self {
+        Self { hash, from, to, index, logs, succeeded }
+    }
+
+    pub fn hash(&self) -> &Bytes {
+        &self.hash
+    }
+
+    pub fn from(&self) -> &Bytes {
+        &self.from
+    }
+
+    pub fn to(&self) -> &Bytes {
+        &self.to
+    }
+
+    pub fn index(&self) -> u64 {
+        self.index
+    }
+
+    pub fn logs(&self) -> &[LogInput] {
+        &self.logs
+    }
+
+    pub fn succeeded(&self) -> bool {
+        self.succeeded
+    }
+}
+
 pub struct BlockTransactionDeltas<T> {
     pub extractor: String,
     pub chain: Chain,

--- a/crates/tycho-common/src/traits.rs
+++ b/crates/tycho-common/src/traits.rs
@@ -5,13 +5,74 @@ use async_trait::async_trait;
 
 use crate::{
     models::{
-        blockchain::{Block, BlockTag, EntryPointWithTracingParams, TracedEntryPoint},
+        blockchain::{
+            Block, BlockAggregatedChanges, BlockTag, EntryPointWithTracingParams, TracedEntryPoint,
+            TxInput,
+        },
         contract::AccountDelta,
         token::{Token, TokenQuality, TransferCost, TransferTax},
         Address, Balance, BlockHash, StoreKey,
     },
     Bytes,
 };
+
+/// Indexes protocol state deltas from raw EVM transactions.
+///
+/// A `TxDeltaIndexer` is a native-code substitute for a Substreams package.
+/// It consumes a stream of finalised [`BlockAggregatedChanges`] to keep its internal
+/// protocol state current, then — on demand — applies a batch of in-flight
+/// [`TxInput`]s and returns the resulting [`BlockAggregatedChanges`]. The primary
+/// consumer is an Ethereum block builder that needs to know how a candidate
+/// transaction bundle alters DEX state before deciding whether to include it.
+///
+/// # Lifecycle
+///
+/// 1. **Hydrate** — call [`apply_block`][TxDeltaIndexer::apply_block] for each finalised block
+///    received from the Tycho client. The first call serves as initialisation: `state_deltas` and
+///    `component_balances` will contain the full snapshot at that height rather than a sparse
+///    delta. Subsequent calls apply incremental deltas.
+///
+/// 2. **Query** — call [`generate_deltas`][TxDeltaIndexer::generate_deltas] with a batch of
+///    in-flight transactions at any point. The indexer applies them against its current internal
+///    state and returns a [`BlockAggregatedChanges`] describing what would change. Internal state
+///    is **not** mutated by this call; it always operates on the state left by the most recent
+///    `apply_block`.
+pub trait TxDeltaIndexer: Send {
+    /// Advances internal protocol state by applying a finalised block.
+    ///
+    /// Must be called in block-height order. The first call initialises the
+    /// indexer from a full snapshot; subsequent calls apply incremental state
+    /// deltas. After this call returns, [`generate_deltas`][TxDeltaIndexer::generate_deltas]
+    /// will produce deltas relative to the new state.
+    ///
+    /// # Parameters
+    ///
+    /// * `block` — a finalised [`BlockAggregatedChanges`] as received from the Tycho client. On the
+    ///   first call this carries the full component and state snapshot; on later calls it carries
+    ///   only the changed attributes and balances.
+    fn apply_block(&mut self, block: &BlockAggregatedChanges);
+
+    /// Applies a batch of in-flight transactions against the current state and
+    /// returns the protocol state deltas they would produce.
+    ///
+    /// The returned [`BlockAggregatedChanges`] contains the aggregated deltas across
+    /// all transactions in the batch: `state_deltas`, `component_balances`,
+    /// `new_protocol_components`, and `deleted_protocol_components`. Block
+    /// metadata (`block`, `chain`, `extractor`, `finalized_block_height`) is
+    /// populated from the state stored by the most recent
+    /// [`apply_block`][TxDeltaIndexer::apply_block] call.
+    ///
+    /// Internal state is **not** modified. Calling `generate_deltas` twice with
+    /// the same transactions returns identical results.
+    ///
+    /// Transactions where `succeeded == false` are silently skipped.
+    ///
+    /// # Parameters
+    ///
+    /// * `txs` — ordered slice of in-flight transactions, typically a builder's candidate bundle or
+    ///   the full mempool selection for one block.
+    fn generate_deltas(&mut self, txs: &[TxInput]) -> BlockAggregatedChanges;
+}
 
 /// A struct representing a request to get an account state.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/tycho-indexer/Cargo.toml
+++ b/crates/tycho-indexer/Cargo.toml
@@ -52,7 +52,7 @@ tracing-subscriber = { version = "0.3.17", default-features = false, features = 
 tycho-common.workspace = true
 tycho-ethereum.workspace = true
 tycho-storage.workspace = true
-uuid.workspace = true
+uuid = { workspace = true, features = ["v4", "fast-rng"] }
 # Pinned: actix-web 4.12+ uses actix-http methods not present in 3.11.x; keep at last working set
 actix-web = { version = "=4.11.0", default-features = false, features = [
     "macros",

--- a/crates/tycho-simulation/Cargo.toml
+++ b/crates/tycho-simulation/Cargo.toml
@@ -23,7 +23,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 typetag = { workspace = true }
-uuid = { workspace = true }
+uuid = { workspace = true, features = ["v4", "fast-rng"] }
 
 # Error handling
 thiserror = { workspace = true }

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -12,7 +12,7 @@ use tracing::{debug, error, info, warn};
 use tycho_client::feed::{synchronizer::ComponentWithState, BlockHeader, FeedMessage, HeaderLike};
 use tycho_common::{
     dto::{ChangeType, ProtocolStateDelta},
-    models::{token::Token, Chain},
+    models::{blockchain::BlockAggregatedChanges, token::Token, Chain},
     simulation::protocol_sim::{Balances, ProtocolSim},
     Bytes,
 };
@@ -61,6 +61,8 @@ struct DecoderState {
     // again TODO: handle more gracefully inside tycho-client. We could fetch the snapshot and
     // try to decode it again.
     failed_components: HashSet<String>,
+    // The block number of the last confirmed block decoded via `decode()`.
+    current_block_number: u64,
 }
 
 type DecodeFut =
@@ -897,6 +899,8 @@ where
             .states
             .extend(updated_states.clone());
 
+        state_guard.current_block_number = block_number_or_timestamp;
+
         // Add new components to persistent state
         for (id, component) in new_pairs.iter() {
             state_guard
@@ -921,6 +925,72 @@ where
         Ok(Update::new(block_number_or_timestamp, updated_states, new_pairs)
             .set_removed_pairs(removed_pairs)
             .set_sync_states(msg.sync_states.clone()))
+    }
+
+    /// Applies pending deltas from one or more `TxDeltaIndexer`s against the current confirmed
+    /// state and returns an ephemeral `Update`.
+    ///
+    /// This is the read-only counterpart of `decode()`. It clones pool states, applies the
+    /// supplied `pending_deltas`, and returns the result — **without writing back** to
+    /// `DecoderState`. Calling this method twice with the same input produces identical results.
+    ///
+    /// Only native protocols are supported: VM protocols that require `update_engine()` are
+    /// silently skipped (their pools will not appear in the returned `Update`).
+    ///
+    /// # Parameters
+    /// * `pending_deltas` — map from extractor name to the `BlockAggregatedChanges` produced by the
+    ///   corresponding `TxDeltaIndexer::generate_deltas()` call.
+    /// * `header` — the target block header. Its `block_number_or_timestamp()` is stamped on the
+    ///   returned [`Update`]; its `block_number` and `block_timestamp` are injected into each state
+    ///   delta so that protocols relying on block context (e.g. aerodrome slipstreams, etherfi)
+    ///   receive correct values.
+    pub async fn apply_deltas_ephemeral(
+        &self,
+        pending_deltas: &HashMap<String, BlockAggregatedChanges>,
+        header: H,
+    ) -> Result<Update, StreamDecodeError> {
+        let block_number_or_timestamp = header
+            .clone()
+            .block_number_or_timestamp();
+        let current_block = header.block();
+        let state_guard = self.state.read().await;
+
+        let mut updated_states: HashMap<String, Box<dyn ProtocolSim>> = HashMap::new();
+
+        for deltas in pending_deltas.values() {
+            let all_balances = Balances {
+                component_balances: deltas
+                    .component_balances
+                    .iter()
+                    .map(|(pool_id, bals)| {
+                        let balances = bals
+                            .iter()
+                            .map(|(t, b)| (t.clone(), b.balance.clone()))
+                            .collect();
+                        (pool_id.clone(), balances)
+                    })
+                    .collect(),
+                account_balances: HashMap::new(),
+            };
+
+            for (id, state_delta) in &deltas.state_deltas {
+                let dto_delta = Self::add_block_info_to_delta(
+                    ProtocolStateDelta::from(state_delta.clone()),
+                    current_block.clone(),
+                );
+                if let Err(e) = Self::apply_update(
+                    id,
+                    dto_delta,
+                    &mut updated_states,
+                    &state_guard,
+                    &all_balances,
+                ) {
+                    warn!(pool = id, error = %e, "EphemeralDeltaTransitionError");
+                }
+            }
+        }
+
+        Ok(Update::new(block_number_or_timestamp, updated_states, HashMap::new()))
     }
 
     /// Add block information (number and timestamp) to a ProtocolStateDelta

--- a/crates/tycho-simulation/src/evm/mod.rs
+++ b/crates/tycho-simulation/src/evm/mod.rs
@@ -4,6 +4,7 @@ use tycho_common::keccak256;
 pub mod account_storage;
 pub mod decoder;
 pub mod engine_db;
+pub mod pending;
 pub mod protocol;
 pub mod query_pool_swap;
 pub mod simulation;

--- a/crates/tycho-simulation/src/evm/pending.rs
+++ b/crates/tycho-simulation/src/evm/pending.rs
@@ -1,0 +1,279 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use thiserror::Error;
+use tokio::sync::{mpsc::UnboundedReceiver, watch};
+use tycho_client::feed::{synchronizer::Snapshot, BlockHeader, FeedMessage};
+use tycho_common::{
+    models::{
+        blockchain::{Block, BlockAggregatedChanges, TxInput},
+        protocol::{ComponentBalance, ProtocolComponent, ProtocolComponentStateDelta},
+        Chain,
+    },
+    traits::TxDeltaIndexer,
+    Bytes,
+};
+
+use crate::{
+    evm::decoder::{StreamDecodeError, TychoStreamDecoder},
+    protocol::models::Update,
+};
+
+/// An ephemeral [`Update`] tagged with a caller-supplied label.
+///
+/// The label is an opaque string chosen by the caller to distinguish parallel bundle evaluations
+/// (e.g. bundle ID, strategy name). It is separate from `update.block_number_or_timestamp`,
+/// which carries the target block the bundle was evaluated against.
+pub struct PendingUpdate {
+    pub label: String,
+    pub update: Update,
+}
+
+#[derive(Debug, Error)]
+pub enum PendingError {
+    /// Returned when `generate_pending_update` is called before the parent block of
+    /// `target_block` has been confirmed. Use
+    /// [`subscribe_confirmed_block`](PendingBlockProcessor::subscribe_confirmed_block) to wait
+    /// for the right block before calling.
+    #[error("parent block {needed} not yet confirmed (current: {current})")]
+    ParentNotYetConfirmed { needed: u64, current: u64 },
+    #[error("decoder error: {0}")]
+    Decoder(#[from] StreamDecodeError),
+}
+
+/// Wires one or more [`TxDeltaIndexer`]s to an existing [`TychoStreamDecoder`], enabling
+/// ephemeral simulation of candidate transaction bundles against the correct parent state
+/// for a specific target block.
+///
+/// # Block targeting
+///
+/// Call [`subscribe_confirmed_block`](Self::subscribe_confirmed_block) to obtain a
+/// [`watch::Receiver<u64>`] that fires on every confirmed block. Use it to wait for the
+/// right parent before submitting a bundle:
+///
+/// ```no_run
+/// # async fn example(
+/// #     mut pending: tycho_simulation::evm::pending::PendingBlockProcessor,
+/// #     txs: &[tycho_common::models::blockchain::TxInput],
+/// #     target_header: tycho_client::feed::BlockHeader,
+/// # ) {
+/// pending
+///     .subscribe_confirmed_block()
+///     .wait_for(|&n| n >= target_header.number - 1)
+///     .await
+///     .expect("stream closed");
+/// let update = pending
+///     .generate_pending_update(txs, target_header, "bundle-1".to_string())
+///     .await
+///     .expect("pending update failed");
+/// # }
+/// ```
+///
+/// # Concurrency
+///
+/// `PendingBlockProcessor` is intentionally **not** wrapped in a `Mutex` at construction
+/// time. The confirmed stream forwards blocks via an unbounded channel — it never blocks
+/// waiting for the consumer. Multiple callers can each hold a watch receiver and
+/// independently decide when to acquire whatever external lock they use around
+/// `generate_pending_update`.
+pub struct PendingBlockProcessor {
+    indexers: HashMap<String, Box<dyn TxDeltaIndexer>>,
+    decoder: Arc<TychoStreamDecoder<BlockHeader>>,
+    chain: Chain,
+    /// Block number of the most recently confirmed block applied to `indexers`.
+    current_confirmed_block: u64,
+    /// Notified on every `advance_inner` call; drives `subscribe_confirmed_block`.
+    confirmed_block_tx: watch::Sender<u64>,
+    /// Confirmed blocks forwarded by the stream pipeline.
+    block_rx: UnboundedReceiver<FeedMessage<BlockHeader>>,
+}
+
+impl PendingBlockProcessor {
+    pub(crate) fn new(
+        indexers: HashMap<String, Box<dyn TxDeltaIndexer>>,
+        decoder: Arc<TychoStreamDecoder<BlockHeader>>,
+        chain: Chain,
+        block_rx: UnboundedReceiver<FeedMessage<BlockHeader>>,
+    ) -> Self {
+        let (confirmed_block_tx, _) = watch::channel(0u64);
+        Self { indexers, decoder, chain, current_confirmed_block: 0, confirmed_block_tx, block_rx }
+    }
+
+    /// Returns a receiver that is notified with the latest confirmed block number every time
+    /// a new block is applied.
+    ///
+    /// Typical usage: `.wait_for(|&n| n >= target_block - 1).await` before calling
+    /// [`generate_pending_update`](Self::generate_pending_update).
+    pub fn subscribe_confirmed_block(&self) -> watch::Receiver<u64> {
+        self.confirmed_block_tx.subscribe()
+    }
+
+    /// Returns the block number of the last confirmed block applied to the indexers.
+    pub fn current_confirmed_block(&self) -> u64 {
+        self.current_confirmed_block
+    }
+
+    /// Advances each registered indexer by applying one confirmed block.
+    ///
+    /// Only needed when using the processor standalone (without
+    /// [`ProtocolStreamBuilder::build_with_pending`](crate::evm::stream::ProtocolStreamBuilder::build_with_pending)).
+    /// When using `build_with_pending`, confirmed blocks are forwarded automatically.
+    pub fn advance(&mut self, msg: &FeedMessage<BlockHeader>) {
+        self.advance_inner(msg);
+    }
+
+    /// Simulates `txs` against the confirmed parent state of `target_block` and returns an
+    /// ephemeral [`Update`].
+    ///
+    /// Drains any confirmed blocks that have arrived since the last call, then immediately
+    /// checks whether the parent block (`target_block - 1`) is available. If not, returns
+    /// [`PendingError::ParentNotYetConfirmed`] — **no blocking**. Use
+    /// [`subscribe_confirmed_block`](Self::subscribe_confirmed_block) to wait for the right
+    /// block before calling.
+    ///
+    /// Neither the indexers' internal state nor the decoder's confirmed pool states are
+    /// mutated. Calling this twice with the same arguments returns identical results.
+    ///
+    /// # Parameters
+    /// * `txs` — candidate bundle in execution order; failed transactions are skipped.
+    /// * `target_header` — header of the block being built. Its `number` is used for the
+    ///   parent-block guard; the full header is forwarded to `apply_deltas_ephemeral` so that block
+    ///   number and timestamp are injected into each state delta.
+    /// * `label` — opaque caller-supplied tag stamped onto the returned [`PendingUpdate`]. Use it
+    ///   to associate the result with a specific bundle or evaluation context.
+    pub async fn generate_pending_update(
+        &mut self,
+        txs: &[TxInput],
+        target_header: BlockHeader,
+        label: String,
+    ) -> Result<PendingUpdate, PendingError> {
+        // Drain any confirmed blocks that have arrived since our last call.
+        while let Ok(msg) = self.block_rx.try_recv() {
+            self.advance_inner(&msg);
+        }
+
+        let parent = target_header.number.saturating_sub(1);
+        if self.current_confirmed_block < parent {
+            return Err(PendingError::ParentNotYetConfirmed {
+                needed: parent,
+                current: self.current_confirmed_block,
+            });
+        }
+
+        let mut pending_deltas: HashMap<String, BlockAggregatedChanges> = HashMap::new();
+        for (extractor, indexer) in &mut self.indexers {
+            let changes = indexer.generate_deltas(txs);
+            pending_deltas.insert(extractor.clone(), changes);
+        }
+
+        let update = self
+            .decoder
+            .apply_deltas_ephemeral(&pending_deltas, target_header)
+            .await?;
+        Ok(PendingUpdate { label, update })
+    }
+
+    fn advance_inner(&mut self, msg: &FeedMessage<BlockHeader>) {
+        let msg_block = msg
+            .state_msgs
+            .values()
+            .map(|s| s.header.number)
+            .max()
+            .unwrap_or(0);
+
+        for (extractor, state_msg) in &msg.state_msgs {
+            let Some(indexer) = self.indexers.get_mut(extractor) else {
+                continue;
+            };
+
+            if !state_msg.snapshots.states.is_empty() {
+                let block_changes = snapshot_to_block_changes(
+                    extractor,
+                    &state_msg.snapshots,
+                    &state_msg.header,
+                    self.chain,
+                );
+                indexer.apply_block(&block_changes);
+            }
+
+            if let Some(deltas) = &state_msg.deltas {
+                indexer.apply_block(deltas);
+            }
+        }
+
+        if msg_block > self.current_confirmed_block {
+            self.current_confirmed_block = msg_block;
+            // Receivers that have been dropped are silently ignored.
+            let _ = self.confirmed_block_tx.send(msg_block);
+        }
+    }
+}
+
+/// Converts a startup snapshot into a `BlockAggregatedChanges` suitable for
+/// [`TxDeltaIndexer::apply_block`].
+fn snapshot_to_block_changes(
+    extractor: &str,
+    snapshot: &Snapshot,
+    header: &BlockHeader,
+    chain: Chain,
+) -> BlockAggregatedChanges {
+    let ts = chrono::DateTime::from_timestamp(header.timestamp as i64, 0)
+        .unwrap_or_default()
+        .naive_utc();
+    let block = Block {
+        number: header.number,
+        chain,
+        hash: header.hash.clone(),
+        parent_hash: header.parent_hash.clone(),
+        ts,
+    };
+
+    let mut new_protocol_components: HashMap<String, ProtocolComponent> = HashMap::new();
+    let mut state_deltas: HashMap<String, ProtocolComponentStateDelta> = HashMap::new();
+    let mut component_balances: HashMap<String, HashMap<Bytes, ComponentBalance>> = HashMap::new();
+
+    for (id, comp_with_state) in &snapshot.states {
+        new_protocol_components.insert(id.clone(), comp_with_state.component.clone());
+
+        state_deltas.insert(
+            id.clone(),
+            ProtocolComponentStateDelta {
+                component_id: id.clone(),
+                updated_attributes: comp_with_state.state.attributes.clone(),
+                deleted_attributes: HashSet::new(),
+            },
+        );
+
+        let token_balances: HashMap<Bytes, ComponentBalance> = comp_with_state
+            .state
+            .balances
+            .iter()
+            .map(|(token, balance)| {
+                (
+                    token.clone(),
+                    ComponentBalance {
+                        token: token.clone(),
+                        balance: balance.clone(),
+                        balance_float: 0.0,
+                        modify_tx: Bytes::default(),
+                        component_id: id.clone(),
+                    },
+                )
+            })
+            .collect();
+        component_balances.insert(id.clone(), token_balances);
+    }
+
+    BlockAggregatedChanges {
+        extractor: extractor.to_string(),
+        chain,
+        block,
+        finalized_block_height: header.number,
+        new_protocol_components,
+        state_deltas,
+        component_balances,
+        ..Default::default()
+    }
+}

--- a/crates/tycho-simulation/src/evm/stream.rs
+++ b/crates/tycho-simulation/src/evm/stream.rs
@@ -114,19 +114,21 @@ use tracing::{debug, error, warn};
 use tycho_client::{
     feed::{
         component_tracker::ComponentFilter, synchronizer::ComponentWithState, BlockHeader,
-        SynchronizerState,
+        FeedMessage, SynchronizerState,
     },
     stream::{RetryConfiguration, StreamError, TychoStreamBuilder},
 };
 use tycho_common::{
     models::{token::Token, Chain},
     simulation::protocol_sim::ProtocolSim,
+    traits::TxDeltaIndexer,
     Bytes,
 };
 
 use crate::{
     evm::{
         decoder::{StreamDecodeError, TychoStreamDecoder},
+        pending::PendingBlockProcessor,
         protocol::uniswap_v4::hooks::hook_handler_creator::initialize_hook_handlers,
     },
     protocol::{
@@ -172,6 +174,8 @@ pub struct ProtocolStreamBuilder {
     decoder: TychoStreamDecoder<BlockHeader>,
     stream_builder: TychoStreamBuilder,
     stream_end_policy: StreamEndPolicy,
+    chain: Chain,
+    pending_indexers: HashMap<String, Box<dyn TxDeltaIndexer>>,
 }
 
 impl ProtocolStreamBuilder {
@@ -183,6 +187,8 @@ impl ProtocolStreamBuilder {
             decoder: TychoStreamDecoder::new(),
             stream_builder: TychoStreamBuilder::new(tycho_url, chain),
             stream_end_policy: StreamEndPolicy::default(),
+            chain,
+            pending_indexers: HashMap::new(),
         }
     }
 
@@ -441,6 +447,94 @@ impl ProtocolStreamBuilder {
 
     pub fn get_decoder(&self) -> &TychoStreamDecoder<BlockHeader> {
         &self.decoder
+    }
+
+    /// Registers a [`TxDeltaIndexer`] for ephemeral pending-block simulation.
+    ///
+    /// The indexer is associated with `extractor` (the protocol synchronizer name, e.g.
+    /// `"uniswap_v3"`). Use [`build_with_pending`](Self::build_with_pending) to obtain both
+    /// the confirmed stream and the pending processor.
+    pub fn with_pending_indexer(
+        mut self,
+        extractor: &str,
+        indexer: Box<dyn TxDeltaIndexer>,
+    ) -> Self {
+        self.pending_indexers
+            .insert(extractor.to_string(), indexer);
+        self
+    }
+
+    /// Builds the confirmed protocol stream and a [`PendingBlockProcessor`] that stays
+    /// in sync with it automatically.
+    ///
+    /// The stream pipeline forwards every confirmed [`FeedMessage`] to the processor via an
+    /// internal unbounded channel — it never blocks waiting for the consumer. The consumer
+    /// owns the returned `PendingBlockProcessor` exclusively and may wrap it in whatever
+    /// synchronisation primitive suits their use case (e.g. `Mutex` for shared access,
+    /// nothing for single-threaded use).
+    ///
+    /// Call [`generate_pending_update`](PendingBlockProcessor::generate_pending_update) to
+    /// simulate a candidate bundle; it drains the channel automatically before computing.
+    pub async fn build_with_pending(
+        self,
+    ) -> Result<
+        (impl Stream<Item = Result<Update, StreamDecodeError>>, PendingBlockProcessor),
+        StreamError,
+    > {
+        initialize_hook_handlers().map_err(|e| {
+            StreamError::SetUpError(format!("Error initializing hook handlers: {e:?}"))
+        })?;
+        let (_, rx) = self.stream_builder.build().await?;
+        let decoder = Arc::new(self.decoder);
+
+        let (advance_tx, advance_rx) =
+            tokio::sync::mpsc::unbounded_channel::<FeedMessage<BlockHeader>>();
+        let pending = PendingBlockProcessor::new(
+            self.pending_indexers,
+            decoder.clone(),
+            self.chain,
+            advance_rx,
+        );
+
+        let stream_end_policy = self.stream_end_policy;
+        let stream = Box::pin(
+            ReceiverStream::new(rx)
+                .take_while(move |msg| match msg {
+                    Ok(msg) => {
+                        let states = msg.sync_states.values();
+                        if stream_end_policy.should_end(states) {
+                            error!(
+                                "Block stream ended due to {:?}: {:?}",
+                                stream_end_policy, msg.sync_states
+                            );
+                            futures::future::ready(false)
+                        } else {
+                            futures::future::ready(true)
+                        }
+                    }
+                    Err(e) => {
+                        error!("Block stream ended with terminal error: {e}");
+                        futures::future::ready(false)
+                    }
+                })
+                .then({
+                    let decoder = decoder.clone();
+                    move |msg| {
+                        let decoder = decoder.clone();
+                        let advance_tx = advance_tx.clone();
+                        async move {
+                            let msg = msg.expect("Safe since stream ends if we receive an error");
+                            // Non-blocking: if the receiver is gone we just skip the send.
+                            let _ = advance_tx.send(msg.clone());
+                            decoder.decode(&msg).await.map_err(|e| {
+                                debug!(msg=?msg, "Decode error: {}", e);
+                                e
+                            })
+                        }
+                    }
+                }),
+        );
+        Ok((stream, pending))
     }
 
     /// Builds and returns the configured protocol stream.

--- a/protocols/crates/uniswap-v2/Cargo.toml
+++ b/protocols/crates/uniswap-v2/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "uniswap-v2-core"
+version = "0.1.0"
+edition = "2021"
+description = "Shared UniswapV2 indexing logic for native and WASM builds"
+
+[dependencies]
+substreams = "0.5.22"
+substreams-ethereum = "0.9.9"
+tycho-substreams = { path = "../../substreams/crates/tycho-substreams" }
+tycho-common = { path = "../../../crates/tycho-common" }
+ethabi = "18.0.0"
+hex = "0.4.3"
+num-bigint = "0.4.4"
+num-traits = { workspace = true }
+
+[target.wasm32-unknown-unknown.dependencies]
+getrandom = { version = "0.2", features = ["custom"] }
+
+[dev-dependencies]
+# Substreams streaming client (same workspace crate).
+tycho-indexer.workspace = true
+# Async runtime and stream utilities.
+tokio.workspace = true
+tokio-stream = { version = "0.1", features = ["sync"] }
+# Archive RPC calls (eth_getLogs, eth_getBlockByNumber).
+alloy = { workspace = true, features = [
+    "providers",
+    "provider-http",
+    "rpc-types-eth",
+    "sol-types",
+    "contract",
+    "network",
+] }
+# .env file loading for CI credentials.
+dotenv.workspace = true
+hex.workspace = true
+num-bigint.workspace = true
+prost = "0.11"

--- a/protocols/crates/uniswap-v2/scripts/build_main_spkg.sh
+++ b/protocols/crates/uniswap-v2/scripts/build_main_spkg.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds the UniswapV2 substreams package from origin/main.
+#
+# The parity integration test uses the substreams output as ground truth. Building
+# the spkg from main (in a temporary git worktree) instead of the working tree
+# guarantees the test compares the native processor against the substreams state
+# deployed from main, even when the current branch modifies the substreams source.
+#
+# Usage: build_main_spkg.sh [output-path]
+#   output-path  defaults to <repo>/target/spkg/ethereum-uniswap-v2-main.spkg
+
+repo_root=$(git rev-parse --show-toplevel)
+out="${1:-$repo_root/target/spkg/ethereum-uniswap-v2-main.spkg}"
+
+worktree=$(mktemp -d)/main
+git -C "$repo_root" fetch origin main
+git -C "$repo_root" worktree add --detach "$worktree" origin/main >/dev/null
+trap 'git -C "$repo_root" worktree remove --force "$worktree"' EXIT
+
+cd "$worktree/protocols/substreams/ethereum-uniswap-v2"
+cargo build --target wasm32-unknown-unknown --release -p ethereum-uniswap-v2
+
+mkdir -p "$(dirname "$out")"
+substreams pack ethereum-uniswap-v2.yaml -o "$out"
+echo "spkg written to $out"

--- a/protocols/crates/uniswap-v2/src/abi/factory.rs
+++ b/protocols/crates/uniswap-v2/src/abi/factory.rs
@@ -1,0 +1,774 @@
+const INTERNAL_ERR: &'static str = "`ethabi_derive` internal error";
+/// Contract's functions.
+#[allow(dead_code, unused_imports, unused_variables)]
+pub mod functions {
+    use super::INTERNAL_ERR;
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct AllPairs {
+        pub param0: substreams::scalar::BigInt,
+    }
+    impl AllPairs {
+        const METHOD_ID: [u8; 4] = [30u8, 61u8, 209u8, 139u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::Uint(256usize)], maybe_data.unwrap())
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                param0: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                match self.param0.clone().to_bytes_be() {
+                    (num_bigint::Sign::Plus, bytes) => bytes,
+                    (num_bigint::Sign::NoSign, bytes) => bytes,
+                    (num_bigint::Sign::Minus, _) => {
+                        panic!("negative numbers are not supported")
+                    }
+                }
+                .as_slice(),
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for AllPairs {
+        const NAME: &'static str = "allPairs";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for AllPairs {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct AllPairsLength {}
+    impl AllPairsLength {
+        const METHOD_ID: [u8; 4] = [87u8, 79u8, 43u8, 163u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for AllPairsLength {
+        const NAME: &'static str = "allPairsLength";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for AllPairsLength {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CreatePair {
+        pub token_a: Vec<u8>,
+        pub token_b: Vec<u8>,
+    }
+    impl CreatePair {
+        const METHOD_ID: [u8; 4] = [201u8, 198u8, 83u8, 150u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Address],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                token_a: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                token_b: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.token_a)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.token_b)),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for CreatePair {
+        const NAME: &'static str = "createPair";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for CreatePair {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct FeeTo {}
+    impl FeeTo {
+        const METHOD_ID: [u8; 4] = [1u8, 126u8, 126u8, 88u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for FeeTo {
+        const NAME: &'static str = "feeTo";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for FeeTo {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct FeeToSetter {}
+    impl FeeToSetter {
+        const METHOD_ID: [u8; 4] = [9u8, 75u8, 116u8, 21u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for FeeToSetter {
+        const NAME: &'static str = "feeToSetter";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for FeeToSetter {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct GetPair {
+        pub param0: Vec<u8>,
+        pub param1: Vec<u8>,
+    }
+    impl GetPair {
+        const METHOD_ID: [u8; 4] = [230u8, 164u8, 57u8, 5u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Address],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                param0: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                param1: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.param0)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.param1)),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for GetPair {
+        const NAME: &'static str = "getPair";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for GetPair {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SetFeeTo {
+        pub fee_to: Vec<u8>,
+    }
+    impl SetFeeTo {
+        const METHOD_ID: [u8; 4] = [244u8, 105u8, 1u8, 237u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                fee_to: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(
+                &self.fee_to,
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for SetFeeTo {
+        const NAME: &'static str = "setFeeTo";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SetFeeToSetter {
+        pub fee_to_setter: Vec<u8>,
+    }
+    impl SetFeeToSetter {
+        const METHOD_ID: [u8; 4] = [162u8, 231u8, 74u8, 246u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                fee_to_setter: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(
+                &self.fee_to_setter,
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for SetFeeToSetter {
+        const NAME: &'static str = "setFeeToSetter";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+}
+/// Contract's events.
+#[allow(dead_code, unused_imports, unused_variables)]
+pub mod events {
+    use super::INTERNAL_ERR;
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct PairCreated {
+        pub token0: Vec<u8>,
+        pub token1: Vec<u8>,
+        pub pair: Vec<u8>,
+        pub param3: substreams::scalar::BigInt,
+    }
+    impl PairCreated {
+        const TOPIC_ID: [u8; 32] = [
+            13u8, 54u8, 72u8, 189u8, 15u8, 107u8, 168u8, 1u8, 52u8, 163u8, 59u8, 169u8, 39u8, 90u8,
+            197u8, 133u8, 217u8, 211u8, 21u8, 240u8, 173u8, 131u8, 85u8, 205u8, 222u8, 253u8,
+            227u8, 26u8, 250u8, 40u8, 208u8, 233u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 64usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                token0: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'token0' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                token1: ethabi::decode(&[ethabi::ParamType::Address], log.topics[2usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'token1' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                pair: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                param3: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for PairCreated {
+        const NAME: &'static str = "PairCreated";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+}

--- a/protocols/crates/uniswap-v2/src/abi/mod.rs
+++ b/protocols/crates/uniswap-v2/src/abi/mod.rs
@@ -1,0 +1,4 @@
+#![allow(clippy::all, clippy::pedantic, clippy::nursery)]
+
+pub mod factory;
+pub mod pool;

--- a/protocols/crates/uniswap-v2/src/abi/pool.rs
+++ b/protocols/crates/uniswap-v2/src/abi/pool.rs
@@ -1,0 +1,3032 @@
+const INTERNAL_ERR: &'static str = "`ethabi_derive` internal error";
+/// Contract's functions.
+#[allow(dead_code, unused_imports, unused_variables)]
+pub mod functions {
+    use super::INTERNAL_ERR;
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Allowance {
+        pub param0: Vec<u8>,
+        pub param1: Vec<u8>,
+    }
+    impl Allowance {
+        const METHOD_ID: [u8; 4] = [221u8, 98u8, 237u8, 62u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Address],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                param0: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                param1: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.param0)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.param1)),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Allowance {
+        const NAME: &'static str = "allowance";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for Allowance {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Approve {
+        pub spender: Vec<u8>,
+        pub value: substreams::scalar::BigInt,
+    }
+    impl Approve {
+        const METHOD_ID: [u8; 4] = [9u8, 94u8, 167u8, 179u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                spender: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                value: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.spender)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.value.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<bool, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<bool, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Bool], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_bool()
+                .expect(INTERNAL_ERR))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<bool> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Approve {
+        const NAME: &'static str = "approve";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<bool> for Approve {
+        fn output(data: &[u8]) -> Result<bool, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct BalanceOf {
+        pub param0: Vec<u8>,
+    }
+    impl BalanceOf {
+        const METHOD_ID: [u8; 4] = [112u8, 160u8, 130u8, 49u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                param0: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(
+                &self.param0,
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for BalanceOf {
+        const NAME: &'static str = "balanceOf";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for BalanceOf {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Burn {
+        pub to: Vec<u8>,
+    }
+    impl Burn {
+        const METHOD_ID: [u8; 4] = [137u8, 175u8, 203u8, 68u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                to: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data =
+                ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(&self.to))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Uint(256usize), ethabi::ParamType::Uint(256usize)],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            values.reverse();
+            Ok((
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            ))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(substreams::scalar::BigInt, substreams::scalar::BigInt)> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Burn {
+        const NAME: &'static str = "burn";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+        )> for Burn
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Decimals {}
+    impl Decimals {
+        const METHOD_ID: [u8; 4] = [49u8, 60u8, 229u8, 103u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(8usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Decimals {
+        const NAME: &'static str = "decimals";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for Decimals {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct DomainSeparator {}
+    impl DomainSeparator {
+        const METHOD_ID: [u8; 4] = [54u8, 68u8, 229u8, 21u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<[u8; 32usize], String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<[u8; 32usize], String> {
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::FixedBytes(32usize)], data.as_ref())
+                    .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut result = [0u8; 32];
+                let v = values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_fixed_bytes()
+                    .expect(INTERNAL_ERR);
+                result.copy_from_slice(&v);
+                result
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<[u8; 32usize]> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for DomainSeparator {
+        const NAME: &'static str = "DOMAIN_SEPARATOR";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<[u8; 32usize]> for DomainSeparator {
+        fn output(data: &[u8]) -> Result<[u8; 32usize], String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Factory {}
+    impl Factory {
+        const METHOD_ID: [u8; 4] = [196u8, 90u8, 1u8, 85u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Factory {
+        const NAME: &'static str = "factory";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for Factory {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct GetReserves {}
+    impl GetReserves {
+        const METHOD_ID: [u8; 4] = [9u8, 2u8, 241u8, 172u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<
+            (substreams::scalar::BigInt, substreams::scalar::BigInt, substreams::scalar::BigInt),
+            String,
+        > {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<
+            (substreams::scalar::BigInt, substreams::scalar::BigInt, substreams::scalar::BigInt),
+            String,
+        > {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Uint(112usize),
+                    ethabi::ParamType::Uint(112usize),
+                    ethabi::ParamType::Uint(32usize),
+                ],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            values.reverse();
+            Ok((
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            ))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+        )> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for GetReserves {
+        const NAME: &'static str = "getReserves";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+        )> for GetReserves
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<
+            (substreams::scalar::BigInt, substreams::scalar::BigInt, substreams::scalar::BigInt),
+            String,
+        > {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Initialize {
+        pub token0: Vec<u8>,
+        pub token1: Vec<u8>,
+    }
+    impl Initialize {
+        const METHOD_ID: [u8; 4] = [72u8, 92u8, 201u8, 85u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Address],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                token0: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                token1: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.token0)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.token1)),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Initialize {
+        const NAME: &'static str = "initialize";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct KLast {}
+    impl KLast {
+        const METHOD_ID: [u8; 4] = [116u8, 100u8, 252u8, 61u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for KLast {
+        const NAME: &'static str = "kLast";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for KLast {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct MinimumLiquidity {}
+    impl MinimumLiquidity {
+        const METHOD_ID: [u8; 4] = [186u8, 154u8, 122u8, 86u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for MinimumLiquidity {
+        const NAME: &'static str = "MINIMUM_LIQUIDITY";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for MinimumLiquidity {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Mint {
+        pub to: Vec<u8>,
+    }
+    impl Mint {
+        const METHOD_ID: [u8; 4] = [106u8, 98u8, 120u8, 66u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                to: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data =
+                ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(&self.to))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Mint {
+        const NAME: &'static str = "mint";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for Mint {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Name {}
+    impl Name {
+        const METHOD_ID: [u8; 4] = [6u8, 253u8, 222u8, 3u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<String, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<String, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::String], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_string()
+                .expect(INTERNAL_ERR))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<String> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Name {
+        const NAME: &'static str = "name";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<String> for Name {
+        fn output(data: &[u8]) -> Result<String, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Nonces {
+        pub param0: Vec<u8>,
+    }
+    impl Nonces {
+        const METHOD_ID: [u8; 4] = [126u8, 206u8, 190u8, 0u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                param0: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(
+                &self.param0,
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Nonces {
+        const NAME: &'static str = "nonces";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for Nonces {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Permit {
+        pub owner: Vec<u8>,
+        pub spender: Vec<u8>,
+        pub value: substreams::scalar::BigInt,
+        pub deadline: substreams::scalar::BigInt,
+        pub v: substreams::scalar::BigInt,
+        pub r: [u8; 32usize],
+        pub s: [u8; 32usize],
+    }
+    impl Permit {
+        const METHOD_ID: [u8; 4] = [213u8, 5u8, 172u8, 207u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(8usize),
+                    ethabi::ParamType::FixedBytes(32usize),
+                    ethabi::ParamType::FixedBytes(32usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                owner: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                spender: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                value: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                deadline: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                v: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                r: {
+                    let mut result = [0u8; 32];
+                    let v = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+                s: {
+                    let mut result = [0u8; 32];
+                    let v = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.owner)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.spender)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.value.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.deadline.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.v.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::FixedBytes(self.r.as_ref().to_vec()),
+                ethabi::Token::FixedBytes(self.s.as_ref().to_vec()),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Permit {
+        const NAME: &'static str = "permit";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct PermitTypehash {}
+    impl PermitTypehash {
+        const METHOD_ID: [u8; 4] = [48u8, 173u8, 248u8, 31u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<[u8; 32usize], String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<[u8; 32usize], String> {
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::FixedBytes(32usize)], data.as_ref())
+                    .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut result = [0u8; 32];
+                let v = values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_fixed_bytes()
+                    .expect(INTERNAL_ERR);
+                result.copy_from_slice(&v);
+                result
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<[u8; 32usize]> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for PermitTypehash {
+        const NAME: &'static str = "PERMIT_TYPEHASH";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<[u8; 32usize]> for PermitTypehash {
+        fn output(data: &[u8]) -> Result<[u8; 32usize], String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Price0CumulativeLast {}
+    impl Price0CumulativeLast {
+        const METHOD_ID: [u8; 4] = [89u8, 9u8, 192u8, 213u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Price0CumulativeLast {
+        const NAME: &'static str = "price0CumulativeLast";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for Price0CumulativeLast {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Price1CumulativeLast {}
+    impl Price1CumulativeLast {
+        const METHOD_ID: [u8; 4] = [90u8, 61u8, 84u8, 147u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Price1CumulativeLast {
+        const NAME: &'static str = "price1CumulativeLast";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for Price1CumulativeLast {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Skim {
+        pub to: Vec<u8>,
+    }
+    impl Skim {
+        const METHOD_ID: [u8; 4] = [188u8, 37u8, 207u8, 119u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                to: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data =
+                ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(&self.to))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Skim {
+        const NAME: &'static str = "skim";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Swap {
+        pub amount0_out: substreams::scalar::BigInt,
+        pub amount1_out: substreams::scalar::BigInt,
+        pub to: Vec<u8>,
+        pub data: Vec<u8>,
+    }
+    impl Swap {
+        const METHOD_ID: [u8; 4] = [2u8, 44u8, 13u8, 159u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Bytes,
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                amount0_out: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount1_out: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                to: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                data: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_bytes()
+                    .expect(INTERNAL_ERR),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount0_out.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount1_out.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.to)),
+                ethabi::Token::Bytes(self.data.clone()),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Swap {
+        const NAME: &'static str = "swap";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Symbol {}
+    impl Symbol {
+        const METHOD_ID: [u8; 4] = [149u8, 216u8, 155u8, 65u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<String, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<String, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::String], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_string()
+                .expect(INTERNAL_ERR))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<String> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Symbol {
+        const NAME: &'static str = "symbol";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<String> for Symbol {
+        fn output(data: &[u8]) -> Result<String, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Sync {}
+    impl Sync {
+        const METHOD_ID: [u8; 4] = [255u8, 246u8, 202u8, 233u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Sync {
+        const NAME: &'static str = "sync";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Token0 {}
+    impl Token0 {
+        const METHOD_ID: [u8; 4] = [13u8, 254u8, 22u8, 129u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Token0 {
+        const NAME: &'static str = "token0";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for Token0 {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Token1 {}
+    impl Token1 {
+        const METHOD_ID: [u8; 4] = [210u8, 18u8, 32u8, 167u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Token1 {
+        const NAME: &'static str = "token1";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for Token1 {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct TotalSupply {}
+    impl TotalSupply {
+        const METHOD_ID: [u8; 4] = [24u8, 22u8, 13u8, 221u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for TotalSupply {
+        const NAME: &'static str = "totalSupply";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for TotalSupply {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Transfer {
+        pub to: Vec<u8>,
+        pub value: substreams::scalar::BigInt,
+    }
+    impl Transfer {
+        const METHOD_ID: [u8; 4] = [169u8, 5u8, 156u8, 187u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                to: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                value: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.to)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.value.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<bool, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<bool, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Bool], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_bool()
+                .expect(INTERNAL_ERR))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<bool> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Transfer {
+        const NAME: &'static str = "transfer";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<bool> for Transfer {
+        fn output(data: &[u8]) -> Result<bool, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct TransferFrom {
+        pub from: Vec<u8>,
+        pub to: Vec<u8>,
+        pub value: substreams::scalar::BigInt,
+    }
+    impl TransferFrom {
+        const METHOD_ID: [u8; 4] = [35u8, 184u8, 114u8, 221u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(256usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                from: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                to: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                value: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.from)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.to)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.value.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<bool, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<bool, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Bool], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_bool()
+                .expect(INTERNAL_ERR))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<bool> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for TransferFrom {
+        const NAME: &'static str = "transferFrom";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<bool> for TransferFrom {
+        fn output(data: &[u8]) -> Result<bool, String> {
+            Self::output(data)
+        }
+    }
+}
+/// Contract's events.
+#[allow(dead_code, unused_imports, unused_variables)]
+pub mod events {
+    use super::INTERNAL_ERR;
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Approval {
+        pub owner: Vec<u8>,
+        pub spender: Vec<u8>,
+        pub value: substreams::scalar::BigInt,
+    }
+    impl Approval {
+        const TOPIC_ID: [u8; 32] = [
+            140u8, 91u8, 225u8, 229u8, 235u8, 236u8, 125u8, 91u8, 209u8, 79u8, 113u8, 66u8, 125u8,
+            30u8, 132u8, 243u8, 221u8, 3u8, 20u8, 192u8, 247u8, 178u8, 41u8, 30u8, 91u8, 32u8,
+            10u8, 200u8, 199u8, 195u8, 185u8, 37u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 32usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::Uint(256usize)], log.data.as_ref())
+                    .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                owner: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'owner' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                spender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[2usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'spender' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                value: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Approval {
+        const NAME: &'static str = "Approval";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Burn {
+        pub sender: Vec<u8>,
+        pub amount0: substreams::scalar::BigInt,
+        pub amount1: substreams::scalar::BigInt,
+        pub to: Vec<u8>,
+    }
+    impl Burn {
+        const TOPIC_ID: [u8; 32] = [
+            220u8, 205u8, 65u8, 47u8, 11u8, 18u8, 82u8, 129u8, 156u8, 177u8, 253u8, 51u8, 11u8,
+            147u8, 34u8, 76u8, 164u8, 38u8, 18u8, 137u8, 43u8, 179u8, 244u8, 247u8, 137u8, 151u8,
+            110u8, 109u8, 129u8, 147u8, 100u8, 150u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 64usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Uint(256usize), ethabi::ParamType::Uint(256usize)],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                sender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'sender' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                to: ethabi::decode(&[ethabi::ParamType::Address], log.topics[2usize].as_ref())
+                    .map_err(|e| {
+                        format!("unable to decode param 'to' from topic of type 'address': {:?}", e)
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount0: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount1: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Burn {
+        const NAME: &'static str = "Burn";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Mint {
+        pub sender: Vec<u8>,
+        pub amount0: substreams::scalar::BigInt,
+        pub amount1: substreams::scalar::BigInt,
+    }
+    impl Mint {
+        const TOPIC_ID: [u8; 32] = [
+            76u8, 32u8, 155u8, 95u8, 200u8, 173u8, 80u8, 117u8, 143u8, 19u8, 226u8, 225u8, 8u8,
+            139u8, 165u8, 106u8, 86u8, 13u8, 255u8, 105u8, 10u8, 28u8, 111u8, 239u8, 38u8, 57u8,
+            79u8, 76u8, 3u8, 130u8, 28u8, 79u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 2usize {
+                return false;
+            }
+            if log.data.len() != 64usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Uint(256usize), ethabi::ParamType::Uint(256usize)],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                sender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'sender' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount0: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount1: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Mint {
+        const NAME: &'static str = "Mint";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Swap {
+        pub sender: Vec<u8>,
+        pub amount0_in: substreams::scalar::BigInt,
+        pub amount1_in: substreams::scalar::BigInt,
+        pub amount0_out: substreams::scalar::BigInt,
+        pub amount1_out: substreams::scalar::BigInt,
+        pub to: Vec<u8>,
+    }
+    impl Swap {
+        const TOPIC_ID: [u8; 32] = [
+            215u8, 138u8, 217u8, 95u8, 164u8, 108u8, 153u8, 75u8, 101u8, 81u8, 208u8, 218u8, 133u8,
+            252u8, 39u8, 95u8, 230u8, 19u8, 206u8, 55u8, 101u8, 127u8, 184u8, 213u8, 227u8, 209u8,
+            48u8, 132u8, 1u8, 89u8, 216u8, 34u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 128usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                ],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                sender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'sender' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                to: ethabi::decode(&[ethabi::ParamType::Address], log.topics[2usize].as_ref())
+                    .map_err(|e| {
+                        format!("unable to decode param 'to' from topic of type 'address': {:?}", e)
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount0_in: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount1_in: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount0_out: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount1_out: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Swap {
+        const NAME: &'static str = "Swap";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Sync {
+        pub reserve0: substreams::scalar::BigInt,
+        pub reserve1: substreams::scalar::BigInt,
+    }
+    impl Sync {
+        const TOPIC_ID: [u8; 32] = [
+            28u8, 65u8, 30u8, 154u8, 150u8, 224u8, 113u8, 36u8, 28u8, 47u8, 33u8, 247u8, 114u8,
+            107u8, 23u8, 174u8, 137u8, 227u8, 202u8, 180u8, 199u8, 139u8, 229u8, 14u8, 6u8, 43u8,
+            3u8, 169u8, 255u8, 251u8, 186u8, 209u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 1usize {
+                return false;
+            }
+            if log.data.len() != 64usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Uint(112usize), ethabi::ParamType::Uint(112usize)],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                reserve0: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                reserve1: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Sync {
+        const NAME: &'static str = "Sync";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Transfer {
+        pub from: Vec<u8>,
+        pub to: Vec<u8>,
+        pub value: substreams::scalar::BigInt,
+    }
+    impl Transfer {
+        const TOPIC_ID: [u8; 32] = [
+            221u8, 242u8, 82u8, 173u8, 27u8, 226u8, 200u8, 155u8, 105u8, 194u8, 176u8, 104u8,
+            252u8, 55u8, 141u8, 170u8, 149u8, 43u8, 167u8, 241u8, 99u8, 196u8, 161u8, 22u8, 40u8,
+            245u8, 90u8, 77u8, 245u8, 35u8, 179u8, 239u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 32usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::Uint(256usize)], log.data.as_ref())
+                    .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                from: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'from' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                to: ethabi::decode(&[ethabi::ParamType::Address], log.topics[2usize].as_ref())
+                    .map_err(|e| {
+                        format!("unable to decode param 'to' from topic of type 'address': {:?}", e)
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                value: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Transfer {
+        const NAME: &'static str = "Transfer";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+}

--- a/protocols/crates/uniswap-v2/src/balance.rs
+++ b/protocols/crates/uniswap-v2/src/balance.rs
@@ -1,0 +1,35 @@
+use std::str::FromStr;
+
+use num_bigint::BigInt;
+
+use crate::events::{PoolEvent, PoolEventKind};
+
+/// An absolute component balance for a single token, encoded as signed big-endian bytes
+/// to match the substreams output.
+pub struct AbsoluteBalance {
+    pub token: Vec<u8>,
+    pub balance: Vec<u8>,
+}
+
+/// Computes the absolute component balances an event produces.
+///
+/// A `Sync` event reports the pool's reserves directly, so the component balances are the
+/// reserves themselves: `token0 = reserve0`, `token1 = reserve1`. No accumulation is needed.
+pub fn event_to_balances(event: &PoolEvent) -> Vec<AbsoluteBalance> {
+    match &event.kind {
+        PoolEventKind::Sync { reserve0, reserve1 } => vec![
+            AbsoluteBalance {
+                token: event.token0.clone(),
+                balance: BigInt::from_str(reserve0)
+                    .unwrap_or_default()
+                    .to_signed_bytes_be(),
+            },
+            AbsoluteBalance {
+                token: event.token1.clone(),
+                balance: BigInt::from_str(reserve1)
+                    .unwrap_or_default()
+                    .to_signed_bytes_be(),
+            },
+        ],
+    }
+}

--- a/protocols/crates/uniswap-v2/src/events.rs
+++ b/protocols/crates/uniswap-v2/src/events.rs
@@ -1,0 +1,57 @@
+use substreams_ethereum::Event;
+
+use crate::abi::pool::events::Sync;
+
+#[derive(Clone)]
+pub struct Pool {
+    pub address: Vec<u8>,
+    pub token0: Vec<u8>,
+    pub token1: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TxRef {
+    pub hash: Vec<u8>,
+    pub from: Vec<u8>,
+    pub to: Vec<u8>,
+    pub index: u64,
+}
+
+pub enum PoolEventKind {
+    /// Emitted on every reserve-altering call. Carries the pool's absolute reserves,
+    /// so it fully describes the post-event state without any prior context.
+    Sync { reserve0: String, reserve1: String },
+}
+
+pub struct PoolEvent {
+    pub log_ordinal: u64,
+    pub pool_address: Vec<u8>,
+    pub token0: Vec<u8>,
+    pub token1: Vec<u8>,
+    pub tx: TxRef,
+    pub kind: PoolEventKind,
+}
+
+/// Decodes a pool log into a `PoolEvent`, or `None` if it is not a handled event.
+///
+/// UniswapV2 only needs the `Sync` event: it is emitted on every reserve-altering
+/// call (mint, burn, swap), so the reserves it carries are sufficient to track pool
+/// state and component balances.
+pub fn decode_log(
+    log: &substreams_ethereum::pb::eth::v2::Log,
+    pool: &Pool,
+    tx: &TxRef,
+) -> Option<PoolEvent> {
+    let sync = Sync::match_and_decode(log)?;
+    Some(PoolEvent {
+        log_ordinal: log.ordinal,
+        pool_address: pool.address.clone(),
+        token0: pool.token0.clone(),
+        token1: pool.token1.clone(),
+        tx: tx.clone(),
+        kind: PoolEventKind::Sync {
+            reserve0: sync.reserve0.to_string(),
+            reserve1: sync.reserve1.to_string(),
+        },
+    })
+}

--- a/protocols/crates/uniswap-v2/src/lib.rs
+++ b/protocols/crates/uniswap-v2/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod abi;
+pub mod balance;
+pub mod events;
+pub mod output;
+pub mod processor;

--- a/protocols/crates/uniswap-v2/src/output.rs
+++ b/protocols/crates/uniswap-v2/src/output.rs
@@ -1,0 +1,36 @@
+use std::str::FromStr;
+
+use num_bigint::BigInt;
+
+use crate::events::{PoolEvent, PoolEventKind};
+
+pub struct AttributeUpdate {
+    pub pool_address: Vec<u8>,
+    pub name: String,
+    pub value: Vec<u8>,
+}
+
+/// Computes the protocol-state attribute updates an event produces.
+///
+/// A `Sync` event sets the pool's `reserve0` and `reserve1` to the absolute values it
+/// carries, encoded as signed big-endian bytes to match the substreams output.
+pub fn event_to_attribute_updates(event: &PoolEvent) -> Vec<AttributeUpdate> {
+    match &event.kind {
+        PoolEventKind::Sync { reserve0, reserve1 } => vec![
+            AttributeUpdate {
+                pool_address: event.pool_address.clone(),
+                name: "reserve0".to_string(),
+                value: BigInt::from_str(reserve0)
+                    .unwrap_or_default()
+                    .to_signed_bytes_be(),
+            },
+            AttributeUpdate {
+                pool_address: event.pool_address.clone(),
+                name: "reserve1".to_string(),
+                value: BigInt::from_str(reserve1)
+                    .unwrap_or_default()
+                    .to_signed_bytes_be(),
+            },
+        ],
+    }
+}

--- a/protocols/crates/uniswap-v2/src/processor.rs
+++ b/protocols/crates/uniswap-v2/src/processor.rs
@@ -1,0 +1,283 @@
+use std::collections::{HashMap, HashSet};
+
+use num_bigint::{BigInt, Sign};
+use num_traits::ToPrimitive as _;
+use tycho_common::{
+    models::{
+        blockchain::{Block, BlockAggregatedChanges, LogInput, TxInput},
+        protocol::{ComponentBalance, ProtocolComponentStateDelta},
+        Chain,
+    },
+    traits::TxDeltaIndexer,
+    Bytes,
+};
+use tycho_substreams::prelude::{
+    Attribute, BalanceChange, ChangeType, EntityChanges, Transaction as SubstreamsTx,
+    TransactionChanges, TransactionChangesBuilder,
+};
+
+use crate::{
+    balance::event_to_balances,
+    events::{decode_log, Pool, PoolEvent, TxRef},
+    output::event_to_attribute_updates,
+};
+
+#[derive(Clone)]
+pub struct UniswapV2Processor {
+    chain: Chain,
+    extractor: String,
+    last_block: Option<Block>,
+    finalized_block_height: u64,
+    pools: HashMap<String, Pool>,
+}
+
+impl TxDeltaIndexer for UniswapV2Processor {
+    fn apply_block(&mut self, block: &BlockAggregatedChanges) {
+        self.chain = block.chain;
+        self.last_block = Some(block.block.clone());
+        self.finalized_block_height = block.finalized_block_height;
+
+        // UniswapV2 `Sync` events carry absolute reserves, so `generate_deltas` is fully
+        // described by each event plus the pool's token list. The only state to reconstruct
+        // is the pool registry — reserves and balances need no running accumulators.
+        for (id, comp) in &block.new_protocol_components {
+            if comp.tokens.len() >= 2 {
+                let key = normalize_id(id);
+                self.pools.insert(
+                    key.clone(),
+                    Pool {
+                        address: hex::decode(&key).unwrap_or_default(),
+                        token0: comp.tokens[0].to_vec(),
+                        token1: comp.tokens[1].to_vec(),
+                    },
+                );
+            }
+        }
+
+        for id in block.deleted_protocol_components.keys() {
+            self.pools.remove(&normalize_id(id));
+        }
+    }
+
+    /// Applies a batch of in-flight transactions against the current state and returns the
+    /// protocol state deltas they would produce.
+    ///
+    /// Component ids in the output use the same format the substreams packages emit
+    /// ("0x"-prefixed lower-case hex), so they match decoder state keys downstream.
+    ///
+    /// Works on a clone of internal state so repeated calls with the same (or different)
+    /// transactions always produce results relative to the last `apply_block` call.
+    fn generate_deltas(&mut self, txs: &[TxInput]) -> BlockAggregatedChanges {
+        let mut scratch = self.clone();
+        let tx_changes = scratch.build_tx_changes(txs);
+
+        let mut state_deltas: HashMap<String, ProtocolComponentStateDelta> = HashMap::new();
+        let mut component_balances: HashMap<String, HashMap<Bytes, ComponentBalance>> =
+            HashMap::new();
+
+        for changes in tx_changes {
+            let tx_hash = changes
+                .tx
+                .as_ref()
+                .map(|t| Bytes::from(t.hash.clone()))
+                .unwrap_or_default();
+
+            for ec in changes.entity_changes {
+                let component_id = emitted_id(&ec.component_id);
+                let delta = state_deltas
+                    .entry(component_id.clone())
+                    .or_insert_with(|| ProtocolComponentStateDelta {
+                        component_id: component_id.clone(),
+                        updated_attributes: HashMap::new(),
+                        deleted_attributes: HashSet::new(),
+                    });
+                for attr in ec.attributes {
+                    if attr.change == i32::from(ChangeType::Deletion) {
+                        delta
+                            .deleted_attributes
+                            .insert(attr.name.clone());
+                        delta
+                            .updated_attributes
+                            .remove(&attr.name);
+                    } else {
+                        delta
+                            .updated_attributes
+                            .insert(attr.name.clone(), Bytes::from(attr.value));
+                        delta
+                            .deleted_attributes
+                            .remove(&attr.name);
+                    }
+                }
+            }
+
+            for bc in changes.balance_changes {
+                let comp_id = emitted_id(&hex::encode(&bc.component_id));
+                let token = Bytes::from(bc.token);
+                let balance = Bytes::from(bc.balance);
+                let balance_float = BigInt::from_bytes_be(Sign::Plus, balance.as_ref())
+                    .to_f64()
+                    .unwrap_or(f64::MAX);
+                component_balances
+                    .entry(comp_id.clone())
+                    .or_default()
+                    .insert(
+                        token.clone(),
+                        ComponentBalance {
+                            token,
+                            balance,
+                            balance_float,
+                            modify_tx: tx_hash.clone(),
+                            component_id: comp_id,
+                        },
+                    );
+            }
+        }
+
+        BlockAggregatedChanges {
+            extractor: self.extractor.clone(),
+            chain: self.chain,
+            block: self.pending_block(),
+            finalized_block_height: self.finalized_block_height,
+            state_deltas,
+            component_balances,
+            ..Default::default()
+        }
+    }
+}
+
+impl UniswapV2Processor {
+    pub fn new(chain: Chain, extractor: String) -> Self {
+        Self {
+            chain,
+            extractor,
+            last_block: None,
+            finalized_block_height: 0,
+            pools: HashMap::new(),
+        }
+    }
+
+    /// Constructs the pending-block descriptor for `generate_deltas` output.
+    ///
+    /// Number is `last_block + 1`; hash is zeroed because the block has not
+    /// been mined yet.
+    fn pending_block(&self) -> Block {
+        match &self.last_block {
+            Some(b) => Block {
+                number: b.number + 1,
+                hash: Bytes::default(),
+                parent_hash: b.hash.clone(),
+                chain: b.chain,
+                ts: b.ts,
+            },
+            None => Block::default(),
+        }
+    }
+
+    fn build_tx_changes(&mut self, txs: &[TxInput]) -> Vec<TransactionChanges> {
+        let mut tx_builders: HashMap<Vec<u8>, (u64, TransactionChangesBuilder)> = HashMap::new();
+
+        for tx in txs {
+            if !tx.succeeded() {
+                continue;
+            }
+
+            let tx_ref = TxRef {
+                hash: tx.hash().to_vec(),
+                from: tx.from().to_vec(),
+                to: tx.to().to_vec(),
+                index: tx.index(),
+            };
+
+            let mut events: Vec<PoolEvent> = Vec::new();
+            for log in tx.logs() {
+                let pool_hex = hex::encode(log.address().as_ref());
+                let Some(pool) = self.pools.get(&pool_hex) else { continue };
+                let ordinal = tx.index() * 100_000 + log.log_index() as u64;
+                let pb_log = log_input_to_pb(log, ordinal);
+                if let Some(event) = decode_log(&pb_log, pool, &tx_ref) {
+                    events.push(event);
+                }
+            }
+
+            if events.is_empty() {
+                continue;
+            }
+
+            tx_builders
+                .entry(tx.hash().to_vec())
+                .or_insert_with(|| {
+                    let substreams_tx = SubstreamsTx {
+                        hash: tx.hash().to_vec(),
+                        from: tx.from().to_vec(),
+                        to: tx.to().to_vec(),
+                        index: tx.index(),
+                    };
+                    (tx.index(), TransactionChangesBuilder::new(&substreams_tx))
+                });
+
+            for event in events {
+                let (_, builder) = tx_builders
+                    .get_mut(tx.hash().as_ref())
+                    .expect("builder inserted above");
+                Self::apply_event(event, builder);
+            }
+        }
+
+        let mut ordered: Vec<(u64, TransactionChangesBuilder)> =
+            tx_builders.into_values().collect();
+        ordered.sort_unstable_by_key(|(idx, _)| *idx);
+        ordered
+            .into_iter()
+            .filter_map(|(_, b)| b.build())
+            .collect()
+    }
+
+    fn apply_event(event: PoolEvent, builder: &mut TransactionChangesBuilder) {
+        let pool_hex = hex::encode(&event.pool_address);
+
+        for balance in event_to_balances(&event) {
+            builder.add_balance_change(&BalanceChange {
+                component_id: event.pool_address.clone(),
+                token: balance.token,
+                balance: balance.balance,
+            });
+        }
+
+        for attr_update in event_to_attribute_updates(&event) {
+            builder.add_entity_change(&EntityChanges {
+                component_id: pool_hex.clone(),
+                attributes: vec![Attribute {
+                    name: attr_update.name,
+                    value: attr_update.value,
+                    change: ChangeType::Update.into(),
+                }],
+            });
+        }
+    }
+}
+
+/// Canonical internal key for a component id: lower-case hex without the "0x" prefix.
+fn normalize_id(id: &str) -> String {
+    id.trim_start_matches("0x")
+        .to_lowercase()
+}
+
+/// Formats a canonical internal key into the id format the substreams packages emit
+/// ("0x"-prefixed lower-case hex).
+fn emitted_id(canonical_hex: &str) -> String {
+    format!("0x{canonical_hex}")
+}
+
+fn log_input_to_pb(log: &LogInput, ordinal: u64) -> substreams_ethereum::pb::eth::v2::Log {
+    substreams_ethereum::pb::eth::v2::Log {
+        address: log.address().to_vec(),
+        topics: log
+            .topics()
+            .iter()
+            .map(|t| t.to_vec())
+            .collect(),
+        data: log.data().to_vec(),
+        ordinal,
+        ..Default::default()
+    }
+}

--- a/protocols/crates/uniswap-v2/tests/integration.rs
+++ b/protocols/crates/uniswap-v2/tests/integration.rs
@@ -1,0 +1,682 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use alloy::{
+    consensus::Transaction as _,
+    eips::BlockNumberOrTag,
+    primitives::B256,
+    providers::{Provider, ProviderBuilder},
+    rpc::types::{BlockTransactions, Filter, Log},
+    transports::http::reqwest::Url,
+};
+use num_bigint::{BigInt, Sign};
+use num_traits::ToPrimitive as _;
+use prost::Message;
+use tokio_stream::StreamExt;
+use tycho_common::{
+    models::{
+        blockchain::{Block, BlockAggregatedChanges, LogInput, TxInput},
+        protocol::{ComponentBalance, ProtocolComponent, ProtocolComponentStateDelta},
+        Chain,
+    },
+    traits::TxDeltaIndexer,
+    Bytes,
+};
+use tycho_indexer::{
+    pb::sf::substreams::v1::Package,
+    substreams::{
+        stream::{BlockResponse, SubstreamsStream},
+        SubstreamsEndpoint,
+    },
+};
+use tycho_substreams::pb::tycho::evm::v1::BlockChanges;
+use uniswap_v2_core::processor::UniswapV2Processor;
+
+// UV2 launch was sparse (a handful of pools for thousands of blocks). Default to a
+// 2000-block window with dozens of pool creations followed by Sync activity, so the
+// comparison covers tens of pools. Override with UV2_START_BLOCK / UV2_STOP_BLOCK.
+const DEFAULT_START_BLOCK: u64 = 10_400_000;
+const DEFAULT_STOP_BLOCK: u64 = DEFAULT_START_BLOCK + 2_000; // 10_402_000
+
+// ─── Substreams helpers ──────────────────────────────────────────────────────
+
+/// Streams every block in `[start, stop]` from the substreams endpoint and
+/// returns `(block_number, block_hash, BlockChanges)` triples in ascending order.
+async fn stream_block_range(
+    endpoint_url: &str,
+    api_key: &str,
+    spkg_path: &str,
+    start: u64,
+    stop: u64,
+) -> Vec<(u64, String, BlockChanges)> {
+    let content = std::fs::read(spkg_path)
+        .unwrap_or_else(|e| panic!("Failed to read spkg at {spkg_path}: {e}"));
+    let package = Package::decode(content.as_slice())
+        .unwrap_or_else(|e| panic!("Failed to decode spkg: {e}"));
+
+    let endpoint = Arc::new(
+        SubstreamsEndpoint::new(endpoint_url, Some(api_key.to_string()))
+            .await
+            .expect("Failed to create substreams endpoint"),
+    );
+
+    let mut stream = SubstreamsStream::new(
+        endpoint,
+        None,
+        Some(package),
+        "map_pool_events".to_string(),
+        start as i64,
+        stop,
+        true,
+        "integration-test".to_string(),
+        false,
+    );
+
+    let mut results = Vec::new();
+    loop {
+        match stream.next().await {
+            Some(Ok(BlockResponse::New(data))) => {
+                let (block_num, block_hash) = data
+                    .clock
+                    .as_ref()
+                    .map_or((0, String::new()), |c| (c.number, c.id.clone()));
+                let map_output = data
+                    .output
+                    .as_ref()
+                    .and_then(|o| o.map_output.as_ref())
+                    .expect("BlockScopedData has no map_output");
+                let changes = BlockChanges::decode(map_output.value.as_slice())
+                    .expect("Failed to decode BlockChanges");
+                results.push((block_num, block_hash, changes));
+            }
+            Some(Ok(BlockResponse::Ended)) => break,
+            Some(Ok(BlockResponse::Undo(_))) => {
+                // Undo signals should not appear with final_blocks_only=true.
+                panic!("Unexpected undo signal in range [{start}, {stop}]");
+            }
+            Some(Err(e)) => panic!("Substreams stream error: {e}"),
+            None => break,
+        }
+    }
+
+    results.sort_unstable_by_key(|(n, _, _)| *n);
+    results
+}
+
+// ─── Archive RPC helpers ─────────────────────────────────────────────────────
+
+// The only UniswapV2 pool event the processor needs: Sync is emitted on every
+// reserve-altering call and carries the pool's absolute reserves.
+// Passed to `Filter::events` which hashes it to a topic0 value internally.
+const UV2_EVENT_SIGNATURES: [&str; 1] = ["Sync(uint112,uint112)"];
+
+/// Returns all UV2 `Sync` logs emitted in `[start_block, stop_block]`.
+///
+/// Not filtered by address — the processor only decodes logs for pools it already knows,
+/// matching the substreams `PoolAddresser` filter, so foreign Sync events are ignored.
+/// Chunked into 10,000-block pages to stay within Alchemy's eth_getLogs limit.
+async fn fetch_range_logs(rpc_url: &str, start_block: u64, stop_block: u64) -> Vec<Log> {
+    const CHUNK: u64 = 10_000;
+    let provider = ProviderBuilder::new().connect_http(
+        rpc_url
+            .parse::<Url>()
+            .expect("invalid RPC URL"),
+    );
+    let mut logs = Vec::new();
+    let mut chunk_start = start_block;
+    while chunk_start <= stop_block {
+        let chunk_end = (chunk_start + CHUNK - 1).min(stop_block);
+        let filter = Filter::new()
+            .from_block(chunk_start)
+            .to_block(chunk_end)
+            .events(UV2_EVENT_SIGNATURES);
+        let chunk_logs = provider
+            .get_logs(&filter)
+            .await
+            .unwrap_or_else(|e| panic!("eth_getLogs [{chunk_start},{chunk_end}] failed: {e}"));
+        logs.extend(chunk_logs);
+        chunk_start = chunk_end + 1;
+    }
+    logs
+}
+
+/// Returns `{tx_hash → (from_bytes, to_bytes, tx_index)}` for all transactions
+/// in the given block by fetching the full block once.
+async fn fetch_block_tx_meta(
+    rpc_url: &str,
+    block_num: u64,
+) -> HashMap<B256, (Vec<u8>, Vec<u8>, u64)> {
+    use alloy::network::{BlockResponse as _, TransactionResponse as _};
+
+    let provider = ProviderBuilder::new().connect_http(
+        rpc_url
+            .parse::<Url>()
+            .expect("invalid RPC URL"),
+    );
+    let block = provider
+        .get_block_by_number(BlockNumberOrTag::Number(block_num))
+        .full()
+        .await
+        .unwrap_or_else(|e| panic!("eth_getBlockByNumber({block_num}) failed: {e}"))
+        .unwrap_or_else(|| panic!("block {block_num} not found"));
+
+    let mut map = HashMap::new();
+    if let BlockTransactions::Full(txns) = block.transactions() {
+        for tx in txns {
+            let hash = tx.tx_hash();
+            let from = tx.from().to_vec();
+            // `to()` lives on the inner consensus transaction.
+            let to = tx
+                .inner
+                .to()
+                .map(|a| a.to_vec())
+                .unwrap_or_default();
+            let index = tx
+                .transaction_index()
+                .unwrap_or_default();
+            map.insert(hash, (from, to, index));
+        }
+    }
+    map
+}
+
+/// Returns a `HashMap<block_num, Vec<TxInput>>` for every block in
+/// `[start_block, stop_block]` that emitted at least one log.
+///
+/// Transactions are ordered by transaction index within each block.
+/// All transactions that emitted logs are treated as succeeded — the EVM
+/// does not emit logs for reverted transactions.
+async fn fetch_range_tx_inputs(
+    rpc_url: &str,
+    start_block: u64,
+    stop_block: u64,
+) -> HashMap<u64, Vec<TxInput>> {
+    let logs = fetch_range_logs(rpc_url, start_block, stop_block).await;
+
+    // Group logs by block number, then by tx hash.
+    let mut blocks_with_tx_hashes: HashMap<u64, HashSet<B256>> = HashMap::new();
+    let mut logs_by_key: HashMap<(u64, B256), Vec<LogInput>> = HashMap::new();
+
+    for log in &logs {
+        let Some(block_num) = log.block_number else { continue };
+        let Some(hash) = log.transaction_hash else { continue };
+        blocks_with_tx_hashes
+            .entry(block_num)
+            .or_default()
+            .insert(hash);
+        logs_by_key
+            .entry((block_num, hash))
+            .or_default()
+            .push(LogInput::new(
+                Bytes::from(log.address().to_vec()),
+                log.topics()
+                    .iter()
+                    .map(|t| Bytes::from(t.to_vec()))
+                    .collect(),
+                Bytes::from(log.data().data.to_vec()),
+                log.log_index.unwrap_or_default() as u32,
+            ));
+    }
+
+    let mut result: HashMap<u64, Vec<TxInput>> = HashMap::new();
+
+    for (block_num, tx_hashes) in blocks_with_tx_hashes {
+        let meta = fetch_block_tx_meta(rpc_url, block_num).await;
+        let mut tx_inputs: Vec<TxInput> = tx_hashes
+            .into_iter()
+            .filter_map(|hash| {
+                let (from, to, index) = meta.get(&hash)?.clone();
+                let logs = logs_by_key
+                    .remove(&(block_num, hash))
+                    .unwrap_or_default();
+                Some(TxInput::new(
+                    Bytes::from(hash.to_vec()),
+                    Bytes::from(from),
+                    Bytes::from(to),
+                    index,
+                    logs,
+                    true,
+                ))
+            })
+            .collect();
+        tx_inputs.sort_unstable_by_key(|t| t.index());
+        result.insert(block_num, tx_inputs);
+    }
+
+    result
+}
+
+// ─── Conversion helpers ──────────────────────────────────────────────────────
+
+/// Decodes a substreams balance-change component_id (the UTF-8 bytes of the id string).
+///
+/// Ids are kept exactly as the substreams emit them ("0x"-prefixed lower-case hex) — the
+/// processor must produce byte-identical ids, so the comparison asserts the format too.
+fn component_id_from_bytes(raw: &[u8]) -> String {
+    std::str::from_utf8(raw)
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// Converts a substreams proto `BlockChanges` to a `BlockAggregatedChanges`, aggregating
+/// all per-transaction entity and balance changes across the block.
+fn substreams_proto_to_model(
+    proto: &BlockChanges,
+    block_num: u64,
+    block_hash_hex: &str,
+) -> BlockAggregatedChanges {
+    use tycho_substreams::prelude::ChangeType as ProtoChangeType;
+
+    let hash_bytes = hex::decode(block_hash_hex.trim_start_matches("0x")).unwrap_or_default();
+    let block = Block {
+        number: block_num,
+        hash: Bytes::from(hash_bytes),
+        parent_hash: Bytes::default(),
+        chain: Chain::Ethereum,
+        ts: Default::default(),
+    };
+
+    let mut new_protocol_components: HashMap<String, ProtocolComponent> = HashMap::new();
+    let mut state_deltas: HashMap<String, ProtocolComponentStateDelta> = HashMap::new();
+    let mut component_balances: HashMap<String, HashMap<Bytes, ComponentBalance>> = HashMap::new();
+
+    for tx_changes in &proto.changes {
+        for comp in &tx_changes.component_changes {
+            let id = comp.id.clone();
+            new_protocol_components
+                .entry(id.clone())
+                .or_insert_with(|| ProtocolComponent {
+                    id: id.clone(),
+                    tokens: comp
+                        .tokens
+                        .iter()
+                        .map(|t| Bytes::from(t.clone()))
+                        .collect(),
+                    ..Default::default()
+                });
+        }
+
+        for ec in &tx_changes.entity_changes {
+            let cid = ec.component_id.clone();
+            let delta = state_deltas
+                .entry(cid.clone())
+                .or_insert_with(|| ProtocolComponentStateDelta {
+                    component_id: cid.clone(),
+                    updated_attributes: HashMap::new(),
+                    deleted_attributes: HashSet::new(),
+                });
+            for attr in &ec.attributes {
+                if attr.change == i32::from(ProtoChangeType::Deletion) {
+                    delta
+                        .deleted_attributes
+                        .insert(attr.name.clone());
+                    delta
+                        .updated_attributes
+                        .remove(&attr.name);
+                } else {
+                    delta
+                        .updated_attributes
+                        .insert(attr.name.clone(), Bytes::from(attr.value.clone()));
+                    delta
+                        .deleted_attributes
+                        .remove(&attr.name);
+                }
+            }
+        }
+
+        for bc in &tx_changes.balance_changes {
+            let cid = component_id_from_bytes(&bc.component_id);
+            let token = Bytes::from(bc.token.clone());
+            let balance = Bytes::from(bc.balance.clone());
+            let balance_float = BigInt::from_bytes_be(Sign::Plus, balance.as_ref())
+                .to_f64()
+                .unwrap_or(f64::MAX);
+            component_balances
+                .entry(cid.clone())
+                .or_default()
+                .insert(
+                    token.clone(),
+                    ComponentBalance {
+                        token,
+                        balance,
+                        balance_float,
+                        modify_tx: Bytes::default(),
+                        component_id: cid,
+                    },
+                );
+        }
+    }
+
+    BlockAggregatedChanges {
+        extractor: "uniswap-v2".to_string(),
+        chain: Chain::Ethereum,
+        block,
+        finalized_block_height: block_num,
+        state_deltas,
+        new_protocol_components,
+        component_balances,
+        ..Default::default()
+    }
+}
+
+// ─── Comparison helpers ──────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct ComparableBlockChanges {
+    /// component_id → { attr_name → value }
+    attributes: HashMap<String, HashMap<String, Vec<u8>>>,
+    /// (component_id, token_hex) → balance
+    balances: HashMap<(String, String), Vec<u8>>,
+}
+
+/// Aggregates all per-transaction entity/balance changes from a substreams block into a
+/// block-level comparable view, filtered to pools already known to the processor.
+///
+/// Pools created in the current block are excluded because the processor learns about them
+/// only after `apply_block` is called, so `generate_deltas` for the same block cannot
+/// produce output for them. This matches production semantics.
+///
+/// Transaction changes are aggregated in ascending transaction-index order so that the
+/// last write for a `(pool, attribute)` is the highest-index transaction's value — the
+/// block-final state. The UniswapV2 substreams emits per-transaction changes in
+/// non-deterministic (hash-map) order, so the explicit sort is required for a pool that
+/// syncs in several transactions within one block; the processor orders by index too.
+fn substreams_to_comparable_block(
+    proto: &BlockChanges,
+    known_pools: &HashSet<String>,
+) -> ComparableBlockChanges {
+    let mut attributes: HashMap<String, HashMap<String, Vec<u8>>> = HashMap::new();
+    let mut balances: HashMap<(String, String), Vec<u8>> = HashMap::new();
+
+    let mut ordered_changes: Vec<&_> = proto.changes.iter().collect();
+    ordered_changes.sort_by_key(|tc| {
+        tc.tx
+            .as_ref()
+            .map(|t| t.index)
+            .unwrap_or_default()
+    });
+
+    for tx_changes in ordered_changes {
+        for ec in &tx_changes.entity_changes {
+            let cid = ec.component_id.clone();
+            if !known_pools.contains(&cid) {
+                continue;
+            }
+            for attr in &ec.attributes {
+                // map_pools_created emits zero-value init attrs for new pools; skip them.
+                if attr.value.iter().all(|&b| b == 0) {
+                    continue;
+                }
+                attributes
+                    .entry(cid.clone())
+                    .or_default()
+                    .insert(attr.name.clone(), attr.value.clone());
+            }
+        }
+
+        for bc in &tx_changes.balance_changes {
+            let cid = component_id_from_bytes(&bc.component_id);
+            if !known_pools.contains(&cid) {
+                continue;
+            }
+            if bc.balance.iter().all(|&b| b == 0) {
+                continue;
+            }
+            let token = hex::encode(&bc.token);
+            balances.insert((cid, token), bc.balance.clone());
+        }
+    }
+
+    ComparableBlockChanges { attributes, balances }
+}
+
+fn processor_to_comparable_block(
+    changes: &BlockAggregatedChanges,
+    known_pools: &HashSet<String>,
+) -> ComparableBlockChanges {
+    let mut attributes: HashMap<String, HashMap<String, Vec<u8>>> = HashMap::new();
+    let mut balances: HashMap<(String, String), Vec<u8>> = HashMap::new();
+
+    for (comp_id, delta) in &changes.state_deltas {
+        if !known_pools.contains(comp_id) {
+            continue;
+        }
+        let entry = attributes
+            .entry(comp_id.clone())
+            .or_default();
+        for (attr_name, attr_val) in &delta.updated_attributes {
+            entry.insert(attr_name.clone(), attr_val.to_vec());
+        }
+    }
+
+    for (comp_id, token_balances) in &changes.component_balances {
+        if !known_pools.contains(comp_id) {
+            continue;
+        }
+        for (token, cb) in token_balances {
+            let token_hex = hex::encode(token.as_ref());
+            balances.insert((comp_id.clone(), token_hex), cb.balance.to_vec());
+        }
+    }
+
+    ComparableBlockChanges { attributes, balances }
+}
+
+// ─── Test ────────────────────────────────────────────────────────────────────
+
+/// Streams UniswapV2 substreams over `[UV2_START_BLOCK, UV2_STOP_BLOCK]` (default: a
+/// 2000-block window with steady pool creations and Sync activity) and verifies that the
+/// native `UniswapV2Processor` produces byte-identical reserve attributes and balance
+/// values for every block in the range.
+///
+/// For each block the test:
+///   1. Calls `generate_deltas` with the raw RPC transactions to get pending state changes.
+///   2. Compares those changes against the aggregated substreams output for the block, restricted
+///      to pools the processor already knows about.
+///   3. Calls `apply_block` with the substreams ground truth to advance processor state.
+///
+/// This matches production semantics: pools created in block N are visible to
+/// `generate_deltas` only from block N+1 onwards.
+///
+/// The ground-truth spkg is built from origin/main (not the working tree) so the
+/// processor is validated against the substreams state deployed from main:
+///   protocols/crates/uniswap-v2/scripts/build_main_spkg.sh
+///
+/// Required env vars:
+///   ETH_RPC_URL         — archive RPC endpoint (supports eth_getLogs over
+///                         multi-thousand-block ranges and eth_getBlockByNumber)
+///   STREAMINGFAST_KEY   — StreamingFast JWT (exchange an api key via
+///                         https://auth.streamingfast.io/v1/auth/issue)
+///   UV2_SPKG_PATH       — (optional) spkg override; defaults to the
+///                         build_main_spkg.sh output path
+///   UV2_START_BLOCK     — (optional) override start block; defaults to 10_400_000
+///   UV2_STOP_BLOCK      — (optional) override stop block; defaults to 10_402_000
+#[tokio::test]
+#[ignore = "requires ETH_RPC_URL, STREAMINGFAST_KEY, and a spkg built via build_main_spkg.sh"]
+async fn test_processor_matches_substreams_genesis_range() {
+    dotenv::dotenv().ok();
+
+    let rpc_url = std::env::var("ETH_RPC_URL").expect("ETH_RPC_URL must be set");
+    let api_key = std::env::var("STREAMINGFAST_KEY").expect("STREAMINGFAST_KEY must be set");
+    let spkg_path = std::env::var("UV2_SPKG_PATH").unwrap_or_else(|_| {
+        format!("{}/../../../target/spkg/ethereum-uniswap-v2-main.spkg", env!("CARGO_MANIFEST_DIR"))
+    });
+    assert!(
+        std::path::Path::new(&spkg_path).exists(),
+        "spkg not found at {spkg_path}. Build it from origin/main with \
+         protocols/crates/uniswap-v2/scripts/build_main_spkg.sh, or point \
+         UV2_SPKG_PATH at an existing .spkg file."
+    );
+    let start_block = std::env::var("UV2_START_BLOCK")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_START_BLOCK);
+    let stop_block = std::env::var("UV2_STOP_BLOCK")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_STOP_BLOCK);
+
+    let endpoint_url = "https://mainnet.eth.streamingfast.io:443";
+
+    // ── Step 1: stream the full range from substreams ────────────────────────
+    let all_block_changes =
+        stream_block_range(endpoint_url, &api_key, &spkg_path, start_block, stop_block).await;
+
+    assert!(
+        !all_block_changes.is_empty(),
+        "Substreams returned no blocks for range [{start_block}, {stop_block}]"
+    );
+
+    // ── Step 2: fetch tx inputs for the full block range ─────────────────────
+    let mut per_block_inputs = fetch_range_tx_inputs(&rpc_url, start_block, stop_block).await;
+
+    // ── Step 3: run the native processor block by block ──────────────────────
+    //
+    // For each block:
+    //   a. generate_deltas(txs) — compare against substreams output (known pools only)
+    //   b. apply_block(model)  — advance state; register new pools for subsequent blocks
+    let mut processor = UniswapV2Processor::new(Chain::Ethereum, "uniswap-v2".to_string());
+    let mut known_pool_ids: HashSet<String> = HashSet::new();
+
+    let mut attr_mismatches: Vec<String> = Vec::new();
+    let mut balance_mismatches: Vec<String> = Vec::new();
+
+    let mut total_compared_blocks: usize = 0;
+    let mut total_compared_attrs: usize = 0;
+    let mut total_compared_balances: usize = 0;
+
+    for (block_num, block_hash, substreams_block) in &all_block_changes {
+        let tx_inputs = per_block_inputs
+            .remove(block_num)
+            .unwrap_or_default();
+
+        // Generate pending deltas from raw transactions against the current state.
+        let pending = processor.generate_deltas(&tx_inputs);
+
+        // Compare block-level aggregates, limited to pools already registered.
+        let expected = substreams_to_comparable_block(substreams_block, &known_pool_ids);
+        let actual = processor_to_comparable_block(&pending, &known_pool_ids);
+
+        if !expected.attributes.is_empty() || !expected.balances.is_empty() {
+            total_compared_blocks += 1;
+        }
+
+        for (cid, expected_attrs) in &expected.attributes {
+            let actual_attrs = actual
+                .attributes
+                .get(cid)
+                .cloned()
+                .unwrap_or_default();
+            let short_cid = &cid[..8.min(cid.len())];
+            for (attr_name, expected_value) in expected_attrs {
+                total_compared_attrs += 1;
+                let ev = hex::encode(expected_value);
+                match actual_attrs.get(attr_name) {
+                    Some(v) if v == expected_value => {
+                        println!(
+                            "  block={block_num} pool={short_cid}.. {attr_name:20}  \
+                             substreams={ev}  processor=✓"
+                        );
+                    }
+                    Some(v) => {
+                        let av = hex::encode(v);
+                        println!(
+                            "  block={block_num} pool={short_cid}.. {attr_name:20}  \
+                             substreams={ev}  processor={av}  MISMATCH"
+                        );
+                        attr_mismatches.push(format!(
+                            "block={block_num} pool={cid} attr={attr_name}: \
+                             expected={ev} got={av}",
+                        ));
+                    }
+                    None => {
+                        println!(
+                            "  block={block_num} pool={short_cid}.. {attr_name:20}  \
+                             substreams={ev}  processor=MISSING"
+                        );
+                        attr_mismatches.push(format!(
+                            "block={block_num} pool={cid} attr={attr_name}: \
+                             expected={ev} but missing",
+                        ));
+                    }
+                }
+            }
+        }
+
+        for ((cid, token), expected_balance) in &expected.balances {
+            total_compared_balances += 1;
+            let short_cid = &cid[..8.min(cid.len())];
+            let short_tok = &token[..8.min(token.len())];
+            let eb = hex::encode(expected_balance);
+            match actual
+                .balances
+                .get(&(cid.clone(), token.clone()))
+            {
+                Some(v) if v == expected_balance => {
+                    println!(
+                        "  block={block_num} pool={short_cid}.. token={short_tok}..  \
+                         balance: substreams={eb}  processor=✓"
+                    );
+                }
+                Some(v) => {
+                    let ab = hex::encode(v);
+                    println!(
+                        "  block={block_num} pool={short_cid}.. token={short_tok}..  \
+                         balance: substreams={eb}  processor={ab}  MISMATCH"
+                    );
+                    balance_mismatches.push(format!(
+                        "block={block_num} pool={cid} token={token}: \
+                         expected={eb} got={ab}",
+                    ));
+                }
+                None => {
+                    println!(
+                        "  block={block_num} pool={short_cid}.. token={short_tok}..  \
+                         balance: substreams={eb}  processor=MISSING"
+                    );
+                    balance_mismatches.push(format!(
+                        "block={block_num} pool={cid} token={token}: \
+                         expected={eb} but missing",
+                    ));
+                }
+            }
+        }
+
+        // Advance processor state with substreams ground truth.
+        let model_block = substreams_proto_to_model(substreams_block, *block_num, block_hash);
+        processor.apply_block(&model_block);
+
+        // Register newly seen pools so subsequent blocks can compare them.
+        for id in model_block
+            .new_protocol_components
+            .keys()
+        {
+            known_pool_ids.insert(id.clone());
+        }
+    }
+
+    println!("\n─── Summary ────────────────────────────────────────────────────────────────");
+    println!("  Blocks streamed:       {}", all_block_changes.len());
+    println!("  Blocks with activity:  {total_compared_blocks}");
+    println!("  Pools registered:      {}", known_pool_ids.len());
+    println!("  Attributes compared:   {total_compared_attrs}");
+    println!("  Balances compared:     {total_compared_balances}");
+    println!("  Attr mismatches:       {}", attr_mismatches.len());
+    println!("  Balance mismatches:    {}", balance_mismatches.len());
+    println!("────────────────────────────────────────────────────────────────────────────");
+
+    assert!(
+        attr_mismatches.is_empty(),
+        "Attribute value mismatches ({} total):\n{}",
+        attr_mismatches.len(),
+        attr_mismatches.join("\n"),
+    );
+    assert!(
+        balance_mismatches.is_empty(),
+        "Balance value mismatches ({} total):\n{}",
+        balance_mismatches.len(),
+        balance_mismatches.join("\n"),
+    );
+}

--- a/protocols/crates/uniswap-v3/Cargo.toml
+++ b/protocols/crates/uniswap-v3/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "uniswap-v3-core"
+version = "0.1.0"
+edition = "2021"
+description = "Shared UniswapV3 indexing logic for native and WASM builds"
+
+[dependencies]
+substreams = "0.5.22"
+substreams-ethereum = "0.9.9"
+tycho-substreams = { path = "../../substreams/crates/tycho-substreams" }
+tycho-common = { path = "../../../crates/tycho-common" }
+ethabi = "18.0.0"
+hex = "0.4.3"
+num-bigint = "0.4.4"
+num-traits = { workspace = true }
+
+[target.wasm32-unknown-unknown.dependencies]
+getrandom = { version = "0.2", features = ["custom"] }
+
+[dev-dependencies]
+# Substreams streaming client (same workspace crate).
+tycho-indexer.workspace = true
+# Async runtime and stream utilities.
+tokio.workspace = true
+tokio-stream = { version = "0.1", features = ["sync"] }
+# Archive RPC calls (slot0, liquidity, token0/1, eth_getLogs).
+alloy = { workspace = true, features = [
+    "providers",
+    "provider-http",
+    "rpc-types-eth",
+    "sol-types",
+    "contract",
+    "network",
+] }
+# .env file loading for CI credentials.
+dotenv.workspace = true
+hex.workspace = true
+num-bigint.workspace = true
+prost = "0.11"

--- a/protocols/crates/uniswap-v3/src/abi/factory.rs
+++ b/protocols/crates/uniswap-v3/src/abi/factory.rs
@@ -1,0 +1,849 @@
+const INTERNAL_ERR: &'static str = "`ethabi_derive` internal error";
+/// Contract's functions.
+#[allow(dead_code, unused_imports, unused_variables)]
+pub mod functions {
+    use super::INTERNAL_ERR;
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CreatePool {
+        pub token_a: Vec<u8>,
+        pub token_b: Vec<u8>,
+        pub fee: substreams::scalar::BigInt,
+    }
+    impl CreatePool {
+        const METHOD_ID: [u8; 4] = [161u8, 103u8, 18u8, 149u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(24usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                token_a: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                token_b: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                fee: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.token_a)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.token_b)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.fee.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for CreatePool {
+        const NAME: &'static str = "createPool";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for CreatePool {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct EnableFeeAmount {
+        pub fee: substreams::scalar::BigInt,
+        pub tick_spacing: substreams::scalar::BigInt,
+    }
+    impl EnableFeeAmount {
+        const METHOD_ID: [u8; 4] = [138u8, 124u8, 25u8, 95u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Uint(24usize), ethabi::ParamType::Int(24usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                fee: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                tick_spacing: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.fee.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                {
+                    let non_full_signed_bytes = self.tick_spacing.to_signed_bytes_be();
+                    let full_signed_bytes_init =
+                        if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                    let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                    non_full_signed_bytes
+                        .into_iter()
+                        .rev()
+                        .enumerate()
+                        .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                    ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                },
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for EnableFeeAmount {
+        const NAME: &'static str = "enableFeeAmount";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct FeeAmountTickSpacing {
+        pub fee: substreams::scalar::BigInt,
+    }
+    impl FeeAmountTickSpacing {
+        const METHOD_ID: [u8; 4] = [34u8, 175u8, 204u8, 203u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::Uint(24usize)], maybe_data.unwrap())
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                fee: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                match self.fee.clone().to_bytes_be() {
+                    (num_bigint::Sign::Plus, bytes) => bytes,
+                    (num_bigint::Sign::NoSign, bytes) => bytes,
+                    (num_bigint::Sign::Minus, _) => {
+                        panic!("negative numbers are not supported")
+                    }
+                }
+                .as_slice(),
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Int(24usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_int()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_signed_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for FeeAmountTickSpacing {
+        const NAME: &'static str = "feeAmountTickSpacing";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for FeeAmountTickSpacing {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct GetPool {
+        pub token_a: Vec<u8>,
+        pub token_b: Vec<u8>,
+        pub fee: substreams::scalar::BigInt,
+    }
+    impl GetPool {
+        const METHOD_ID: [u8; 4] = [22u8, 152u8, 238u8, 130u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(24usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                token_a: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                token_b: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                fee: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.token_a)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.token_b)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.fee.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for GetPool {
+        const NAME: &'static str = "getPool";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for GetPool {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Owner {}
+    impl Owner {
+        const METHOD_ID: [u8; 4] = [141u8, 165u8, 203u8, 91u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Owner {
+        const NAME: &'static str = "owner";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for Owner {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SetOwner {
+        pub owner: Vec<u8>,
+    }
+    impl SetOwner {
+        const METHOD_ID: [u8; 4] = [19u8, 175u8, 64u8, 53u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                owner: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data =
+                ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(&self.owner))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for SetOwner {
+        const NAME: &'static str = "setOwner";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+}
+/// Contract's events.
+#[allow(dead_code, unused_imports, unused_variables)]
+pub mod events {
+    use super::INTERNAL_ERR;
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct FeeAmountEnabled {
+        pub fee: substreams::scalar::BigInt,
+        pub tick_spacing: substreams::scalar::BigInt,
+    }
+    impl FeeAmountEnabled {
+        const TOPIC_ID: [u8; 32] = [
+            198u8, 106u8, 63u8, 223u8, 7u8, 35u8, 44u8, 221u8, 24u8, 95u8, 235u8, 204u8, 101u8,
+            121u8, 212u8, 8u8, 194u8, 65u8, 180u8, 122u8, 226u8, 249u8, 144u8, 125u8, 132u8, 190u8,
+            101u8, 81u8, 65u8, 238u8, 174u8, 204u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 0usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Ok(Self {
+                fee: {
+                    let mut v = [0 as u8; 32];
+                    ethabi::decode(
+                        &[ethabi::ParamType::Uint(24usize)],
+                        log.topics[1usize].as_ref(),
+                    )
+                    .map_err(|e| {
+                        format!("unable to decode param 'fee' from topic of type 'uint24': {:?}", e)
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                tick_spacing: substreams::scalar::BigInt::from_signed_bytes_be(
+                    log.topics[2usize].as_ref(),
+                ),
+            })
+        }
+    }
+    impl substreams_ethereum::Event for FeeAmountEnabled {
+        const NAME: &'static str = "FeeAmountEnabled";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct OwnerChanged {
+        pub old_owner: Vec<u8>,
+        pub new_owner: Vec<u8>,
+    }
+    impl OwnerChanged {
+        const TOPIC_ID: [u8; 32] = [
+            181u8, 50u8, 7u8, 59u8, 56u8, 200u8, 49u8, 69u8, 227u8, 229u8, 19u8, 83u8, 119u8,
+            160u8, 139u8, 249u8, 170u8, 181u8, 91u8, 192u8, 253u8, 124u8, 17u8, 121u8, 205u8, 79u8,
+            185u8, 149u8, 210u8, 165u8, 21u8, 156u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 0usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Ok(Self {
+                old_owner: ethabi::decode(
+                    &[ethabi::ParamType::Address],
+                    log.topics[1usize].as_ref(),
+                )
+                .map_err(|e| {
+                    format!(
+                        "unable to decode param 'old_owner' from topic of type 'address': {:?}",
+                        e
+                    )
+                })?
+                .pop()
+                .expect(INTERNAL_ERR)
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec(),
+                new_owner: ethabi::decode(
+                    &[ethabi::ParamType::Address],
+                    log.topics[2usize].as_ref(),
+                )
+                .map_err(|e| {
+                    format!(
+                        "unable to decode param 'new_owner' from topic of type 'address': {:?}",
+                        e
+                    )
+                })?
+                .pop()
+                .expect(INTERNAL_ERR)
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec(),
+            })
+        }
+    }
+    impl substreams_ethereum::Event for OwnerChanged {
+        const NAME: &'static str = "OwnerChanged";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct PoolCreated {
+        pub token0: Vec<u8>,
+        pub token1: Vec<u8>,
+        pub fee: substreams::scalar::BigInt,
+        pub tick_spacing: substreams::scalar::BigInt,
+        pub pool: Vec<u8>,
+    }
+    impl PoolCreated {
+        const TOPIC_ID: [u8; 32] = [
+            120u8, 60u8, 202u8, 28u8, 4u8, 18u8, 221u8, 13u8, 105u8, 94u8, 120u8, 69u8, 104u8,
+            201u8, 109u8, 162u8, 233u8, 194u8, 47u8, 249u8, 137u8, 53u8, 122u8, 46u8, 139u8, 29u8,
+            155u8, 43u8, 78u8, 107u8, 113u8, 24u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 4usize {
+                return false;
+            }
+            if log.data.len() != 64usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Int(24usize), ethabi::ParamType::Address],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                token0: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'token0' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                token1: ethabi::decode(&[ethabi::ParamType::Address], log.topics[2usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'token1' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                fee: {
+                    let mut v = [0 as u8; 32];
+                    ethabi::decode(
+                        &[ethabi::ParamType::Uint(24usize)],
+                        log.topics[3usize].as_ref(),
+                    )
+                    .map_err(|e| {
+                        format!("unable to decode param 'fee' from topic of type 'uint24': {:?}", e)
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                tick_spacing: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                pool: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+    }
+    impl substreams_ethereum::Event for PoolCreated {
+        const NAME: &'static str = "PoolCreated";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+}

--- a/protocols/crates/uniswap-v3/src/abi/mod.rs
+++ b/protocols/crates/uniswap-v3/src/abi/mod.rs
@@ -1,0 +1,4 @@
+#![allow(clippy::all, clippy::pedantic, clippy::nursery)]
+
+pub mod factory;
+pub mod pool;

--- a/protocols/crates/uniswap-v3/src/abi/pool.rs
+++ b/protocols/crates/uniswap-v3/src/abi/pool.rs
@@ -1,0 +1,4440 @@
+const INTERNAL_ERR: &'static str = "`ethabi_derive` internal error";
+/// Contract's functions.
+#[allow(dead_code, unused_imports, unused_variables)]
+pub mod functions {
+    use super::INTERNAL_ERR;
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Burn {
+        pub tick_lower: substreams::scalar::BigInt,
+        pub tick_upper: substreams::scalar::BigInt,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl Burn {
+        const METHOD_ID: [u8; 4] = [163u8, 65u8, 35u8, 167u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Int(24usize),
+                    ethabi::ParamType::Int(24usize),
+                    ethabi::ParamType::Uint(128usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                tick_lower: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                tick_upper: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                {
+                    let non_full_signed_bytes = self.tick_lower.to_signed_bytes_be();
+                    let full_signed_bytes_init =
+                        if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                    let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                    non_full_signed_bytes
+                        .into_iter()
+                        .rev()
+                        .enumerate()
+                        .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                    ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                },
+                {
+                    let non_full_signed_bytes = self.tick_upper.to_signed_bytes_be();
+                    let full_signed_bytes_init =
+                        if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                    let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                    non_full_signed_bytes
+                        .into_iter()
+                        .rev()
+                        .enumerate()
+                        .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                    ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                },
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Uint(256usize), ethabi::ParamType::Uint(256usize)],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            values.reverse();
+            Ok((
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            ))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(substreams::scalar::BigInt, substreams::scalar::BigInt)> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Burn {
+        const NAME: &'static str = "burn";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+        )> for Burn
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Collect {
+        pub recipient: Vec<u8>,
+        pub tick_lower: substreams::scalar::BigInt,
+        pub tick_upper: substreams::scalar::BigInt,
+        pub amount0_requested: substreams::scalar::BigInt,
+        pub amount1_requested: substreams::scalar::BigInt,
+    }
+    impl Collect {
+        const METHOD_ID: [u8; 4] = [79u8, 30u8, 179u8, 216u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Int(24usize),
+                    ethabi::ParamType::Int(24usize),
+                    ethabi::ParamType::Uint(128usize),
+                    ethabi::ParamType::Uint(128usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                recipient: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                tick_lower: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                tick_upper: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                amount0_requested: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount1_requested: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.recipient)),
+                {
+                    let non_full_signed_bytes = self.tick_lower.to_signed_bytes_be();
+                    let full_signed_bytes_init =
+                        if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                    let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                    non_full_signed_bytes
+                        .into_iter()
+                        .rev()
+                        .enumerate()
+                        .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                    ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                },
+                {
+                    let non_full_signed_bytes = self.tick_upper.to_signed_bytes_be();
+                    let full_signed_bytes_init =
+                        if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                    let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                    non_full_signed_bytes
+                        .into_iter()
+                        .rev()
+                        .enumerate()
+                        .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                    ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                },
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self
+                        .amount0_requested
+                        .clone()
+                        .to_bytes_be()
+                    {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self
+                        .amount1_requested
+                        .clone()
+                        .to_bytes_be()
+                    {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Uint(128usize), ethabi::ParamType::Uint(128usize)],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            values.reverse();
+            Ok((
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            ))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(substreams::scalar::BigInt, substreams::scalar::BigInt)> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Collect {
+        const NAME: &'static str = "collect";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+        )> for Collect
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CollectProtocol {
+        pub recipient: Vec<u8>,
+        pub amount0_requested: substreams::scalar::BigInt,
+        pub amount1_requested: substreams::scalar::BigInt,
+    }
+    impl CollectProtocol {
+        const METHOD_ID: [u8; 4] = [133u8, 182u8, 103u8, 41u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(128usize),
+                    ethabi::ParamType::Uint(128usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                recipient: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount0_requested: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount1_requested: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.recipient)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self
+                        .amount0_requested
+                        .clone()
+                        .to_bytes_be()
+                    {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self
+                        .amount1_requested
+                        .clone()
+                        .to_bytes_be()
+                    {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Uint(128usize), ethabi::ParamType::Uint(128usize)],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            values.reverse();
+            Ok((
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            ))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(substreams::scalar::BigInt, substreams::scalar::BigInt)> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for CollectProtocol {
+        const NAME: &'static str = "collectProtocol";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+        )> for CollectProtocol
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Factory {}
+    impl Factory {
+        const METHOD_ID: [u8; 4] = [196u8, 90u8, 1u8, 85u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Factory {
+        const NAME: &'static str = "factory";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for Factory {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Fee {}
+    impl Fee {
+        const METHOD_ID: [u8; 4] = [221u8, 202u8, 63u8, 67u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(24usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Fee {
+        const NAME: &'static str = "fee";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for Fee {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct FeeGrowthGlobal0X128 {}
+    impl FeeGrowthGlobal0X128 {
+        const METHOD_ID: [u8; 4] = [243u8, 5u8, 131u8, 153u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for FeeGrowthGlobal0X128 {
+        const NAME: &'static str = "feeGrowthGlobal0X128";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for FeeGrowthGlobal0X128 {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct FeeGrowthGlobal1X128 {}
+    impl FeeGrowthGlobal1X128 {
+        const METHOD_ID: [u8; 4] = [70u8, 20u8, 19u8, 25u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for FeeGrowthGlobal1X128 {
+        const NAME: &'static str = "feeGrowthGlobal1X128";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for FeeGrowthGlobal1X128 {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Flash {
+        pub recipient: Vec<u8>,
+        pub amount0: substreams::scalar::BigInt,
+        pub amount1: substreams::scalar::BigInt,
+        pub data: Vec<u8>,
+    }
+    impl Flash {
+        const METHOD_ID: [u8; 4] = [73u8, 14u8, 108u8, 188u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Bytes,
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                recipient: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount0: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount1: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                data: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_bytes()
+                    .expect(INTERNAL_ERR),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.recipient)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount0.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount1.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Bytes(self.data.clone()),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Flash {
+        const NAME: &'static str = "flash";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct IncreaseObservationCardinalityNext {
+        pub observation_cardinality_next: substreams::scalar::BigInt,
+    }
+    impl IncreaseObservationCardinalityNext {
+        const METHOD_ID: [u8; 4] = [50u8, 20u8, 143u8, 103u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::Uint(16usize)], maybe_data.unwrap())
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                observation_cardinality_next: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                match self
+                    .observation_cardinality_next
+                    .clone()
+                    .to_bytes_be()
+                {
+                    (num_bigint::Sign::Plus, bytes) => bytes,
+                    (num_bigint::Sign::NoSign, bytes) => bytes,
+                    (num_bigint::Sign::Minus, _) => {
+                        panic!("negative numbers are not supported")
+                    }
+                }
+                .as_slice(),
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for IncreaseObservationCardinalityNext {
+        const NAME: &'static str = "increaseObservationCardinalityNext";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Initialize {
+        pub sqrt_price_x96: substreams::scalar::BigInt,
+    }
+    impl Initialize {
+        const METHOD_ID: [u8; 4] = [246u8, 55u8, 115u8, 29u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::Uint(160usize)], maybe_data.unwrap())
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                sqrt_price_x96: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                match self
+                    .sqrt_price_x96
+                    .clone()
+                    .to_bytes_be()
+                {
+                    (num_bigint::Sign::Plus, bytes) => bytes,
+                    (num_bigint::Sign::NoSign, bytes) => bytes,
+                    (num_bigint::Sign::Minus, _) => {
+                        panic!("negative numbers are not supported")
+                    }
+                }
+                .as_slice(),
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Initialize {
+        const NAME: &'static str = "initialize";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Liquidity {}
+    impl Liquidity {
+        const METHOD_ID: [u8; 4] = [26u8, 104u8, 101u8, 2u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(128usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Liquidity {
+        const NAME: &'static str = "liquidity";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for Liquidity {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct MaxLiquidityPerTick {}
+    impl MaxLiquidityPerTick {
+        const METHOD_ID: [u8; 4] = [112u8, 207u8, 117u8, 74u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(128usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for MaxLiquidityPerTick {
+        const NAME: &'static str = "maxLiquidityPerTick";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for MaxLiquidityPerTick {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Mint {
+        pub recipient: Vec<u8>,
+        pub tick_lower: substreams::scalar::BigInt,
+        pub tick_upper: substreams::scalar::BigInt,
+        pub amount: substreams::scalar::BigInt,
+        pub data: Vec<u8>,
+    }
+    impl Mint {
+        const METHOD_ID: [u8; 4] = [60u8, 138u8, 125u8, 141u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Int(24usize),
+                    ethabi::ParamType::Int(24usize),
+                    ethabi::ParamType::Uint(128usize),
+                    ethabi::ParamType::Bytes,
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                recipient: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                tick_lower: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                tick_upper: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                data: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_bytes()
+                    .expect(INTERNAL_ERR),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.recipient)),
+                {
+                    let non_full_signed_bytes = self.tick_lower.to_signed_bytes_be();
+                    let full_signed_bytes_init =
+                        if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                    let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                    non_full_signed_bytes
+                        .into_iter()
+                        .rev()
+                        .enumerate()
+                        .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                    ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                },
+                {
+                    let non_full_signed_bytes = self.tick_upper.to_signed_bytes_be();
+                    let full_signed_bytes_init =
+                        if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                    let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                    non_full_signed_bytes
+                        .into_iter()
+                        .rev()
+                        .enumerate()
+                        .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                    ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                },
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Bytes(self.data.clone()),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Uint(256usize), ethabi::ParamType::Uint(256usize)],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            values.reverse();
+            Ok((
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            ))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(substreams::scalar::BigInt, substreams::scalar::BigInt)> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Mint {
+        const NAME: &'static str = "mint";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+        )> for Mint
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Observations {
+        pub index: substreams::scalar::BigInt,
+    }
+    impl Observations {
+        const METHOD_ID: [u8; 4] = [37u8, 44u8, 9u8, 215u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::Uint(256usize)], maybe_data.unwrap())
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                index: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                match self.index.clone().to_bytes_be() {
+                    (num_bigint::Sign::Plus, bytes) => bytes,
+                    (num_bigint::Sign::NoSign, bytes) => bytes,
+                    (num_bigint::Sign::Minus, _) => {
+                        panic!("negative numbers are not supported")
+                    }
+                }
+                .as_slice(),
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                bool,
+            ),
+            String,
+        > {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                bool,
+            ),
+            String,
+        > {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Uint(32usize),
+                    ethabi::ParamType::Int(56usize),
+                    ethabi::ParamType::Uint(160usize),
+                    ethabi::ParamType::Bool,
+                ],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            values.reverse();
+            Ok((
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_bool()
+                    .expect(INTERNAL_ERR),
+            ))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            bool,
+        )> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Observations {
+        const NAME: &'static str = "observations";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            bool,
+        )> for Observations
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                bool,
+            ),
+            String,
+        > {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Observe {
+        pub seconds_agos: Vec<substreams::scalar::BigInt>,
+    }
+    impl Observe {
+        const METHOD_ID: [u8; 4] = [136u8, 59u8, 219u8, 253u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Array(Box::new(ethabi::ParamType::Uint(32usize)))],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                seconds_agos: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_array()
+                    .expect(INTERNAL_ERR)
+                    .into_iter()
+                    .map(|inner| {
+                        let mut v = [0 as u8; 32];
+                        inner
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                    })
+                    .collect(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[{
+                let v = self
+                    .seconds_agos
+                    .iter()
+                    .map(|inner| {
+                        ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                            match inner.clone().to_bytes_be() {
+                                (num_bigint::Sign::Plus, bytes) => bytes,
+                                (num_bigint::Sign::NoSign, bytes) => bytes,
+                                (num_bigint::Sign::Minus, _) => {
+                                    panic!("negative numbers are not supported")
+                                }
+                            }
+                            .as_slice(),
+                        ))
+                    })
+                    .collect();
+                ethabi::Token::Array(v)
+            }]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<(Vec<substreams::scalar::BigInt>, Vec<substreams::scalar::BigInt>), String>
+        {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<(Vec<substreams::scalar::BigInt>, Vec<substreams::scalar::BigInt>), String>
+        {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Array(Box::new(ethabi::ParamType::Int(56usize))),
+                    ethabi::ParamType::Array(Box::new(ethabi::ParamType::Uint(160usize))),
+                ],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            values.reverse();
+            Ok((
+                values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_array()
+                    .expect(INTERNAL_ERR)
+                    .into_iter()
+                    .map(|inner| {
+                        let mut v = [0 as u8; 32];
+                        inner
+                            .into_int()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                    })
+                    .collect(),
+                values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_array()
+                    .expect(INTERNAL_ERR)
+                    .into_iter()
+                    .map(|inner| {
+                        let mut v = [0 as u8; 32];
+                        inner
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                    })
+                    .collect(),
+            ))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(Vec<substreams::scalar::BigInt>, Vec<substreams::scalar::BigInt>)> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Observe {
+        const NAME: &'static str = "observe";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            Vec<substreams::scalar::BigInt>,
+            Vec<substreams::scalar::BigInt>,
+        )> for Observe
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<(Vec<substreams::scalar::BigInt>, Vec<substreams::scalar::BigInt>), String>
+        {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Positions {
+        pub key: [u8; 32usize],
+    }
+    impl Positions {
+        const METHOD_ID: [u8; 4] = [81u8, 78u8, 164u8, 191u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::FixedBytes(32usize)], maybe_data.unwrap())
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                key: {
+                    let mut result = [0u8; 32];
+                    let v = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::FixedBytes(self.key.as_ref().to_vec())]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+            ),
+            String,
+        > {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+            ),
+            String,
+        > {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Uint(128usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(128usize),
+                    ethabi::ParamType::Uint(128usize),
+                ],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            values.reverse();
+            Ok((
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            ))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+        )> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Positions {
+        const NAME: &'static str = "positions";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+        )> for Positions
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+            ),
+            String,
+        > {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct ProtocolFees {}
+    impl ProtocolFees {
+        const METHOD_ID: [u8; 4] = [26u8, 216u8, 176u8, 59u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Uint(128usize), ethabi::ParamType::Uint(128usize)],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            values.reverse();
+            Ok((
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            ))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(substreams::scalar::BigInt, substreams::scalar::BigInt)> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for ProtocolFees {
+        const NAME: &'static str = "protocolFees";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+        )> for ProtocolFees
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SetFeeProtocol {
+        pub fee_protocol0: substreams::scalar::BigInt,
+        pub fee_protocol1: substreams::scalar::BigInt,
+    }
+    impl SetFeeProtocol {
+        const METHOD_ID: [u8; 4] = [130u8, 6u8, 164u8, 209u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Uint(8usize), ethabi::ParamType::Uint(8usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                fee_protocol0: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                fee_protocol1: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.fee_protocol0.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.fee_protocol1.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for SetFeeProtocol {
+        const NAME: &'static str = "setFeeProtocol";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Slot0 {}
+    impl Slot0 {
+        const METHOD_ID: [u8; 4] = [56u8, 80u8, 199u8, 189u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                bool,
+            ),
+            String,
+        > {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                bool,
+            ),
+            String,
+        > {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Uint(160usize),
+                    ethabi::ParamType::Int(24usize),
+                    ethabi::ParamType::Uint(16usize),
+                    ethabi::ParamType::Uint(16usize),
+                    ethabi::ParamType::Uint(16usize),
+                    ethabi::ParamType::Uint(8usize),
+                    ethabi::ParamType::Bool,
+                ],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            values.reverse();
+            Ok((
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_bool()
+                    .expect(INTERNAL_ERR),
+            ))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            bool,
+        )> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Slot0 {
+        const NAME: &'static str = "slot0";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            bool,
+        )> for Slot0
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                bool,
+            ),
+            String,
+        > {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SnapshotCumulativesInside {
+        pub tick_lower: substreams::scalar::BigInt,
+        pub tick_upper: substreams::scalar::BigInt,
+    }
+    impl SnapshotCumulativesInside {
+        const METHOD_ID: [u8; 4] = [163u8, 136u8, 7u8, 242u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Int(24usize), ethabi::ParamType::Int(24usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                tick_lower: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                tick_upper: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                {
+                    let non_full_signed_bytes = self.tick_lower.to_signed_bytes_be();
+                    let full_signed_bytes_init =
+                        if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                    let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                    non_full_signed_bytes
+                        .into_iter()
+                        .rev()
+                        .enumerate()
+                        .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                    ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                },
+                {
+                    let non_full_signed_bytes = self.tick_upper.to_signed_bytes_be();
+                    let full_signed_bytes_init =
+                        if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                    let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                    non_full_signed_bytes
+                        .into_iter()
+                        .rev()
+                        .enumerate()
+                        .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                    ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                },
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<
+            (substreams::scalar::BigInt, substreams::scalar::BigInt, substreams::scalar::BigInt),
+            String,
+        > {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<
+            (substreams::scalar::BigInt, substreams::scalar::BigInt, substreams::scalar::BigInt),
+            String,
+        > {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Int(56usize),
+                    ethabi::ParamType::Uint(160usize),
+                    ethabi::ParamType::Uint(32usize),
+                ],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            values.reverse();
+            Ok((
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            ))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+        )> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for SnapshotCumulativesInside {
+        const NAME: &'static str = "snapshotCumulativesInside";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+        )> for SnapshotCumulativesInside
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<
+            (substreams::scalar::BigInt, substreams::scalar::BigInt, substreams::scalar::BigInt),
+            String,
+        > {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Swap {
+        pub recipient: Vec<u8>,
+        pub zero_for_one: bool,
+        pub amount_specified: substreams::scalar::BigInt,
+        pub sqrt_price_limit_x96: substreams::scalar::BigInt,
+        pub data: Vec<u8>,
+    }
+    impl Swap {
+        const METHOD_ID: [u8; 4] = [18u8, 138u8, 203u8, 8u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Bool,
+                    ethabi::ParamType::Int(256usize),
+                    ethabi::ParamType::Uint(160usize),
+                    ethabi::ParamType::Bytes,
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                recipient: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                zero_for_one: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_bool()
+                    .expect(INTERNAL_ERR),
+                amount_specified: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                sqrt_price_limit_x96: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                data: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_bytes()
+                    .expect(INTERNAL_ERR),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.recipient)),
+                ethabi::Token::Bool(self.zero_for_one.clone()),
+                {
+                    let non_full_signed_bytes = self
+                        .amount_specified
+                        .to_signed_bytes_be();
+                    let full_signed_bytes_init =
+                        if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                    let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                    non_full_signed_bytes
+                        .into_iter()
+                        .rev()
+                        .enumerate()
+                        .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                    ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                },
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self
+                        .sqrt_price_limit_x96
+                        .clone()
+                        .to_bytes_be()
+                    {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Bytes(self.data.clone()),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Int(256usize), ethabi::ParamType::Int(256usize)],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            values.reverse();
+            Ok((
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+            ))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(substreams::scalar::BigInt, substreams::scalar::BigInt)> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Swap {
+        const NAME: &'static str = "swap";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+        )> for Swap
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct TickBitmap {
+        pub word_position: substreams::scalar::BigInt,
+    }
+    impl TickBitmap {
+        const METHOD_ID: [u8; 4] = [83u8, 57u8, 194u8, 150u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::Int(16usize)], maybe_data.unwrap())
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                word_position: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[{
+                let non_full_signed_bytes = self.word_position.to_signed_bytes_be();
+                let full_signed_bytes_init =
+                    if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                non_full_signed_bytes
+                    .into_iter()
+                    .rev()
+                    .enumerate()
+                    .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+            }]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for TickBitmap {
+        const NAME: &'static str = "tickBitmap";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for TickBitmap {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct TickSpacing {}
+    impl TickSpacing {
+        const METHOD_ID: [u8; 4] = [208u8, 201u8, 58u8, 124u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Int(24usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_int()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_signed_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for TickSpacing {
+        const NAME: &'static str = "tickSpacing";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for TickSpacing {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Ticks {
+        pub tick: substreams::scalar::BigInt,
+    }
+    impl Ticks {
+        const METHOD_ID: [u8; 4] = [243u8, 13u8, 186u8, 147u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::Int(24usize)], maybe_data.unwrap())
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                tick: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[{
+                let non_full_signed_bytes = self.tick.to_signed_bytes_be();
+                let full_signed_bytes_init =
+                    if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                non_full_signed_bytes
+                    .into_iter()
+                    .rev()
+                    .enumerate()
+                    .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+            }]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                bool,
+            ),
+            String,
+        > {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                bool,
+            ),
+            String,
+        > {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Uint(128usize),
+                    ethabi::ParamType::Int(128usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Int(56usize),
+                    ethabi::ParamType::Uint(160usize),
+                    ethabi::ParamType::Uint(32usize),
+                    ethabi::ParamType::Bool,
+                ],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            values.reverse();
+            Ok((
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_bool()
+                    .expect(INTERNAL_ERR),
+            ))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            bool,
+        )> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Ticks {
+        const NAME: &'static str = "ticks";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            bool,
+        )> for Ticks
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<
+            (
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                substreams::scalar::BigInt,
+                bool,
+            ),
+            String,
+        > {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Token0 {}
+    impl Token0 {
+        const METHOD_ID: [u8; 4] = [13u8, 254u8, 22u8, 129u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Token0 {
+        const NAME: &'static str = "token0";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for Token0 {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Token1 {}
+    impl Token1 {
+        const METHOD_ID: [u8; 4] = [210u8, 18u8, 32u8, 167u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Token1 {
+        const NAME: &'static str = "token1";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for Token1 {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+}
+/// Contract's events.
+#[allow(dead_code, unused_imports, unused_variables)]
+pub mod events {
+    use super::INTERNAL_ERR;
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Burn {
+        pub owner: Vec<u8>,
+        pub tick_lower: substreams::scalar::BigInt,
+        pub tick_upper: substreams::scalar::BigInt,
+        pub amount: substreams::scalar::BigInt,
+        pub amount0: substreams::scalar::BigInt,
+        pub amount1: substreams::scalar::BigInt,
+    }
+    impl Burn {
+        const TOPIC_ID: [u8; 32] = [
+            12u8, 57u8, 108u8, 217u8, 137u8, 163u8, 159u8, 68u8, 89u8, 181u8, 250u8, 26u8, 237u8,
+            106u8, 154u8, 141u8, 205u8, 188u8, 69u8, 144u8, 138u8, 207u8, 214u8, 126u8, 2u8, 140u8,
+            213u8, 104u8, 218u8, 152u8, 152u8, 44u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 4usize {
+                return false;
+            }
+            if log.data.len() != 96usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Uint(128usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                ],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                owner: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'owner' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                tick_lower: substreams::scalar::BigInt::from_signed_bytes_be(
+                    log.topics[2usize].as_ref(),
+                ),
+                tick_upper: substreams::scalar::BigInt::from_signed_bytes_be(
+                    log.topics[3usize].as_ref(),
+                ),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount0: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount1: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Burn {
+        const NAME: &'static str = "Burn";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Collect {
+        pub owner: Vec<u8>,
+        pub recipient: Vec<u8>,
+        pub tick_lower: substreams::scalar::BigInt,
+        pub tick_upper: substreams::scalar::BigInt,
+        pub amount0: substreams::scalar::BigInt,
+        pub amount1: substreams::scalar::BigInt,
+    }
+    impl Collect {
+        const TOPIC_ID: [u8; 32] = [
+            112u8, 147u8, 83u8, 56u8, 230u8, 151u8, 117u8, 69u8, 106u8, 133u8, 221u8, 239u8, 34u8,
+            108u8, 57u8, 95u8, 182u8, 104u8, 182u8, 63u8, 160u8, 17u8, 95u8, 95u8, 32u8, 97u8,
+            11u8, 56u8, 142u8, 108u8, 169u8, 192u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 4usize {
+                return false;
+            }
+            if log.data.len() != 96usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(128usize),
+                    ethabi::ParamType::Uint(128usize),
+                ],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                owner: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'owner' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                tick_lower: substreams::scalar::BigInt::from_signed_bytes_be(
+                    log.topics[2usize].as_ref(),
+                ),
+                tick_upper: substreams::scalar::BigInt::from_signed_bytes_be(
+                    log.topics[3usize].as_ref(),
+                ),
+                recipient: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount0: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount1: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Collect {
+        const NAME: &'static str = "Collect";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CollectProtocol {
+        pub sender: Vec<u8>,
+        pub recipient: Vec<u8>,
+        pub amount0: substreams::scalar::BigInt,
+        pub amount1: substreams::scalar::BigInt,
+    }
+    impl CollectProtocol {
+        const TOPIC_ID: [u8; 32] = [
+            89u8, 107u8, 87u8, 57u8, 6u8, 33u8, 141u8, 52u8, 17u8, 133u8, 11u8, 38u8, 166u8, 180u8,
+            55u8, 214u8, 196u8, 82u8, 47u8, 219u8, 67u8, 210u8, 210u8, 56u8, 98u8, 99u8, 248u8,
+            109u8, 80u8, 184u8, 177u8, 81u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 64usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Uint(128usize), ethabi::ParamType::Uint(128usize)],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                sender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'sender' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                recipient: ethabi::decode(
+                    &[ethabi::ParamType::Address],
+                    log.topics[2usize].as_ref(),
+                )
+                .map_err(|e| {
+                    format!(
+                        "unable to decode param 'recipient' from topic of type 'address': {:?}",
+                        e
+                    )
+                })?
+                .pop()
+                .expect(INTERNAL_ERR)
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec(),
+                amount0: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount1: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for CollectProtocol {
+        const NAME: &'static str = "CollectProtocol";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Flash {
+        pub sender: Vec<u8>,
+        pub recipient: Vec<u8>,
+        pub amount0: substreams::scalar::BigInt,
+        pub amount1: substreams::scalar::BigInt,
+        pub paid0: substreams::scalar::BigInt,
+        pub paid1: substreams::scalar::BigInt,
+    }
+    impl Flash {
+        const TOPIC_ID: [u8; 32] = [
+            189u8, 189u8, 183u8, 29u8, 120u8, 96u8, 55u8, 107u8, 165u8, 43u8, 37u8, 165u8, 2u8,
+            139u8, 238u8, 162u8, 53u8, 129u8, 54u8, 74u8, 64u8, 82u8, 47u8, 107u8, 207u8, 184u8,
+            107u8, 177u8, 242u8, 220u8, 166u8, 51u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 128usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                ],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                sender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'sender' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                recipient: ethabi::decode(
+                    &[ethabi::ParamType::Address],
+                    log.topics[2usize].as_ref(),
+                )
+                .map_err(|e| {
+                    format!(
+                        "unable to decode param 'recipient' from topic of type 'address': {:?}",
+                        e
+                    )
+                })?
+                .pop()
+                .expect(INTERNAL_ERR)
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec(),
+                amount0: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount1: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                paid0: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                paid1: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Flash {
+        const NAME: &'static str = "Flash";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct IncreaseObservationCardinalityNext {
+        pub observation_cardinality_next_old: substreams::scalar::BigInt,
+        pub observation_cardinality_next_new: substreams::scalar::BigInt,
+    }
+    impl IncreaseObservationCardinalityNext {
+        const TOPIC_ID: [u8; 32] = [
+            172u8, 73u8, 229u8, 24u8, 249u8, 10u8, 53u8, 143u8, 101u8, 46u8, 68u8, 0u8, 22u8, 79u8,
+            5u8, 165u8, 216u8, 247u8, 227u8, 94u8, 119u8, 71u8, 39u8, 155u8, 195u8, 169u8, 61u8,
+            191u8, 88u8, 78u8, 18u8, 90u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 1usize {
+                return false;
+            }
+            if log.data.len() != 64usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Uint(16usize), ethabi::ParamType::Uint(16usize)],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                observation_cardinality_next_old: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                observation_cardinality_next_new: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for IncreaseObservationCardinalityNext {
+        const NAME: &'static str = "IncreaseObservationCardinalityNext";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Initialize {
+        pub sqrt_price_x96: substreams::scalar::BigInt,
+        pub tick: substreams::scalar::BigInt,
+    }
+    impl Initialize {
+        const TOPIC_ID: [u8; 32] = [
+            152u8, 99u8, 96u8, 54u8, 203u8, 102u8, 169u8, 193u8, 154u8, 55u8, 67u8, 94u8, 252u8,
+            30u8, 144u8, 20u8, 33u8, 144u8, 33u8, 78u8, 138u8, 190u8, 184u8, 33u8, 189u8, 186u8,
+            63u8, 41u8, 144u8, 221u8, 76u8, 149u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 1usize {
+                return false;
+            }
+            if log.data.len() != 64usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Uint(160usize), ethabi::ParamType::Int(24usize)],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                sqrt_price_x96: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                tick: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Initialize {
+        const NAME: &'static str = "Initialize";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Mint {
+        pub sender: Vec<u8>,
+        pub owner: Vec<u8>,
+        pub tick_lower: substreams::scalar::BigInt,
+        pub tick_upper: substreams::scalar::BigInt,
+        pub amount: substreams::scalar::BigInt,
+        pub amount0: substreams::scalar::BigInt,
+        pub amount1: substreams::scalar::BigInt,
+    }
+    impl Mint {
+        const TOPIC_ID: [u8; 32] = [
+            122u8, 83u8, 8u8, 11u8, 164u8, 20u8, 21u8, 139u8, 231u8, 236u8, 105u8, 185u8, 135u8,
+            181u8, 251u8, 125u8, 7u8, 222u8, 225u8, 1u8, 254u8, 133u8, 72u8, 143u8, 8u8, 83u8,
+            174u8, 22u8, 35u8, 157u8, 11u8, 222u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 4usize {
+                return false;
+            }
+            if log.data.len() != 128usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(128usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                ],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                owner: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'owner' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                tick_lower: substreams::scalar::BigInt::from_signed_bytes_be(
+                    log.topics[2usize].as_ref(),
+                ),
+                tick_upper: substreams::scalar::BigInt::from_signed_bytes_be(
+                    log.topics[3usize].as_ref(),
+                ),
+                sender: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount0: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount1: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Mint {
+        const NAME: &'static str = "Mint";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SetFeeProtocol {
+        pub fee_protocol0_old: substreams::scalar::BigInt,
+        pub fee_protocol1_old: substreams::scalar::BigInt,
+        pub fee_protocol0_new: substreams::scalar::BigInt,
+        pub fee_protocol1_new: substreams::scalar::BigInt,
+    }
+    impl SetFeeProtocol {
+        const TOPIC_ID: [u8; 32] = [
+            151u8, 61u8, 141u8, 146u8, 187u8, 41u8, 159u8, 74u8, 246u8, 206u8, 73u8, 181u8, 42u8,
+            138u8, 219u8, 133u8, 174u8, 70u8, 185u8, 242u8, 20u8, 196u8, 196u8, 252u8, 6u8, 172u8,
+            119u8, 64u8, 18u8, 55u8, 177u8, 51u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 1usize {
+                return false;
+            }
+            if log.data.len() != 128usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Uint(8usize),
+                    ethabi::ParamType::Uint(8usize),
+                    ethabi::ParamType::Uint(8usize),
+                    ethabi::ParamType::Uint(8usize),
+                ],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                fee_protocol0_old: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                fee_protocol1_old: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                fee_protocol0_new: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                fee_protocol1_new: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for SetFeeProtocol {
+        const NAME: &'static str = "SetFeeProtocol";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Swap {
+        pub sender: Vec<u8>,
+        pub recipient: Vec<u8>,
+        pub amount0: substreams::scalar::BigInt,
+        pub amount1: substreams::scalar::BigInt,
+        pub sqrt_price_x96: substreams::scalar::BigInt,
+        pub liquidity: substreams::scalar::BigInt,
+        pub tick: substreams::scalar::BigInt,
+    }
+    impl Swap {
+        const TOPIC_ID: [u8; 32] = [
+            196u8, 32u8, 121u8, 249u8, 74u8, 99u8, 80u8, 215u8, 230u8, 35u8, 95u8, 41u8, 23u8,
+            73u8, 36u8, 249u8, 40u8, 204u8, 42u8, 200u8, 24u8, 235u8, 100u8, 254u8, 216u8, 0u8,
+            78u8, 17u8, 95u8, 188u8, 202u8, 103u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 160usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Int(256usize),
+                    ethabi::ParamType::Int(256usize),
+                    ethabi::ParamType::Uint(160usize),
+                    ethabi::ParamType::Uint(128usize),
+                    ethabi::ParamType::Int(24usize),
+                ],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                sender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'sender' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                recipient: ethabi::decode(
+                    &[ethabi::ParamType::Address],
+                    log.topics[2usize].as_ref(),
+                )
+                .map_err(|e| {
+                    format!(
+                        "unable to decode param 'recipient' from topic of type 'address': {:?}",
+                        e
+                    )
+                })?
+                .pop()
+                .expect(INTERNAL_ERR)
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec(),
+                amount0: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                amount1: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                sqrt_price_x96: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                liquidity: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                tick: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Swap {
+        const NAME: &'static str = "Swap";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+}

--- a/protocols/crates/uniswap-v3/src/balance.rs
+++ b/protocols/crates/uniswap-v3/src/balance.rs
@@ -1,0 +1,94 @@
+use std::str::FromStr;
+
+use num_bigint::BigInt;
+use tycho_substreams::pb::tycho::evm::v1::BalanceDelta as ProtoBalanceDelta;
+
+use crate::events::{PoolEvent, PoolEventKind};
+
+pub struct BalanceDelta {
+    pub token: Vec<u8>,
+    pub component_id: Vec<u8>,
+    pub delta: BigInt,
+}
+
+impl From<BalanceDelta> for ProtoBalanceDelta {
+    fn from(d: BalanceDelta) -> Self {
+        Self {
+            token: d.token,
+            delta: d.delta.to_signed_bytes_be(),
+            component_id: format!("0x{}", hex::encode(&d.component_id)).into_bytes(),
+            ord: 0,
+            tx: None,
+        }
+    }
+}
+
+pub fn event_to_balance_deltas(event: &PoolEvent) -> Vec<BalanceDelta> {
+    let component_id = event.pool_address.clone();
+
+    match &event.kind {
+        PoolEventKind::Mint { amount0, amount1, .. } => vec![
+            BalanceDelta {
+                token: event.token0.clone(),
+                component_id: component_id.clone(),
+                delta: BigInt::from_str(amount0).unwrap_or_default(),
+            },
+            BalanceDelta {
+                token: event.token1.clone(),
+                component_id,
+                delta: BigInt::from_str(amount1).unwrap_or_default(),
+            },
+        ],
+        PoolEventKind::Collect { amount0, amount1 } => vec![
+            BalanceDelta {
+                token: event.token0.clone(),
+                component_id: component_id.clone(),
+                delta: -BigInt::from_str(amount0).unwrap_or_default(),
+            },
+            BalanceDelta {
+                token: event.token1.clone(),
+                component_id,
+                delta: -BigInt::from_str(amount1).unwrap_or_default(),
+            },
+        ],
+        // Burn balance changes are accounted for in the Collect event.
+        PoolEventKind::Burn { .. } => vec![],
+        PoolEventKind::Swap { amount0, amount1, .. } => vec![
+            BalanceDelta {
+                token: event.token0.clone(),
+                component_id: component_id.clone(),
+                delta: BigInt::from_str(amount0).unwrap_or_default(),
+            },
+            BalanceDelta {
+                token: event.token1.clone(),
+                component_id,
+                delta: BigInt::from_str(amount1).unwrap_or_default(),
+            },
+        ],
+        PoolEventKind::Flash { paid0, paid1 } => vec![
+            BalanceDelta {
+                token: event.token0.clone(),
+                component_id: component_id.clone(),
+                delta: BigInt::from_str(paid0).unwrap_or_default(),
+            },
+            BalanceDelta {
+                token: event.token1.clone(),
+                component_id,
+                delta: BigInt::from_str(paid1).unwrap_or_default(),
+            },
+        ],
+        PoolEventKind::CollectProtocol { amount0, amount1 } => vec![
+            BalanceDelta {
+                token: event.token0.clone(),
+                component_id: component_id.clone(),
+                delta: -BigInt::from_str(amount0).unwrap_or_default(),
+            },
+            BalanceDelta {
+                token: event.token1.clone(),
+                component_id,
+                delta: -BigInt::from_str(amount1).unwrap_or_default(),
+            },
+        ],
+        _ => vec![],
+    }
+}

--- a/protocols/crates/uniswap-v3/src/events.rs
+++ b/protocols/crates/uniswap-v3/src/events.rs
@@ -1,0 +1,176 @@
+use substreams_ethereum::Event;
+
+use crate::abi::pool::events::{
+    Burn, Collect, CollectProtocol, Flash, Initialize, Mint, SetFeeProtocol, Swap,
+};
+
+#[derive(Clone)]
+pub struct Pool {
+    pub address: Vec<u8>,
+    pub token0: Vec<u8>,
+    pub token1: Vec<u8>,
+}
+
+pub trait PoolRegistry {
+    fn get_pool(&self, pool_address_hex: &str) -> Option<&Pool>;
+}
+
+#[derive(Debug, Clone)]
+pub struct TxRef {
+    pub hash: Vec<u8>,
+    pub from: Vec<u8>,
+    pub to: Vec<u8>,
+    pub index: u64,
+}
+
+pub enum PoolEventKind {
+    Initialize { sqrt_price: String, tick: i32 },
+    Swap { amount0: String, amount1: String, sqrt_price: String, liquidity: String, tick: i32 },
+    Mint { tick_lower: i32, tick_upper: i32, amount: String, amount0: String, amount1: String },
+    Burn { tick_lower: i32, tick_upper: i32, amount: String, amount0: String, amount1: String },
+    Collect { amount0: String, amount1: String },
+    Flash { paid0: String, paid1: String },
+    CollectProtocol { amount0: String, amount1: String },
+    SetFeeProtocol { fee0_new: u64, fee1_new: u64 },
+}
+
+pub struct PoolEvent {
+    pub log_ordinal: u64,
+    pub pool_address: Vec<u8>,
+    pub token0: Vec<u8>,
+    pub token1: Vec<u8>,
+    pub tx: TxRef,
+    pub kind: PoolEventKind,
+}
+
+pub fn decode_log(
+    log: &substreams_ethereum::pb::eth::v2::Log,
+    pool: &Pool,
+    tx: &TxRef,
+) -> Option<PoolEvent> {
+    let tx_ref =
+        TxRef { hash: tx.hash.clone(), from: tx.from.clone(), to: tx.to.clone(), index: tx.index };
+
+    if let Some(init) = Initialize::match_and_decode(log) {
+        return Some(PoolEvent {
+            log_ordinal: log.ordinal,
+            pool_address: pool.address.clone(),
+            token0: pool.token0.clone(),
+            token1: pool.token1.clone(),
+            tx: tx_ref,
+            kind: PoolEventKind::Initialize {
+                sqrt_price: init.sqrt_price_x96.to_string(),
+                tick: init.tick.into(),
+            },
+        });
+    }
+
+    if let Some(swap) = Swap::match_and_decode(log) {
+        return Some(PoolEvent {
+            log_ordinal: log.ordinal,
+            pool_address: pool.address.clone(),
+            token0: pool.token0.clone(),
+            token1: pool.token1.clone(),
+            tx: tx_ref,
+            kind: PoolEventKind::Swap {
+                amount0: swap.amount0.to_string(),
+                amount1: swap.amount1.to_string(),
+                sqrt_price: swap.sqrt_price_x96.to_string(),
+                liquidity: swap.liquidity.to_string(),
+                tick: swap.tick.into(),
+            },
+        });
+    }
+
+    if let Some(flash) = Flash::match_and_decode(log) {
+        return Some(PoolEvent {
+            log_ordinal: log.ordinal,
+            pool_address: pool.address.clone(),
+            token0: pool.token0.clone(),
+            token1: pool.token1.clone(),
+            tx: tx_ref,
+            kind: PoolEventKind::Flash {
+                paid0: flash.paid0.to_string(),
+                paid1: flash.paid1.to_string(),
+            },
+        });
+    }
+
+    if let Some(mint) = Mint::match_and_decode(log) {
+        return Some(PoolEvent {
+            log_ordinal: log.ordinal,
+            pool_address: pool.address.clone(),
+            token0: pool.token0.clone(),
+            token1: pool.token1.clone(),
+            tx: tx_ref,
+            kind: PoolEventKind::Mint {
+                tick_lower: mint.tick_lower.into(),
+                tick_upper: mint.tick_upper.into(),
+                amount: mint.amount.to_string(),
+                amount0: mint.amount0.to_string(),
+                amount1: mint.amount1.to_string(),
+            },
+        });
+    }
+
+    if let Some(burn) = Burn::match_and_decode(log) {
+        return Some(PoolEvent {
+            log_ordinal: log.ordinal,
+            pool_address: pool.address.clone(),
+            token0: pool.token0.clone(),
+            token1: pool.token1.clone(),
+            tx: tx_ref,
+            kind: PoolEventKind::Burn {
+                tick_lower: burn.tick_lower.into(),
+                tick_upper: burn.tick_upper.into(),
+                amount: burn.amount.to_string(),
+                amount0: burn.amount0.to_string(),
+                amount1: burn.amount1.to_string(),
+            },
+        });
+    }
+
+    if let Some(collect) = Collect::match_and_decode(log) {
+        return Some(PoolEvent {
+            log_ordinal: log.ordinal,
+            pool_address: pool.address.clone(),
+            token0: pool.token0.clone(),
+            token1: pool.token1.clone(),
+            tx: tx_ref,
+            kind: PoolEventKind::Collect {
+                amount0: collect.amount0.to_string(),
+                amount1: collect.amount1.to_string(),
+            },
+        });
+    }
+
+    if let Some(set_fp) = SetFeeProtocol::match_and_decode(log) {
+        return Some(PoolEvent {
+            log_ordinal: log.ordinal,
+            pool_address: pool.address.clone(),
+            token0: pool.token0.clone(),
+            token1: pool.token1.clone(),
+            tx: tx_ref,
+            kind: PoolEventKind::SetFeeProtocol {
+                fee0_new: set_fp.fee_protocol0_new.to_u64(),
+                fee1_new: set_fp.fee_protocol1_new.to_u64(),
+            },
+        });
+    }
+
+    if let Some(cp) = CollectProtocol::match_and_decode(log) {
+        return Some(PoolEvent {
+            log_ordinal: log.ordinal,
+            pool_address: pool.address.clone(),
+            token0: pool.token0.clone(),
+            token1: pool.token1.clone(),
+            tx: tx_ref,
+            kind: PoolEventKind::CollectProtocol {
+                amount0: cp.amount0.to_string(),
+                amount1: cp.amount1.to_string(),
+            },
+        });
+    }
+
+    None
+}

--- a/protocols/crates/uniswap-v3/src/lib.rs
+++ b/protocols/crates/uniswap-v3/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod abi;
+pub mod balance;
+pub mod events;
+pub mod liquidity;
+pub mod output;
+pub mod processor;
+pub mod ticks;

--- a/protocols/crates/uniswap-v3/src/liquidity.rs
+++ b/protocols/crates/uniswap-v3/src/liquidity.rs
@@ -1,0 +1,57 @@
+use std::str::FromStr;
+
+use num_bigint::BigInt;
+
+use crate::events::{PoolEvent, PoolEventKind};
+
+pub enum LiquidityChangeKind {
+    Delta,
+    Absolute,
+}
+
+pub struct LiquidityDelta {
+    pub pool_address: Vec<u8>,
+    pub value: BigInt,
+    pub kind: LiquidityChangeKind,
+}
+
+pub fn event_to_liquidity_delta(current_tick: i64, event: &PoolEvent) -> Option<LiquidityDelta> {
+    match &event.kind {
+        PoolEventKind::Mint { tick_lower, tick_upper, amount, .. } => {
+            if current_tick >= i64::from(*tick_lower) && current_tick < i64::from(*tick_upper) {
+                Some(LiquidityDelta {
+                    pool_address: event.pool_address.clone(),
+                    value: BigInt::from_str(amount).unwrap_or_default(),
+                    kind: LiquidityChangeKind::Delta,
+                })
+            } else {
+                None
+            }
+        }
+        PoolEventKind::Burn { tick_lower, tick_upper, amount, .. } => {
+            if current_tick >= i64::from(*tick_lower) && current_tick < i64::from(*tick_upper) {
+                Some(LiquidityDelta {
+                    pool_address: event.pool_address.clone(),
+                    value: -BigInt::from_str(amount).unwrap_or_default(),
+                    kind: LiquidityChangeKind::Delta,
+                })
+            } else {
+                None
+            }
+        }
+        PoolEventKind::Swap { liquidity, .. } => Some(LiquidityDelta {
+            pool_address: event.pool_address.clone(),
+            value: BigInt::from_str(liquidity).unwrap_or_default(),
+            kind: LiquidityChangeKind::Absolute,
+        }),
+        _ => None,
+    }
+}
+
+pub fn event_to_current_tick(event: &PoolEvent) -> Option<i64> {
+    match &event.kind {
+        PoolEventKind::Initialize { tick, .. } => Some(i64::from(*tick)),
+        PoolEventKind::Swap { tick, .. } => Some(i64::from(*tick)),
+        _ => None,
+    }
+}

--- a/protocols/crates/uniswap-v3/src/output.rs
+++ b/protocols/crates/uniswap-v3/src/output.rs
@@ -1,0 +1,70 @@
+use std::str::FromStr;
+
+use num_bigint::BigInt;
+
+use crate::events::{PoolEvent, PoolEventKind};
+
+pub struct AttributeUpdate {
+    pub pool_address: Vec<u8>,
+    pub name: String,
+    pub value: Vec<u8>,
+    pub is_creation: bool,
+}
+
+pub fn event_to_attribute_updates(event: &PoolEvent) -> Vec<AttributeUpdate> {
+    match &event.kind {
+        PoolEventKind::Initialize { sqrt_price, tick } => {
+            vec![
+                AttributeUpdate {
+                    pool_address: event.pool_address.clone(),
+                    name: "sqrt_price_x96".to_string(),
+                    value: BigInt::from_str(sqrt_price)
+                        .unwrap_or_default()
+                        .to_signed_bytes_be(),
+                    is_creation: false,
+                },
+                AttributeUpdate {
+                    pool_address: event.pool_address.clone(),
+                    name: "tick".to_string(),
+                    value: BigInt::from(*tick).to_signed_bytes_be(),
+                    is_creation: false,
+                },
+            ]
+        }
+        PoolEventKind::Swap { sqrt_price, tick, .. } => {
+            vec![
+                AttributeUpdate {
+                    pool_address: event.pool_address.clone(),
+                    name: "sqrt_price_x96".to_string(),
+                    value: BigInt::from_str(sqrt_price)
+                        .unwrap_or_default()
+                        .to_signed_bytes_be(),
+                    is_creation: false,
+                },
+                AttributeUpdate {
+                    pool_address: event.pool_address.clone(),
+                    name: "tick".to_string(),
+                    value: BigInt::from(*tick).to_signed_bytes_be(),
+                    is_creation: false,
+                },
+            ]
+        }
+        PoolEventKind::SetFeeProtocol { fee0_new, fee1_new } => {
+            vec![
+                AttributeUpdate {
+                    pool_address: event.pool_address.clone(),
+                    name: "protocol_fees/token0".to_string(),
+                    value: BigInt::from(*fee0_new).to_signed_bytes_be(),
+                    is_creation: false,
+                },
+                AttributeUpdate {
+                    pool_address: event.pool_address.clone(),
+                    name: "protocol_fees/token1".to_string(),
+                    value: BigInt::from(*fee1_new).to_signed_bytes_be(),
+                    is_creation: false,
+                },
+            ]
+        }
+        _ => vec![],
+    }
+}

--- a/protocols/crates/uniswap-v3/src/processor.rs
+++ b/protocols/crates/uniswap-v3/src/processor.rs
@@ -1,0 +1,412 @@
+use std::collections::{HashMap, HashSet};
+
+use num_bigint::{BigInt, Sign};
+use num_traits::ToPrimitive as _;
+use tycho_common::{
+    models::{
+        blockchain::{Block, BlockAggregatedChanges, LogInput, TxInput},
+        protocol::{ComponentBalance, ProtocolComponentStateDelta},
+        Chain,
+    },
+    traits::TxDeltaIndexer,
+    Bytes,
+};
+use tycho_substreams::prelude::{
+    Attribute, BalanceChange, ChangeType, EntityChanges, Transaction as SubstreamsTx,
+    TransactionChanges, TransactionChangesBuilder,
+};
+
+use crate::{
+    balance::event_to_balance_deltas,
+    events::{decode_log, Pool, PoolEvent, TxRef},
+    liquidity::{event_to_current_tick, event_to_liquidity_delta, LiquidityChangeKind},
+    output::event_to_attribute_updates,
+    ticks::event_to_tick_deltas,
+};
+
+#[derive(Clone)]
+pub struct UniswapV3Processor {
+    chain: Chain,
+    extractor: String,
+    last_block: Option<Block>,
+    finalized_block_height: u64,
+    pools: HashMap<String, Pool>,
+    balances: HashMap<(String, String), BigInt>,
+    tick_liquidity: HashMap<(String, i32), BigInt>,
+    current_tick: HashMap<String, i64>,
+    pool_liquidity: HashMap<String, BigInt>,
+    baseline_tick_keys: HashSet<(String, i32)>,
+}
+
+impl TxDeltaIndexer for UniswapV3Processor {
+    fn apply_block(&mut self, block: &BlockAggregatedChanges) {
+        self.chain = block.chain;
+        self.last_block = Some(block.block.clone());
+        self.finalized_block_height = block.finalized_block_height;
+
+        for (id, comp) in &block.new_protocol_components {
+            if comp.tokens.len() >= 2 {
+                self.pools.insert(
+                    id.clone(),
+                    Pool {
+                        address: hex::decode(id).unwrap_or_default(),
+                        token0: comp.tokens[0].to_vec(),
+                        token1: comp.tokens[1].to_vec(),
+                    },
+                );
+            }
+        }
+
+        for (component_id, delta) in &block.state_deltas {
+            self.apply_state_delta(component_id, delta);
+        }
+
+        for (component_id, token_balances) in &block.component_balances {
+            for (token_bytes, balance) in token_balances {
+                let token_hex = hex::encode(token_bytes.as_ref());
+                let balance_val = BigInt::from_bytes_be(Sign::Plus, balance.balance.as_ref());
+                self.balances
+                    .insert((component_id.clone(), token_hex), balance_val);
+            }
+        }
+
+        for id in block.deleted_protocol_components.keys() {
+            self.remove_pool(id);
+        }
+    }
+
+    /// Applies a batch of in-flight transactions against the current state and returns the
+    /// protocol state deltas they would produce.
+    ///
+    /// Works on a clone of internal state so repeated calls with the same (or different)
+    /// transactions always produce results relative to the last `apply_block` call.
+    fn generate_deltas(&mut self, txs: &[TxInput]) -> BlockAggregatedChanges {
+        let mut scratch = self.clone();
+        let tx_changes = scratch.build_tx_changes(txs);
+
+        let mut state_deltas: HashMap<String, ProtocolComponentStateDelta> = HashMap::new();
+        let mut component_balances: HashMap<String, HashMap<Bytes, ComponentBalance>> =
+            HashMap::new();
+
+        for changes in tx_changes {
+            let tx_hash = changes
+                .tx
+                .as_ref()
+                .map(|t| Bytes::from(t.hash.clone()))
+                .unwrap_or_default();
+
+            for ec in changes.entity_changes {
+                let delta = state_deltas
+                    .entry(ec.component_id.clone())
+                    .or_insert_with(|| ProtocolComponentStateDelta {
+                        component_id: ec.component_id.clone(),
+                        updated_attributes: HashMap::new(),
+                        deleted_attributes: HashSet::new(),
+                    });
+                for attr in ec.attributes {
+                    if attr.change == i32::from(ChangeType::Deletion) {
+                        delta
+                            .deleted_attributes
+                            .insert(attr.name.clone());
+                        delta
+                            .updated_attributes
+                            .remove(&attr.name);
+                    } else {
+                        delta
+                            .updated_attributes
+                            .insert(attr.name.clone(), Bytes::from(attr.value));
+                        delta
+                            .deleted_attributes
+                            .remove(&attr.name);
+                    }
+                }
+            }
+
+            for bc in changes.balance_changes {
+                let comp_id = hex::encode(&bc.component_id);
+                let token = Bytes::from(bc.token);
+                let balance = Bytes::from(bc.balance);
+                let balance_float = BigInt::from_bytes_be(Sign::Plus, balance.as_ref())
+                    .to_f64()
+                    .unwrap_or(f64::MAX);
+                component_balances
+                    .entry(comp_id.clone())
+                    .or_default()
+                    .insert(
+                        token.clone(),
+                        ComponentBalance {
+                            token,
+                            balance,
+                            balance_float,
+                            modify_tx: tx_hash.clone(),
+                            component_id: comp_id,
+                        },
+                    );
+            }
+        }
+
+        BlockAggregatedChanges {
+            extractor: self.extractor.clone(),
+            chain: self.chain,
+            block: self.pending_block(),
+            finalized_block_height: self.finalized_block_height,
+            state_deltas,
+            component_balances,
+            ..Default::default()
+        }
+    }
+}
+
+impl UniswapV3Processor {
+    pub fn new(chain: Chain, extractor: String) -> Self {
+        Self {
+            chain,
+            extractor,
+            last_block: None,
+            finalized_block_height: 0,
+            pools: HashMap::new(),
+            balances: HashMap::new(),
+            tick_liquidity: HashMap::new(),
+            current_tick: HashMap::new(),
+            pool_liquidity: HashMap::new(),
+            baseline_tick_keys: HashSet::new(),
+        }
+    }
+
+    /// Constructs the pending-block descriptor for `generate_deltas` output.
+    ///
+    /// Number is `last_block + 1`; hash is zeroed because the block has not
+    /// been mined yet.
+    fn pending_block(&self) -> Block {
+        match &self.last_block {
+            Some(b) => Block {
+                number: b.number + 1,
+                hash: Bytes::default(),
+                parent_hash: b.hash.clone(),
+                chain: b.chain,
+                ts: b.ts,
+            },
+            None => Block::default(),
+        }
+    }
+
+    fn apply_state_delta(&mut self, component_id: &str, delta: &ProtocolComponentStateDelta) {
+        for attr_name in &delta.deleted_attributes {
+            if attr_name == "tick" {
+                self.current_tick.remove(component_id);
+            } else if attr_name == "liquidity" {
+                self.pool_liquidity.remove(component_id);
+            } else if let Some(rest) = attr_name.strip_prefix("ticks/") {
+                if let Some(idx_str) = rest.strip_suffix("/net-liquidity") {
+                    if let Ok(idx) = idx_str.parse::<i32>() {
+                        self.tick_liquidity
+                            .remove(&(component_id.to_string(), idx));
+                        self.baseline_tick_keys
+                            .remove(&(component_id.to_string(), idx));
+                    }
+                }
+            }
+        }
+
+        for (attr_name, attr_val) in &delta.updated_attributes {
+            if attr_name == "tick" {
+                let tick_val = BigInt::from_signed_bytes_be(attr_val.as_ref());
+                let (sign, digits) = tick_val.to_u64_digits();
+                let magnitude = digits.first().copied().unwrap_or(0) as i64;
+                let tick_i64 = if sign == Sign::Minus { -magnitude } else { magnitude };
+                self.current_tick
+                    .insert(component_id.to_string(), tick_i64);
+            } else if attr_name == "liquidity" {
+                self.pool_liquidity.insert(
+                    component_id.to_string(),
+                    BigInt::from_signed_bytes_be(attr_val.as_ref()),
+                );
+            } else if let Some(rest) = attr_name.strip_prefix("ticks/") {
+                if let Some(idx_str) = rest.strip_suffix("/net-liquidity") {
+                    if let Ok(idx) = idx_str.parse::<i32>() {
+                        let key = (component_id.to_string(), idx);
+                        self.tick_liquidity
+                            .insert(key.clone(), BigInt::from_signed_bytes_be(attr_val.as_ref()));
+                        self.baseline_tick_keys.insert(key);
+                    }
+                }
+            }
+        }
+    }
+
+    fn remove_pool(&mut self, id: &str) {
+        self.pools.remove(id);
+        self.current_tick.remove(id);
+        self.pool_liquidity.remove(id);
+        self.balances
+            .retain(|(pool_id, _), _| pool_id != id);
+        self.tick_liquidity
+            .retain(|(pool_id, _), _| pool_id != id);
+        self.baseline_tick_keys
+            .retain(|(pool_id, _)| pool_id != id);
+    }
+
+    fn build_tx_changes(&mut self, txs: &[TxInput]) -> Vec<TransactionChanges> {
+        let mut tx_builders: HashMap<Vec<u8>, (u64, TransactionChangesBuilder)> = HashMap::new();
+
+        for tx in txs {
+            if !tx.succeeded() {
+                continue;
+            }
+
+            let tx_ref = TxRef {
+                hash: tx.hash().to_vec(),
+                from: tx.from().to_vec(),
+                to: tx.to().to_vec(),
+                index: tx.index(),
+            };
+
+            let mut events: Vec<PoolEvent> = Vec::new();
+            for log in tx.logs() {
+                let pool_hex = hex::encode(log.address().as_ref());
+                let Some(pool) = self.pools.get(&pool_hex) else { continue };
+                let ordinal = tx.index() * 100_000 + log.log_index() as u64;
+                let pb_log = log_input_to_pb(log, ordinal);
+                if let Some(event) = decode_log(&pb_log, pool, &tx_ref) {
+                    events.push(event);
+                }
+            }
+
+            if events.is_empty() {
+                continue;
+            }
+
+            tx_builders
+                .entry(tx.hash().to_vec())
+                .or_insert_with(|| {
+                    let substreams_tx = SubstreamsTx {
+                        hash: tx.hash().to_vec(),
+                        from: tx.from().to_vec(),
+                        to: tx.to().to_vec(),
+                        index: tx.index(),
+                    };
+                    (tx.index(), TransactionChangesBuilder::new(&substreams_tx))
+                });
+
+            for event in events {
+                let (_, builder) = tx_builders
+                    .get_mut(tx.hash().as_ref())
+                    .expect("builder inserted above");
+                self.apply_event(event, builder);
+            }
+        }
+
+        let mut ordered: Vec<(u64, TransactionChangesBuilder)> =
+            tx_builders.into_values().collect();
+        ordered.sort_unstable_by_key(|(idx, _)| *idx);
+        ordered
+            .into_iter()
+            .filter_map(|(_, b)| b.build())
+            .collect()
+    }
+
+    fn apply_event(&mut self, event: PoolEvent, builder: &mut TransactionChangesBuilder) {
+        let pool_hex = hex::encode(&event.pool_address);
+
+        if let Some(new_tick) = event_to_current_tick(&event) {
+            self.current_tick
+                .insert(pool_hex.clone(), new_tick);
+        }
+
+        for delta in event_to_balance_deltas(&event) {
+            let token_hex = hex::encode(&delta.token);
+            let running = self
+                .balances
+                .entry((pool_hex.clone(), token_hex))
+                .or_default();
+            *running += &delta.delta;
+            let clamped =
+                if *running < BigInt::default() { BigInt::default() } else { running.clone() };
+            builder.add_balance_change(&BalanceChange {
+                component_id: event.pool_address.clone(),
+                token: delta.token.clone(),
+                balance: clamped.to_bytes_be().1,
+            });
+        }
+
+        for tick_delta in event_to_tick_deltas(&event) {
+            let key = (pool_hex.clone(), tick_delta.tick_index);
+            let existed_before =
+                self.tick_liquidity.contains_key(&key) || self.baseline_tick_keys.contains(&key);
+            let running = self
+                .tick_liquidity
+                .entry(key)
+                .or_default();
+            *running += &tick_delta.liquidity_net_delta;
+            let new_val = running.clone();
+
+            let change_type = if !existed_before {
+                ChangeType::Creation
+            } else if new_val == BigInt::default() {
+                ChangeType::Deletion
+            } else {
+                ChangeType::Update
+            };
+
+            builder.add_entity_change(&EntityChanges {
+                component_id: pool_hex.clone(),
+                attributes: vec![Attribute {
+                    name: format!("ticks/{}/net-liquidity", tick_delta.tick_index),
+                    value: new_val.to_signed_bytes_be(),
+                    change: change_type.into(),
+                }],
+            });
+        }
+
+        let cur_tick = *self
+            .current_tick
+            .get(&pool_hex)
+            .unwrap_or(&0);
+        if let Some(liq_delta) = event_to_liquidity_delta(cur_tick, &event) {
+            let running = self
+                .pool_liquidity
+                .entry(pool_hex.clone())
+                .or_default();
+            match liq_delta.kind {
+                LiquidityChangeKind::Delta => *running += &liq_delta.value,
+                LiquidityChangeKind::Absolute => *running = liq_delta.value.clone(),
+            }
+            builder.add_entity_change(&EntityChanges {
+                component_id: pool_hex.clone(),
+                attributes: vec![Attribute {
+                    name: "liquidity".to_string(),
+                    value: running.to_signed_bytes_be(),
+                    change: ChangeType::Update.into(),
+                }],
+            });
+        }
+
+        for attr_update in event_to_attribute_updates(&event) {
+            let comp_id = hex::encode(&attr_update.pool_address);
+            let change_type =
+                if attr_update.is_creation { ChangeType::Creation } else { ChangeType::Update };
+            builder.add_entity_change(&EntityChanges {
+                component_id: comp_id,
+                attributes: vec![Attribute {
+                    name: attr_update.name,
+                    value: attr_update.value,
+                    change: change_type.into(),
+                }],
+            });
+        }
+    }
+}
+
+fn log_input_to_pb(log: &LogInput, ordinal: u64) -> substreams_ethereum::pb::eth::v2::Log {
+    substreams_ethereum::pb::eth::v2::Log {
+        address: log.address().to_vec(),
+        topics: log
+            .topics()
+            .iter()
+            .map(|t| t.to_vec())
+            .collect(),
+        data: log.data().to_vec(),
+        ordinal,
+        ..Default::default()
+    }
+}

--- a/protocols/crates/uniswap-v3/src/processor.rs
+++ b/protocols/crates/uniswap-v3/src/processor.rs
@@ -46,10 +46,11 @@ impl TxDeltaIndexer for UniswapV3Processor {
 
         for (id, comp) in &block.new_protocol_components {
             if comp.tokens.len() >= 2 {
+                let key = normalize_id(id);
                 self.pools.insert(
-                    id.clone(),
+                    key.clone(),
                     Pool {
-                        address: hex::decode(id).unwrap_or_default(),
+                        address: hex::decode(&key).unwrap_or_default(),
                         token0: comp.tokens[0].to_vec(),
                         token1: comp.tokens[1].to_vec(),
                     },
@@ -58,25 +59,29 @@ impl TxDeltaIndexer for UniswapV3Processor {
         }
 
         for (component_id, delta) in &block.state_deltas {
-            self.apply_state_delta(component_id, delta);
+            self.apply_state_delta(&normalize_id(component_id), delta);
         }
 
         for (component_id, token_balances) in &block.component_balances {
+            let comp_key = normalize_id(component_id);
             for (token_bytes, balance) in token_balances {
                 let token_hex = hex::encode(token_bytes.as_ref());
                 let balance_val = BigInt::from_bytes_be(Sign::Plus, balance.balance.as_ref());
                 self.balances
-                    .insert((component_id.clone(), token_hex), balance_val);
+                    .insert((comp_key.clone(), token_hex), balance_val);
             }
         }
 
         for id in block.deleted_protocol_components.keys() {
-            self.remove_pool(id);
+            self.remove_pool(&normalize_id(id));
         }
     }
 
     /// Applies a batch of in-flight transactions against the current state and returns the
     /// protocol state deltas they would produce.
+    ///
+    /// Component ids in the output use the same format the substreams packages emit
+    /// ("0x"-prefixed lower-case hex), so they match decoder state keys downstream.
     ///
     /// Works on a clone of internal state so repeated calls with the same (or different)
     /// transactions always produce results relative to the last `apply_block` call.
@@ -96,10 +101,11 @@ impl TxDeltaIndexer for UniswapV3Processor {
                 .unwrap_or_default();
 
             for ec in changes.entity_changes {
+                let component_id = emitted_id(&ec.component_id);
                 let delta = state_deltas
-                    .entry(ec.component_id.clone())
+                    .entry(component_id.clone())
                     .or_insert_with(|| ProtocolComponentStateDelta {
-                        component_id: ec.component_id.clone(),
+                        component_id: component_id.clone(),
                         updated_attributes: HashMap::new(),
                         deleted_attributes: HashSet::new(),
                     });
@@ -123,7 +129,7 @@ impl TxDeltaIndexer for UniswapV3Processor {
             }
 
             for bc in changes.balance_changes {
-                let comp_id = hex::encode(&bc.component_id);
+                let comp_id = emitted_id(&hex::encode(&bc.component_id));
                 let token = Bytes::from(bc.token);
                 let balance = Bytes::from(bc.balance);
                 let balance_float = BigInt::from_bytes_be(Sign::Plus, balance.as_ref())
@@ -395,6 +401,18 @@ impl UniswapV3Processor {
             });
         }
     }
+}
+
+/// Canonical internal key for a component id: lower-case hex without the "0x" prefix.
+fn normalize_id(id: &str) -> String {
+    id.trim_start_matches("0x")
+        .to_lowercase()
+}
+
+/// Formats a canonical internal key into the id format the substreams packages emit
+/// ("0x"-prefixed lower-case hex).
+fn emitted_id(canonical_hex: &str) -> String {
+    format!("0x{canonical_hex}")
 }
 
 fn log_input_to_pb(log: &LogInput, ordinal: u64) -> substreams_ethereum::pb::eth::v2::Log {

--- a/protocols/crates/uniswap-v3/src/ticks.rs
+++ b/protocols/crates/uniswap-v3/src/ticks.rs
@@ -1,0 +1,47 @@
+use std::str::FromStr;
+
+use num_bigint::BigInt;
+
+use crate::events::{PoolEvent, PoolEventKind};
+
+pub struct TickDelta {
+    pub pool_address: Vec<u8>,
+    pub tick_index: i32,
+    pub liquidity_net_delta: BigInt,
+}
+
+pub fn event_to_tick_deltas(event: &PoolEvent) -> Vec<TickDelta> {
+    match &event.kind {
+        PoolEventKind::Mint { tick_lower, tick_upper, amount, .. } => {
+            let amount_val = BigInt::from_str(amount).unwrap_or_default();
+            vec![
+                TickDelta {
+                    pool_address: event.pool_address.clone(),
+                    tick_index: *tick_lower,
+                    liquidity_net_delta: amount_val.clone(),
+                },
+                TickDelta {
+                    pool_address: event.pool_address.clone(),
+                    tick_index: *tick_upper,
+                    liquidity_net_delta: -amount_val,
+                },
+            ]
+        }
+        PoolEventKind::Burn { tick_lower, tick_upper, amount, .. } => {
+            let amount_val = BigInt::from_str(amount).unwrap_or_default();
+            vec![
+                TickDelta {
+                    pool_address: event.pool_address.clone(),
+                    tick_index: *tick_lower,
+                    liquidity_net_delta: -amount_val.clone(),
+                },
+                TickDelta {
+                    pool_address: event.pool_address.clone(),
+                    tick_index: *tick_upper,
+                    liquidity_net_delta: amount_val,
+                },
+            ]
+        }
+        _ => vec![],
+    }
+}

--- a/protocols/crates/uniswap-v3/tests/integration.rs
+++ b/protocols/crates/uniswap-v3/tests/integration.rs
@@ -1,0 +1,662 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use alloy::{
+    consensus::Transaction as _,
+    eips::BlockNumberOrTag,
+    primitives::B256,
+    providers::{Provider, ProviderBuilder},
+    rpc::types::{BlockTransactions, Filter, Log},
+    transports::http::reqwest::Url,
+};
+use num_bigint::{BigInt, Sign};
+use num_traits::ToPrimitive as _;
+use prost::Message;
+use tokio_stream::StreamExt;
+use tycho_common::{
+    models::{
+        blockchain::{Block, BlockAggregatedChanges, LogInput, TxInput},
+        protocol::{ComponentBalance, ProtocolComponent, ProtocolComponentStateDelta},
+        Chain,
+    },
+    traits::TxDeltaIndexer,
+    Bytes,
+};
+use tycho_indexer::{
+    pb::sf::substreams::v1::Package,
+    substreams::{
+        stream::{BlockResponse, SubstreamsStream},
+        SubstreamsEndpoint,
+    },
+};
+use tycho_substreams::pb::tycho::evm::v1::BlockChanges;
+use uniswap_v3_core::processor::UniswapV3Processor;
+
+// UV3 factory deployed at this block on mainnet.
+const START_BLOCK: u64 = 12_369_621;
+// Default: 2000 blocks ≈ 8 h of chain time, long enough to see all event types.
+// Override with UV3_STOP_BLOCK env var for a wider or narrower range.
+const DEFAULT_STOP_BLOCK: u64 = START_BLOCK + 2_000; // 12_371_621
+
+// ─── Substreams helpers ──────────────────────────────────────────────────────
+
+/// Streams every block in `[start, stop]` from the substreams endpoint and
+/// returns `(block_number, block_hash, BlockChanges)` triples in ascending order.
+async fn stream_block_range(
+    endpoint_url: &str,
+    api_key: &str,
+    spkg_path: &str,
+    start: u64,
+    stop: u64,
+) -> Vec<(u64, String, BlockChanges)> {
+    let content = std::fs::read(spkg_path)
+        .unwrap_or_else(|e| panic!("Failed to read spkg at {spkg_path}: {e}"));
+    let package = Package::decode(content.as_slice())
+        .unwrap_or_else(|e| panic!("Failed to decode spkg: {e}"));
+
+    let endpoint = Arc::new(
+        SubstreamsEndpoint::new(endpoint_url, Some(api_key.to_string()))
+            .await
+            .expect("Failed to create substreams endpoint"),
+    );
+
+    let mut stream = SubstreamsStream::new(
+        endpoint,
+        None,
+        Some(package),
+        "map_protocol_changes".to_string(),
+        start as i64,
+        stop,
+        true,
+        "integration-test".to_string(),
+        false,
+    );
+
+    let mut results = Vec::new();
+    loop {
+        match stream.next().await {
+            Some(Ok(BlockResponse::New(data))) => {
+                let (block_num, block_hash) = data
+                    .clock
+                    .as_ref()
+                    .map_or((0, String::new()), |c| (c.number, c.id.clone()));
+                let map_output = data
+                    .output
+                    .as_ref()
+                    .and_then(|o| o.map_output.as_ref())
+                    .expect("BlockScopedData has no map_output");
+                let changes = BlockChanges::decode(map_output.value.as_slice())
+                    .expect("Failed to decode BlockChanges");
+                results.push((block_num, block_hash, changes));
+            }
+            Some(Ok(BlockResponse::Ended)) => break,
+            Some(Ok(BlockResponse::Undo(_))) => {
+                // Undo signals should not appear with final_blocks_only=true.
+                panic!("Unexpected undo signal in range [{start}, {stop}]");
+            }
+            Some(Err(e)) => panic!("Substreams stream error: {e}"),
+            None => break,
+        }
+    }
+
+    results.sort_unstable_by_key(|(n, _, _)| *n);
+    results
+}
+
+// ─── Archive RPC helpers ─────────────────────────────────────────────────────
+
+// Canonical Uniswap V3 pool event ABI signatures.
+// Passed to `Filter::events` which hashes them to topic0 values internally.
+const UV3_EVENT_SIGNATURES: [&str; 8] = [
+    "Swap(address,address,int256,int256,uint160,uint128,int24)",
+    "Mint(address,address,int24,int24,uint128,uint256,uint256)",
+    "Burn(address,int24,int24,uint128,uint256,uint256)",
+    "Collect(address,address,int24,int24,uint128,uint128)",
+    "Initialize(uint160,int24)",
+    "Flash(address,address,uint256,uint256,uint256,uint256)",
+    "CollectProtocol(address,address,uint128,uint128)",
+    "SetFeeProtocol(uint8,uint8,uint8,uint8)",
+];
+
+/// Returns all UV3 pool logs emitted in `[start_block, stop_block]`.
+///
+/// Chunked into 10,000-block pages to stay within Alchemy's eth_getLogs limit.
+async fn fetch_range_logs(rpc_url: &str, start_block: u64, stop_block: u64) -> Vec<Log> {
+    const CHUNK: u64 = 10_000;
+    let provider = ProviderBuilder::new().connect_http(
+        rpc_url
+            .parse::<Url>()
+            .expect("invalid RPC URL"),
+    );
+    let mut logs = Vec::new();
+    let mut chunk_start = start_block;
+    while chunk_start <= stop_block {
+        let chunk_end = (chunk_start + CHUNK - 1).min(stop_block);
+        let filter = Filter::new()
+            .from_block(chunk_start)
+            .to_block(chunk_end)
+            .events(UV3_EVENT_SIGNATURES);
+        let chunk_logs = provider
+            .get_logs(&filter)
+            .await
+            .unwrap_or_else(|e| panic!("eth_getLogs [{chunk_start},{chunk_end}] failed: {e}"));
+        logs.extend(chunk_logs);
+        chunk_start = chunk_end + 1;
+    }
+    logs
+}
+
+/// Returns `{tx_hash → (from_bytes, to_bytes, tx_index)}` for all transactions
+/// in the given block by fetching the full block once.
+async fn fetch_block_tx_meta(
+    rpc_url: &str,
+    block_num: u64,
+) -> HashMap<B256, (Vec<u8>, Vec<u8>, u64)> {
+    use alloy::network::{BlockResponse as _, TransactionResponse as _};
+
+    let provider = ProviderBuilder::new().connect_http(
+        rpc_url
+            .parse::<Url>()
+            .expect("invalid RPC URL"),
+    );
+    let block = provider
+        .get_block_by_number(BlockNumberOrTag::Number(block_num))
+        .full()
+        .await
+        .unwrap_or_else(|e| panic!("eth_getBlockByNumber({block_num}) failed: {e}"))
+        .unwrap_or_else(|| panic!("block {block_num} not found"));
+
+    let mut map = HashMap::new();
+    if let BlockTransactions::Full(txns) = block.transactions() {
+        for tx in txns {
+            let hash = tx.tx_hash();
+            let from = tx.from().to_vec();
+            // `to()` lives on the inner consensus transaction.
+            let to = tx
+                .inner
+                .to()
+                .map(|a| a.to_vec())
+                .unwrap_or_default();
+            let index = tx
+                .transaction_index()
+                .unwrap_or_default();
+            map.insert(hash, (from, to, index));
+        }
+    }
+    map
+}
+
+/// Returns a `HashMap<block_num, Vec<TxInput>>` for every block in
+/// `[start_block, stop_block]` that emitted at least one log.
+///
+/// Transactions are ordered by transaction index within each block.
+/// All transactions that emitted logs are treated as succeeded — the EVM
+/// does not emit logs for reverted transactions.
+async fn fetch_range_tx_inputs(
+    rpc_url: &str,
+    start_block: u64,
+    stop_block: u64,
+) -> HashMap<u64, Vec<TxInput>> {
+    let logs = fetch_range_logs(rpc_url, start_block, stop_block).await;
+
+    // Group logs by block number, then by tx hash.
+    let mut blocks_with_tx_hashes: HashMap<u64, HashSet<B256>> = HashMap::new();
+    let mut logs_by_key: HashMap<(u64, B256), Vec<LogInput>> = HashMap::new();
+
+    for log in &logs {
+        let Some(block_num) = log.block_number else { continue };
+        let Some(hash) = log.transaction_hash else { continue };
+        blocks_with_tx_hashes
+            .entry(block_num)
+            .or_default()
+            .insert(hash);
+        logs_by_key
+            .entry((block_num, hash))
+            .or_default()
+            .push(LogInput::new(
+                Bytes::from(log.address().to_vec()),
+                log.topics()
+                    .iter()
+                    .map(|t| Bytes::from(t.to_vec()))
+                    .collect(),
+                Bytes::from(log.data().data.to_vec()),
+                log.log_index.unwrap_or_default() as u32,
+            ));
+    }
+
+    let mut result: HashMap<u64, Vec<TxInput>> = HashMap::new();
+
+    for (block_num, tx_hashes) in blocks_with_tx_hashes {
+        let meta = fetch_block_tx_meta(rpc_url, block_num).await;
+        let mut tx_inputs: Vec<TxInput> = tx_hashes
+            .into_iter()
+            .filter_map(|hash| {
+                let (from, to, index) = meta.get(&hash)?.clone();
+                let logs = logs_by_key
+                    .remove(&(block_num, hash))
+                    .unwrap_or_default();
+                Some(TxInput::new(
+                    Bytes::from(hash.to_vec()),
+                    Bytes::from(from),
+                    Bytes::from(to),
+                    index,
+                    logs,
+                    true,
+                ))
+            })
+            .collect();
+        tx_inputs.sort_unstable_by_key(|t| t.index());
+        result.insert(block_num, tx_inputs);
+    }
+
+    result
+}
+
+// ─── Conversion helpers ──────────────────────────────────────────────────────
+
+/// Normalise a component_id from substreams output to lower-case hex without "0x".
+fn normalise_component_id(raw: &[u8]) -> String {
+    let s = std::str::from_utf8(raw).unwrap_or_default();
+    s.trim_start_matches("0x")
+        .to_lowercase()
+}
+
+fn normalise_str_id(s: &str) -> String {
+    s.trim_start_matches("0x")
+        .to_lowercase()
+}
+
+/// Converts a substreams proto `BlockChanges` to a `BlockAggregatedChanges`, aggregating
+/// all per-transaction entity and balance changes across the block.
+fn substreams_proto_to_model(
+    proto: &BlockChanges,
+    block_num: u64,
+    block_hash_hex: &str,
+) -> BlockAggregatedChanges {
+    use tycho_substreams::prelude::ChangeType as ProtoChangeType;
+
+    let hash_bytes = hex::decode(block_hash_hex.trim_start_matches("0x")).unwrap_or_default();
+    let block = Block {
+        number: block_num,
+        hash: Bytes::from(hash_bytes),
+        parent_hash: Bytes::default(),
+        chain: Chain::Ethereum,
+        ts: Default::default(),
+    };
+
+    let mut new_protocol_components: HashMap<String, ProtocolComponent> = HashMap::new();
+    let mut state_deltas: HashMap<String, ProtocolComponentStateDelta> = HashMap::new();
+    let mut component_balances: HashMap<String, HashMap<Bytes, ComponentBalance>> = HashMap::new();
+
+    for tx_changes in &proto.changes {
+        for comp in &tx_changes.component_changes {
+            let id = normalise_str_id(&comp.id);
+            new_protocol_components
+                .entry(id.clone())
+                .or_insert_with(|| ProtocolComponent {
+                    id: id.clone(),
+                    tokens: comp
+                        .tokens
+                        .iter()
+                        .map(|t| Bytes::from(t.clone()))
+                        .collect(),
+                    ..Default::default()
+                });
+        }
+
+        for ec in &tx_changes.entity_changes {
+            let cid = normalise_str_id(&ec.component_id);
+            let delta = state_deltas
+                .entry(cid.clone())
+                .or_insert_with(|| ProtocolComponentStateDelta {
+                    component_id: cid.clone(),
+                    updated_attributes: HashMap::new(),
+                    deleted_attributes: HashSet::new(),
+                });
+            for attr in &ec.attributes {
+                if attr.change == i32::from(ProtoChangeType::Deletion) {
+                    delta
+                        .deleted_attributes
+                        .insert(attr.name.clone());
+                    delta
+                        .updated_attributes
+                        .remove(&attr.name);
+                } else {
+                    delta
+                        .updated_attributes
+                        .insert(attr.name.clone(), Bytes::from(attr.value.clone()));
+                    delta
+                        .deleted_attributes
+                        .remove(&attr.name);
+                }
+            }
+        }
+
+        for bc in &tx_changes.balance_changes {
+            let cid = normalise_component_id(&bc.component_id);
+            let token = Bytes::from(bc.token.clone());
+            let balance = Bytes::from(bc.balance.clone());
+            let balance_float = BigInt::from_bytes_be(Sign::Plus, balance.as_ref())
+                .to_f64()
+                .unwrap_or(f64::MAX);
+            component_balances
+                .entry(cid.clone())
+                .or_default()
+                .insert(
+                    token.clone(),
+                    ComponentBalance {
+                        token,
+                        balance,
+                        balance_float,
+                        modify_tx: Bytes::default(),
+                        component_id: cid,
+                    },
+                );
+        }
+    }
+
+    BlockAggregatedChanges {
+        extractor: "uniswap-v3".to_string(),
+        chain: Chain::Ethereum,
+        block,
+        finalized_block_height: block_num,
+        state_deltas,
+        new_protocol_components,
+        component_balances,
+        ..Default::default()
+    }
+}
+
+// ─── Comparison helpers ──────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct ComparableBlockChanges {
+    /// component_id → { attr_name → value }
+    attributes: HashMap<String, HashMap<String, Vec<u8>>>,
+    /// (component_id, token_hex) → balance
+    balances: HashMap<(String, String), Vec<u8>>,
+}
+
+/// Aggregates all per-transaction entity/balance changes from a substreams block into a
+/// block-level comparable view, filtered to pools already known to the processor.
+///
+/// Pools created in the current block are excluded because the processor learns about them
+/// only after `apply_block` is called, so `generate_deltas` for the same block cannot
+/// produce output for them. This matches production semantics.
+fn substreams_to_comparable_block(
+    proto: &BlockChanges,
+    known_pools: &HashSet<String>,
+) -> ComparableBlockChanges {
+    let mut attributes: HashMap<String, HashMap<String, Vec<u8>>> = HashMap::new();
+    let mut balances: HashMap<(String, String), Vec<u8>> = HashMap::new();
+
+    for tx_changes in &proto.changes {
+        for ec in &tx_changes.entity_changes {
+            let cid = normalise_str_id(&ec.component_id);
+            if !known_pools.contains(&cid) {
+                continue;
+            }
+            for attr in &ec.attributes {
+                // map_pools_created emits zero-value init attrs for new pools; skip them.
+                if attr.value.iter().all(|&b| b == 0) {
+                    continue;
+                }
+                attributes
+                    .entry(cid.clone())
+                    .or_default()
+                    .insert(attr.name.clone(), attr.value.clone());
+            }
+        }
+
+        for bc in &tx_changes.balance_changes {
+            let cid = normalise_component_id(&bc.component_id);
+            if !known_pools.contains(&cid) {
+                continue;
+            }
+            if bc.balance.iter().all(|&b| b == 0) {
+                continue;
+            }
+            let token = hex::encode(&bc.token);
+            balances.insert((cid, token), bc.balance.clone());
+        }
+    }
+
+    ComparableBlockChanges { attributes, balances }
+}
+
+fn processor_to_comparable_block(
+    changes: &BlockAggregatedChanges,
+    known_pools: &HashSet<String>,
+) -> ComparableBlockChanges {
+    let mut attributes: HashMap<String, HashMap<String, Vec<u8>>> = HashMap::new();
+    let mut balances: HashMap<(String, String), Vec<u8>> = HashMap::new();
+
+    for (comp_id, delta) in &changes.state_deltas {
+        if !known_pools.contains(comp_id) {
+            continue;
+        }
+        let entry = attributes
+            .entry(comp_id.clone())
+            .or_default();
+        for (attr_name, attr_val) in &delta.updated_attributes {
+            entry.insert(attr_name.clone(), attr_val.to_vec());
+        }
+    }
+
+    for (comp_id, token_balances) in &changes.component_balances {
+        if !known_pools.contains(comp_id) {
+            continue;
+        }
+        for (token, cb) in token_balances {
+            let token_hex = hex::encode(token.as_ref());
+            balances.insert((comp_id.clone(), token_hex), cb.balance.to_vec());
+        }
+    }
+
+    ComparableBlockChanges { attributes, balances }
+}
+
+// ─── Test ────────────────────────────────────────────────────────────────────
+
+/// Streams UniswapV3 substreams from the genesis block (12_369_621) through
+/// `UV3_STOP_BLOCK` (default +2000 blocks) and verifies that the native
+/// `UniswapV3Processor` produces byte-identical attribute and balance values
+/// for every block in the range.
+///
+/// For each block the test:
+///   1. Calls `generate_deltas` with the raw RPC transactions to get pending state changes.
+///   2. Compares those changes against the aggregated substreams output for the block, restricted
+///      to pools the processor already knows about.
+///   3. Calls `apply_block` with the substreams ground truth to advance processor state.
+///
+/// This matches production semantics: pools created in block N are visible to
+/// `generate_deltas` only from block N+1 onwards.
+///
+/// Required env vars:
+///   ETH_RPC_URL         — archive RPC endpoint (supports eth_getLogs over
+///                         multi-thousand-block ranges and eth_getBlockByNumber)
+///   STREAMINGFAST_KEY   — StreamingFast API token
+///   UV3_SPKG_PATH       — path to the built `ethereum-uniswap-v3.spkg`
+///                         (build: cd protocols/substreams/ethereum-uniswap-v3-logs-only
+///                                 cargo build --target wasm32-unknown-unknown --release
+///                                 substreams pack -o /tmp/uniswap-v3.spkg
+/// ethereum-uniswap-v3.yaml)   UV3_STOP_BLOCK      — (optional) override stop block; defaults to
+/// 12_371_621
+#[tokio::test]
+#[ignore = "requires ETH_RPC_URL, STREAMINGFAST_KEY, and UV3_SPKG_PATH"]
+async fn test_processor_matches_substreams_genesis_range() {
+    dotenv::dotenv().ok();
+
+    let rpc_url = std::env::var("ETH_RPC_URL").expect("ETH_RPC_URL must be set");
+    let api_key = std::env::var("STREAMINGFAST_KEY").expect("STREAMINGFAST_KEY must be set");
+    let spkg_path = std::env::var("UV3_SPKG_PATH")
+        .expect("UV3_SPKG_PATH must be set (path to the built .spkg file)");
+    let stop_block = std::env::var("UV3_STOP_BLOCK")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_STOP_BLOCK);
+
+    let endpoint_url = "https://mainnet.eth.streamingfast.io:443";
+
+    // ── Step 1: stream the full range from substreams ────────────────────────
+    let all_block_changes =
+        stream_block_range(endpoint_url, &api_key, &spkg_path, START_BLOCK, stop_block).await;
+
+    assert!(
+        !all_block_changes.is_empty(),
+        "Substreams returned no blocks for range [{START_BLOCK}, {stop_block}]"
+    );
+
+    // ── Step 2: fetch tx inputs for the full block range ─────────────────────
+    let mut per_block_inputs = fetch_range_tx_inputs(&rpc_url, START_BLOCK, stop_block).await;
+
+    // ── Step 3: run the native processor block by block ──────────────────────
+    //
+    // For each block:
+    //   a. generate_deltas(txs) — compare against substreams output (known pools only)
+    //   b. apply_block(model)  — advance state; register new pools for subsequent blocks
+    let mut processor = UniswapV3Processor::new(Chain::Ethereum, "uniswap-v3".to_string());
+    let mut known_pool_ids: HashSet<String> = HashSet::new();
+
+    let mut attr_mismatches: Vec<String> = Vec::new();
+    let mut balance_mismatches: Vec<String> = Vec::new();
+
+    let mut total_compared_blocks: usize = 0;
+    let mut total_compared_attrs: usize = 0;
+    let mut total_compared_balances: usize = 0;
+
+    for (block_num, block_hash, substreams_block) in &all_block_changes {
+        let tx_inputs = per_block_inputs
+            .remove(block_num)
+            .unwrap_or_default();
+
+        // Generate pending deltas from raw transactions against the current state.
+        let pending = processor.generate_deltas(&tx_inputs);
+
+        // Compare block-level aggregates, limited to pools already registered.
+        let expected = substreams_to_comparable_block(substreams_block, &known_pool_ids);
+        let actual = processor_to_comparable_block(&pending, &known_pool_ids);
+
+        if !expected.attributes.is_empty() || !expected.balances.is_empty() {
+            total_compared_blocks += 1;
+        }
+
+        for (cid, expected_attrs) in &expected.attributes {
+            let actual_attrs = actual
+                .attributes
+                .get(cid)
+                .cloned()
+                .unwrap_or_default();
+            let short_cid = &cid[..8.min(cid.len())];
+            for (attr_name, expected_value) in expected_attrs {
+                total_compared_attrs += 1;
+                let ev = hex::encode(expected_value);
+                match actual_attrs.get(attr_name) {
+                    Some(v) if v == expected_value => {
+                        println!(
+                            "  block={block_num} pool={short_cid}.. {attr_name:20}  \
+                             substreams={ev}  processor=✓"
+                        );
+                    }
+                    Some(v) => {
+                        let av = hex::encode(v);
+                        println!(
+                            "  block={block_num} pool={short_cid}.. {attr_name:20}  \
+                             substreams={ev}  processor={av}  MISMATCH"
+                        );
+                        attr_mismatches.push(format!(
+                            "block={block_num} pool={cid} attr={attr_name}: \
+                             expected={ev} got={av}",
+                        ));
+                    }
+                    None => {
+                        println!(
+                            "  block={block_num} pool={short_cid}.. {attr_name:20}  \
+                             substreams={ev}  processor=MISSING"
+                        );
+                        attr_mismatches.push(format!(
+                            "block={block_num} pool={cid} attr={attr_name}: \
+                             expected={ev} but missing",
+                        ));
+                    }
+                }
+            }
+        }
+
+        for ((cid, token), expected_balance) in &expected.balances {
+            total_compared_balances += 1;
+            let short_cid = &cid[..8.min(cid.len())];
+            let short_tok = &token[..8.min(token.len())];
+            let eb = hex::encode(expected_balance);
+            match actual
+                .balances
+                .get(&(cid.clone(), token.clone()))
+            {
+                Some(v) if v == expected_balance => {
+                    println!(
+                        "  block={block_num} pool={short_cid}.. token={short_tok}..  \
+                         balance: substreams={eb}  processor=✓"
+                    );
+                }
+                Some(v) => {
+                    let ab = hex::encode(v);
+                    println!(
+                        "  block={block_num} pool={short_cid}.. token={short_tok}..  \
+                         balance: substreams={eb}  processor={ab}  MISMATCH"
+                    );
+                    balance_mismatches.push(format!(
+                        "block={block_num} pool={cid} token={token}: \
+                         expected={eb} got={ab}",
+                    ));
+                }
+                None => {
+                    println!(
+                        "  block={block_num} pool={short_cid}.. token={short_tok}..  \
+                         balance: substreams={eb}  processor=MISSING"
+                    );
+                    balance_mismatches.push(format!(
+                        "block={block_num} pool={cid} token={token}: \
+                         expected={eb} but missing",
+                    ));
+                }
+            }
+        }
+
+        // Advance processor state with substreams ground truth.
+        let model_block = substreams_proto_to_model(substreams_block, *block_num, block_hash);
+        processor.apply_block(&model_block);
+
+        // Register newly seen pools so subsequent blocks can compare them.
+        for id in model_block
+            .new_protocol_components
+            .keys()
+        {
+            known_pool_ids.insert(id.clone());
+        }
+    }
+
+    println!("\n─── Summary ────────────────────────────────────────────────────────────────");
+    println!("  Blocks streamed:       {}", all_block_changes.len());
+    println!("  Blocks with activity:  {total_compared_blocks}");
+    println!("  Pools registered:      {}", known_pool_ids.len());
+    println!("  Attributes compared:   {total_compared_attrs}");
+    println!("  Balances compared:     {total_compared_balances}");
+    println!("  Attr mismatches:       {}", attr_mismatches.len());
+    println!("  Balance mismatches:    {}", balance_mismatches.len());
+    println!("────────────────────────────────────────────────────────────────────────────");
+
+    assert!(
+        attr_mismatches.is_empty(),
+        "Attribute value mismatches ({} total):\n{}",
+        attr_mismatches.len(),
+        attr_mismatches.join("\n"),
+    );
+    assert!(
+        balance_mismatches.is_empty(),
+        "Balance value mismatches ({} total):\n{}",
+        balance_mismatches.len(),
+        balance_mismatches.join("\n"),
+    );
+}

--- a/protocols/crates/uniswap-v3/tests/integration.rs
+++ b/protocols/crates/uniswap-v3/tests/integration.rs
@@ -256,16 +256,14 @@ async fn fetch_range_tx_inputs(
 
 // ─── Conversion helpers ──────────────────────────────────────────────────────
 
-/// Normalise a component_id from substreams output to lower-case hex without "0x".
-fn normalise_component_id(raw: &[u8]) -> String {
-    let s = std::str::from_utf8(raw).unwrap_or_default();
-    s.trim_start_matches("0x")
-        .to_lowercase()
-}
-
-fn normalise_str_id(s: &str) -> String {
-    s.trim_start_matches("0x")
-        .to_lowercase()
+/// Decodes a substreams balance-change component_id (the UTF-8 bytes of the id string).
+///
+/// Ids are kept exactly as the substreams emit them ("0x"-prefixed lower-case hex) — the
+/// processor must produce byte-identical ids, so the comparison asserts the format too.
+fn component_id_from_bytes(raw: &[u8]) -> String {
+    std::str::from_utf8(raw)
+        .unwrap_or_default()
+        .to_string()
 }
 
 /// Converts a substreams proto `BlockChanges` to a `BlockAggregatedChanges`, aggregating
@@ -292,7 +290,7 @@ fn substreams_proto_to_model(
 
     for tx_changes in &proto.changes {
         for comp in &tx_changes.component_changes {
-            let id = normalise_str_id(&comp.id);
+            let id = comp.id.clone();
             new_protocol_components
                 .entry(id.clone())
                 .or_insert_with(|| ProtocolComponent {
@@ -307,7 +305,7 @@ fn substreams_proto_to_model(
         }
 
         for ec in &tx_changes.entity_changes {
-            let cid = normalise_str_id(&ec.component_id);
+            let cid = ec.component_id.clone();
             let delta = state_deltas
                 .entry(cid.clone())
                 .or_insert_with(|| ProtocolComponentStateDelta {
@@ -335,7 +333,7 @@ fn substreams_proto_to_model(
         }
 
         for bc in &tx_changes.balance_changes {
-            let cid = normalise_component_id(&bc.component_id);
+            let cid = component_id_from_bytes(&bc.component_id);
             let token = Bytes::from(bc.token.clone());
             let balance = Bytes::from(bc.balance.clone());
             let balance_float = BigInt::from_bytes_be(Sign::Plus, balance.as_ref())
@@ -394,7 +392,7 @@ fn substreams_to_comparable_block(
 
     for tx_changes in &proto.changes {
         for ec in &tx_changes.entity_changes {
-            let cid = normalise_str_id(&ec.component_id);
+            let cid = ec.component_id.clone();
             if !known_pools.contains(&cid) {
                 continue;
             }
@@ -411,7 +409,7 @@ fn substreams_to_comparable_block(
         }
 
         for bc in &tx_changes.balance_changes {
-            let cid = normalise_component_id(&bc.component_id);
+            let cid = component_id_from_bytes(&bc.component_id);
             if !known_pools.contains(&cid) {
                 continue;
             }

--- a/protocols/crates/uniswap-v4/Cargo.toml
+++ b/protocols/crates/uniswap-v4/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "uniswap-v4-core"
+version = "0.1.0"
+edition = "2021"
+description = "Shared UniswapV4 indexing logic for native and WASM builds"
+
+[dependencies]
+substreams = "0.5.22"
+substreams-ethereum = "0.9.9"
+tycho-substreams = { path = "../../substreams/crates/tycho-substreams" }
+tycho-common = { path = "../../../crates/tycho-common" }
+ethabi = "18.0.0"
+hex = "0.4.3"
+num-bigint = "0.4.4"
+num-traits = { workspace = true }
+
+[target.wasm32-unknown-unknown.dependencies]
+getrandom = { version = "0.2", features = ["custom"] }
+
+[dev-dependencies]
+rstest.workspace = true
+# Substreams streaming client (same workspace crate).
+tycho-indexer.workspace = true
+# Async runtime and stream utilities.
+tokio.workspace = true
+tokio-stream = { version = "0.1", features = ["sync"] }
+# Archive RPC calls (eth_getLogs, eth_getBlockByNumber).
+alloy = { workspace = true, features = [
+    "providers",
+    "provider-http",
+    "rpc-types-eth",
+    "sol-types",
+    "contract",
+    "network",
+] }
+# .env file loading for CI credentials.
+dotenv.workspace = true
+hex.workspace = true
+num-bigint.workspace = true
+prost = "0.11"

--- a/protocols/crates/uniswap-v4/scripts/build_main_spkg.sh
+++ b/protocols/crates/uniswap-v4/scripts/build_main_spkg.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds the UniswapV4 no-hooks substreams package from origin/main.
+#
+# The parity integration test uses the substreams output as ground truth. Building
+# the spkg from main (in a temporary git worktree) instead of the working tree
+# guarantees the test compares the native processor against the substreams state
+# deployed from main, even when the current branch modifies the substreams source.
+#
+# Usage: build_main_spkg.sh [output-path]
+#   output-path  defaults to <repo>/target/spkg/ethereum-uniswap-v4-no-hooks-main.spkg
+
+repo_root=$(git rev-parse --show-toplevel)
+out="${1:-$repo_root/target/spkg/ethereum-uniswap-v4-no-hooks-main.spkg}"
+
+worktree=$(mktemp -d)/main
+git -C "$repo_root" fetch origin main
+git -C "$repo_root" worktree add --detach "$worktree" origin/main >/dev/null
+trap 'git -C "$repo_root" worktree remove --force "$worktree"' EXIT
+
+cd "$worktree/protocols/substreams/ethereum-uniswap-v4"
+cargo build --target wasm32-unknown-unknown --release -p ethereum-uniswap-v4-no-hooks
+
+mkdir -p "$(dirname "$out")"
+substreams pack no-hooks/ethereum-uniswap-v4-no-hooks.yaml -o "$out"
+echo "spkg written to $out"

--- a/protocols/crates/uniswap-v4/src/abi/mod.rs
+++ b/protocols/crates/uniswap-v4/src/abi/mod.rs
@@ -1,0 +1,3 @@
+#![allow(clippy::all, clippy::pedantic, clippy::nursery)]
+
+pub mod pool_manager;

--- a/protocols/crates/uniswap-v4/src/abi/pool_manager.rs
+++ b/protocols/crates/uniswap-v4/src/abi/pool_manager.rs
@@ -1,0 +1,5091 @@
+const INTERNAL_ERR: &'static str = "`ethabi_derive` internal error";
+/// Contract's functions.
+#[allow(dead_code, unused_imports, unused_variables)]
+pub mod functions {
+    use super::INTERNAL_ERR;
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Allowance {
+        pub owner: Vec<u8>,
+        pub spender: Vec<u8>,
+        pub id: substreams::scalar::BigInt,
+    }
+    impl Allowance {
+        const METHOD_ID: [u8; 4] = [89u8, 138u8, 249u8, 231u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(256usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                owner: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                spender: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                id: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.owner)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.spender)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.id.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Allowance {
+        const NAME: &'static str = "allowance";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for Allowance {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Approve {
+        pub spender: Vec<u8>,
+        pub id: substreams::scalar::BigInt,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl Approve {
+        const METHOD_ID: [u8; 4] = [66u8, 106u8, 132u8, 147u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                spender: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                id: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.spender)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.id.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<bool, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<bool, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Bool], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_bool()
+                .expect(INTERNAL_ERR))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<bool> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Approve {
+        const NAME: &'static str = "approve";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<bool> for Approve {
+        fn output(data: &[u8]) -> Result<bool, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct BalanceOf {
+        pub owner: Vec<u8>,
+        pub id: substreams::scalar::BigInt,
+    }
+    impl BalanceOf {
+        const METHOD_ID: [u8; 4] = [0u8, 253u8, 213u8, 142u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                owner: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                id: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.owner)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.id.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for BalanceOf {
+        const NAME: &'static str = "balanceOf";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for BalanceOf {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Burn {
+        pub from: Vec<u8>,
+        pub id: substreams::scalar::BigInt,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl Burn {
+        const METHOD_ID: [u8; 4] = [245u8, 41u8, 138u8, 202u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                from: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                id: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.from)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.id.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Burn {
+        const NAME: &'static str = "burn";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Clear {
+        pub currency: Vec<u8>,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl Clear {
+        const METHOD_ID: [u8; 4] = [128u8, 240u8, 180u8, 76u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                currency: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.currency)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Clear {
+        const NAME: &'static str = "clear";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct CollectProtocolFees {
+        pub recipient: Vec<u8>,
+        pub currency: Vec<u8>,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl CollectProtocolFees {
+        const METHOD_ID: [u8; 4] = [129u8, 97u8, 184u8, 116u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(256usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                recipient: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                currency: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.recipient)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.currency)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for CollectProtocolFees {
+        const NAME: &'static str = "collectProtocolFees";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for CollectProtocolFees {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Donate {
+        pub key:
+            (Vec<u8>, Vec<u8>, substreams::scalar::BigInt, substreams::scalar::BigInt, Vec<u8>),
+        pub amount0: substreams::scalar::BigInt,
+        pub amount1: substreams::scalar::BigInt,
+        pub hook_data: Vec<u8>,
+    }
+    impl Donate {
+        const METHOD_ID: [u8; 4] = [35u8, 66u8, 102u8, 215u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Tuple(vec![
+                        ethabi::ParamType::Address,
+                        ethabi::ParamType::Address,
+                        ethabi::ParamType::Uint(24usize),
+                        ethabi::ParamType::Int(24usize),
+                        ethabi::ParamType::Address,
+                    ]),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Bytes,
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                key: {
+                    let tuple_elements = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_tuple()
+                        .expect(INTERNAL_ERR);
+                    (
+                        tuple_elements[0usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                        tuple_elements[1usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[2usize]
+                                .clone()
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                        },
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[3usize]
+                                .clone()
+                                .into_int()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                        },
+                        tuple_elements[4usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                    )
+                },
+                amount0: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount1: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                hook_data: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_bytes()
+                    .expect(INTERNAL_ERR),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Tuple(vec![
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.0)),
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.1)),
+                    ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                        match self.key.2.clone().to_bytes_be() {
+                            (num_bigint::Sign::Plus, bytes) => bytes,
+                            (num_bigint::Sign::NoSign, bytes) => bytes,
+                            (num_bigint::Sign::Minus, _) => {
+                                panic!("negative numbers are not supported")
+                            }
+                        }
+                        .as_slice(),
+                    )),
+                    {
+                        let non_full_signed_bytes = self.key.3.to_signed_bytes_be();
+                        let full_signed_bytes_init =
+                            if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                        let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                        non_full_signed_bytes
+                            .into_iter()
+                            .rev()
+                            .enumerate()
+                            .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                        ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                    },
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.4)),
+                ]),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount0.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount1.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Bytes(self.hook_data.clone()),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Int(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_int()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_signed_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Donate {
+        const NAME: &'static str = "donate";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for Donate {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Extsload1 {
+        pub slot: [u8; 32usize],
+    }
+    impl Extsload1 {
+        const METHOD_ID: [u8; 4] = [30u8, 46u8, 174u8, 175u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::FixedBytes(32usize)], maybe_data.unwrap())
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                slot: {
+                    let mut result = [0u8; 32];
+                    let v = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::FixedBytes(self.slot.as_ref().to_vec())]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<[u8; 32usize], String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<[u8; 32usize], String> {
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::FixedBytes(32usize)], data.as_ref())
+                    .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut result = [0u8; 32];
+                let v = values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_fixed_bytes()
+                    .expect(INTERNAL_ERR);
+                result.copy_from_slice(&v);
+                result
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<[u8; 32usize]> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Extsload1 {
+        const NAME: &'static str = "extsload";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<[u8; 32usize]> for Extsload1 {
+        fn output(data: &[u8]) -> Result<[u8; 32usize], String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Extsload2 {
+        pub start_slot: [u8; 32usize],
+        pub n_slots: substreams::scalar::BigInt,
+    }
+    impl Extsload2 {
+        const METHOD_ID: [u8; 4] = [53u8, 253u8, 99u8, 26u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::FixedBytes(32usize), ethabi::ParamType::Uint(256usize)],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                start_slot: {
+                    let mut result = [0u8; 32];
+                    let v = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+                n_slots: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::FixedBytes(self.start_slot.as_ref().to_vec()),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.n_slots.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<[u8; 32usize]>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<[u8; 32usize]>, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Array(Box::new(ethabi::ParamType::FixedBytes(32usize)))],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_array()
+                .expect(INTERNAL_ERR)
+                .into_iter()
+                .map(|inner| {
+                    let mut result = [0u8; 32];
+                    let v = inner
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                })
+                .collect())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<[u8; 32usize]>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Extsload2 {
+        const NAME: &'static str = "extsload";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<[u8; 32usize]>> for Extsload2 {
+        fn output(data: &[u8]) -> Result<Vec<[u8; 32usize]>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Extsload3 {
+        pub slots: Vec<[u8; 32usize]>,
+    }
+    impl Extsload3 {
+        const METHOD_ID: [u8; 4] = [219u8, 208u8, 53u8, 255u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Array(Box::new(ethabi::ParamType::FixedBytes(32usize)))],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                slots: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_array()
+                    .expect(INTERNAL_ERR)
+                    .into_iter()
+                    .map(|inner| {
+                        let mut result = [0u8; 32];
+                        let v = inner
+                            .into_fixed_bytes()
+                            .expect(INTERNAL_ERR);
+                        result.copy_from_slice(&v);
+                        result
+                    })
+                    .collect(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[{
+                let v = self
+                    .slots
+                    .iter()
+                    .map(|inner| ethabi::Token::FixedBytes(inner.as_ref().to_vec()))
+                    .collect();
+                ethabi::Token::Array(v)
+            }]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<[u8; 32usize]>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<[u8; 32usize]>, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Array(Box::new(ethabi::ParamType::FixedBytes(32usize)))],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_array()
+                .expect(INTERNAL_ERR)
+                .into_iter()
+                .map(|inner| {
+                    let mut result = [0u8; 32];
+                    let v = inner
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                })
+                .collect())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<[u8; 32usize]>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Extsload3 {
+        const NAME: &'static str = "extsload";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<[u8; 32usize]>> for Extsload3 {
+        fn output(data: &[u8]) -> Result<Vec<[u8; 32usize]>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Exttload1 {
+        pub slots: Vec<[u8; 32usize]>,
+    }
+    impl Exttload1 {
+        const METHOD_ID: [u8; 4] = [155u8, 246u8, 100u8, 95u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Array(Box::new(ethabi::ParamType::FixedBytes(32usize)))],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                slots: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_array()
+                    .expect(INTERNAL_ERR)
+                    .into_iter()
+                    .map(|inner| {
+                        let mut result = [0u8; 32];
+                        let v = inner
+                            .into_fixed_bytes()
+                            .expect(INTERNAL_ERR);
+                        result.copy_from_slice(&v);
+                        result
+                    })
+                    .collect(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[{
+                let v = self
+                    .slots
+                    .iter()
+                    .map(|inner| ethabi::Token::FixedBytes(inner.as_ref().to_vec()))
+                    .collect();
+                ethabi::Token::Array(v)
+            }]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<[u8; 32usize]>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<[u8; 32usize]>, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Array(Box::new(ethabi::ParamType::FixedBytes(32usize)))],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_array()
+                .expect(INTERNAL_ERR)
+                .into_iter()
+                .map(|inner| {
+                    let mut result = [0u8; 32];
+                    let v = inner
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                })
+                .collect())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<[u8; 32usize]>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Exttload1 {
+        const NAME: &'static str = "exttload";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<[u8; 32usize]>> for Exttload1 {
+        fn output(data: &[u8]) -> Result<Vec<[u8; 32usize]>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Exttload2 {
+        pub slot: [u8; 32usize],
+    }
+    impl Exttload2 {
+        const METHOD_ID: [u8; 4] = [241u8, 53u8, 186u8, 170u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::FixedBytes(32usize)], maybe_data.unwrap())
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                slot: {
+                    let mut result = [0u8; 32];
+                    let v = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::FixedBytes(self.slot.as_ref().to_vec())]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<[u8; 32usize], String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<[u8; 32usize], String> {
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::FixedBytes(32usize)], data.as_ref())
+                    .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut result = [0u8; 32];
+                let v = values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_fixed_bytes()
+                    .expect(INTERNAL_ERR);
+                result.copy_from_slice(&v);
+                result
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<[u8; 32usize]> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Exttload2 {
+        const NAME: &'static str = "exttload";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<[u8; 32usize]> for Exttload2 {
+        fn output(data: &[u8]) -> Result<[u8; 32usize], String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Initialize {
+        pub key:
+            (Vec<u8>, Vec<u8>, substreams::scalar::BigInt, substreams::scalar::BigInt, Vec<u8>),
+        pub sqrt_price_x96: substreams::scalar::BigInt,
+    }
+    impl Initialize {
+        const METHOD_ID: [u8; 4] = [98u8, 118u8, 203u8, 190u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Tuple(vec![
+                        ethabi::ParamType::Address,
+                        ethabi::ParamType::Address,
+                        ethabi::ParamType::Uint(24usize),
+                        ethabi::ParamType::Int(24usize),
+                        ethabi::ParamType::Address,
+                    ]),
+                    ethabi::ParamType::Uint(160usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                key: {
+                    let tuple_elements = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_tuple()
+                        .expect(INTERNAL_ERR);
+                    (
+                        tuple_elements[0usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                        tuple_elements[1usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[2usize]
+                                .clone()
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                        },
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[3usize]
+                                .clone()
+                                .into_int()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                        },
+                        tuple_elements[4usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                    )
+                },
+                sqrt_price_x96: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Tuple(vec![
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.0)),
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.1)),
+                    ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                        match self.key.2.clone().to_bytes_be() {
+                            (num_bigint::Sign::Plus, bytes) => bytes,
+                            (num_bigint::Sign::NoSign, bytes) => bytes,
+                            (num_bigint::Sign::Minus, _) => {
+                                panic!("negative numbers are not supported")
+                            }
+                        }
+                        .as_slice(),
+                    )),
+                    {
+                        let non_full_signed_bytes = self.key.3.to_signed_bytes_be();
+                        let full_signed_bytes_init =
+                            if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                        let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                        non_full_signed_bytes
+                            .into_iter()
+                            .rev()
+                            .enumerate()
+                            .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                        ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                    },
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.4)),
+                ]),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self
+                        .sqrt_price_x96
+                        .clone()
+                        .to_bytes_be()
+                    {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Int(24usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_int()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_signed_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Initialize {
+        const NAME: &'static str = "initialize";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for Initialize {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct IsOperator {
+        pub owner: Vec<u8>,
+        pub operator: Vec<u8>,
+    }
+    impl IsOperator {
+        const METHOD_ID: [u8; 4] = [182u8, 54u8, 60u8, 242u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Address],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                owner: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                operator: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.owner)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.operator)),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<bool, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<bool, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Bool], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_bool()
+                .expect(INTERNAL_ERR))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<bool> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for IsOperator {
+        const NAME: &'static str = "isOperator";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<bool> for IsOperator {
+        fn output(data: &[u8]) -> Result<bool, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Mint {
+        pub to: Vec<u8>,
+        pub id: substreams::scalar::BigInt,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl Mint {
+        const METHOD_ID: [u8; 4] = [21u8, 110u8, 41u8, 246u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                to: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                id: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.to)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.id.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Mint {
+        const NAME: &'static str = "mint";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct ModifyLiquidity {
+        pub key:
+            (Vec<u8>, Vec<u8>, substreams::scalar::BigInt, substreams::scalar::BigInt, Vec<u8>),
+        pub params: (
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+            [u8; 32usize],
+        ),
+        pub hook_data: Vec<u8>,
+    }
+    impl ModifyLiquidity {
+        const METHOD_ID: [u8; 4] = [90u8, 107u8, 207u8, 218u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Tuple(vec![
+                        ethabi::ParamType::Address,
+                        ethabi::ParamType::Address,
+                        ethabi::ParamType::Uint(24usize),
+                        ethabi::ParamType::Int(24usize),
+                        ethabi::ParamType::Address,
+                    ]),
+                    ethabi::ParamType::Tuple(vec![
+                        ethabi::ParamType::Int(24usize),
+                        ethabi::ParamType::Int(24usize),
+                        ethabi::ParamType::Int(256usize),
+                        ethabi::ParamType::FixedBytes(32usize),
+                    ]),
+                    ethabi::ParamType::Bytes,
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                key: {
+                    let tuple_elements = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_tuple()
+                        .expect(INTERNAL_ERR);
+                    (
+                        tuple_elements[0usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                        tuple_elements[1usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[2usize]
+                                .clone()
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                        },
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[3usize]
+                                .clone()
+                                .into_int()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                        },
+                        tuple_elements[4usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                    )
+                },
+                params: {
+                    let tuple_elements = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_tuple()
+                        .expect(INTERNAL_ERR);
+                    (
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[0usize]
+                                .clone()
+                                .into_int()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                        },
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[1usize]
+                                .clone()
+                                .into_int()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                        },
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[2usize]
+                                .clone()
+                                .into_int()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                        },
+                        {
+                            let mut result = [0u8; 32];
+                            let v = tuple_elements[3usize]
+                                .clone()
+                                .into_fixed_bytes()
+                                .expect(INTERNAL_ERR);
+                            result.copy_from_slice(&v);
+                            result
+                        },
+                    )
+                },
+                hook_data: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_bytes()
+                    .expect(INTERNAL_ERR),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Tuple(vec![
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.0)),
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.1)),
+                    ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                        match self.key.2.clone().to_bytes_be() {
+                            (num_bigint::Sign::Plus, bytes) => bytes,
+                            (num_bigint::Sign::NoSign, bytes) => bytes,
+                            (num_bigint::Sign::Minus, _) => {
+                                panic!("negative numbers are not supported")
+                            }
+                        }
+                        .as_slice(),
+                    )),
+                    {
+                        let non_full_signed_bytes = self.key.3.to_signed_bytes_be();
+                        let full_signed_bytes_init =
+                            if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                        let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                        non_full_signed_bytes
+                            .into_iter()
+                            .rev()
+                            .enumerate()
+                            .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                        ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                    },
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.4)),
+                ]),
+                ethabi::Token::Tuple(vec![
+                    {
+                        let non_full_signed_bytes = self.params.0.to_signed_bytes_be();
+                        let full_signed_bytes_init =
+                            if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                        let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                        non_full_signed_bytes
+                            .into_iter()
+                            .rev()
+                            .enumerate()
+                            .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                        ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                    },
+                    {
+                        let non_full_signed_bytes = self.params.1.to_signed_bytes_be();
+                        let full_signed_bytes_init =
+                            if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                        let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                        non_full_signed_bytes
+                            .into_iter()
+                            .rev()
+                            .enumerate()
+                            .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                        ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                    },
+                    {
+                        let non_full_signed_bytes = self.params.2.to_signed_bytes_be();
+                        let full_signed_bytes_init =
+                            if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                        let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                        non_full_signed_bytes
+                            .into_iter()
+                            .rev()
+                            .enumerate()
+                            .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                        ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                    },
+                    ethabi::Token::FixedBytes(self.params.3.as_ref().to_vec()),
+                ]),
+                ethabi::Token::Bytes(self.hook_data.clone()),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(
+            data: &[u8],
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Int(256usize), ethabi::ParamType::Int(256usize)],
+                data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            values.reverse();
+            Ok((
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+            ))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(
+            &self,
+            address: Vec<u8>,
+        ) -> Option<(substreams::scalar::BigInt, substreams::scalar::BigInt)> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for ModifyLiquidity {
+        const NAME: &'static str = "modifyLiquidity";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl
+        substreams_ethereum::rpc::RPCDecodable<(
+            substreams::scalar::BigInt,
+            substreams::scalar::BigInt,
+        )> for ModifyLiquidity
+    {
+        fn output(
+            data: &[u8],
+        ) -> Result<(substreams::scalar::BigInt, substreams::scalar::BigInt), String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Owner {}
+    impl Owner {
+        const METHOD_ID: [u8; 4] = [141u8, 165u8, 203u8, 91u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Owner {
+        const NAME: &'static str = "owner";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for Owner {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct ProtocolFeeController {}
+    impl ProtocolFeeController {
+        const METHOD_ID: [u8; 4] = [240u8, 45u8, 227u8, 178u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec())
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for ProtocolFeeController {
+        const NAME: &'static str = "protocolFeeController";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for ProtocolFeeController {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct ProtocolFeesAccrued {
+        pub currency: Vec<u8>,
+    }
+    impl ProtocolFeesAccrued {
+        const METHOD_ID: [u8; 4] = [151u8, 232u8, 205u8, 78u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                currency: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(
+                &self.currency,
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for ProtocolFeesAccrued {
+        const NAME: &'static str = "protocolFeesAccrued";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for ProtocolFeesAccrued {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SetOperator {
+        pub operator: Vec<u8>,
+        pub approved: bool,
+    }
+    impl SetOperator {
+        const METHOD_ID: [u8; 4] = [85u8, 138u8, 114u8, 151u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Bool],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                operator: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                approved: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_bool()
+                    .expect(INTERNAL_ERR),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.operator)),
+                ethabi::Token::Bool(self.approved.clone()),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<bool, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<bool, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Bool], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_bool()
+                .expect(INTERNAL_ERR))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<bool> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for SetOperator {
+        const NAME: &'static str = "setOperator";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<bool> for SetOperator {
+        fn output(data: &[u8]) -> Result<bool, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SetProtocolFee {
+        pub key:
+            (Vec<u8>, Vec<u8>, substreams::scalar::BigInt, substreams::scalar::BigInt, Vec<u8>),
+        pub new_protocol_fee: substreams::scalar::BigInt,
+    }
+    impl SetProtocolFee {
+        const METHOD_ID: [u8; 4] = [126u8, 135u8, 206u8, 125u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Tuple(vec![
+                        ethabi::ParamType::Address,
+                        ethabi::ParamType::Address,
+                        ethabi::ParamType::Uint(24usize),
+                        ethabi::ParamType::Int(24usize),
+                        ethabi::ParamType::Address,
+                    ]),
+                    ethabi::ParamType::Uint(24usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                key: {
+                    let tuple_elements = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_tuple()
+                        .expect(INTERNAL_ERR);
+                    (
+                        tuple_elements[0usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                        tuple_elements[1usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[2usize]
+                                .clone()
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                        },
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[3usize]
+                                .clone()
+                                .into_int()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                        },
+                        tuple_elements[4usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                    )
+                },
+                new_protocol_fee: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Tuple(vec![
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.0)),
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.1)),
+                    ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                        match self.key.2.clone().to_bytes_be() {
+                            (num_bigint::Sign::Plus, bytes) => bytes,
+                            (num_bigint::Sign::NoSign, bytes) => bytes,
+                            (num_bigint::Sign::Minus, _) => {
+                                panic!("negative numbers are not supported")
+                            }
+                        }
+                        .as_slice(),
+                    )),
+                    {
+                        let non_full_signed_bytes = self.key.3.to_signed_bytes_be();
+                        let full_signed_bytes_init =
+                            if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                        let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                        non_full_signed_bytes
+                            .into_iter()
+                            .rev()
+                            .enumerate()
+                            .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                        ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                    },
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.4)),
+                ]),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self
+                        .new_protocol_fee
+                        .clone()
+                        .to_bytes_be()
+                    {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for SetProtocolFee {
+        const NAME: &'static str = "setProtocolFee";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SetProtocolFeeController {
+        pub controller: Vec<u8>,
+    }
+    impl SetProtocolFeeController {
+        const METHOD_ID: [u8; 4] = [45u8, 119u8, 19u8, 137u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                controller: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(
+                &self.controller,
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for SetProtocolFeeController {
+        const NAME: &'static str = "setProtocolFeeController";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Settle {}
+    impl Settle {
+        const METHOD_ID: [u8; 4] = [17u8, 218u8, 96u8, 180u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Ok(Self {})
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Settle {
+        const NAME: &'static str = "settle";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for Settle {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SettleFor {
+        pub recipient: Vec<u8>,
+    }
+    impl SettleFor {
+        const METHOD_ID: [u8; 4] = [61u8, 212u8, 90u8, 219u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                recipient: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(
+                &self.recipient,
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for SettleFor {
+        const NAME: &'static str = "settleFor";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for SettleFor {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SupportsInterface {
+        pub interface_id: [u8; 4usize],
+    }
+    impl SupportsInterface {
+        const METHOD_ID: [u8; 4] = [1u8, 255u8, 201u8, 167u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::FixedBytes(4usize)], maybe_data.unwrap())
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                interface_id: {
+                    let mut result = [0u8; 4];
+                    let v = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data =
+                ethabi::encode(&[ethabi::Token::FixedBytes(self.interface_id.as_ref().to_vec())]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<bool, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<bool, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Bool], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_bool()
+                .expect(INTERNAL_ERR))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<bool> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for SupportsInterface {
+        const NAME: &'static str = "supportsInterface";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<bool> for SupportsInterface {
+        fn output(data: &[u8]) -> Result<bool, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Swap {
+        pub key:
+            (Vec<u8>, Vec<u8>, substreams::scalar::BigInt, substreams::scalar::BigInt, Vec<u8>),
+        pub params: (bool, substreams::scalar::BigInt, substreams::scalar::BigInt),
+        pub hook_data: Vec<u8>,
+    }
+    impl Swap {
+        const METHOD_ID: [u8; 4] = [243u8, 205u8, 145u8, 76u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Tuple(vec![
+                        ethabi::ParamType::Address,
+                        ethabi::ParamType::Address,
+                        ethabi::ParamType::Uint(24usize),
+                        ethabi::ParamType::Int(24usize),
+                        ethabi::ParamType::Address,
+                    ]),
+                    ethabi::ParamType::Tuple(vec![
+                        ethabi::ParamType::Bool,
+                        ethabi::ParamType::Int(256usize),
+                        ethabi::ParamType::Uint(160usize),
+                    ]),
+                    ethabi::ParamType::Bytes,
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                key: {
+                    let tuple_elements = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_tuple()
+                        .expect(INTERNAL_ERR);
+                    (
+                        tuple_elements[0usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                        tuple_elements[1usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[2usize]
+                                .clone()
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                        },
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[3usize]
+                                .clone()
+                                .into_int()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                        },
+                        tuple_elements[4usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                    )
+                },
+                params: {
+                    let tuple_elements = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_tuple()
+                        .expect(INTERNAL_ERR);
+                    (
+                        tuple_elements[0usize]
+                            .clone()
+                            .into_bool()
+                            .expect(INTERNAL_ERR),
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[1usize]
+                                .clone()
+                                .into_int()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                        },
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[2usize]
+                                .clone()
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                        },
+                    )
+                },
+                hook_data: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_bytes()
+                    .expect(INTERNAL_ERR),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Tuple(vec![
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.0)),
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.1)),
+                    ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                        match self.key.2.clone().to_bytes_be() {
+                            (num_bigint::Sign::Plus, bytes) => bytes,
+                            (num_bigint::Sign::NoSign, bytes) => bytes,
+                            (num_bigint::Sign::Minus, _) => {
+                                panic!("negative numbers are not supported")
+                            }
+                        }
+                        .as_slice(),
+                    )),
+                    {
+                        let non_full_signed_bytes = self.key.3.to_signed_bytes_be();
+                        let full_signed_bytes_init =
+                            if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                        let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                        non_full_signed_bytes
+                            .into_iter()
+                            .rev()
+                            .enumerate()
+                            .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                        ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                    },
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.4)),
+                ]),
+                ethabi::Token::Tuple(vec![
+                    ethabi::Token::Bool(self.params.0.clone()),
+                    {
+                        let non_full_signed_bytes = self.params.1.to_signed_bytes_be();
+                        let full_signed_bytes_init =
+                            if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                        let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                        non_full_signed_bytes
+                            .into_iter()
+                            .rev()
+                            .enumerate()
+                            .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                        ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                    },
+                    ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                        match self.params.2.clone().to_bytes_be() {
+                            (num_bigint::Sign::Plus, bytes) => bytes,
+                            (num_bigint::Sign::NoSign, bytes) => bytes,
+                            (num_bigint::Sign::Minus, _) => {
+                                panic!("negative numbers are not supported")
+                            }
+                        }
+                        .as_slice(),
+                    )),
+                ]),
+                ethabi::Token::Bytes(self.hook_data.clone()),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Int(256usize)], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok({
+                let mut v = [0 as u8; 32];
+                values
+                    .pop()
+                    .expect("one output data should have existed")
+                    .into_int()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                substreams::scalar::BigInt::from_signed_bytes_be(&v)
+            })
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Swap {
+        const NAME: &'static str = "swap";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt> for Swap {
+        fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Sync {
+        pub currency: Vec<u8>,
+    }
+    impl Sync {
+        const METHOD_ID: [u8; 4] = [165u8, 132u8, 17u8, 148u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                currency: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(
+                &self.currency,
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Sync {
+        const NAME: &'static str = "sync";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Take {
+        pub currency: Vec<u8>,
+        pub to: Vec<u8>,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl Take {
+        const METHOD_ID: [u8; 4] = [11u8, 13u8, 156u8, 9u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(256usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                currency: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                to: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.currency)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.to)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Take {
+        const NAME: &'static str = "take";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Transfer {
+        pub receiver: Vec<u8>,
+        pub id: substreams::scalar::BigInt,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl Transfer {
+        const METHOD_ID: [u8; 4] = [9u8, 91u8, 205u8, 182u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                receiver: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                id: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.receiver)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.id.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<bool, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<bool, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Bool], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_bool()
+                .expect(INTERNAL_ERR))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<bool> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Transfer {
+        const NAME: &'static str = "transfer";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<bool> for Transfer {
+        fn output(data: &[u8]) -> Result<bool, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct TransferFrom {
+        pub sender: Vec<u8>,
+        pub receiver: Vec<u8>,
+        pub id: substreams::scalar::BigInt,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl TransferFrom {
+        const METHOD_ID: [u8; 4] = [254u8, 153u8, 4u8, 154u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(256usize),
+                    ethabi::ParamType::Uint(256usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                sender: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                receiver: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                id: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.sender)),
+                ethabi::Token::Address(ethabi::Address::from_slice(&self.receiver)),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.id.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self.amount.clone().to_bytes_be() {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<bool, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<bool, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Bool], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_bool()
+                .expect(INTERNAL_ERR))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<bool> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for TransferFrom {
+        const NAME: &'static str = "transferFrom";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<bool> for TransferFrom {
+        fn output(data: &[u8]) -> Result<bool, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct TransferOwnership {
+        pub new_owner: Vec<u8>,
+    }
+    impl TransferOwnership {
+        const METHOD_ID: [u8; 4] = [242u8, 253u8, 227u8, 139u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Address], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                new_owner: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Address(ethabi::Address::from_slice(
+                &self.new_owner,
+            ))]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for TransferOwnership {
+        const NAME: &'static str = "transferOwnership";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Unlock {
+        pub data: Vec<u8>,
+    }
+    impl Unlock {
+        const METHOD_ID: [u8; 4] = [72u8, 200u8, 148u8, 145u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(&[ethabi::ParamType::Bytes], maybe_data.unwrap())
+                .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                data: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_bytes()
+                    .expect(INTERNAL_ERR),
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[ethabi::Token::Bytes(self.data.clone())]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn output_call(
+            call: &substreams_ethereum::pb::eth::v2::Call,
+        ) -> Result<Vec<u8>, String> {
+            Self::output(call.return_data.as_ref())
+        }
+        pub fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Bytes], data.as_ref())
+                .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+            Ok(values
+                .pop()
+                .expect("one output data should have existed")
+                .into_bytes()
+                .expect(INTERNAL_ERR))
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+        pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            use substreams_ethereum::pb::eth::rpc;
+            let rpc_calls = rpc::RpcCalls {
+                calls: vec![rpc::RpcCall { to_addr: address, data: self.encode() }],
+            };
+            let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
+            let response = responses
+                .get(0)
+                .expect("one response should have existed");
+            if response.failed {
+                return None;
+            }
+            match Self::output(response.raw.as_ref()) {
+                Ok(data) => Some(data),
+                Err(err) => {
+                    use substreams_ethereum::Function;
+                    substreams::log::info!(
+                        "Call output for function `{}` failed to decode with error: {}",
+                        Self::NAME,
+                        err
+                    );
+                    None
+                }
+            }
+        }
+    }
+    impl substreams_ethereum::Function for Unlock {
+        const NAME: &'static str = "unlock";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+    impl substreams_ethereum::rpc::RPCDecodable<Vec<u8>> for Unlock {
+        fn output(data: &[u8]) -> Result<Vec<u8>, String> {
+            Self::output(data)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct UpdateDynamicLpFee {
+        pub key:
+            (Vec<u8>, Vec<u8>, substreams::scalar::BigInt, substreams::scalar::BigInt, Vec<u8>),
+        pub new_dynamic_lp_fee: substreams::scalar::BigInt,
+    }
+    impl UpdateDynamicLpFee {
+        const METHOD_ID: [u8; 4] = [82u8, 117u8, 150u8, 81u8];
+        pub fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            let maybe_data = call.input.get(4..);
+            if maybe_data.is_none() {
+                return Err("no data to decode".to_string());
+            }
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Tuple(vec![
+                        ethabi::ParamType::Address,
+                        ethabi::ParamType::Address,
+                        ethabi::ParamType::Uint(24usize),
+                        ethabi::ParamType::Int(24usize),
+                        ethabi::ParamType::Address,
+                    ]),
+                    ethabi::ParamType::Uint(24usize),
+                ],
+                maybe_data.unwrap(),
+            )
+            .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                key: {
+                    let tuple_elements = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_tuple()
+                        .expect(INTERNAL_ERR);
+                    (
+                        tuple_elements[0usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                        tuple_elements[1usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[2usize]
+                                .clone()
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                        },
+                        {
+                            let mut v = [0 as u8; 32];
+                            tuple_elements[3usize]
+                                .clone()
+                                .into_int()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                        },
+                        tuple_elements[4usize]
+                            .clone()
+                            .into_address()
+                            .expect(INTERNAL_ERR)
+                            .as_bytes()
+                            .to_vec(),
+                    )
+                },
+                new_dynamic_lp_fee: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+        pub fn encode(&self) -> Vec<u8> {
+            let data = ethabi::encode(&[
+                ethabi::Token::Tuple(vec![
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.0)),
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.1)),
+                    ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                        match self.key.2.clone().to_bytes_be() {
+                            (num_bigint::Sign::Plus, bytes) => bytes,
+                            (num_bigint::Sign::NoSign, bytes) => bytes,
+                            (num_bigint::Sign::Minus, _) => {
+                                panic!("negative numbers are not supported")
+                            }
+                        }
+                        .as_slice(),
+                    )),
+                    {
+                        let non_full_signed_bytes = self.key.3.to_signed_bytes_be();
+                        let full_signed_bytes_init =
+                            if non_full_signed_bytes[0] & 0x80 == 0x80 { 0xff } else { 0x00 };
+                        let mut full_signed_bytes = [full_signed_bytes_init as u8; 32];
+                        non_full_signed_bytes
+                            .into_iter()
+                            .rev()
+                            .enumerate()
+                            .for_each(|(i, byte)| full_signed_bytes[31 - i] = byte);
+                        ethabi::Token::Int(ethabi::Int::from_big_endian(full_signed_bytes.as_ref()))
+                    },
+                    ethabi::Token::Address(ethabi::Address::from_slice(&self.key.4)),
+                ]),
+                ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+                    match self
+                        .new_dynamic_lp_fee
+                        .clone()
+                        .to_bytes_be()
+                    {
+                        (num_bigint::Sign::Plus, bytes) => bytes,
+                        (num_bigint::Sign::NoSign, bytes) => bytes,
+                        (num_bigint::Sign::Minus, _) => {
+                            panic!("negative numbers are not supported")
+                        }
+                    }
+                    .as_slice(),
+                )),
+            ]);
+            let mut encoded = Vec::with_capacity(4 + data.len());
+            encoded.extend(Self::METHOD_ID);
+            encoded.extend(data);
+            encoded
+        }
+        pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            match call.input.get(0..4) {
+                Some(signature) => Self::METHOD_ID == signature,
+                None => false,
+            }
+        }
+    }
+    impl substreams_ethereum::Function for UpdateDynamicLpFee {
+        const NAME: &'static str = "updateDynamicLPFee";
+        fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
+            Self::match_call(call)
+        }
+        fn decode(call: &substreams_ethereum::pb::eth::v2::Call) -> Result<Self, String> {
+            Self::decode(call)
+        }
+        fn encode(&self) -> Vec<u8> {
+            self.encode()
+        }
+    }
+}
+/// Contract's events.
+#[allow(dead_code, unused_imports, unused_variables)]
+pub mod events {
+    use super::INTERNAL_ERR;
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Approval {
+        pub owner: Vec<u8>,
+        pub spender: Vec<u8>,
+        pub id: substreams::scalar::BigInt,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl Approval {
+        const TOPIC_ID: [u8; 32] = [
+            179u8, 253u8, 80u8, 113u8, 131u8, 88u8, 135u8, 86u8, 122u8, 6u8, 113u8, 21u8, 17u8,
+            33u8, 137u8, 77u8, 220u8, 204u8, 40u8, 66u8, 241u8, 209u8, 11u8, 237u8, 173u8, 19u8,
+            224u8, 209u8, 124u8, 172u8, 233u8, 167u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 4usize {
+                return false;
+            }
+            if log.data.len() != 32usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values =
+                ethabi::decode(&[ethabi::ParamType::Uint(256usize)], log.data.as_ref())
+                    .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                owner: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'owner' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                spender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[2usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'spender' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                id: {
+                    let mut v = [0 as u8; 32];
+                    ethabi::decode(
+                        &[ethabi::ParamType::Uint(256usize)],
+                        log.topics[3usize].as_ref(),
+                    )
+                    .map_err(|e| {
+                        format!("unable to decode param 'id' from topic of type 'uint256': {:?}", e)
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Approval {
+        const NAME: &'static str = "Approval";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Donate {
+        pub id: [u8; 32usize],
+        pub sender: Vec<u8>,
+        pub amount0: substreams::scalar::BigInt,
+        pub amount1: substreams::scalar::BigInt,
+    }
+    impl Donate {
+        const TOPIC_ID: [u8; 32] = [
+            41u8, 239u8, 5u8, 202u8, 175u8, 249u8, 64u8, 75u8, 124u8, 182u8, 209u8, 192u8, 233u8,
+            187u8, 174u8, 158u8, 170u8, 122u8, 178u8, 84u8, 31u8, 235u8, 161u8, 169u8, 196u8, 36u8,
+            133u8, 148u8, 192u8, 129u8, 86u8, 203u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 64usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Uint(256usize), ethabi::ParamType::Uint(256usize)],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                id: {
+                    let mut result = [0u8; 32];
+                    let v = ethabi::decode(
+                        &[ethabi::ParamType::FixedBytes(32usize)],
+                        log.topics[1usize].as_ref(),
+                    )
+                    .map_err(|e| {
+                        format!("unable to decode param 'id' from topic of type 'bytes32': {:?}", e)
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_fixed_bytes()
+                    .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+                sender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[2usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'sender' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount0: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                amount1: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Donate {
+        const NAME: &'static str = "Donate";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Initialize {
+        pub id: [u8; 32usize],
+        pub currency0: Vec<u8>,
+        pub currency1: Vec<u8>,
+        pub fee: substreams::scalar::BigInt,
+        pub tick_spacing: substreams::scalar::BigInt,
+        pub hooks: Vec<u8>,
+        pub sqrt_price_x96: substreams::scalar::BigInt,
+        pub tick: substreams::scalar::BigInt,
+    }
+    impl Initialize {
+        const TOPIC_ID: [u8; 32] = [
+            221u8, 70u8, 110u8, 103u8, 78u8, 165u8, 87u8, 245u8, 98u8, 149u8, 226u8, 208u8, 33u8,
+            138u8, 18u8, 94u8, 164u8, 180u8, 240u8, 246u8, 243u8, 48u8, 123u8, 149u8, 248u8, 94u8,
+            97u8, 16u8, 131u8, 141u8, 100u8, 56u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 4usize {
+                return false;
+            }
+            if log.data.len() != 160usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Uint(24usize),
+                    ethabi::ParamType::Int(24usize),
+                    ethabi::ParamType::Address,
+                    ethabi::ParamType::Uint(160usize),
+                    ethabi::ParamType::Int(24usize),
+                ],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                id: {
+                    let mut result = [0u8; 32];
+                    let v = ethabi::decode(
+                        &[ethabi::ParamType::FixedBytes(32usize)],
+                        log.topics[1usize].as_ref(),
+                    )
+                    .map_err(|e| {
+                        format!("unable to decode param 'id' from topic of type 'bytes32': {:?}", e)
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_fixed_bytes()
+                    .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+                currency0: ethabi::decode(
+                    &[ethabi::ParamType::Address],
+                    log.topics[2usize].as_ref(),
+                )
+                .map_err(|e| {
+                    format!(
+                        "unable to decode param 'currency0' from topic of type 'address': {:?}",
+                        e
+                    )
+                })?
+                .pop()
+                .expect(INTERNAL_ERR)
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec(),
+                currency1: ethabi::decode(
+                    &[ethabi::ParamType::Address],
+                    log.topics[3usize].as_ref(),
+                )
+                .map_err(|e| {
+                    format!(
+                        "unable to decode param 'currency1' from topic of type 'address': {:?}",
+                        e
+                    )
+                })?
+                .pop()
+                .expect(INTERNAL_ERR)
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec(),
+                fee: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                tick_spacing: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                hooks: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                sqrt_price_x96: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                tick: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Initialize {
+        const NAME: &'static str = "Initialize";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct ModifyLiquidity {
+        pub id: [u8; 32usize],
+        pub sender: Vec<u8>,
+        pub tick_lower: substreams::scalar::BigInt,
+        pub tick_upper: substreams::scalar::BigInt,
+        pub liquidity_delta: substreams::scalar::BigInt,
+        pub salt: [u8; 32usize],
+    }
+    impl ModifyLiquidity {
+        const TOPIC_ID: [u8; 32] = [
+            242u8, 8u8, 244u8, 145u8, 39u8, 130u8, 253u8, 37u8, 199u8, 241u8, 20u8, 202u8, 55u8,
+            35u8, 162u8, 213u8, 221u8, 111u8, 59u8, 204u8, 58u8, 200u8, 219u8, 90u8, 246u8, 59u8,
+            170u8, 133u8, 247u8, 17u8, 213u8, 236u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 128usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Int(24usize),
+                    ethabi::ParamType::Int(24usize),
+                    ethabi::ParamType::Int(256usize),
+                    ethabi::ParamType::FixedBytes(32usize),
+                ],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                id: {
+                    let mut result = [0u8; 32];
+                    let v = ethabi::decode(
+                        &[ethabi::ParamType::FixedBytes(32usize)],
+                        log.topics[1usize].as_ref(),
+                    )
+                    .map_err(|e| {
+                        format!("unable to decode param 'id' from topic of type 'bytes32': {:?}", e)
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_fixed_bytes()
+                    .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+                sender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[2usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'sender' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                tick_lower: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                tick_upper: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                liquidity_delta: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                salt: {
+                    let mut result = [0u8; 32];
+                    let v = values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_fixed_bytes()
+                        .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for ModifyLiquidity {
+        const NAME: &'static str = "ModifyLiquidity";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct OperatorSet {
+        pub owner: Vec<u8>,
+        pub operator: Vec<u8>,
+        pub approved: bool,
+    }
+    impl OperatorSet {
+        const TOPIC_ID: [u8; 32] = [
+            206u8, 181u8, 118u8, 217u8, 241u8, 94u8, 78u8, 32u8, 15u8, 219u8, 80u8, 150u8, 214u8,
+            77u8, 93u8, 253u8, 102u8, 126u8, 22u8, 222u8, 242u8, 12u8, 30u8, 239u8, 209u8, 66u8,
+            86u8, 216u8, 227u8, 250u8, 162u8, 103u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 32usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Bool], log.data.as_ref())
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                owner: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'owner' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                operator: ethabi::decode(
+                    &[ethabi::ParamType::Address],
+                    log.topics[2usize].as_ref(),
+                )
+                .map_err(|e| {
+                    format!(
+                        "unable to decode param 'operator' from topic of type 'address': {:?}",
+                        e
+                    )
+                })?
+                .pop()
+                .expect(INTERNAL_ERR)
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec(),
+                approved: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_bool()
+                    .expect(INTERNAL_ERR),
+            })
+        }
+    }
+    impl substreams_ethereum::Event for OperatorSet {
+        const NAME: &'static str = "OperatorSet";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct OwnershipTransferred {
+        pub user: Vec<u8>,
+        pub new_owner: Vec<u8>,
+    }
+    impl OwnershipTransferred {
+        const TOPIC_ID: [u8; 32] = [
+            139u8, 224u8, 7u8, 156u8, 83u8, 22u8, 89u8, 20u8, 19u8, 68u8, 205u8, 31u8, 208u8,
+            164u8, 242u8, 132u8, 25u8, 73u8, 127u8, 151u8, 34u8, 163u8, 218u8, 175u8, 227u8, 180u8,
+            24u8, 111u8, 107u8, 100u8, 87u8, 224u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 0usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Ok(Self {
+                user: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'user' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                new_owner: ethabi::decode(
+                    &[ethabi::ParamType::Address],
+                    log.topics[2usize].as_ref(),
+                )
+                .map_err(|e| {
+                    format!(
+                        "unable to decode param 'new_owner' from topic of type 'address': {:?}",
+                        e
+                    )
+                })?
+                .pop()
+                .expect(INTERNAL_ERR)
+                .into_address()
+                .expect(INTERNAL_ERR)
+                .as_bytes()
+                .to_vec(),
+            })
+        }
+    }
+    impl substreams_ethereum::Event for OwnershipTransferred {
+        const NAME: &'static str = "OwnershipTransferred";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct ProtocolFeeControllerUpdated {
+        pub protocol_fee_controller: Vec<u8>,
+    }
+    impl ProtocolFeeControllerUpdated {
+        const TOPIC_ID: [u8; 32] = [
+            180u8, 189u8, 142u8, 245u8, 61u8, 246u8, 144u8, 185u8, 148u8, 61u8, 51u8, 24u8, 153u8,
+            96u8, 6u8, 219u8, 184u8, 42u8, 37u8, 245u8, 71u8, 25u8, 216u8, 200u8, 3u8, 91u8, 81u8,
+            106u8, 42u8, 91u8, 138u8, 204u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 2usize {
+                return false;
+            }
+            if log.data.len() != 0usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Ok(Self {
+                protocol_fee_controller: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'protocol_fee_controller' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+            })
+        }
+    }
+    impl substreams_ethereum::Event for ProtocolFeeControllerUpdated {
+        const NAME: &'static str = "ProtocolFeeControllerUpdated";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct ProtocolFeeUpdated {
+        pub id: [u8; 32usize],
+        pub protocol_fee: substreams::scalar::BigInt,
+    }
+    impl ProtocolFeeUpdated {
+        const TOPIC_ID: [u8; 32] = [
+            233u8, 196u8, 37u8, 147u8, 231u8, 31u8, 132u8, 64u8, 59u8, 132u8, 53u8, 44u8, 209u8,
+            104u8, 214u8, 147u8, 226u8, 201u8, 252u8, 209u8, 253u8, 188u8, 195u8, 254u8, 178u8,
+            29u8, 146u8, 180u8, 62u8, 102u8, 150u8, 249u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 2usize {
+                return false;
+            }
+            if log.data.len() != 32usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(&[ethabi::ParamType::Uint(24usize)], log.data.as_ref())
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                id: {
+                    let mut result = [0u8; 32];
+                    let v = ethabi::decode(
+                        &[ethabi::ParamType::FixedBytes(32usize)],
+                        log.topics[1usize].as_ref(),
+                    )
+                    .map_err(|e| {
+                        format!("unable to decode param 'id' from topic of type 'bytes32': {:?}", e)
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_fixed_bytes()
+                    .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+                protocol_fee: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for ProtocolFeeUpdated {
+        const NAME: &'static str = "ProtocolFeeUpdated";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Swap {
+        pub id: [u8; 32usize],
+        pub sender: Vec<u8>,
+        pub amount0: substreams::scalar::BigInt,
+        pub amount1: substreams::scalar::BigInt,
+        pub sqrt_price_x96: substreams::scalar::BigInt,
+        pub liquidity: substreams::scalar::BigInt,
+        pub tick: substreams::scalar::BigInt,
+        pub fee: substreams::scalar::BigInt,
+    }
+    impl Swap {
+        const TOPIC_ID: [u8; 32] = [
+            64u8, 233u8, 206u8, 203u8, 159u8, 95u8, 31u8, 28u8, 91u8, 156u8, 151u8, 222u8, 194u8,
+            145u8, 123u8, 126u8, 233u8, 46u8, 87u8, 186u8, 85u8, 99u8, 112u8, 141u8, 172u8, 169u8,
+            77u8, 216u8, 74u8, 215u8, 17u8, 47u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 3usize {
+                return false;
+            }
+            if log.data.len() != 192usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[
+                    ethabi::ParamType::Int(128usize),
+                    ethabi::ParamType::Int(128usize),
+                    ethabi::ParamType::Uint(160usize),
+                    ethabi::ParamType::Uint(128usize),
+                    ethabi::ParamType::Int(24usize),
+                    ethabi::ParamType::Uint(24usize),
+                ],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                id: {
+                    let mut result = [0u8; 32];
+                    let v = ethabi::decode(
+                        &[ethabi::ParamType::FixedBytes(32usize)],
+                        log.topics[1usize].as_ref(),
+                    )
+                    .map_err(|e| {
+                        format!("unable to decode param 'id' from topic of type 'bytes32': {:?}", e)
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_fixed_bytes()
+                    .expect(INTERNAL_ERR);
+                    result.copy_from_slice(&v);
+                    result
+                },
+                sender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[2usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'sender' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount0: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                amount1: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                sqrt_price_x96: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                liquidity: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                tick: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_int()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_signed_bytes_be(&v)
+                },
+                fee: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Swap {
+        const NAME: &'static str = "Swap";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Transfer {
+        pub caller: Vec<u8>,
+        pub from: Vec<u8>,
+        pub to: Vec<u8>,
+        pub id: substreams::scalar::BigInt,
+        pub amount: substreams::scalar::BigInt,
+    }
+    impl Transfer {
+        const TOPIC_ID: [u8; 32] = [
+            27u8, 61u8, 126u8, 219u8, 46u8, 156u8, 11u8, 14u8, 124u8, 82u8, 91u8, 32u8, 170u8,
+            174u8, 240u8, 245u8, 148u8, 13u8, 46u8, 215u8, 22u8, 99u8, 199u8, 211u8, 146u8, 102u8,
+            236u8, 175u8, 172u8, 114u8, 136u8, 89u8,
+        ];
+        pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            if log.topics.len() != 4usize {
+                return false;
+            }
+            if log.data.len() != 64usize {
+                return false;
+            }
+            return log
+                .topics
+                .get(0)
+                .expect("bounds already checked")
+                .as_ref() ==
+                Self::TOPIC_ID;
+        }
+        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            let mut values = ethabi::decode(
+                &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
+                log.data.as_ref(),
+            )
+            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+            values.reverse();
+            Ok(Self {
+                from: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'from' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                to: ethabi::decode(&[ethabi::ParamType::Address], log.topics[2usize].as_ref())
+                    .map_err(|e| {
+                        format!("unable to decode param 'to' from topic of type 'address': {:?}", e)
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                id: {
+                    let mut v = [0 as u8; 32];
+                    ethabi::decode(
+                        &[ethabi::ParamType::Uint(256usize)],
+                        log.topics[3usize].as_ref(),
+                    )
+                    .map_err(|e| {
+                        format!("unable to decode param 'id' from topic of type 'uint256': {:?}", e)
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_uint()
+                    .expect(INTERNAL_ERR)
+                    .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+                caller: values
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
+                amount: {
+                    let mut v = [0 as u8; 32];
+                    values
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
+                },
+            })
+        }
+    }
+    impl substreams_ethereum::Event for Transfer {
+        const NAME: &'static str = "Transfer";
+        fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
+            Self::match_log(log)
+        }
+        fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+            Self::decode(log)
+        }
+    }
+}

--- a/protocols/crates/uniswap-v4/src/balance.rs
+++ b/protocols/crates/uniswap-v4/src/balance.rs
@@ -1,0 +1,87 @@
+use std::str::FromStr;
+
+use num_bigint::BigInt;
+use num_traits::Zero as _;
+
+use crate::{
+    events::{PoolEvent, PoolEventKind},
+    math::calculate_token_amounts,
+};
+
+pub struct BalanceDelta {
+    pub token: Vec<u8>,
+    pub component_id: Vec<u8>,
+    pub delta: BigInt,
+}
+
+/// Computes the component balance deltas an event produces.
+///
+/// `current_sqrt_price` must be the pool's sqrt price as of the event (set by the
+/// last `Initialize` or `Swap` before it) — `ModifyLiquidity` amounts depend on it.
+///
+/// Swap deltas exclude the LP fee portion: collected fees are not part of the
+/// component balance since they aren't accounted for during swaps, so they are
+/// subtracted (rounded half-up) from the incoming-token delta.
+pub fn event_to_balance_deltas(
+    current_sqrt_price: &BigInt,
+    event: &PoolEvent,
+) -> Vec<BalanceDelta> {
+    let component_id = event.pool_id.clone();
+
+    match &event.kind {
+        PoolEventKind::ModifyLiquidity { tick_lower, tick_upper, liquidity_delta } => {
+            let Ok(liquidity_delta) = liquidity_delta.parse::<i128>() else {
+                return vec![];
+            };
+            let Ok((delta0, delta1)) = calculate_token_amounts(
+                current_sqrt_price.clone(),
+                *tick_lower,
+                *tick_upper,
+                liquidity_delta,
+            ) else {
+                return vec![];
+            };
+            vec![
+                BalanceDelta {
+                    token: event.currency0.clone(),
+                    component_id: component_id.clone(),
+                    delta: delta0,
+                },
+                BalanceDelta { token: event.currency1.clone(), component_id, delta: delta1 },
+            ]
+        }
+        PoolEventKind::Swap { amount0, amount1, fee, .. } => {
+            let delta0 = -BigInt::from_str(amount0).unwrap_or_default();
+            let delta1 = -BigInt::from_str(amount1).unwrap_or_default();
+            vec![
+                BalanceDelta {
+                    token: event.currency0.clone(),
+                    component_id: component_id.clone(),
+                    delta: subtract_fee(delta0, *fee),
+                },
+                BalanceDelta {
+                    token: event.currency1.clone(),
+                    component_id,
+                    delta: subtract_fee(delta1, *fee),
+                },
+            ]
+        }
+        PoolEventKind::Initialize { .. } | PoolEventKind::ProtocolFeeUpdated { .. } => vec![],
+    }
+}
+
+/// Removes the LP fee portion from a positive (incoming) swap delta.
+///
+/// Fees are expressed in hundredths of a bip (1e-6). Integer division rounds to
+/// the nearest integer: remainders of at least half the divisor round up.
+fn subtract_fee(delta: BigInt, fee: u32) -> BigInt {
+    if delta <= BigInt::zero() {
+        return delta;
+    }
+    let bips_divisor = BigInt::from(1_000_000u32);
+    let half_divisor = BigInt::from(500_000u32);
+    let fee_part = &delta * fee;
+    let quotient = &fee_part / &bips_divisor;
+    let remainder = &fee_part % &bips_divisor;
+    delta - if remainder >= half_divisor { quotient + 1u32 } else { quotient }
+}

--- a/protocols/crates/uniswap-v4/src/events.rs
+++ b/protocols/crates/uniswap-v4/src/events.rs
@@ -1,0 +1,106 @@
+use substreams_ethereum::Event;
+
+use crate::abi::pool_manager::events::{Initialize, ModifyLiquidity, ProtocolFeeUpdated, Swap};
+
+/// A UniswapV4 pool tracked by the processor. Pools are identified by their
+/// 32-byte `PoolId` rather than a contract address — all events are emitted
+/// by the singleton `PoolManager`.
+#[derive(Clone)]
+pub struct Pool {
+    pub id: Vec<u8>,
+    pub currency0: Vec<u8>,
+    pub currency1: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TxRef {
+    pub hash: Vec<u8>,
+    pub from: Vec<u8>,
+    pub to: Vec<u8>,
+    pub index: u64,
+}
+
+pub enum PoolEventKind {
+    Initialize {
+        sqrt_price: String,
+        tick: i32,
+    },
+    Swap {
+        amount0: String,
+        amount1: String,
+        sqrt_price: String,
+        liquidity: String,
+        tick: i32,
+        fee: u32,
+    },
+    ModifyLiquidity {
+        tick_lower: i32,
+        tick_upper: i32,
+        liquidity_delta: String,
+    },
+    ProtocolFeeUpdated {
+        protocol_fee: u32,
+    },
+}
+
+pub struct PoolEvent {
+    pub log_ordinal: u64,
+    pub pool_id: Vec<u8>,
+    pub currency0: Vec<u8>,
+    pub currency1: Vec<u8>,
+    pub tx: TxRef,
+    pub kind: PoolEventKind,
+}
+
+/// Decodes a `PoolManager` log into the pool id it targets and the event payload.
+///
+/// Returns `None` for logs that are not one of the handled UniswapV4 events
+/// (`Initialize`, `Swap`, `ModifyLiquidity`, `ProtocolFeeUpdated`). `Donate` is
+/// intentionally ignored — it does not affect pool liquidity or tracked state.
+pub fn decode_pool_event(
+    log: &substreams_ethereum::pb::eth::v2::Log,
+) -> Option<(Vec<u8>, PoolEventKind)> {
+    if let Some(init) = Initialize::match_and_decode(log) {
+        return Some((
+            init.id.to_vec(),
+            PoolEventKind::Initialize {
+                sqrt_price: init.sqrt_price_x96.to_string(),
+                tick: init.tick.into(),
+            },
+        ));
+    }
+
+    if let Some(swap) = Swap::match_and_decode(log) {
+        return Some((
+            swap.id.to_vec(),
+            PoolEventKind::Swap {
+                amount0: swap.amount0.to_string(),
+                amount1: swap.amount1.to_string(),
+                sqrt_price: swap.sqrt_price_x96.to_string(),
+                liquidity: swap.liquidity.to_string(),
+                tick: swap.tick.into(),
+                fee: swap.fee.into(),
+            },
+        ));
+    }
+
+    if let Some(modify) = ModifyLiquidity::match_and_decode(log) {
+        return Some((
+            modify.id.to_vec(),
+            PoolEventKind::ModifyLiquidity {
+                tick_lower: modify.tick_lower.into(),
+                tick_upper: modify.tick_upper.into(),
+                liquidity_delta: modify.liquidity_delta.to_string(),
+            },
+        ));
+    }
+
+    if let Some(fee_update) = ProtocolFeeUpdated::match_and_decode(log) {
+        return Some((
+            fee_update.id.to_vec(),
+            PoolEventKind::ProtocolFeeUpdated { protocol_fee: fee_update.protocol_fee.into() },
+        ));
+    }
+
+    None
+}

--- a/protocols/crates/uniswap-v4/src/lib.rs
+++ b/protocols/crates/uniswap-v4/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod abi;
+pub mod balance;
+pub mod events;
+pub mod liquidity;
+pub mod math;
+pub mod output;
+pub mod processor;
+pub mod ticks;

--- a/protocols/crates/uniswap-v4/src/liquidity.rs
+++ b/protocols/crates/uniswap-v4/src/liquidity.rs
@@ -1,0 +1,59 @@
+use std::str::FromStr;
+
+use num_bigint::BigInt;
+
+use crate::events::{PoolEvent, PoolEventKind};
+
+pub enum LiquidityChangeKind {
+    Delta,
+    Absolute,
+}
+
+pub struct LiquidityDelta {
+    pub pool_id: Vec<u8>,
+    pub value: BigInt,
+    pub kind: LiquidityChangeKind,
+}
+
+/// Computes the change to a pool's active liquidity for an event.
+///
+/// `ModifyLiquidity` contributes a delta only when the position straddles the
+/// current tick; `Swap` carries the pool's absolute post-swap liquidity.
+pub fn event_to_liquidity_delta(current_tick: i64, event: &PoolEvent) -> Option<LiquidityDelta> {
+    match &event.kind {
+        PoolEventKind::ModifyLiquidity { tick_lower, tick_upper, liquidity_delta } => {
+            if current_tick >= i64::from(*tick_lower) && current_tick < i64::from(*tick_upper) {
+                Some(LiquidityDelta {
+                    pool_id: event.pool_id.clone(),
+                    value: BigInt::from_str(liquidity_delta).unwrap_or_default(),
+                    kind: LiquidityChangeKind::Delta,
+                })
+            } else {
+                None
+            }
+        }
+        PoolEventKind::Swap { liquidity, .. } => Some(LiquidityDelta {
+            pool_id: event.pool_id.clone(),
+            value: BigInt::from_str(liquidity).unwrap_or_default(),
+            kind: LiquidityChangeKind::Absolute,
+        }),
+        PoolEventKind::Initialize { .. } | PoolEventKind::ProtocolFeeUpdated { .. } => None,
+    }
+}
+
+pub fn event_to_current_tick(event: &PoolEvent) -> Option<i64> {
+    match &event.kind {
+        PoolEventKind::Initialize { tick, .. } => Some(i64::from(*tick)),
+        PoolEventKind::Swap { tick, .. } => Some(i64::from(*tick)),
+        PoolEventKind::ModifyLiquidity { .. } | PoolEventKind::ProtocolFeeUpdated { .. } => None,
+    }
+}
+
+pub fn event_to_current_sqrt_price(event: &PoolEvent) -> Option<BigInt> {
+    match &event.kind {
+        PoolEventKind::Initialize { sqrt_price, .. } | PoolEventKind::Swap { sqrt_price, .. } => {
+            BigInt::from_str(sqrt_price).ok()
+        }
+        PoolEventKind::ModifyLiquidity { .. } | PoolEventKind::ProtocolFeeUpdated { .. } => None,
+    }
+}

--- a/protocols/crates/uniswap-v4/src/math.rs
+++ b/protocols/crates/uniswap-v4/src/math.rs
@@ -1,0 +1,473 @@
+use std::ops::Shr;
+
+use num_bigint::BigInt;
+
+/// Calculates the amounts of token0 and token1 for a given position
+///
+/// Source: https://github.com/Uniswap/v4-core/blob/main/src/libraries/Pool.sol
+/// Function: modifyLiquidity
+///
+/// # Arguments
+/// * `current_sqrt_price` - Current square root price
+/// * `tick_lower` - Lower tick of the position
+/// * `tick_upper` - Upper tick of the position
+/// * `liquidity_delta` - Amount of liquidity to add/remove
+///
+/// # Returns
+/// * `Result<(BigInt, BigInt), String>` - Token amounts (amount0, amount1)
+pub fn calculate_token_amounts(
+    current_sqrt_price: BigInt,
+    tick_lower: i32,
+    tick_upper: i32,
+    liquidity_delta: i128,
+) -> Result<(BigInt, BigInt), String> {
+    let sqrt_price_lower_x96: BigInt = get_sqrt_ratio_at_tick(tick_lower)?;
+    let sqrt_price_upper_x96: BigInt = get_sqrt_ratio_at_tick(tick_upper)?;
+
+    // Calculate amounts based on current price relative to the range
+    let (amount0, amount1) = if current_sqrt_price < sqrt_price_lower_x96 {
+        // Current price is below the range: position in token0
+        let amount0 =
+            get_amount_0_delta_signed(sqrt_price_lower_x96, sqrt_price_upper_x96, liquidity_delta)?;
+        (amount0, BigInt::from(0))
+    } else if current_sqrt_price < sqrt_price_upper_x96 {
+        // Current price is within the range: position in both tokens
+        let amount0 = get_amount_0_delta_signed(
+            current_sqrt_price.clone(),
+            sqrt_price_upper_x96,
+            liquidity_delta,
+        )?;
+
+        let amount1 =
+            get_amount_1_delta_signed(sqrt_price_lower_x96, current_sqrt_price, liquidity_delta)?;
+
+        (amount0, amount1)
+    } else {
+        // Current price is above the range: position in token1
+        let amount1 =
+            get_amount_1_delta_signed(sqrt_price_lower_x96, sqrt_price_upper_x96, liquidity_delta)?;
+
+        (BigInt::from(0), amount1)
+    };
+
+    Ok((amount0, amount1))
+}
+
+const MAX_TICK: i32 = 887272;
+
+/// Returns the sqrt ratio as a Q64.96 for the given tick. The sqrt ratio is computed as
+/// sqrt(1.0001)^tick
+/// Adapted from: https://github.com/shuhuiluo/uniswap-v3-sdk-rs/blob/v2.9.1/src/utils/tick_math.rs#L57
+fn get_sqrt_ratio_at_tick(tick: i32) -> Result<BigInt, String> {
+    let abs_tick = tick.abs();
+
+    if abs_tick > MAX_TICK {
+        return Err("Tick out of bounds".to_string());
+    }
+
+    // Initialize ratio with either 2^128 / sqrt(1.0001) or 2^128
+    let mut ratio = if abs_tick & 0x1 != 0 {
+        BigInt::parse_bytes(b"fffcb933bd6fad37aa2d162d1a594001", 16).unwrap()
+    } else {
+        BigInt::from(1) << 128
+    };
+
+    if abs_tick & 0x2 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"fff97272373d413259a46990580e213a", 16).unwrap())
+            .shr(128);
+    }
+    if abs_tick & 0x4 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"fff2e50f5f656932ef12357cf3c7fdcc", 16).unwrap())
+            .shr(128);
+    }
+    if abs_tick & 0x8 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"ffe5caca7e10e4e61c3624eaa0941cd0", 16).unwrap())
+            .shr(128);
+    }
+    if abs_tick & 0x10 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"ffcb9843d60f6159c9db58835c926644", 16).unwrap())
+            .shr(128);
+    }
+    if abs_tick & 0x20 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"ff973b41fa98c081472e6896dfb254c0", 16).unwrap())
+            .shr(128);
+    }
+    if abs_tick & 0x40 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"ff2ea16466c96a3843ec78b326b52861", 16).unwrap())
+            .shr(128);
+    }
+    if abs_tick & 0x80 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"fe5dee046a99a2a811c461f1969c3053", 16).unwrap())
+            .shr(128);
+    }
+    if abs_tick & 0x100 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"fcbe86c7900a88aedcffc83b479aa3a4", 16).unwrap())
+            .shr(128);
+    }
+    if abs_tick & 0x200 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"f987a7253ac413176f2b074cf7815e54", 16).unwrap())
+            .shr(128);
+    }
+    if abs_tick & 0x400 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"f3392b0822b70005940c7a398e4b70f3", 16).unwrap())
+            .shr(128);
+    }
+    if abs_tick & 0x800 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"e7159475a2c29b7443b29c7fa6e889d9", 16).unwrap())
+            .shr(128);
+    }
+    if abs_tick & 0x1000 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"d097f3bdfd2022b8845ad8f792aa5825", 16).unwrap())
+            .shr(128);
+    }
+    if abs_tick & 0x2000 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"a9f746462d870fdf8a65dc1f90e061e5", 16).unwrap())
+            .shr(128);
+    }
+    if abs_tick & 0x4000 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"70d869a156d2a1b890bb3df62baf32f7", 16).unwrap())
+            .shr(128);
+    }
+    if abs_tick & 0x8000 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"31be135f97d08fd981231505542fcfa6", 16).unwrap())
+            .shr(128);
+    }
+    if abs_tick & 0x10000 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"9aa508b5b7a84e1c677de54f3e99bc9", 16).unwrap())
+            .shr(128);
+    }
+    if abs_tick & 0x20000 != 0 {
+        ratio =
+            (&ratio * BigInt::parse_bytes(b"5d6af8dedb81196699c329225ee604", 16).unwrap()).shr(128);
+    }
+    if abs_tick & 0x40000 != 0 {
+        ratio =
+            (&ratio * BigInt::parse_bytes(b"2216e584f5fa1ea926041bedfe98", 16).unwrap()).shr(128);
+    }
+    if abs_tick & 0x80000 != 0 {
+        ratio = (&ratio * BigInt::parse_bytes(b"48a170391f7dc42444e8fa2", 16).unwrap()).shr(128);
+    }
+
+    if tick > 0 {
+        let max = (BigInt::from(1) << 256) - 1;
+        ratio = max / ratio;
+    }
+    // Add 2^32 - 1 and shift right by 32
+    ratio = (ratio + ((BigInt::from(1) << 32) - 1)) >> 32;
+
+    Ok(ratio)
+}
+
+/// Helper that gets signed token0 delta
+/// Source: https://github.com/shuhuiluo/uniswap-v3-sdk-rs/blob/v2.9.1/src/utils/sqrt_price_math.rs#L422
+///
+/// ## Arguments
+///
+/// * `sqrt_ratio_a_x96`: A sqrt price
+/// * `sqrt_ratio_b_x96`: Another sqrt price
+/// * `liquidity`: The change in liquidity for which to compute the amount0 delta
+///
+/// ## Returns
+///
+/// Amount of token0 corresponding to the passed liquidityDelta between the two prices
+fn get_amount_0_delta_signed(
+    sqrt_ratio_a_x96: BigInt,
+    sqrt_ratio_b_x96: BigInt,
+    liquidity: i128,
+) -> Result<BigInt, String> {
+    let sign = !liquidity.is_negative();
+    // Create mask for negative numbers
+    let mask = if sign { 0u128 } else { u128::MAX };
+
+    // Get absolute value of liquidity using XOR and addition
+    let liquidity = mask ^ mask.wrapping_add_signed(liquidity);
+
+    // Convert mask to BigInt (all 1s or all 0s)
+    let mask = if sign { BigInt::from(0) } else { -BigInt::from(1) };
+
+    let amount_0 = get_amount_0_delta(sqrt_ratio_a_x96, sqrt_ratio_b_x96, liquidity, sign)?;
+
+    // Apply the mask using XOR and subtraction to restore the sign
+    Ok((amount_0 ^ &mask) - mask)
+}
+
+/// Gets the amount0 delta between two prices
+///
+/// Calculates liquidity / sqrt(lower) - liquidity / sqrt(upper),
+/// i.e. liquidity * (sqrt(upper) - sqrt(lower)) / (sqrt(upper) * sqrt(lower))
+///
+/// ## Arguments
+///
+/// * `sqrt_ratio_a_x96`: A sqrt price assumed to be lower otherwise swapped
+/// * `sqrt_ratio_b_x96`: Another sqrt price
+/// * `liquidity`: The amount of usable liquidity
+/// * `round_up`: Whether to round the amount up or down
+///
+/// ## Returns
+///
+/// Amount of token0 required to cover a position of size liquidity between the two passed prices
+fn get_amount_0_delta(
+    sqrt_ratio_a_x96: BigInt,
+    sqrt_ratio_b_x96: BigInt,
+    liquidity: u128,
+    round_up: bool,
+) -> Result<BigInt, String> {
+    let (sqrt_ratio_a_x96, sqrt_ratio_b_x96) = if sqrt_ratio_a_x96 < sqrt_ratio_b_x96 {
+        (sqrt_ratio_a_x96, sqrt_ratio_b_x96)
+    } else {
+        (sqrt_ratio_b_x96, sqrt_ratio_a_x96)
+    };
+
+    if sqrt_ratio_a_x96 == BigInt::from(0) {
+        return Err("Price cannot be zero".to_string());
+    }
+
+    let numerator_1 = BigInt::from(liquidity) << 96;
+    let numerator_2 = &sqrt_ratio_b_x96 - &sqrt_ratio_a_x96;
+
+    if round_up {
+        // For rounding up: ceil(ceil(numerator_1 * numerator_2 / sqrt_ratio_b_x96) /
+        // sqrt_ratio_a_x96)
+        let temp =
+            (&numerator_1 * &numerator_2 + &sqrt_ratio_b_x96 - BigInt::from(1)) / &sqrt_ratio_b_x96;
+        Ok((&temp + &sqrt_ratio_a_x96 - BigInt::from(1)) / sqrt_ratio_a_x96)
+    } else {
+        // For rounding down: floor(floor(numerator_1 * numerator_2 / sqrt_ratio_b_x96) /
+        // sqrt_ratio_a_x96)
+        Ok((&numerator_1 * &numerator_2) / &sqrt_ratio_b_x96 / sqrt_ratio_a_x96)
+    }
+}
+
+const Q96: u128 = 1 << 96;
+
+/// Helper that gets signed token1 delta
+///
+/// ## Arguments
+///
+/// * `sqrt_ratio_a_x96`: A sqrt price
+/// * `sqrt_ratio_b_x96`: Another sqrt price
+/// * `liquidity`: The change in liquidity for which to compute the amount1 delta
+///
+/// ## Returns
+///
+/// Amount of token1 corresponding to the passed liquidityDelta between the two prices
+fn get_amount_1_delta_signed(
+    sqrt_ratio_a_x96: BigInt,
+    sqrt_ratio_b_x96: BigInt,
+    liquidity: i128,
+) -> Result<BigInt, String> {
+    let sign = !liquidity.is_negative();
+
+    // Create mask for negative numbers
+    let mask = if sign { 0u128 } else { u128::MAX };
+
+    // Get absolute value of liquidity using XOR and addition
+    let liquidity = mask ^ mask.wrapping_add_signed(liquidity);
+
+    // Convert mask to BigInt (all 1s or all 0s)
+    let mask = if sign { BigInt::from(0) } else { -BigInt::from(1) };
+
+    let amount_1 = get_amount_1_delta(sqrt_ratio_a_x96, sqrt_ratio_b_x96, liquidity, sign)?;
+
+    // Apply the mask using XOR and subtraction to restore the sign
+    Ok((amount_1 ^ &mask) - mask)
+}
+
+/// Gets the amount1 delta between two prices
+///
+/// Calculates liquidity * (sqrt(upper) - sqrt(lower))
+///
+/// ## Arguments
+///
+/// * `sqrt_ratio_a_x96`: A sqrt price assumed to be lower otherwise swapped
+/// * `sqrt_ratio_b_x96`: Another sqrt price
+/// * `liquidity`: The amount of usable liquidity
+/// * `round_up`: Whether to round the amount up, or down
+///
+/// ## Returns
+///
+/// Amount of token1 required to cover a position of size liquidity between the two passed prices
+fn get_amount_1_delta(
+    sqrt_ratio_a_x96: BigInt,
+    sqrt_ratio_b_x96: BigInt,
+    liquidity: u128,
+    round_up: bool,
+) -> Result<BigInt, String> {
+    let (sqrt_ratio_a_x96, sqrt_ratio_b_x96) = if sqrt_ratio_a_x96 < sqrt_ratio_b_x96 {
+        (sqrt_ratio_a_x96, sqrt_ratio_b_x96)
+    } else {
+        (sqrt_ratio_b_x96, sqrt_ratio_a_x96)
+    };
+
+    let numerator = &sqrt_ratio_b_x96 - &sqrt_ratio_a_x96;
+    let denominator = BigInt::from(Q96);
+
+    let liquidity = BigInt::from(liquidity);
+    let amount_1 = &liquidity * &numerator / &denominator;
+
+    // Calculate if there's a remainder
+    let remainder = (&liquidity * &numerator) % &denominator;
+    let carry = remainder > BigInt::from(0) && round_up;
+
+    Ok(if carry { amount_1 + 1 } else { amount_1 })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use num_bigint::BigInt;
+    use rstest::rstest;
+
+    use super::*;
+    const MIN_TICK: i32 = -887272;
+
+    #[test]
+    fn test_get_sqrt_ratio_at_tick_is_valid_min_tick() {
+        assert_eq!(get_sqrt_ratio_at_tick(MIN_TICK).unwrap(), BigInt::from(4295128739_u128));
+    }
+
+    #[test]
+    fn test_get_sqrt_ratio_at_tick_is_valid_min_tick_add_one() {
+        assert_eq!(get_sqrt_ratio_at_tick(MIN_TICK + 1).unwrap(), BigInt::from(4295343490_u128));
+    }
+
+    #[test]
+    fn test_get_sqrt_ratio_at_tick_is_valid_max_tick() {
+        assert_eq!(
+            get_sqrt_ratio_at_tick(MAX_TICK).unwrap(),
+            BigInt::from_str("1461446703485210103287273052203988822378723970342").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_get_sqrt_ratio_at_tick_is_valid_max_tick_sub_one() {
+        assert_eq!(
+            get_sqrt_ratio_at_tick(MAX_TICK - 1).unwrap(),
+            BigInt::from_str("1461373636630004318706518188784493106690254656249").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_get_sqrt_ratio_at_tick_is_valid_tick_zero() {
+        assert_eq!(
+            get_sqrt_ratio_at_tick(0).unwrap(),
+            BigInt::from_str("79228162514264337593543950336").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_get_sqrt_ratio_at_tick_is_less_than_js_impl_min_tick() {
+        let js_min_sqrt_price = BigInt::from(6085630636u64);
+        let sol_min_sqrt_price = get_sqrt_ratio_at_tick(MIN_TICK).unwrap();
+        assert!(sol_min_sqrt_price < js_min_sqrt_price);
+    }
+
+    #[test]
+    fn test_get_sqrt_ratio_at_tick_is_greater_than_js_impl_max_tick() {
+        let js_max_sqrt_price =
+            BigInt::from_str("1033437718471923706666374484006904511252097097914").unwrap();
+        let sol_max_sqrt_price = get_sqrt_ratio_at_tick(MAX_TICK).unwrap();
+        assert!(sol_max_sqrt_price > js_max_sqrt_price);
+    }
+    #[test]
+    fn test_get_amount_0_delta_returns_0_if_liquidity_is_0() {
+        let result = get_amount_0_delta(
+            BigInt::from_str("79228162514264337593543950336").unwrap(),
+            BigInt::from_str("112045541949572279837463876454").unwrap(),
+            0,
+            true,
+        )
+        .unwrap();
+        assert_eq!(result, BigInt::from(0));
+    }
+
+    #[test]
+    fn test_get_amount_0_delta_returns_0_if_prices_are_equal() {
+        let result = get_amount_0_delta(
+            BigInt::from_str("79228162514264337593543950336").unwrap(),
+            BigInt::from_str("79228162514264337593543950336").unwrap(),
+            0,
+            true,
+        )
+        .unwrap();
+        assert_eq!(result, BigInt::from(0));
+    }
+
+    #[test]
+    fn test_get_amount_0_delta_reverts_if_price_is_zero() {
+        let result = get_amount_0_delta(BigInt::from(0), BigInt::from(1), 1, true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_amount_0_delta_1_amount_1_for_price_of_1_to_1_21() {
+        let sqrt_price_1_1 = BigInt::from_str("79228162514264337593543950336").unwrap();
+        let sqrt_price_121_100 = BigInt::from_str("87150978765690771352898345369").unwrap();
+
+        let amount_0 = get_amount_0_delta(
+            sqrt_price_1_1.clone(),
+            sqrt_price_121_100.clone(),
+            1_000_000_000_000_000_000,
+            true,
+        )
+        .unwrap();
+        assert_eq!(amount_0, BigInt::from(90_909_090_909_090_910u128));
+
+        let amount_0_rounded_down = get_amount_0_delta(
+            sqrt_price_1_1,
+            sqrt_price_121_100,
+            1_000_000_000_000_000_000,
+            false,
+        )
+        .unwrap();
+        assert_eq!(amount_0_rounded_down, amount_0 - 1);
+    }
+
+    #[test]
+    fn test_get_amount_0_delta_works_for_prices_that_overflow() {
+        let sqrt_p_1 = BigInt::from_str("2787593149816327892691964784081045188247552").unwrap();
+        let sqrt_p_2 = BigInt::from_str("22300745198530623141535718272648361505980416").unwrap();
+
+        let amount_0_up =
+            get_amount_0_delta(sqrt_p_1.clone(), sqrt_p_2.clone(), 1_000_000_000_000_000_000, true)
+                .unwrap();
+        let amount_0_down =
+            get_amount_0_delta(sqrt_p_1, sqrt_p_2, 1_000_000_000_000_000_000, false).unwrap();
+
+        assert_eq!(amount_0_up, amount_0_down + 1);
+    }
+
+    #[rstest]
+    #[case(
+        BigInt::from(79228162514264337593543950336_i128),
+        -887270,
+        887270,
+        2779504125,
+        BigInt::from(2779504125_u128),
+        BigInt::from(2779504125_u128)
+    )]
+    #[case(
+        BigInt::from(17189630842187678489986852982138_i128),
+        -138200,
+        107600,
+        -79381057257465377800177,
+        BigInt::from(-445577797388351_i128),
+        BigInt::from(-17222724212376326765220041_i128)
+    )]
+    fn test_calculate_token_amounts(
+        #[case] current_sqrtprice: BigInt,
+        #[case] tick_lower: i32,
+        #[case] tick_upper: i32,
+        #[case] liquidity_delta: i128,
+        #[case] expected_amount0: BigInt,
+        #[case] expected_amount1: BigInt,
+    ) {
+        let (amount0, amount1) =
+            calculate_token_amounts(current_sqrtprice, tick_lower, tick_upper, liquidity_delta)
+                .unwrap();
+
+        assert_eq!(amount0, expected_amount0);
+        assert_eq!(amount1, expected_amount1);
+    }
+}

--- a/protocols/crates/uniswap-v4/src/output.rs
+++ b/protocols/crates/uniswap-v4/src/output.rs
@@ -1,0 +1,53 @@
+use std::str::FromStr;
+
+use num_bigint::BigInt;
+
+use crate::events::{PoolEvent, PoolEventKind};
+
+pub struct AttributeUpdate {
+    pub pool_id: Vec<u8>,
+    pub name: String,
+    pub value: Vec<u8>,
+}
+
+/// Computes plain attribute updates for an event.
+///
+/// `Swap` updates `sqrt_price_x96` and `tick`. `ProtocolFeeUpdated` splits the
+/// packed uint24 fee into the lower 12 bits (`protocol_fees/zero2one`) and the
+/// next 12 bits (`protocol_fees/one2zero`). `Initialize` is handled at pool
+/// creation, not here.
+pub fn event_to_attribute_updates(event: &PoolEvent) -> Vec<AttributeUpdate> {
+    match &event.kind {
+        PoolEventKind::Swap { sqrt_price, tick, .. } => vec![
+            AttributeUpdate {
+                pool_id: event.pool_id.clone(),
+                name: "sqrt_price_x96".to_string(),
+                value: BigInt::from_str(sqrt_price)
+                    .unwrap_or_default()
+                    .to_signed_bytes_be(),
+            },
+            AttributeUpdate {
+                pool_id: event.pool_id.clone(),
+                name: "tick".to_string(),
+                value: BigInt::from(*tick).to_signed_bytes_be(),
+            },
+        ],
+        PoolEventKind::ProtocolFeeUpdated { protocol_fee } => {
+            let zero2one = protocol_fee & 0xFFF;
+            let one2zero = (protocol_fee >> 12) & 0xFFF;
+            vec![
+                AttributeUpdate {
+                    pool_id: event.pool_id.clone(),
+                    name: "protocol_fees/zero2one".to_string(),
+                    value: BigInt::from(zero2one).to_signed_bytes_be(),
+                },
+                AttributeUpdate {
+                    pool_id: event.pool_id.clone(),
+                    name: "protocol_fees/one2zero".to_string(),
+                    value: BigInt::from(one2zero).to_signed_bytes_be(),
+                },
+            ]
+        }
+        PoolEventKind::Initialize { .. } | PoolEventKind::ModifyLiquidity { .. } => vec![],
+    }
+}

--- a/protocols/crates/uniswap-v4/src/processor.rs
+++ b/protocols/crates/uniswap-v4/src/processor.rs
@@ -1,0 +1,434 @@
+use std::collections::{HashMap, HashSet};
+
+use num_bigint::{BigInt, Sign};
+use num_traits::{ToPrimitive as _, Zero as _};
+use tycho_common::{
+    models::{
+        blockchain::{Block, BlockAggregatedChanges, LogInput, TxInput},
+        protocol::{ComponentBalance, ProtocolComponentStateDelta},
+        Chain,
+    },
+    traits::TxDeltaIndexer,
+    Bytes,
+};
+use tycho_substreams::prelude::{
+    Attribute, BalanceChange, ChangeType, EntityChanges, Transaction as SubstreamsTx,
+    TransactionChanges, TransactionChangesBuilder,
+};
+
+use crate::{
+    balance::event_to_balance_deltas,
+    events::{decode_pool_event, Pool, PoolEvent, TxRef},
+    liquidity::{
+        event_to_current_sqrt_price, event_to_current_tick, event_to_liquidity_delta,
+        LiquidityChangeKind,
+    },
+    output::event_to_attribute_updates,
+    ticks::event_to_tick_deltas,
+};
+
+#[derive(Clone)]
+pub struct UniswapV4Processor {
+    chain: Chain,
+    extractor: String,
+    last_block: Option<Block>,
+    finalized_block_height: u64,
+    pools: HashMap<String, Pool>,
+    balances: HashMap<(String, String), BigInt>,
+    tick_liquidity: HashMap<(String, i32), BigInt>,
+    current_tick: HashMap<String, i64>,
+    current_sqrt_price: HashMap<String, BigInt>,
+    pool_liquidity: HashMap<String, BigInt>,
+}
+
+impl TxDeltaIndexer for UniswapV4Processor {
+    fn apply_block(&mut self, block: &BlockAggregatedChanges) {
+        self.chain = block.chain;
+        self.last_block = Some(block.block.clone());
+        self.finalized_block_height = block.finalized_block_height;
+
+        for (id, comp) in &block.new_protocol_components {
+            if comp.tokens.len() >= 2 {
+                self.pools.insert(
+                    id.clone(),
+                    Pool {
+                        id: hex::decode(id.trim_start_matches("0x")).unwrap_or_default(),
+                        currency0: comp.tokens[0].to_vec(),
+                        currency1: comp.tokens[1].to_vec(),
+                    },
+                );
+            }
+        }
+
+        for (component_id, delta) in &block.state_deltas {
+            self.apply_state_delta(component_id, delta);
+        }
+
+        for (component_id, token_balances) in &block.component_balances {
+            for (token_bytes, balance) in token_balances {
+                let token_hex = hex::encode(token_bytes.as_ref());
+                let balance_val = BigInt::from_bytes_be(Sign::Plus, balance.balance.as_ref());
+                self.balances
+                    .insert((component_id.clone(), token_hex), balance_val);
+            }
+        }
+
+        for id in block.deleted_protocol_components.keys() {
+            self.remove_pool(id);
+        }
+    }
+
+    /// Applies a batch of in-flight transactions against the current state and returns the
+    /// protocol state deltas they would produce.
+    ///
+    /// Works on a clone of internal state so repeated calls with the same (or different)
+    /// transactions always produce results relative to the last `apply_block` call.
+    fn generate_deltas(&mut self, txs: &[TxInput]) -> BlockAggregatedChanges {
+        let mut scratch = self.clone();
+        let tx_changes = scratch.build_tx_changes(txs);
+
+        let mut state_deltas: HashMap<String, ProtocolComponentStateDelta> = HashMap::new();
+        let mut component_balances: HashMap<String, HashMap<Bytes, ComponentBalance>> =
+            HashMap::new();
+
+        for changes in tx_changes {
+            let tx_hash = changes
+                .tx
+                .as_ref()
+                .map(|t| Bytes::from(t.hash.clone()))
+                .unwrap_or_default();
+
+            for ec in changes.entity_changes {
+                let delta = state_deltas
+                    .entry(ec.component_id.clone())
+                    .or_insert_with(|| ProtocolComponentStateDelta {
+                        component_id: ec.component_id.clone(),
+                        updated_attributes: HashMap::new(),
+                        deleted_attributes: HashSet::new(),
+                    });
+                for attr in ec.attributes {
+                    if attr.change == i32::from(ChangeType::Deletion) {
+                        delta
+                            .deleted_attributes
+                            .insert(attr.name.clone());
+                        delta
+                            .updated_attributes
+                            .remove(&attr.name);
+                    } else {
+                        delta
+                            .updated_attributes
+                            .insert(attr.name.clone(), Bytes::from(attr.value));
+                        delta
+                            .deleted_attributes
+                            .remove(&attr.name);
+                    }
+                }
+            }
+
+            for bc in changes.balance_changes {
+                let comp_id = hex::encode(&bc.component_id);
+                let token = Bytes::from(bc.token);
+                let balance = Bytes::from(bc.balance);
+                let balance_float = BigInt::from_bytes_be(Sign::Plus, balance.as_ref())
+                    .to_f64()
+                    .unwrap_or(f64::MAX);
+                component_balances
+                    .entry(comp_id.clone())
+                    .or_default()
+                    .insert(
+                        token.clone(),
+                        ComponentBalance {
+                            token,
+                            balance,
+                            balance_float,
+                            modify_tx: tx_hash.clone(),
+                            component_id: comp_id,
+                        },
+                    );
+            }
+        }
+
+        BlockAggregatedChanges {
+            extractor: self.extractor.clone(),
+            chain: self.chain,
+            block: self.pending_block(),
+            finalized_block_height: self.finalized_block_height,
+            state_deltas,
+            component_balances,
+            ..Default::default()
+        }
+    }
+}
+
+impl UniswapV4Processor {
+    pub fn new(chain: Chain, extractor: String) -> Self {
+        Self {
+            chain,
+            extractor,
+            last_block: None,
+            finalized_block_height: 0,
+            pools: HashMap::new(),
+            balances: HashMap::new(),
+            tick_liquidity: HashMap::new(),
+            current_tick: HashMap::new(),
+            current_sqrt_price: HashMap::new(),
+            pool_liquidity: HashMap::new(),
+        }
+    }
+
+    /// Constructs the pending-block descriptor for `generate_deltas` output.
+    ///
+    /// Number is `last_block + 1`; hash is zeroed because the block has not
+    /// been mined yet.
+    fn pending_block(&self) -> Block {
+        match &self.last_block {
+            Some(b) => Block {
+                number: b.number + 1,
+                hash: Bytes::default(),
+                parent_hash: b.hash.clone(),
+                chain: b.chain,
+                ts: b.ts,
+            },
+            None => Block::default(),
+        }
+    }
+
+    fn apply_state_delta(&mut self, component_id: &str, delta: &ProtocolComponentStateDelta) {
+        for attr_name in &delta.deleted_attributes {
+            if attr_name == "tick" {
+                self.current_tick.remove(component_id);
+            } else if attr_name == "liquidity" {
+                self.pool_liquidity.remove(component_id);
+            } else if attr_name == "sqrt_price_x96" {
+                self.current_sqrt_price
+                    .remove(component_id);
+            } else if let Some(rest) = attr_name.strip_prefix("ticks/") {
+                if let Some(idx_str) = rest.strip_suffix("/net-liquidity") {
+                    if let Ok(idx) = idx_str.parse::<i32>() {
+                        self.tick_liquidity
+                            .remove(&(component_id.to_string(), idx));
+                    }
+                }
+            }
+        }
+
+        for (attr_name, attr_val) in &delta.updated_attributes {
+            if attr_name == "tick" {
+                let tick_val = BigInt::from_signed_bytes_be(attr_val.as_ref());
+                let (sign, digits) = tick_val.to_u64_digits();
+                let magnitude = digits.first().copied().unwrap_or(0) as i64;
+                let tick_i64 = if sign == Sign::Minus { -magnitude } else { magnitude };
+                self.current_tick
+                    .insert(component_id.to_string(), tick_i64);
+            } else if attr_name == "liquidity" {
+                self.pool_liquidity.insert(
+                    component_id.to_string(),
+                    BigInt::from_signed_bytes_be(attr_val.as_ref()),
+                );
+            } else if attr_name == "sqrt_price_x96" {
+                self.current_sqrt_price.insert(
+                    component_id.to_string(),
+                    BigInt::from_signed_bytes_be(attr_val.as_ref()),
+                );
+            } else if let Some(rest) = attr_name.strip_prefix("ticks/") {
+                if let Some(idx_str) = rest.strip_suffix("/net-liquidity") {
+                    if let Ok(idx) = idx_str.parse::<i32>() {
+                        self.tick_liquidity.insert(
+                            (component_id.to_string(), idx),
+                            BigInt::from_signed_bytes_be(attr_val.as_ref()),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn remove_pool(&mut self, id: &str) {
+        self.pools.remove(id);
+        self.current_tick.remove(id);
+        self.current_sqrt_price.remove(id);
+        self.pool_liquidity.remove(id);
+        self.balances
+            .retain(|(pool_id, _), _| pool_id != id);
+        self.tick_liquidity
+            .retain(|(pool_id, _), _| pool_id != id);
+    }
+
+    fn build_tx_changes(&mut self, txs: &[TxInput]) -> Vec<TransactionChanges> {
+        let mut tx_builders: HashMap<Vec<u8>, (u64, TransactionChangesBuilder)> = HashMap::new();
+
+        for tx in txs {
+            if !tx.succeeded() {
+                continue;
+            }
+
+            let tx_ref = TxRef {
+                hash: tx.hash().to_vec(),
+                from: tx.from().to_vec(),
+                to: tx.to().to_vec(),
+                index: tx.index(),
+            };
+
+            let mut events: Vec<PoolEvent> = Vec::new();
+            for log in tx.logs() {
+                let ordinal = tx.index() * 100_000 + log.log_index() as u64;
+                let pb_log = log_input_to_pb(log, ordinal);
+                let Some((pool_id, kind)) = decode_pool_event(&pb_log) else { continue };
+                let pool_hex = hex::encode(&pool_id);
+                let Some(pool) = self.pools.get(&pool_hex) else { continue };
+                events.push(PoolEvent {
+                    log_ordinal: ordinal,
+                    pool_id,
+                    currency0: pool.currency0.clone(),
+                    currency1: pool.currency1.clone(),
+                    tx: tx_ref.clone(),
+                    kind,
+                });
+            }
+
+            if events.is_empty() {
+                continue;
+            }
+
+            tx_builders
+                .entry(tx.hash().to_vec())
+                .or_insert_with(|| {
+                    let substreams_tx = SubstreamsTx {
+                        hash: tx.hash().to_vec(),
+                        from: tx.from().to_vec(),
+                        to: tx.to().to_vec(),
+                        index: tx.index(),
+                    };
+                    (tx.index(), TransactionChangesBuilder::new(&substreams_tx))
+                });
+
+            for event in events {
+                let (_, builder) = tx_builders
+                    .get_mut(tx.hash().as_ref())
+                    .expect("builder inserted above");
+                self.apply_event(event, builder);
+            }
+        }
+
+        let mut ordered: Vec<(u64, TransactionChangesBuilder)> =
+            tx_builders.into_values().collect();
+        ordered.sort_unstable_by_key(|(idx, _)| *idx);
+        ordered
+            .into_iter()
+            .filter_map(|(_, b)| b.build())
+            .collect()
+    }
+
+    fn apply_event(&mut self, event: PoolEvent, builder: &mut TransactionChangesBuilder) {
+        let pool_hex = hex::encode(&event.pool_id);
+
+        if let Some(new_tick) = event_to_current_tick(&event) {
+            self.current_tick
+                .insert(pool_hex.clone(), new_tick);
+        }
+        if let Some(new_sqrt_price) = event_to_current_sqrt_price(&event) {
+            self.current_sqrt_price
+                .insert(pool_hex.clone(), new_sqrt_price);
+        }
+
+        let sqrt_price = self
+            .current_sqrt_price
+            .get(&pool_hex)
+            .cloned()
+            .unwrap_or_default();
+        for delta in event_to_balance_deltas(&sqrt_price, &event) {
+            let token_hex = hex::encode(&delta.token);
+            let running = self
+                .balances
+                .entry((pool_hex.clone(), token_hex))
+                .or_default();
+            *running += &delta.delta;
+            let clamped =
+                if *running < BigInt::default() { BigInt::default() } else { running.clone() };
+            builder.add_balance_change(&BalanceChange {
+                component_id: event.pool_id.clone(),
+                token: delta.token.clone(),
+                balance: clamped.to_bytes_be().1,
+            });
+        }
+
+        for tick_delta in event_to_tick_deltas(&event) {
+            let key = (pool_hex.clone(), tick_delta.tick_index);
+            let was_zero_or_missing = self
+                .tick_liquidity
+                .get(&key)
+                .is_none_or(|v| v.is_zero());
+            let running = self
+                .tick_liquidity
+                .entry(key)
+                .or_default();
+            *running += &tick_delta.liquidity_net_delta;
+            let new_val = running.clone();
+
+            let change_type = if was_zero_or_missing {
+                ChangeType::Creation
+            } else if new_val.is_zero() {
+                ChangeType::Deletion
+            } else {
+                ChangeType::Update
+            };
+
+            builder.add_entity_change(&EntityChanges {
+                component_id: pool_hex.clone(),
+                attributes: vec![Attribute {
+                    name: format!("ticks/{}/net-liquidity", tick_delta.tick_index),
+                    value: new_val.to_signed_bytes_be(),
+                    change: change_type.into(),
+                }],
+            });
+        }
+
+        let cur_tick = *self
+            .current_tick
+            .get(&pool_hex)
+            .unwrap_or(&0);
+        if let Some(liq_delta) = event_to_liquidity_delta(cur_tick, &event) {
+            let running = self
+                .pool_liquidity
+                .entry(pool_hex.clone())
+                .or_default();
+            match liq_delta.kind {
+                LiquidityChangeKind::Delta => *running += &liq_delta.value,
+                LiquidityChangeKind::Absolute => *running = liq_delta.value.clone(),
+            }
+            builder.add_entity_change(&EntityChanges {
+                component_id: pool_hex.clone(),
+                attributes: vec![Attribute {
+                    name: "liquidity".to_string(),
+                    value: running.to_signed_bytes_be(),
+                    change: ChangeType::Update.into(),
+                }],
+            });
+        }
+
+        for attr_update in event_to_attribute_updates(&event) {
+            builder.add_entity_change(&EntityChanges {
+                component_id: hex::encode(&attr_update.pool_id),
+                attributes: vec![Attribute {
+                    name: attr_update.name,
+                    value: attr_update.value,
+                    change: ChangeType::Update.into(),
+                }],
+            });
+        }
+    }
+}
+
+fn log_input_to_pb(log: &LogInput, ordinal: u64) -> substreams_ethereum::pb::eth::v2::Log {
+    substreams_ethereum::pb::eth::v2::Log {
+        address: log.address().to_vec(),
+        topics: log
+            .topics()
+            .iter()
+            .map(|t| t.to_vec())
+            .collect(),
+        data: log.data().to_vec(),
+        ordinal,
+        ..Default::default()
+    }
+}

--- a/protocols/crates/uniswap-v4/src/processor.rs
+++ b/protocols/crates/uniswap-v4/src/processor.rs
@@ -49,10 +49,11 @@ impl TxDeltaIndexer for UniswapV4Processor {
 
         for (id, comp) in &block.new_protocol_components {
             if comp.tokens.len() >= 2 {
+                let key = normalize_id(id);
                 self.pools.insert(
-                    id.clone(),
+                    key.clone(),
                     Pool {
-                        id: hex::decode(id.trim_start_matches("0x")).unwrap_or_default(),
+                        id: hex::decode(&key).unwrap_or_default(),
                         currency0: comp.tokens[0].to_vec(),
                         currency1: comp.tokens[1].to_vec(),
                     },
@@ -61,25 +62,29 @@ impl TxDeltaIndexer for UniswapV4Processor {
         }
 
         for (component_id, delta) in &block.state_deltas {
-            self.apply_state_delta(component_id, delta);
+            self.apply_state_delta(&normalize_id(component_id), delta);
         }
 
         for (component_id, token_balances) in &block.component_balances {
+            let comp_key = normalize_id(component_id);
             for (token_bytes, balance) in token_balances {
                 let token_hex = hex::encode(token_bytes.as_ref());
                 let balance_val = BigInt::from_bytes_be(Sign::Plus, balance.balance.as_ref());
                 self.balances
-                    .insert((component_id.clone(), token_hex), balance_val);
+                    .insert((comp_key.clone(), token_hex), balance_val);
             }
         }
 
         for id in block.deleted_protocol_components.keys() {
-            self.remove_pool(id);
+            self.remove_pool(&normalize_id(id));
         }
     }
 
     /// Applies a batch of in-flight transactions against the current state and returns the
     /// protocol state deltas they would produce.
+    ///
+    /// Component ids in the output use the same format the substreams packages emit
+    /// ("0x"-prefixed lower-case hex), so they match decoder state keys downstream.
     ///
     /// Works on a clone of internal state so repeated calls with the same (or different)
     /// transactions always produce results relative to the last `apply_block` call.
@@ -99,10 +104,11 @@ impl TxDeltaIndexer for UniswapV4Processor {
                 .unwrap_or_default();
 
             for ec in changes.entity_changes {
+                let component_id = emitted_id(&ec.component_id);
                 let delta = state_deltas
-                    .entry(ec.component_id.clone())
+                    .entry(component_id.clone())
                     .or_insert_with(|| ProtocolComponentStateDelta {
-                        component_id: ec.component_id.clone(),
+                        component_id: component_id.clone(),
                         updated_attributes: HashMap::new(),
                         deleted_attributes: HashSet::new(),
                     });
@@ -126,7 +132,7 @@ impl TxDeltaIndexer for UniswapV4Processor {
             }
 
             for bc in changes.balance_changes {
-                let comp_id = hex::encode(&bc.component_id);
+                let comp_id = emitted_id(&hex::encode(&bc.component_id));
                 let token = Bytes::from(bc.token);
                 let balance = Bytes::from(bc.balance);
                 let balance_float = BigInt::from_bytes_be(Sign::Plus, balance.as_ref())
@@ -417,6 +423,18 @@ impl UniswapV4Processor {
             });
         }
     }
+}
+
+/// Canonical internal key for a component id: lower-case hex without the "0x" prefix.
+fn normalize_id(id: &str) -> String {
+    id.trim_start_matches("0x")
+        .to_lowercase()
+}
+
+/// Formats a canonical internal key into the id format the substreams packages emit
+/// ("0x"-prefixed lower-case hex).
+fn emitted_id(canonical_hex: &str) -> String {
+    format!("0x{canonical_hex}")
 }
 
 fn log_input_to_pb(log: &LogInput, ordinal: u64) -> substreams_ethereum::pb::eth::v2::Log {

--- a/protocols/crates/uniswap-v4/src/ticks.rs
+++ b/protocols/crates/uniswap-v4/src/ticks.rs
@@ -1,0 +1,39 @@
+use std::str::FromStr;
+
+use num_bigint::BigInt;
+
+use crate::events::{PoolEvent, PoolEventKind};
+
+pub struct TickDelta {
+    pub pool_id: Vec<u8>,
+    pub tick_index: i32,
+    pub liquidity_net_delta: BigInt,
+}
+
+/// Computes per-tick net-liquidity deltas for an event.
+///
+/// On UniswapV4 only `ModifyLiquidity` changes tick liquidity. A positive
+/// `liquidity_delta` (mint) adds at the lower tick and subtracts at the upper;
+/// a negative one (burn) does the opposite.
+pub fn event_to_tick_deltas(event: &PoolEvent) -> Vec<TickDelta> {
+    match &event.kind {
+        PoolEventKind::ModifyLiquidity { tick_lower, tick_upper, liquidity_delta } => {
+            let amount = BigInt::from_str(liquidity_delta).unwrap_or_default();
+            vec![
+                TickDelta {
+                    pool_id: event.pool_id.clone(),
+                    tick_index: *tick_lower,
+                    liquidity_net_delta: amount.clone(),
+                },
+                TickDelta {
+                    pool_id: event.pool_id.clone(),
+                    tick_index: *tick_upper,
+                    liquidity_net_delta: -amount,
+                },
+            ]
+        }
+        PoolEventKind::Initialize { .. } |
+        PoolEventKind::Swap { .. } |
+        PoolEventKind::ProtocolFeeUpdated { .. } => vec![],
+    }
+}

--- a/protocols/crates/uniswap-v4/tests/integration.rs
+++ b/protocols/crates/uniswap-v4/tests/integration.rs
@@ -1,0 +1,680 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use alloy::{
+    consensus::Transaction as _,
+    eips::BlockNumberOrTag,
+    primitives::{address, Address, B256},
+    providers::{Provider, ProviderBuilder},
+    rpc::types::{BlockTransactions, Filter, Log},
+    transports::http::reqwest::Url,
+};
+use num_bigint::{BigInt, Sign};
+use num_traits::ToPrimitive as _;
+use prost::Message;
+use tokio_stream::StreamExt;
+use tycho_common::{
+    models::{
+        blockchain::{Block, BlockAggregatedChanges, LogInput, TxInput},
+        protocol::{ComponentBalance, ProtocolComponent, ProtocolComponentStateDelta},
+        Chain,
+    },
+    traits::TxDeltaIndexer,
+    Bytes,
+};
+use tycho_indexer::{
+    pb::sf::substreams::v1::Package,
+    substreams::{
+        stream::{BlockResponse, SubstreamsStream},
+        SubstreamsEndpoint,
+    },
+};
+use tycho_substreams::pb::tycho::evm::v1::BlockChanges;
+use uniswap_v4_core::processor::UniswapV4Processor;
+
+// V4 launch activity was sparse: the PoolManager deployed at 21_688_329 but pools and
+// swaps only picked up days later. Default to a 2000-block window (~8 h of chain time)
+// with steady pool creations, swaps, and liquidity changes. Override with
+// UV4_START_BLOCK / UV4_STOP_BLOCK for a different range.
+const DEFAULT_START_BLOCK: u64 = 21_750_000;
+const DEFAULT_STOP_BLOCK: u64 = DEFAULT_START_BLOCK + 2_000; // 21_752_000
+
+// All UV4 events are emitted by the singleton PoolManager.
+const POOL_MANAGER: Address = address!("000000000004444c5dc75cB358380D2e3dE08A90");
+
+// ─── Substreams helpers ──────────────────────────────────────────────────────
+
+/// Streams every block in `[start, stop]` from the substreams endpoint and
+/// returns `(block_number, block_hash, BlockChanges)` triples in ascending order.
+async fn stream_block_range(
+    endpoint_url: &str,
+    api_key: &str,
+    spkg_path: &str,
+    start: u64,
+    stop: u64,
+) -> Vec<(u64, String, BlockChanges)> {
+    let content = std::fs::read(spkg_path)
+        .unwrap_or_else(|e| panic!("Failed to read spkg at {spkg_path}: {e}"));
+    let package = Package::decode(content.as_slice())
+        .unwrap_or_else(|e| panic!("Failed to decode spkg: {e}"));
+
+    let endpoint = Arc::new(
+        SubstreamsEndpoint::new(endpoint_url, Some(api_key.to_string()))
+            .await
+            .expect("Failed to create substreams endpoint"),
+    );
+
+    let mut stream = SubstreamsStream::new(
+        endpoint,
+        None,
+        Some(package),
+        "map_protocol_changes".to_string(),
+        start as i64,
+        stop,
+        true,
+        "integration-test".to_string(),
+        false,
+    );
+
+    let mut results = Vec::new();
+    loop {
+        match stream.next().await {
+            Some(Ok(BlockResponse::New(data))) => {
+                let (block_num, block_hash) = data
+                    .clock
+                    .as_ref()
+                    .map_or((0, String::new()), |c| (c.number, c.id.clone()));
+                let map_output = data
+                    .output
+                    .as_ref()
+                    .and_then(|o| o.map_output.as_ref())
+                    .expect("BlockScopedData has no map_output");
+                let changes = BlockChanges::decode(map_output.value.as_slice())
+                    .expect("Failed to decode BlockChanges");
+                results.push((block_num, block_hash, changes));
+            }
+            Some(Ok(BlockResponse::Ended)) => break,
+            Some(Ok(BlockResponse::Undo(_))) => {
+                // Undo signals should not appear with final_blocks_only=true.
+                panic!("Unexpected undo signal in range [{start}, {stop}]");
+            }
+            Some(Err(e)) => panic!("Substreams stream error: {e}"),
+            None => break,
+        }
+    }
+
+    results.sort_unstable_by_key(|(n, _, _)| *n);
+    results
+}
+
+// ─── Archive RPC helpers ─────────────────────────────────────────────────────
+
+// Canonical Uniswap V4 PoolManager event ABI signatures handled by the processor.
+// Passed to `Filter::events` which hashes them to topic0 values internally.
+const UV4_EVENT_SIGNATURES: [&str; 4] = [
+    "Initialize(bytes32,address,address,uint24,int24,address,uint160,int24)",
+    "Swap(bytes32,address,int128,int128,uint160,uint128,int24,uint24)",
+    "ModifyLiquidity(bytes32,address,int24,int24,int256,bytes32)",
+    "ProtocolFeeUpdated(bytes32,uint24)",
+];
+
+/// Returns all UV4 PoolManager logs emitted in `[start_block, stop_block]`.
+///
+/// Chunked into 10,000-block pages to stay within Alchemy's eth_getLogs limit.
+async fn fetch_range_logs(rpc_url: &str, start_block: u64, stop_block: u64) -> Vec<Log> {
+    const CHUNK: u64 = 10_000;
+    let provider = ProviderBuilder::new().connect_http(
+        rpc_url
+            .parse::<Url>()
+            .expect("invalid RPC URL"),
+    );
+    let mut logs = Vec::new();
+    let mut chunk_start = start_block;
+    while chunk_start <= stop_block {
+        let chunk_end = (chunk_start + CHUNK - 1).min(stop_block);
+        let filter = Filter::new()
+            .address(POOL_MANAGER)
+            .from_block(chunk_start)
+            .to_block(chunk_end)
+            .events(UV4_EVENT_SIGNATURES);
+        let chunk_logs = provider
+            .get_logs(&filter)
+            .await
+            .unwrap_or_else(|e| panic!("eth_getLogs [{chunk_start},{chunk_end}] failed: {e}"));
+        logs.extend(chunk_logs);
+        chunk_start = chunk_end + 1;
+    }
+    logs
+}
+
+/// Returns `{tx_hash → (from_bytes, to_bytes, tx_index)}` for all transactions
+/// in the given block by fetching the full block once.
+async fn fetch_block_tx_meta(
+    rpc_url: &str,
+    block_num: u64,
+) -> HashMap<B256, (Vec<u8>, Vec<u8>, u64)> {
+    use alloy::network::{BlockResponse as _, TransactionResponse as _};
+
+    let provider = ProviderBuilder::new().connect_http(
+        rpc_url
+            .parse::<Url>()
+            .expect("invalid RPC URL"),
+    );
+    let block = provider
+        .get_block_by_number(BlockNumberOrTag::Number(block_num))
+        .full()
+        .await
+        .unwrap_or_else(|e| panic!("eth_getBlockByNumber({block_num}) failed: {e}"))
+        .unwrap_or_else(|| panic!("block {block_num} not found"));
+
+    let mut map = HashMap::new();
+    if let BlockTransactions::Full(txns) = block.transactions() {
+        for tx in txns {
+            let hash = tx.tx_hash();
+            let from = tx.from().to_vec();
+            // `to()` lives on the inner consensus transaction.
+            let to = tx
+                .inner
+                .to()
+                .map(|a| a.to_vec())
+                .unwrap_or_default();
+            let index = tx
+                .transaction_index()
+                .unwrap_or_default();
+            map.insert(hash, (from, to, index));
+        }
+    }
+    map
+}
+
+/// Returns a `HashMap<block_num, Vec<TxInput>>` for every block in
+/// `[start_block, stop_block]` that emitted at least one log.
+///
+/// Transactions are ordered by transaction index within each block.
+/// All transactions that emitted logs are treated as succeeded — the EVM
+/// does not emit logs for reverted transactions.
+async fn fetch_range_tx_inputs(
+    rpc_url: &str,
+    start_block: u64,
+    stop_block: u64,
+) -> HashMap<u64, Vec<TxInput>> {
+    let logs = fetch_range_logs(rpc_url, start_block, stop_block).await;
+
+    // Group logs by block number, then by tx hash.
+    let mut blocks_with_tx_hashes: HashMap<u64, HashSet<B256>> = HashMap::new();
+    let mut logs_by_key: HashMap<(u64, B256), Vec<LogInput>> = HashMap::new();
+
+    for log in &logs {
+        let Some(block_num) = log.block_number else { continue };
+        let Some(hash) = log.transaction_hash else { continue };
+        blocks_with_tx_hashes
+            .entry(block_num)
+            .or_default()
+            .insert(hash);
+        logs_by_key
+            .entry((block_num, hash))
+            .or_default()
+            .push(LogInput::new(
+                Bytes::from(log.address().to_vec()),
+                log.topics()
+                    .iter()
+                    .map(|t| Bytes::from(t.to_vec()))
+                    .collect(),
+                Bytes::from(log.data().data.to_vec()),
+                log.log_index.unwrap_or_default() as u32,
+            ));
+    }
+
+    let mut result: HashMap<u64, Vec<TxInput>> = HashMap::new();
+
+    for (block_num, tx_hashes) in blocks_with_tx_hashes {
+        let meta = fetch_block_tx_meta(rpc_url, block_num).await;
+        let mut tx_inputs: Vec<TxInput> = tx_hashes
+            .into_iter()
+            .filter_map(|hash| {
+                let (from, to, index) = meta.get(&hash)?.clone();
+                let logs = logs_by_key
+                    .remove(&(block_num, hash))
+                    .unwrap_or_default();
+                Some(TxInput::new(
+                    Bytes::from(hash.to_vec()),
+                    Bytes::from(from),
+                    Bytes::from(to),
+                    index,
+                    logs,
+                    true,
+                ))
+            })
+            .collect();
+        tx_inputs.sort_unstable_by_key(|t| t.index());
+        result.insert(block_num, tx_inputs);
+    }
+
+    result
+}
+
+// ─── Conversion helpers ──────────────────────────────────────────────────────
+
+/// Normalise a component_id from substreams output to lower-case hex without "0x".
+fn normalise_component_id(raw: &[u8]) -> String {
+    let s = std::str::from_utf8(raw).unwrap_or_default();
+    s.trim_start_matches("0x")
+        .to_lowercase()
+}
+
+fn normalise_str_id(s: &str) -> String {
+    s.trim_start_matches("0x")
+        .to_lowercase()
+}
+
+/// Converts a substreams proto `BlockChanges` to a `BlockAggregatedChanges`, aggregating
+/// all per-transaction entity and balance changes across the block.
+fn substreams_proto_to_model(
+    proto: &BlockChanges,
+    block_num: u64,
+    block_hash_hex: &str,
+) -> BlockAggregatedChanges {
+    use tycho_substreams::prelude::ChangeType as ProtoChangeType;
+
+    let hash_bytes = hex::decode(block_hash_hex.trim_start_matches("0x")).unwrap_or_default();
+    let block = Block {
+        number: block_num,
+        hash: Bytes::from(hash_bytes),
+        parent_hash: Bytes::default(),
+        chain: Chain::Ethereum,
+        ts: Default::default(),
+    };
+
+    let mut new_protocol_components: HashMap<String, ProtocolComponent> = HashMap::new();
+    let mut state_deltas: HashMap<String, ProtocolComponentStateDelta> = HashMap::new();
+    let mut component_balances: HashMap<String, HashMap<Bytes, ComponentBalance>> = HashMap::new();
+
+    for tx_changes in &proto.changes {
+        for comp in &tx_changes.component_changes {
+            let id = normalise_str_id(&comp.id);
+            new_protocol_components
+                .entry(id.clone())
+                .or_insert_with(|| ProtocolComponent {
+                    id: id.clone(),
+                    tokens: comp
+                        .tokens
+                        .iter()
+                        .map(|t| Bytes::from(t.clone()))
+                        .collect(),
+                    ..Default::default()
+                });
+        }
+
+        for ec in &tx_changes.entity_changes {
+            let cid = normalise_str_id(&ec.component_id);
+            let delta = state_deltas
+                .entry(cid.clone())
+                .or_insert_with(|| ProtocolComponentStateDelta {
+                    component_id: cid.clone(),
+                    updated_attributes: HashMap::new(),
+                    deleted_attributes: HashSet::new(),
+                });
+            for attr in &ec.attributes {
+                if attr.change == i32::from(ProtoChangeType::Deletion) {
+                    delta
+                        .deleted_attributes
+                        .insert(attr.name.clone());
+                    delta
+                        .updated_attributes
+                        .remove(&attr.name);
+                } else {
+                    delta
+                        .updated_attributes
+                        .insert(attr.name.clone(), Bytes::from(attr.value.clone()));
+                    delta
+                        .deleted_attributes
+                        .remove(&attr.name);
+                }
+            }
+        }
+
+        for bc in &tx_changes.balance_changes {
+            let cid = normalise_component_id(&bc.component_id);
+            let token = Bytes::from(bc.token.clone());
+            let balance = Bytes::from(bc.balance.clone());
+            let balance_float = BigInt::from_bytes_be(Sign::Plus, balance.as_ref())
+                .to_f64()
+                .unwrap_or(f64::MAX);
+            component_balances
+                .entry(cid.clone())
+                .or_default()
+                .insert(
+                    token.clone(),
+                    ComponentBalance {
+                        token,
+                        balance,
+                        balance_float,
+                        modify_tx: Bytes::default(),
+                        component_id: cid,
+                    },
+                );
+        }
+    }
+
+    BlockAggregatedChanges {
+        extractor: "uniswap-v4".to_string(),
+        chain: Chain::Ethereum,
+        block,
+        finalized_block_height: block_num,
+        state_deltas,
+        new_protocol_components,
+        component_balances,
+        ..Default::default()
+    }
+}
+
+// ─── Comparison helpers ──────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct ComparableBlockChanges {
+    /// component_id → { attr_name → value }
+    attributes: HashMap<String, HashMap<String, Vec<u8>>>,
+    /// (component_id, token_hex) → balance
+    balances: HashMap<(String, String), Vec<u8>>,
+}
+
+/// Aggregates all per-transaction entity/balance changes from a substreams block into a
+/// block-level comparable view, filtered to pools already known to the processor.
+///
+/// Pools created in the current block are excluded because the processor learns about them
+/// only after `apply_block` is called, so `generate_deltas` for the same block cannot
+/// produce output for them. This matches production semantics.
+fn substreams_to_comparable_block(
+    proto: &BlockChanges,
+    known_pools: &HashSet<String>,
+) -> ComparableBlockChanges {
+    let mut attributes: HashMap<String, HashMap<String, Vec<u8>>> = HashMap::new();
+    let mut balances: HashMap<(String, String), Vec<u8>> = HashMap::new();
+
+    for tx_changes in &proto.changes {
+        for ec in &tx_changes.entity_changes {
+            let cid = normalise_str_id(&ec.component_id);
+            if !known_pools.contains(&cid) {
+                continue;
+            }
+            for attr in &ec.attributes {
+                // map_pools_created emits zero-value init attrs for new pools; skip them.
+                if attr.value.iter().all(|&b| b == 0) {
+                    continue;
+                }
+                attributes
+                    .entry(cid.clone())
+                    .or_default()
+                    .insert(attr.name.clone(), attr.value.clone());
+            }
+        }
+
+        for bc in &tx_changes.balance_changes {
+            let cid = normalise_component_id(&bc.component_id);
+            if !known_pools.contains(&cid) {
+                continue;
+            }
+            if bc.balance.iter().all(|&b| b == 0) {
+                continue;
+            }
+            let token = hex::encode(&bc.token);
+            balances.insert((cid, token), bc.balance.clone());
+        }
+    }
+
+    ComparableBlockChanges { attributes, balances }
+}
+
+fn processor_to_comparable_block(
+    changes: &BlockAggregatedChanges,
+    known_pools: &HashSet<String>,
+) -> ComparableBlockChanges {
+    let mut attributes: HashMap<String, HashMap<String, Vec<u8>>> = HashMap::new();
+    let mut balances: HashMap<(String, String), Vec<u8>> = HashMap::new();
+
+    for (comp_id, delta) in &changes.state_deltas {
+        if !known_pools.contains(comp_id) {
+            continue;
+        }
+        let entry = attributes
+            .entry(comp_id.clone())
+            .or_default();
+        for (attr_name, attr_val) in &delta.updated_attributes {
+            entry.insert(attr_name.clone(), attr_val.to_vec());
+        }
+    }
+
+    for (comp_id, token_balances) in &changes.component_balances {
+        if !known_pools.contains(comp_id) {
+            continue;
+        }
+        for (token, cb) in token_balances {
+            let token_hex = hex::encode(token.as_ref());
+            balances.insert((comp_id.clone(), token_hex), cb.balance.to_vec());
+        }
+    }
+
+    ComparableBlockChanges { attributes, balances }
+}
+
+// ─── Test ────────────────────────────────────────────────────────────────────
+
+/// Streams UniswapV4 substreams over `[UV4_START_BLOCK, UV4_STOP_BLOCK]`
+/// (default: a 2000-block window with steady V4 activity) and verifies that the
+/// native `UniswapV4Processor` produces byte-identical attribute and balance
+/// values for every block in the range.
+///
+/// For each block the test:
+///   1. Calls `generate_deltas` with the raw RPC transactions to get pending state changes.
+///   2. Compares those changes against the aggregated substreams output for the block, restricted
+///      to pools the processor already knows about.
+///   3. Calls `apply_block` with the substreams ground truth to advance processor state.
+///
+/// This matches production semantics: pools created in block N are visible to
+/// `generate_deltas` only from block N+1 onwards.
+///
+/// The ground-truth spkg is built from origin/main (not the working tree) so the
+/// processor is validated against the substreams state deployed from main:
+///   protocols/crates/uniswap-v4/scripts/build_main_spkg.sh
+///
+/// Required env vars:
+///   ETH_RPC_URL         — archive RPC endpoint (supports eth_getLogs over
+///                         multi-thousand-block ranges and eth_getBlockByNumber)
+///   STREAMINGFAST_KEY   — StreamingFast JWT (exchange an api key via
+///                         https://auth.streamingfast.io/v1/auth/issue)
+///   UV4_SPKG_PATH       — (optional) spkg override; defaults to the
+///                         build_main_spkg.sh output path
+///   UV4_START_BLOCK     — (optional) override start block; defaults to 21_750_000
+///   UV4_STOP_BLOCK      — (optional) override stop block; defaults to 21_752_000
+#[tokio::test]
+#[ignore = "requires ETH_RPC_URL, STREAMINGFAST_KEY, and a spkg built via build_main_spkg.sh"]
+async fn test_processor_matches_substreams_genesis_range() {
+    dotenv::dotenv().ok();
+
+    let rpc_url = std::env::var("ETH_RPC_URL").expect("ETH_RPC_URL must be set");
+    let api_key = std::env::var("STREAMINGFAST_KEY").expect("STREAMINGFAST_KEY must be set");
+    let spkg_path = std::env::var("UV4_SPKG_PATH").unwrap_or_else(|_| {
+        format!(
+            "{}/../../../target/spkg/ethereum-uniswap-v4-no-hooks-main.spkg",
+            env!("CARGO_MANIFEST_DIR")
+        )
+    });
+    assert!(
+        std::path::Path::new(&spkg_path).exists(),
+        "spkg not found at {spkg_path}. Build it from origin/main with \
+         protocols/crates/uniswap-v4/scripts/build_main_spkg.sh, or point \
+         UV4_SPKG_PATH at an existing .spkg file."
+    );
+    let start_block = std::env::var("UV4_START_BLOCK")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_START_BLOCK);
+    let stop_block = std::env::var("UV4_STOP_BLOCK")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_STOP_BLOCK);
+
+    let endpoint_url = "https://mainnet.eth.streamingfast.io:443";
+
+    // ── Step 1: stream the full range from substreams ────────────────────────
+    let all_block_changes =
+        stream_block_range(endpoint_url, &api_key, &spkg_path, start_block, stop_block).await;
+
+    assert!(
+        !all_block_changes.is_empty(),
+        "Substreams returned no blocks for range [{start_block}, {stop_block}]"
+    );
+
+    // ── Step 2: fetch tx inputs for the full block range ─────────────────────
+    let mut per_block_inputs = fetch_range_tx_inputs(&rpc_url, start_block, stop_block).await;
+
+    // ── Step 3: run the native processor block by block ──────────────────────
+    //
+    // For each block:
+    //   a. generate_deltas(txs) — compare against substreams output (known pools only)
+    //   b. apply_block(model)  — advance state; register new pools for subsequent blocks
+    let mut processor = UniswapV4Processor::new(Chain::Ethereum, "uniswap-v4".to_string());
+    let mut known_pool_ids: HashSet<String> = HashSet::new();
+
+    let mut attr_mismatches: Vec<String> = Vec::new();
+    let mut balance_mismatches: Vec<String> = Vec::new();
+
+    let mut total_compared_blocks: usize = 0;
+    let mut total_compared_attrs: usize = 0;
+    let mut total_compared_balances: usize = 0;
+
+    for (block_num, block_hash, substreams_block) in &all_block_changes {
+        let tx_inputs = per_block_inputs
+            .remove(block_num)
+            .unwrap_or_default();
+
+        // Generate pending deltas from raw transactions against the current state.
+        let pending = processor.generate_deltas(&tx_inputs);
+
+        // Compare block-level aggregates, limited to pools already registered.
+        let expected = substreams_to_comparable_block(substreams_block, &known_pool_ids);
+        let actual = processor_to_comparable_block(&pending, &known_pool_ids);
+
+        if !expected.attributes.is_empty() || !expected.balances.is_empty() {
+            total_compared_blocks += 1;
+        }
+
+        for (cid, expected_attrs) in &expected.attributes {
+            let actual_attrs = actual
+                .attributes
+                .get(cid)
+                .cloned()
+                .unwrap_or_default();
+            let short_cid = &cid[..8.min(cid.len())];
+            for (attr_name, expected_value) in expected_attrs {
+                total_compared_attrs += 1;
+                let ev = hex::encode(expected_value);
+                match actual_attrs.get(attr_name) {
+                    Some(v) if v == expected_value => {
+                        println!(
+                            "  block={block_num} pool={short_cid}.. {attr_name:20}  \
+                             substreams={ev}  processor=✓"
+                        );
+                    }
+                    Some(v) => {
+                        let av = hex::encode(v);
+                        println!(
+                            "  block={block_num} pool={short_cid}.. {attr_name:20}  \
+                             substreams={ev}  processor={av}  MISMATCH"
+                        );
+                        attr_mismatches.push(format!(
+                            "block={block_num} pool={cid} attr={attr_name}: \
+                             expected={ev} got={av}",
+                        ));
+                    }
+                    None => {
+                        println!(
+                            "  block={block_num} pool={short_cid}.. {attr_name:20}  \
+                             substreams={ev}  processor=MISSING"
+                        );
+                        attr_mismatches.push(format!(
+                            "block={block_num} pool={cid} attr={attr_name}: \
+                             expected={ev} but missing",
+                        ));
+                    }
+                }
+            }
+        }
+
+        for ((cid, token), expected_balance) in &expected.balances {
+            total_compared_balances += 1;
+            let short_cid = &cid[..8.min(cid.len())];
+            let short_tok = &token[..8.min(token.len())];
+            let eb = hex::encode(expected_balance);
+            match actual
+                .balances
+                .get(&(cid.clone(), token.clone()))
+            {
+                Some(v) if v == expected_balance => {
+                    println!(
+                        "  block={block_num} pool={short_cid}.. token={short_tok}..  \
+                         balance: substreams={eb}  processor=✓"
+                    );
+                }
+                Some(v) => {
+                    let ab = hex::encode(v);
+                    println!(
+                        "  block={block_num} pool={short_cid}.. token={short_tok}..  \
+                         balance: substreams={eb}  processor={ab}  MISMATCH"
+                    );
+                    balance_mismatches.push(format!(
+                        "block={block_num} pool={cid} token={token}: \
+                         expected={eb} got={ab}",
+                    ));
+                }
+                None => {
+                    println!(
+                        "  block={block_num} pool={short_cid}.. token={short_tok}..  \
+                         balance: substreams={eb}  processor=MISSING"
+                    );
+                    balance_mismatches.push(format!(
+                        "block={block_num} pool={cid} token={token}: \
+                         expected={eb} but missing",
+                    ));
+                }
+            }
+        }
+
+        // Advance processor state with substreams ground truth.
+        let model_block = substreams_proto_to_model(substreams_block, *block_num, block_hash);
+        processor.apply_block(&model_block);
+
+        // Register newly seen pools so subsequent blocks can compare them.
+        for id in model_block
+            .new_protocol_components
+            .keys()
+        {
+            known_pool_ids.insert(id.clone());
+        }
+    }
+
+    println!("\n─── Summary ────────────────────────────────────────────────────────────────");
+    println!("  Blocks streamed:       {}", all_block_changes.len());
+    println!("  Blocks with activity:  {total_compared_blocks}");
+    println!("  Pools registered:      {}", known_pool_ids.len());
+    println!("  Attributes compared:   {total_compared_attrs}");
+    println!("  Balances compared:     {total_compared_balances}");
+    println!("  Attr mismatches:       {}", attr_mismatches.len());
+    println!("  Balance mismatches:    {}", balance_mismatches.len());
+    println!("────────────────────────────────────────────────────────────────────────────");
+
+    assert!(
+        attr_mismatches.is_empty(),
+        "Attribute value mismatches ({} total):\n{}",
+        attr_mismatches.len(),
+        attr_mismatches.join("\n"),
+    );
+    assert!(
+        balance_mismatches.is_empty(),
+        "Balance value mismatches ({} total):\n{}",
+        balance_mismatches.len(),
+        balance_mismatches.join("\n"),
+    );
+}

--- a/protocols/crates/uniswap-v4/tests/integration.rs
+++ b/protocols/crates/uniswap-v4/tests/integration.rs
@@ -257,16 +257,14 @@ async fn fetch_range_tx_inputs(
 
 // ─── Conversion helpers ──────────────────────────────────────────────────────
 
-/// Normalise a component_id from substreams output to lower-case hex without "0x".
-fn normalise_component_id(raw: &[u8]) -> String {
-    let s = std::str::from_utf8(raw).unwrap_or_default();
-    s.trim_start_matches("0x")
-        .to_lowercase()
-}
-
-fn normalise_str_id(s: &str) -> String {
-    s.trim_start_matches("0x")
-        .to_lowercase()
+/// Decodes a substreams balance-change component_id (the UTF-8 bytes of the id string).
+///
+/// Ids are kept exactly as the substreams emit them ("0x"-prefixed lower-case hex) — the
+/// processor must produce byte-identical ids, so the comparison asserts the format too.
+fn component_id_from_bytes(raw: &[u8]) -> String {
+    std::str::from_utf8(raw)
+        .unwrap_or_default()
+        .to_string()
 }
 
 /// Converts a substreams proto `BlockChanges` to a `BlockAggregatedChanges`, aggregating
@@ -293,7 +291,7 @@ fn substreams_proto_to_model(
 
     for tx_changes in &proto.changes {
         for comp in &tx_changes.component_changes {
-            let id = normalise_str_id(&comp.id);
+            let id = comp.id.clone();
             new_protocol_components
                 .entry(id.clone())
                 .or_insert_with(|| ProtocolComponent {
@@ -308,7 +306,7 @@ fn substreams_proto_to_model(
         }
 
         for ec in &tx_changes.entity_changes {
-            let cid = normalise_str_id(&ec.component_id);
+            let cid = ec.component_id.clone();
             let delta = state_deltas
                 .entry(cid.clone())
                 .or_insert_with(|| ProtocolComponentStateDelta {
@@ -336,7 +334,7 @@ fn substreams_proto_to_model(
         }
 
         for bc in &tx_changes.balance_changes {
-            let cid = normalise_component_id(&bc.component_id);
+            let cid = component_id_from_bytes(&bc.component_id);
             let token = Bytes::from(bc.token.clone());
             let balance = Bytes::from(bc.balance.clone());
             let balance_float = BigInt::from_bytes_be(Sign::Plus, balance.as_ref())
@@ -395,7 +393,7 @@ fn substreams_to_comparable_block(
 
     for tx_changes in &proto.changes {
         for ec in &tx_changes.entity_changes {
-            let cid = normalise_str_id(&ec.component_id);
+            let cid = ec.component_id.clone();
             if !known_pools.contains(&cid) {
                 continue;
             }
@@ -412,7 +410,7 @@ fn substreams_to_comparable_block(
         }
 
         for bc in &tx_changes.balance_changes {
-            let cid = normalise_component_id(&bc.component_id);
+            let cid = component_id_from_bytes(&bc.component_id);
             if !known_pools.contains(&cid) {
                 continue;
             }

--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -49,6 +49,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +259,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +428,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +488,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +528,26 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "deepsize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb987ec36f6bf7bfbea3f928b75590b736fc42af8e54d97592481351b2b96c"
+dependencies = [
+ "deepsize_derive",
+]
+
+[[package]]
+name = "deepsize_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990101d41f3bc8c1a45641024377ee284ecc338e5ecf3ea0f0e236d897c72796"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -654,6 +712,17 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -862,7 +931,7 @@ dependencies = [
  "substreams 0.5.22",
  "substreams-ethereum 0.9.13",
  "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.5.0)",
- "tycho-substreams 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tycho-substreams 0.8.0",
 ]
 
 [[package]]
@@ -961,7 +1030,7 @@ dependencies = [
  "serde_json",
  "substreams 0.5.22",
  "substreams-ethereum 0.9.13",
- "tycho-substreams 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tycho-substreams 0.8.0",
 ]
 
 [[package]]
@@ -1104,8 +1173,9 @@ dependencies = [
  "prost 0.11.9",
  "substreams 0.5.22",
  "substreams-ethereum 0.9.13",
- "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.4.0)",
- "tycho-substreams 0.2.2",
+ "substreams-helper 0.0.2",
+ "tycho-substreams 0.8.0",
+ "uniswap-v3-core",
 ]
 
 [[package]]
@@ -1451,6 +1521,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,6 +1607,15 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1947,6 +2050,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -2620,6 +2747,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "substreams"
 version = "0.5.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,6 +3204,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tycho-common"
+version = "0.275.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "deepsize",
+ "hex",
+ "itertools 0.10.5",
+ "num-bigint",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 1.0.69",
+ "tiny-keccak",
+ "tracing",
+ "typetag",
+ "utoipa",
+ "uuid",
+]
+
+[[package]]
 name = "tycho-substreams"
 version = "0.2.0"
 source = "git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=3c08359#3c08359cf112e15c137dd5256b8dc8e9cd6c1626"
@@ -3205,27 +3407,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "tycho-substreams"
-version = "0.8.0"
+name = "typeid"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8158444c99f55b314f5d63837b794f4842975d148feb03ea8e2720ecab957eba"
-dependencies = [
- "ethabi 18.0.0",
- "hex",
- "itertools 0.12.1",
- "num-bigint",
- "prost 0.11.9",
- "serde",
- "serde_json",
- "substreams 0.5.22",
- "substreams-ethereum 0.9.13",
-]
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "typetag"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "ucd-trie"
@@ -3307,6 +3522,56 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "uniswap-v3-core"
+version = "0.1.0"
+dependencies = [
+ "ethabi 18.0.0",
+ "getrandom 0.2.17",
+ "hex",
+ "num-bigint",
+ "num-traits",
+ "substreams 0.5.22",
+ "substreams-ethereum 0.9.13",
+ "tycho-common",
+ "tycho-substreams 0.8.0",
+]
+
+[[package]]
+name = "utoipa"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -3445,10 +3710,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/protocols/substreams/Cargo.toml
+++ b/protocols/substreams/Cargo.toml
@@ -31,6 +31,13 @@ members = [
 ]
 resolver = "2"
 
+# Redirect crates.io tycho-substreams to the local workspace crate so that
+# uniswap-v3-core (root workspace member) and the substreams modules all share
+# the same types when compiled together.
+[patch.crates-io]
+tycho-substreams = { path = "crates/tycho-substreams" }
+substreams-helper = { path = "crates/substreams-helper" }
+
 [profile.release]
 lto = true
 opt-level = 's'

--- a/protocols/substreams/crates/tycho-substreams/src/block_storage.rs
+++ b/protocols/substreams/crates/tycho-substreams/src/block_storage.rs
@@ -166,8 +166,11 @@ mod test {
         let changes = get_block_storage_changes(&block);
 
         let mut balance_map: HashMap<String, HashMap<String, String>> = HashMap::new();
-        let mut storage_map: HashMap<String, HashMap<String, HashMap<String, (String, String)>>> =
-            HashMap::new();
+        #[allow(clippy::type_complexity)]
+        let mut storage_map: HashMap<
+            String,
+            HashMap<String, HashMap<String, (String, String)>>,
+        > = HashMap::new();
         for change in changes {
             let tx_hash = change.tx.unwrap().hash.clone();
             let balance_tx_entry = balance_map

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/Cargo.toml
@@ -16,8 +16,9 @@ num-bigint = "0.4.4"
 prost = "0.11"
 substreams = "0.5.22"
 substreams-ethereum = "0.9.9"
-substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", tag = "0.4.0" }
+substreams-helper = { path = "../crates/substreams-helper" }
+tycho-substreams = { path = "../crates/tycho-substreams" }
+uniswap-v3-core = { path = "../../crates/uniswap-v3" }
 
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = { version = "0.2", features = ["custom"] }

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/rust-toolchain.toml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.87.0"
 components = [ "rustfmt" ]
 targets = [ "wasm32-unknown-unknown" ]

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/src/lib.rs
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/src/lib.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
-mod abi;
 mod modules;
 mod pb;
 

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/1_map_pool_created.rs
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/1_map_pool_created.rs
@@ -6,7 +6,7 @@ use substreams_ethereum::pb::eth::v2::{self as eth};
 
 use substreams_helper::{event_handler::EventHandler, hex::Hexable};
 
-use crate::abi::factory::events::PoolCreated;
+use uniswap_v3_core::abi::factory::events::PoolCreated;
 
 use tycho_substreams::prelude::*;
 

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/3_map_events.rs
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/3_map_events.rs
@@ -1,187 +1,48 @@
-use anyhow::Ok;
-use substreams::{
-    store::{StoreGet, StoreGetProto},
-    Hex,
-};
-use substreams_ethereum::{
-    pb::eth::v2::{self as eth, Log, TransactionTrace},
-    Event,
-};
+use substreams::store::{StoreGet, StoreGetProto};
+use substreams_ethereum::pb::eth::v2::{self as eth};
 use substreams_helper::hex::Hexable;
+use uniswap_v3_core::events::{Pool, TxRef};
 
-use crate::{
-    abi::pool::events::{
-        Burn, Collect, CollectProtocol, Flash, Initialize, Mint, SetFeeProtocol, Swap,
-    },
-    pb::uniswap::v3::{
-        events::{
-            pool_event::{self, Type},
-            PoolEvent,
-        },
-        Events, Pool,
-    },
-};
+use crate::pb::uniswap::v3::{events::PoolEvent, Events, Pool as ProtoPool};
 
 #[substreams::handlers::map]
 pub fn map_events(
     block: eth::Block,
-    pools_store: StoreGetProto<Pool>,
+    pools_store: StoreGetProto<ProtoPool>,
 ) -> Result<Events, anyhow::Error> {
-    let mut pool_events = block
+    let mut pool_events: Vec<PoolEvent> = block
         .transaction_traces
         .into_iter()
         .filter(|tx| tx.status == 1)
         .flat_map(|tx| {
+            let tx_ref = TxRef {
+                hash: tx.hash.clone(),
+                from: tx.from.clone(),
+                to: tx.to.clone(),
+                index: tx.index as u64,
+            };
             let receipt = tx
                 .receipt
                 .as_ref()
-                .expect("all transaction traces have a receipt");
-
+                .expect("receipt missing");
             receipt
                 .logs
                 .iter()
                 .filter_map(|log| {
                     let key = format!("{}:{}", "Pool", log.address.to_hex());
-                    // Skip if the log is not from a known uniswapV3 pool.
-                    if let Some(pool) = pools_store.get_last(key) {
-                        log_to_event(log, pool, &tx)
-                    } else {
-                        None
-                    }
+                    let proto_pool = pools_store.get_last(key)?;
+                    let pool = Pool {
+                        address: proto_pool.address.clone(),
+                        token0: proto_pool.token0.clone(),
+                        token1: proto_pool.token1.clone(),
+                    };
+                    let core_event = uniswap_v3_core::events::decode_log(log, &pool, &tx_ref)?;
+                    Some(core_event.into())
                 })
                 .collect::<Vec<_>>()
         })
-        .collect::<Vec<_>>();
+        .collect();
 
     pool_events.sort_unstable_by_key(|e| e.log_ordinal);
-
     Ok(Events { pool_events })
-}
-
-fn log_to_event(event: &Log, pool: Pool, tx: &TransactionTrace) -> Option<PoolEvent> {
-    if let Some(init) = Initialize::match_and_decode(event) {
-        Some(PoolEvent {
-            log_ordinal: event.ordinal,
-            pool_address: Hex(pool.address).to_string(),
-            token0: Hex(pool.token0).to_string(),
-            token1: Hex(pool.token1).to_string(),
-            transaction: Some(tx.into()),
-            r#type: Some(Type::Initialize(pool_event::Initialize {
-                sqrt_price: init.sqrt_price_x96.to_string(),
-                tick: init.tick.into(),
-            })),
-        })
-    } else if let Some(swap) = Swap::match_and_decode(event) {
-        Some(PoolEvent {
-            log_ordinal: event.ordinal,
-            pool_address: Hex(pool.address).to_string(),
-            token0: Hex(pool.token0).to_string(),
-            token1: Hex(pool.token1).to_string(),
-            transaction: Some(tx.into()),
-            r#type: Some(Type::Swap(pool_event::Swap {
-                sender: Hex(swap.sender).to_string(),
-                recipient: Hex(swap.recipient).to_string(),
-                amount_0: swap.amount0.to_string(),
-                amount_1: swap.amount1.to_string(),
-                sqrt_price: swap.sqrt_price_x96.to_string(),
-                liquidity: swap.liquidity.to_string(),
-                tick: swap.tick.into(),
-            })),
-        })
-    } else if let Some(flash) = Flash::match_and_decode(event) {
-        Some(PoolEvent {
-            log_ordinal: event.ordinal,
-            pool_address: Hex(pool.address).to_string(),
-            token0: Hex(pool.token0).to_string(),
-            token1: Hex(pool.token1).to_string(),
-            transaction: Some(tx.into()),
-            r#type: Some(Type::Flash(pool_event::Flash {
-                sender: Hex(flash.sender).to_string(),
-                recipient: Hex(flash.recipient).to_string(),
-                amount_0: flash.amount0.to_string(),
-                amount_1: flash.amount1.to_string(),
-                paid_0: flash.paid0.to_string(),
-                paid_1: flash.paid1.to_string(),
-            })),
-        })
-    } else if let Some(mint) = Mint::match_and_decode(event) {
-        Some(PoolEvent {
-            log_ordinal: event.ordinal,
-            pool_address: Hex(pool.address).to_string(),
-            token0: Hex(pool.token0).to_string(),
-            token1: Hex(pool.token1).to_string(),
-            transaction: Some(tx.into()),
-            r#type: Some(Type::Mint(pool_event::Mint {
-                sender: Hex(mint.sender).to_string(),
-                owner: Hex(mint.owner).to_string(),
-                tick_lower: mint.tick_lower.into(),
-                tick_upper: mint.tick_upper.into(),
-                amount: mint.amount.to_string(),
-                amount_0: mint.amount0.to_string(),
-                amount_1: mint.amount1.to_string(),
-            })),
-        })
-    } else if let Some(burn) = Burn::match_and_decode(event) {
-        Some(PoolEvent {
-            log_ordinal: event.ordinal,
-            pool_address: Hex(pool.address).to_string(),
-            token0: Hex(pool.token0).to_string(),
-            token1: Hex(pool.token1).to_string(),
-            transaction: Some(tx.into()),
-            r#type: Some(Type::Burn(pool_event::Burn {
-                owner: Hex(burn.owner).to_string(),
-                tick_lower: burn.tick_lower.into(),
-                tick_upper: burn.tick_upper.into(),
-                amount: burn.amount.to_string(),
-                amount_0: burn.amount0.to_string(),
-                amount_1: burn.amount1.to_string(),
-            })),
-        })
-    } else if let Some(collect) = Collect::match_and_decode(event) {
-        Some(PoolEvent {
-            log_ordinal: event.ordinal,
-            pool_address: Hex(pool.address).to_string(),
-            token0: Hex(pool.token0).to_string(),
-            token1: Hex(pool.token1).to_string(),
-            transaction: Some(tx.into()),
-            r#type: Some(Type::Collect(pool_event::Collect {
-                owner: Hex(collect.owner).to_string(),
-                recipient: Hex(collect.recipient).to_string(),
-                tick_lower: collect.tick_lower.into(),
-                tick_upper: collect.tick_upper.into(),
-                amount_0: collect.amount0.to_string(),
-                amount_1: collect.amount1.to_string(),
-            })),
-        })
-    } else if let Some(set_fp) = SetFeeProtocol::match_and_decode(event) {
-        Some(PoolEvent {
-            log_ordinal: event.ordinal,
-            pool_address: Hex(pool.address).to_string(),
-            token0: Hex(pool.token0).to_string(),
-            token1: Hex(pool.token1).to_string(),
-            transaction: Some(tx.into()),
-            r#type: Some(Type::SetFeeProtocol(pool_event::SetFeeProtocol {
-                fee_protocol_0_old: set_fp.fee_protocol0_old.to_u64(),
-                fee_protocol_1_old: set_fp.fee_protocol1_old.to_u64(),
-                fee_protocol_0_new: set_fp.fee_protocol0_new.to_u64(),
-                fee_protocol_1_new: set_fp.fee_protocol1_new.to_u64(),
-            })),
-        })
-    } else if let Some(cp) = CollectProtocol::match_and_decode(event) {
-        Some(PoolEvent {
-            log_ordinal: event.ordinal,
-            pool_address: Hex(pool.address).to_string(),
-            token0: Hex(pool.token0).to_string(),
-            token1: Hex(pool.token1).to_string(),
-            transaction: Some(tx.into()),
-            r#type: Some(Type::CollectProtocol(pool_event::CollectProtocol {
-                sender: Hex(cp.sender).to_string(),
-                recipient: Hex(cp.recipient).to_string(),
-                amount_0: cp.amount0.to_string(),
-                amount_1: cp.amount1.to_string(),
-            })),
-        })
-    } else {
-        None
-    }
 }

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/4_map_and_store_balance_changes.rs
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/4_map_and_store_balance_changes.rs
@@ -1,23 +1,27 @@
-use std::str::FromStr;
-
-use anyhow::Ok;
 use tycho_substreams::models::{BalanceDelta, BlockBalanceDeltas};
 
-use crate::pb::uniswap::v3::{
-    events::{pool_event, PoolEvent},
-    Events,
-};
-use substreams::{
-    scalar::BigInt,
-    store::{StoreAddBigInt, StoreNew},
-};
+use crate::pb::uniswap::v3::Events;
+use substreams::store::{StoreAddBigInt, StoreNew};
+
+use uniswap_v3_core::events::PoolEvent as CorePoolEvent;
 
 #[substreams::handlers::map]
 pub fn map_balance_changes(events: Events) -> Result<BlockBalanceDeltas, anyhow::Error> {
     let balance_deltas = events
         .pool_events
         .into_iter()
-        .flat_map(event_to_balance_deltas)
+        .flat_map(|proto_event| {
+            let ordinal = proto_event.log_ordinal;
+            let tx = proto_event.transaction.clone();
+            let core_event = CorePoolEvent::from(&proto_event);
+            uniswap_v3_core::balance::event_to_balance_deltas(&core_event)
+                .into_iter()
+                .map(move |d| BalanceDelta {
+                    ord: ordinal,
+                    tx: tx.as_ref().map(Into::into),
+                    ..d.into()
+                })
+        })
         .collect();
 
     Ok(BlockBalanceDeltas { balance_deltas })
@@ -26,138 +30,4 @@ pub fn map_balance_changes(events: Events) -> Result<BlockBalanceDeltas, anyhow:
 #[substreams::handlers::store]
 pub fn store_pools_balances(balances_deltas: BlockBalanceDeltas, store: StoreAddBigInt) {
     tycho_substreams::balances::store_balance_changes(balances_deltas, store);
-}
-
-fn event_to_balance_deltas(event: PoolEvent) -> Vec<BalanceDelta> {
-    let address = format!("0x{}", event.pool_address)
-        .as_bytes()
-        .to_vec();
-    match event.r#type.unwrap() {
-        pool_event::Type::Mint(e) => vec![
-            BalanceDelta {
-                token: hex::decode(event.token0).unwrap(),
-                delta: BigInt::from_str(&e.amount_0)
-                    .unwrap()
-                    .to_signed_bytes_be(),
-                component_id: address.clone(),
-                ord: event.log_ordinal,
-                tx: event
-                    .transaction
-                    .as_ref()
-                    .map(Into::into),
-            },
-            BalanceDelta {
-                token: hex::decode(event.token1).unwrap(),
-                delta: BigInt::from_str(&e.amount_1)
-                    .unwrap()
-                    .to_signed_bytes_be(),
-                component_id: address,
-                ord: event.log_ordinal,
-                tx: event.transaction.map(Into::into),
-            },
-        ],
-        pool_event::Type::Collect(e) => vec![
-            BalanceDelta {
-                token: hex::decode(event.token0).unwrap(),
-                delta: BigInt::from_str(&e.amount_0)
-                    .unwrap()
-                    .neg()
-                    .to_signed_bytes_be(),
-                component_id: address.clone(),
-                ord: event.log_ordinal,
-                tx: event
-                    .transaction
-                    .as_ref()
-                    .map(Into::into),
-            },
-            BalanceDelta {
-                token: hex::decode(event.token1).unwrap(),
-                delta: BigInt::from_str(&e.amount_1)
-                    .unwrap()
-                    .neg()
-                    .to_signed_bytes_be(),
-                component_id: address,
-                ord: event.log_ordinal,
-                tx: event.transaction.map(Into::into),
-            },
-        ],
-        //Burn balance changes are accounted for in the Collect event.
-        pool_event::Type::Burn(_) => vec![],
-        pool_event::Type::Swap(e) => {
-            vec![
-                BalanceDelta {
-                    token: hex::decode(event.token0).unwrap(),
-                    delta: BigInt::from_str(&e.amount_0)
-                        .unwrap()
-                        .to_signed_bytes_be(),
-                    component_id: address.clone(),
-                    ord: event.log_ordinal,
-                    tx: event
-                        .transaction
-                        .as_ref()
-                        .map(Into::into),
-                },
-                BalanceDelta {
-                    token: hex::decode(event.token1).unwrap(),
-                    delta: BigInt::from_str(&e.amount_1)
-                        .unwrap()
-                        .to_signed_bytes_be(),
-                    component_id: address,
-                    ord: event.log_ordinal,
-                    tx: event.transaction.map(Into::into),
-                },
-            ]
-        }
-        pool_event::Type::Flash(e) => vec![
-            BalanceDelta {
-                token: hex::decode(event.token0).unwrap(),
-                delta: BigInt::from_str(&e.paid_0)
-                    .unwrap()
-                    .to_signed_bytes_be(),
-                component_id: address.clone(),
-                ord: event.log_ordinal,
-                tx: event
-                    .transaction
-                    .as_ref()
-                    .map(Into::into),
-            },
-            BalanceDelta {
-                token: hex::decode(event.token1).unwrap(),
-                delta: BigInt::from_str(&e.paid_1)
-                    .unwrap()
-                    .to_signed_bytes_be(),
-                component_id: address,
-                ord: event.log_ordinal,
-                tx: event.transaction.map(Into::into),
-            },
-        ],
-        pool_event::Type::CollectProtocol(e) => {
-            vec![
-                BalanceDelta {
-                    token: hex::decode(event.token0).unwrap(),
-                    delta: BigInt::from_str(&e.amount_0)
-                        .unwrap()
-                        .neg()
-                        .to_signed_bytes_be(),
-                    component_id: address.clone(),
-                    ord: event.log_ordinal,
-                    tx: event
-                        .transaction
-                        .as_ref()
-                        .map(Into::into),
-                },
-                BalanceDelta {
-                    token: hex::decode(event.token1).unwrap(),
-                    delta: BigInt::from_str(&e.amount_1)
-                        .unwrap()
-                        .neg()
-                        .to_signed_bytes_be(),
-                    component_id: address,
-                    ord: event.log_ordinal,
-                    tx: event.transaction.map(Into::into),
-                },
-            ]
-        }
-        _ => vec![],
-    }
 }

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/4_map_and_store_liquidity.rs
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/4_map_and_store_liquidity.rs
@@ -1,26 +1,26 @@
-use std::str::FromStr;
-
 use substreams::store::{
     StoreGet, StoreGetInt64, StoreSet, StoreSetInt64, StoreSetSum, StoreSetSumBigInt,
 };
 
-use crate::pb::uniswap::v3::{
-    events::{pool_event, PoolEvent},
-    Events, LiquidityChange, LiquidityChangeType, LiquidityChanges,
-};
+use crate::pb::uniswap::v3::{Events, LiquidityChange, LiquidityChangeType, LiquidityChanges};
 
 use substreams::{scalar::BigInt, store::StoreNew};
 
-use anyhow::Ok;
+use uniswap_v3_core::events::PoolEvent as CorePoolEvent;
 
 #[substreams::handlers::store]
 pub fn store_pool_current_tick(events: Events, store: StoreSetInt64) {
     events
         .pool_events
         .into_iter()
-        .filter_map(event_to_current_tick)
-        .for_each(|(pool, ordinal, new_tick_index)| {
-            store.set(ordinal, format!("pool:{pool}"), &new_tick_index.into())
+        .for_each(|proto_event| {
+            let pool_address = proto_event.pool_address.clone();
+            let ordinal = proto_event.log_ordinal;
+            let core_event = CorePoolEvent::from(&proto_event);
+            if let Some(tick) = uniswap_v3_core::liquidity::event_to_current_tick(&core_event) {
+                // tick from core is i64; store expects i64 reference
+                store.set(ordinal, format!("pool:{pool_address}"), &tick)
+            }
         });
 }
 
@@ -32,16 +32,17 @@ pub fn map_liquidity_changes(
     let mut changes = events
         .pool_events
         .into_iter()
-        .filter(PoolEvent::can_introduce_liquidity_changes)
-        .map(|e| {
-            (
-                pools_current_tick_store
-                    .get_at(e.log_ordinal, format!("pool:{0}", &e.pool_address))
-                    .unwrap_or(0),
-                e,
-            )
+        .filter_map(|proto_event| {
+            let current_tick = pools_current_tick_store
+                .get_at(proto_event.log_ordinal, format!("pool:{0}", proto_event.pool_address))
+                .unwrap_or(0);
+            let ordinal = proto_event.log_ordinal;
+            let transaction = proto_event.transaction.clone();
+            let core_event = CorePoolEvent::from(&proto_event);
+            let delta =
+                uniswap_v3_core::liquidity::event_to_liquidity_delta(current_tick, &core_event)?;
+            Some(LiquidityChange { ordinal, transaction, ..delta.into() })
         })
-        .filter_map(|(current_tick, event)| event_to_liquidity_deltas(current_tick, event))
         .collect::<Vec<_>>();
 
     changes.sort_unstable_by_key(|l| l.ordinal);
@@ -69,69 +70,4 @@ pub fn store_liquidity(ticks_deltas: LiquidityChanges, store: StoreSetSumBigInt)
                 );
             }
         });
-}
-
-fn event_to_liquidity_deltas(current_tick: i64, event: PoolEvent) -> Option<LiquidityChange> {
-    match event.r#type.as_ref().unwrap() {
-        pool_event::Type::Mint(mint) => {
-            if current_tick >= mint.tick_lower.into() && current_tick < mint.tick_upper.into() {
-                Some(LiquidityChange {
-                    pool_address: hex::decode(event.pool_address).unwrap(),
-                    value: BigInt::from_str(&mint.amount)
-                        .unwrap()
-                        .to_signed_bytes_be(),
-                    change_type: LiquidityChangeType::Delta.into(),
-                    ordinal: event.log_ordinal,
-                    transaction: Some(event.transaction.unwrap()),
-                })
-            } else {
-                None
-            }
-        }
-        pool_event::Type::Burn(burn) => {
-            if current_tick >= burn.tick_lower.into() && current_tick < burn.tick_upper.into() {
-                Some(LiquidityChange {
-                    pool_address: hex::decode(event.pool_address).unwrap(),
-                    value: BigInt::from_str(&burn.amount)
-                        .unwrap()
-                        .neg()
-                        .to_signed_bytes_be(),
-                    change_type: LiquidityChangeType::Delta.into(),
-                    ordinal: event.log_ordinal,
-                    transaction: Some(event.transaction.unwrap()),
-                })
-            } else {
-                None
-            }
-        }
-        pool_event::Type::Swap(swap) => Some(LiquidityChange {
-            pool_address: hex::decode(event.pool_address).unwrap(),
-            value: BigInt::from_str(&swap.liquidity)
-                .unwrap()
-                .to_signed_bytes_be(),
-            change_type: LiquidityChangeType::Absolute.into(),
-            ordinal: event.log_ordinal,
-            transaction: Some(event.transaction.unwrap()),
-        }),
-        _ => None,
-    }
-}
-
-impl PoolEvent {
-    fn can_introduce_liquidity_changes(&self) -> bool {
-        matches!(
-            self.r#type.as_ref().unwrap(),
-            pool_event::Type::Mint(_) | pool_event::Type::Burn(_) | pool_event::Type::Swap(_)
-        )
-    }
-}
-
-fn event_to_current_tick(event: PoolEvent) -> Option<(String, u64, i32)> {
-    match event.r#type.as_ref().unwrap() {
-        pool_event::Type::Initialize(initialize) => {
-            Some((event.pool_address, event.log_ordinal, initialize.tick))
-        }
-        pool_event::Type::Swap(swap) => Some((event.pool_address, event.log_ordinal, swap.tick)),
-        _ => None,
-    }
 }

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/4_map_and_store_ticks.rs
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/4_map_and_store_ticks.rs
@@ -1,25 +1,24 @@
-use std::str::FromStr;
-
-use substreams::store::StoreAddBigInt;
-
-use crate::pb::uniswap::v3::{
-    events::{pool_event, PoolEvent},
-    Events, TickDelta, TickDeltas,
-};
-
+use crate::pb::uniswap::v3::{Events, TickDelta, TickDeltas};
 use substreams::{
     scalar::BigInt,
-    store::{StoreAdd, StoreNew},
+    store::{StoreAdd, StoreAddBigInt, StoreNew},
 };
 
-use anyhow::Ok;
+use uniswap_v3_core::events::PoolEvent as CorePoolEvent;
 
 #[substreams::handlers::map]
 pub fn map_ticks_changes(events: Events) -> Result<TickDeltas, anyhow::Error> {
     let ticks_deltas = events
         .pool_events
         .into_iter()
-        .flat_map(event_to_ticks_deltas)
+        .flat_map(|proto_event| {
+            let ordinal = proto_event.log_ordinal;
+            let transaction = proto_event.transaction.clone();
+            let core_event = CorePoolEvent::from(&proto_event);
+            uniswap_v3_core::ticks::event_to_tick_deltas(&core_event)
+                .into_iter()
+                .map(move |d| TickDelta { ordinal, transaction: transaction.clone(), ..d.into() })
+        })
         .collect();
 
     Ok(TickDeltas { deltas: ticks_deltas })
@@ -38,54 +37,4 @@ pub fn store_ticks_liquidity(ticks_deltas: TickDeltas, store: StoreAddBigInt) {
             BigInt::from_signed_bytes_be(&delta.liquidity_net_delta),
         );
     });
-}
-
-fn event_to_ticks_deltas(event: PoolEvent) -> Vec<TickDelta> {
-    match event.r#type.as_ref().unwrap() {
-        pool_event::Type::Mint(mint) => {
-            vec![
-                TickDelta {
-                    pool_address: hex::decode(&event.pool_address).unwrap(),
-                    tick_index: mint.tick_lower,
-                    liquidity_net_delta: BigInt::from_str(&mint.amount)
-                        .unwrap()
-                        .to_signed_bytes_be(),
-                    ordinal: event.log_ordinal,
-                    transaction: event.transaction.clone(),
-                },
-                TickDelta {
-                    pool_address: hex::decode(&event.pool_address).unwrap(),
-                    tick_index: mint.tick_upper,
-                    liquidity_net_delta: BigInt::from_str(&mint.amount)
-                        .unwrap()
-                        .neg()
-                        .to_signed_bytes_be(),
-                    ordinal: event.log_ordinal,
-                    transaction: event.transaction,
-                },
-            ]
-        }
-        pool_event::Type::Burn(burn) => vec![
-            TickDelta {
-                pool_address: hex::decode(&event.pool_address).unwrap(),
-                tick_index: burn.tick_lower,
-                liquidity_net_delta: BigInt::from_str(&burn.amount)
-                    .unwrap()
-                    .neg()
-                    .to_signed_bytes_be(),
-                ordinal: event.log_ordinal,
-                transaction: event.transaction.clone(),
-            },
-            TickDelta {
-                pool_address: hex::decode(&event.pool_address).unwrap(),
-                tick_index: burn.tick_upper,
-                liquidity_net_delta: BigInt::from_str(&burn.amount)
-                    .unwrap()
-                    .to_signed_bytes_be(),
-                ordinal: event.log_ordinal,
-                transaction: event.transaction,
-            },
-        ],
-        _ => vec![],
-    }
 }

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/5_map_protocol_changes.rs
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/5_map_protocol_changes.rs
@@ -1,7 +1,4 @@
-use crate::pb::uniswap::v3::{
-    events::{pool_event, PoolEvent},
-    Events, LiquidityChanges, TickDeltas,
-};
+use crate::pb::uniswap::v3::{Events, LiquidityChanges, TickDeltas};
 use itertools::Itertools;
 use std::{collections::HashMap, str::FromStr, vec};
 use substreams::{pb::substreams::StoreDeltas, scalar::BigInt};
@@ -9,7 +6,7 @@ use substreams_ethereum::pb::eth::v2::{self as eth};
 use substreams_helper::hex::Hexable;
 use tycho_substreams::{balances::aggregate_balances_changes, prelude::*};
 
-type PoolAddress = Vec<u8>;
+use uniswap_v3_core::events::PoolEvent as CorePoolEvent;
 
 #[substreams::handlers::map]
 pub fn map_protocol_changes(
@@ -142,15 +139,28 @@ pub fn map_protocol_changes(
     events
         .pool_events
         .into_iter()
-        .flat_map(event_to_attributes_updates)
-        .for_each(|(tx, pool_address, attr)| {
-            let builder = transaction_changes
-                .entry(tx.index)
-                .or_insert_with(|| TransactionChangesBuilder::new(&tx));
-            builder.add_entity_change(&EntityChanges {
-                component_id: pool_address.to_hex(),
-                attributes: vec![attr],
-            });
+        .for_each(|proto_event| {
+            let tx: Transaction = proto_event
+                .transaction
+                .as_ref()
+                .unwrap()
+                .into();
+            let core_event = CorePoolEvent::from(&proto_event);
+            for update in uniswap_v3_core::output::event_to_attribute_updates(&core_event) {
+                let change_type =
+                    if update.is_creation { ChangeType::Creation } else { ChangeType::Update };
+                let builder = transaction_changes
+                    .entry(tx.index)
+                    .or_insert_with(|| TransactionChangesBuilder::new(&tx));
+                builder.add_entity_change(&EntityChanges {
+                    component_id: update.pool_address.to_hex(),
+                    attributes: vec![Attribute {
+                        name: update.name,
+                        value: update.value,
+                        change: change_type.into(),
+                    }],
+                });
+            }
         });
 
     Ok(BlockChanges {
@@ -162,88 +172,4 @@ pub fn map_protocol_changes(
             .collect::<Vec<_>>(),
         ..Default::default()
     })
-}
-
-fn event_to_attributes_updates(event: PoolEvent) -> Vec<(Transaction, PoolAddress, Attribute)> {
-    match event.r#type.as_ref().unwrap() {
-        pool_event::Type::Initialize(initalize) => {
-            vec![
-                (
-                    event
-                        .transaction
-                        .as_ref()
-                        .unwrap()
-                        .into(),
-                    hex::decode(&event.pool_address).unwrap(),
-                    Attribute {
-                        name: "sqrt_price_x96".to_string(),
-                        value: BigInt::from_str(&initalize.sqrt_price)
-                            .unwrap()
-                            .to_signed_bytes_be(),
-                        change: ChangeType::Update.into(),
-                    },
-                ),
-                (
-                    event.transaction.unwrap().into(),
-                    hex::decode(event.pool_address).unwrap(),
-                    Attribute {
-                        name: "tick".to_string(),
-                        value: BigInt::from(initalize.tick).to_signed_bytes_be(),
-                        change: ChangeType::Update.into(),
-                    },
-                ),
-            ]
-        }
-        pool_event::Type::Swap(swap) => vec![
-            (
-                event
-                    .transaction
-                    .as_ref()
-                    .unwrap()
-                    .into(),
-                hex::decode(&event.pool_address).unwrap(),
-                Attribute {
-                    name: "sqrt_price_x96".to_string(),
-                    value: BigInt::from_str(&swap.sqrt_price)
-                        .unwrap()
-                        .to_signed_bytes_be(),
-                    change: ChangeType::Update.into(),
-                },
-            ),
-            (
-                event.transaction.unwrap().into(),
-                hex::decode(event.pool_address).unwrap(),
-                Attribute {
-                    name: "tick".to_string(),
-                    value: BigInt::from(swap.tick).to_signed_bytes_be(),
-                    change: ChangeType::Update.into(),
-                },
-            ),
-        ],
-        pool_event::Type::SetFeeProtocol(sfp) => vec![
-            (
-                event
-                    .transaction
-                    .as_ref()
-                    .unwrap()
-                    .into(),
-                hex::decode(&event.pool_address).unwrap(),
-                Attribute {
-                    name: "protocol_fees/token0".to_string(),
-                    value: BigInt::from(sfp.fee_protocol_0_new).to_signed_bytes_be(),
-                    change: ChangeType::Update.into(),
-                },
-            ),
-            (
-                event.transaction.unwrap().into(),
-                hex::decode(event.pool_address).unwrap(),
-                Attribute {
-                    name: "protocol_fees/token1".to_string(),
-                    value: BigInt::from(sfp.fee_protocol_1_new).to_signed_bytes_be(),
-                    change: ChangeType::Update.into(),
-                },
-            ),
-        ],
-        _ => vec![],
-    }
 }

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/mod.rs
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/mod.rs
@@ -3,7 +3,15 @@ pub use map_protocol_changes::map_protocol_changes;
 pub use store_pools::store_pools;
 use substreams_ethereum::pb::eth::v2::TransactionTrace;
 
-use crate::pb::uniswap::v3::Transaction;
+use crate::pb::uniswap::v3::{
+    events::{pool_event, PoolEvent as ProtoPoolEvent},
+    LiquidityChange, LiquidityChangeType, TickDelta as ProtoTickDelta, Transaction,
+};
+use uniswap_v3_core::{
+    events::{PoolEvent as CorePoolEvent, PoolEventKind, TxRef},
+    liquidity::{LiquidityChangeKind, LiquidityDelta as CoreLiquidityDelta},
+    ticks::TickDelta as CoreTickDelta,
+};
 
 #[path = "1_map_pool_created.rs"]
 mod map_pool_created;
@@ -57,5 +65,187 @@ impl From<&Transaction> for tycho_substreams::prelude::Transaction {
 impl From<Transaction> for tycho_substreams::prelude::Transaction {
     fn from(value: Transaction) -> Self {
         Self { hash: value.hash, from: value.from, to: value.to, index: value.index }
+    }
+}
+
+/// Converts a proto `PoolEvent` to a core `PoolEvent`.
+/// Proto stores addresses as hex strings; core uses raw bytes.
+impl From<&ProtoPoolEvent> for CorePoolEvent {
+    fn from(proto: &ProtoPoolEvent) -> Self {
+        let pool_address = hex::decode(&proto.pool_address).unwrap_or_default();
+        let token0 = hex::decode(&proto.token0).unwrap_or_default();
+        let token1 = hex::decode(&proto.token1).unwrap_or_default();
+        let tx = proto.transaction.as_ref().map_or_else(
+            || TxRef { hash: vec![], from: vec![], to: vec![], index: 0 },
+            |t| TxRef {
+                hash: t.hash.clone(),
+                from: t.from.clone(),
+                to: t.to.clone(),
+                index: t.index,
+            },
+        );
+        let kind = match proto.r#type.as_ref().unwrap() {
+            pool_event::Type::Initialize(e) => {
+                PoolEventKind::Initialize { sqrt_price: e.sqrt_price.clone(), tick: e.tick }
+            }
+            pool_event::Type::Swap(e) => PoolEventKind::Swap {
+                amount0: e.amount_0.clone(),
+                amount1: e.amount_1.clone(),
+                sqrt_price: e.sqrt_price.clone(),
+                liquidity: e.liquidity.clone(),
+                tick: e.tick,
+            },
+            pool_event::Type::Mint(e) => PoolEventKind::Mint {
+                tick_lower: e.tick_lower,
+                tick_upper: e.tick_upper,
+                amount: e.amount.clone(),
+                amount0: e.amount_0.clone(),
+                amount1: e.amount_1.clone(),
+            },
+            pool_event::Type::Burn(e) => PoolEventKind::Burn {
+                tick_lower: e.tick_lower,
+                tick_upper: e.tick_upper,
+                amount: e.amount.clone(),
+                amount0: e.amount_0.clone(),
+                amount1: e.amount_1.clone(),
+            },
+            pool_event::Type::Collect(e) => {
+                PoolEventKind::Collect { amount0: e.amount_0.clone(), amount1: e.amount_1.clone() }
+            }
+            pool_event::Type::Flash(e) => {
+                PoolEventKind::Flash { paid0: e.paid_0.clone(), paid1: e.paid_1.clone() }
+            }
+            pool_event::Type::CollectProtocol(e) => PoolEventKind::CollectProtocol {
+                amount0: e.amount_0.clone(),
+                amount1: e.amount_1.clone(),
+            },
+            pool_event::Type::SetFeeProtocol(e) => PoolEventKind::SetFeeProtocol {
+                fee0_new: e.fee_protocol_0_new,
+                fee1_new: e.fee_protocol_1_new,
+            },
+        };
+        CorePoolEvent { log_ordinal: proto.log_ordinal, pool_address, token0, token1, tx, kind }
+    }
+}
+
+/// Converts a core `PoolEvent` to a proto `PoolEvent`.
+/// Core uses raw bytes; proto stores addresses as hex strings.
+impl From<CorePoolEvent> for ProtoPoolEvent {
+    fn from(e: CorePoolEvent) -> Self {
+        let transaction = Some(crate::pb::uniswap::v3::Transaction {
+            hash: e.tx.hash,
+            from: e.tx.from,
+            to: e.tx.to,
+            index: e.tx.index,
+        });
+        let r#type = Some(match e.kind {
+            PoolEventKind::Initialize { sqrt_price, tick } => {
+                pool_event::Type::Initialize(pool_event::Initialize { sqrt_price, tick })
+            }
+            PoolEventKind::Swap { amount0, amount1, sqrt_price, liquidity, tick } => {
+                pool_event::Type::Swap(pool_event::Swap {
+                    sender: String::new(),
+                    recipient: String::new(),
+                    amount_0: amount0,
+                    amount_1: amount1,
+                    sqrt_price,
+                    liquidity,
+                    tick,
+                })
+            }
+            PoolEventKind::Mint { tick_lower, tick_upper, amount, amount0, amount1 } => {
+                pool_event::Type::Mint(pool_event::Mint {
+                    sender: String::new(),
+                    owner: String::new(),
+                    tick_lower,
+                    tick_upper,
+                    amount,
+                    amount_0: amount0,
+                    amount_1: amount1,
+                })
+            }
+            PoolEventKind::Burn { tick_lower, tick_upper, amount, amount0, amount1 } => {
+                pool_event::Type::Burn(pool_event::Burn {
+                    owner: String::new(),
+                    tick_lower,
+                    tick_upper,
+                    amount,
+                    amount_0: amount0,
+                    amount_1: amount1,
+                })
+            }
+            PoolEventKind::Collect { amount0, amount1 } => {
+                pool_event::Type::Collect(pool_event::Collect {
+                    owner: String::new(),
+                    recipient: String::new(),
+                    tick_lower: 0,
+                    tick_upper: 0,
+                    amount_0: amount0,
+                    amount_1: amount1,
+                })
+            }
+            PoolEventKind::Flash { paid0, paid1 } => pool_event::Type::Flash(pool_event::Flash {
+                sender: String::new(),
+                recipient: String::new(),
+                amount_0: String::new(),
+                amount_1: String::new(),
+                paid_0: paid0,
+                paid_1: paid1,
+            }),
+            PoolEventKind::CollectProtocol { amount0, amount1 } => {
+                pool_event::Type::CollectProtocol(pool_event::CollectProtocol {
+                    sender: String::new(),
+                    recipient: String::new(),
+                    amount_0: amount0,
+                    amount_1: amount1,
+                })
+            }
+            PoolEventKind::SetFeeProtocol { fee0_new, fee1_new } => {
+                pool_event::Type::SetFeeProtocol(pool_event::SetFeeProtocol {
+                    fee_protocol_0_old: 0,
+                    fee_protocol_1_old: 0,
+                    fee_protocol_0_new: fee0_new,
+                    fee_protocol_1_new: fee1_new,
+                })
+            }
+        });
+        ProtoPoolEvent {
+            log_ordinal: e.log_ordinal,
+            pool_address: hex::encode(&e.pool_address),
+            token0: hex::encode(&e.token0),
+            token1: hex::encode(&e.token1),
+            transaction,
+            r#type,
+        }
+    }
+}
+
+impl From<CoreTickDelta> for ProtoTickDelta {
+    fn from(d: CoreTickDelta) -> Self {
+        Self {
+            pool_address: d.pool_address,
+            tick_index: d.tick_index,
+            liquidity_net_delta: d
+                .liquidity_net_delta
+                .to_signed_bytes_be(),
+            ordinal: 0,
+            transaction: None,
+        }
+    }
+}
+
+impl From<CoreLiquidityDelta> for LiquidityChange {
+    fn from(d: CoreLiquidityDelta) -> Self {
+        let change_type = match d.kind {
+            LiquidityChangeKind::Delta => LiquidityChangeType::Delta,
+            LiquidityChangeKind::Absolute => LiquidityChangeType::Absolute,
+        };
+        Self {
+            pool_address: d.pool_address,
+            value: d.value.to_signed_bytes_be(),
+            change_type: change_type.into(),
+            ordinal: 0,
+            transaction: None,
+        }
     }
 }

--- a/protocols/substreams/ethereum-uniswap-v3/rust-toolchain.toml
+++ b/protocols/substreams/ethereum-uniswap-v3/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.87.0"
 components = [ "rustfmt" ]
 targets = [ "wasm32-unknown-unknown" ]

--- a/protocols/substreams/ethereum-uniswap-v3/src/modules/3_map_balance_changes.rs
+++ b/protocols/substreams/ethereum-uniswap-v3/src/modules/3_map_balance_changes.rs
@@ -23,8 +23,7 @@ pub fn map_balance_changes(
             .flat_map(|call| &call.logs)
         {
             // Skip if the log is not from a known uniswapV3 pool.
-            if let Some(pool) =
-                pools_store.get_last(format!("{}:{}", "Pool", &log.address.to_hex()))
+            if let Some(pool) = pools_store.get_last(format!("{}:{}", "Pool", log.address.to_hex()))
             {
                 tx_deltas.extend(get_log_changed_balances(log, &pool))
             } else {

--- a/protocols/substreams/ethereum-uniswap-v3/src/modules/5_map_pool_events.rs
+++ b/protocols/substreams/ethereum-uniswap-v3/src/modules/5_map_pool_events.rs
@@ -37,8 +37,7 @@ pub fn map_pool_events(
     for trx in block.transactions() {
         for (log, call_view) in trx.logs_with_calls() {
             // Skip if the log is not from a known uniswapV3 pool.
-            if let Some(pool) =
-                pools_store.get_last(format!("{}:{}", "Pool", &log.address.to_hex()))
+            if let Some(pool) = pools_store.get_last(format!("{}:{}", "Pool", log.address.to_hex()))
             {
                 let changed_attributes = get_log_changed_attributes(
                     log,


### PR DESCRIPTION
## Summary

Extracts shared UniswapV3 indexing logic into a new `uniswap-v3-core` crate that compiles for both native and WASM targets. The substreams handlers in `ethereum-uniswap-v3-logs-only` become thin wrappers that delegate to it.

Adds a `TxDeltaIndexer` trait to `tycho-common`:

- `apply_block(block: &dto::BlockChanges)` — hydrates internal state from a finalised block; the first call serves as initialisation from a full snapshot, subsequent calls apply incremental deltas.
- `generate_deltas(txs: &[TxInput]) -> dto::BlockChanges` — applies a batch of in-flight transactions against the current state and returns the aggregated protocol state deltas they would produce. Does not mutate state; repeated calls with the same transactions return identical results.

The trait is designed as a native-code substitute for a Substreams package: an Ethereum block builder can feed it finalised `BlockChanges` from the Tycho client and then call `generate_deltas` to discover how a candidate transaction bundle would alter DEX state before deciding whether to include it.

`UniswapV3Processor` implements the trait. It stores chain/extractor metadata, running tick and liquidity maps, and token balances. `generate_deltas` operates on a clone of internal state so it is safe to call repeatedly.

`LogInput` and `TxInput` are defined in `tycho-common` with private fields and public constructors.

The integration test streams from substreams genesis (block 12_369_621) and compares processor output against substreams ground truth across 2000 blocks using `apply_block` / `generate_deltas` — 0 attribute mismatches, 0 balance mismatches across 136 attributes and 98 balances.

Also bumps the `ethereum-uniswap-v3` and `ethereum-uniswap-v3-logs-only` substreams toolchains from 1.83.0 to 1.87.0 — `hashbrown 0.17` (via `indexmap 2.14`) requires edition 2024 which needs Cargo ≥ 1.85.