### PR TITLE
fix: ensure_chains seeds token prices for pre-existing chains

### DIFF
--- a/crates/tycho-storage/src/postgres/mod.rs
+++ b/crates/tycho-storage/src/postgres/mod.rs
@@ -636,25 +636,22 @@ async fn ensure_chains(chains: &[Chain], pool: Pool<AsyncPgConnection>) {
     let mut conn = pool.get().await.expect("connection ok");
 
     for chain in chains {
-        let chain_id_res: Result<i64, _> = diesel::insert_into(schema::chain::table)
+        diesel::insert_into(schema::chain::table)
             .values(schema::chain::name.eq(chain.to_string()))
             .on_conflict_do_nothing()
-            .returning(schema::chain::id)
-            .get_result(&mut conn)
-            .await;
+            .execute(&mut conn)
+            .await
+            .expect("Could not ensure chain in database");
 
-        match chain_id_res {
-            Ok(chain_id) => {
-                ensure_token_with_price(chain_id, &chain.native_token(), &mut conn).await;
-                ensure_token_with_price(chain_id, &chain.wrapped_native_token(), &mut conn).await;
-            }
-            Err(diesel::result::Error::NotFound) => {
-                continue;
-            }
-            Err(err) => {
-                panic!("Could not ensure chain enum in database: {err}");
-            }
-        }
+        let chain_id: i64 = schema::chain::table
+            .select(schema::chain::id)
+            .filter(schema::chain::name.eq(chain.to_string()))
+            .first(&mut conn)
+            .await
+            .expect("Chain must exist after insert");
+
+        ensure_token_with_price(chain_id, &chain.native_token(), &mut conn).await;
+        ensure_token_with_price(chain_id, &chain.wrapped_native_token(), &mut conn).await;
     }
 
     debug!("Ensured chain enum and native token presence for: {:?}", chains);


### PR DESCRIPTION
## Summary

- Fixes a bug where `ensure_chains` skipped seeding native/wrapped-native token prices when the chain already existed in the DB
- The `INSERT ... ON CONFLICT DO NOTHING ... RETURNING id` pattern returns `NotFound` for existing rows, causing the code to `continue` and skip `ensure_token_with_price` entirely
- Replaced with insert-then-lookup so token prices are always seeded regardless of chain pre-existence

**JIRA:** [ENG-5967](https://propeller-heads.atlassian.net/browse/ENG-5967)

## Test plan

- [x] Deployed to dev with pre-existing Polygon chain — confirmed POL + WMATIC prices were NOT seeded (reproduces the bug)
- [ ] Deploy this fix and verify token prices appear for the pre-existing chain
- [x] Clippy and format pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-5967]: https://propeller-heads.atlassian.net/browse/ENG-5967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ