### PR TITLE
fix(encoding): Estimate gas properly for grouped swaps

### DIFF
--- a/crates/tycho-execution/src/encoding/evm/gas_estimator.rs
+++ b/crates/tycho-execution/src/encoding/evm/gas_estimator.rs
@@ -20,6 +20,7 @@ pub const PROTOCOLS_CALLBACK: &[&str] = &[
     "ekubo_v3",
     "aerodrome_slipstreams",
     "velodrome_slipstreams",
+    "vm:balancer_v3",
 ];
 
 /// ProtocolWillDebit: the router must `approve(protocol)` before swapping.

--- a/crates/tycho-execution/src/encoding/evm/group_swaps.rs
+++ b/crates/tycho-execution/src/encoding/evm/group_swaps.rs
@@ -101,7 +101,8 @@ pub fn group_swaps(swaps: &[Swap]) -> Vec<SwapGroup> {
 /// Aggregate per-swap gas estimates for a group, discounting transfers skipped by batching.
 ///
 /// Each swap's `estimated_gas` is assumed to include its input and output token transfer
-/// costs. When swaps are batched (e.g. USV4's PoolManager flash accounting), intermediate
+/// costs (this is acceptable because all protocols that can group do so with a callback mechanism).
+/// When swaps are batched (e.g. USV4's PoolManager flash accounting), intermediate
 /// transfers are saved: the first swap's output transfer, every middle swap's input and
 /// output transfers, and the last swap's input transfer. The group's external input and
 /// output transfers remain.

--- a/crates/tycho-execution/src/encoding/evm/group_swaps.rs
+++ b/crates/tycho-execution/src/encoding/evm/group_swaps.rs
@@ -12,7 +12,7 @@ use crate::encoding::{evm::constants::GROUPABLE_PROTOCOLS, models::Swap};
 /// * `protocol_system`: String, the protocol system of the swaps
 /// * `swaps`: Vec<Swap>, the sequence of swaps to be executed as a group
 /// * `split`: f64, the split percentage of the first swap in the group
-/// * `estimated_gas_usage`: BigUint, the estimated gas usage of the swap group
+/// * `estimated_gas`: BigUint, the estimated gas usage of the swap group
 #[derive(Clone, Debug)]
 pub struct SwapGroup {
     pub token_in: Bytes,
@@ -20,7 +20,7 @@ pub struct SwapGroup {
     pub protocol_system: String,
     pub swaps: Vec<Swap>,
     pub split: f64,
-    pub estimated_gas_usage: BigUint,
+    pub estimated_gas: BigUint,
 }
 
 impl PartialEq for SwapGroup {
@@ -29,7 +29,8 @@ impl PartialEq for SwapGroup {
             self.token_out == other.token_out &&
             self.protocol_system == other.protocol_system &&
             self.swaps == other.swaps &&
-            self.split == other.split
+            self.split == other.split &&
+            self.estimated_gas == other.estimated_gas
     }
 }
 
@@ -74,8 +75,9 @@ pub fn group_swaps(swaps: &[Swap]) -> Vec<SwapGroup> {
         } else {
             // Not second or later USV4 pool. Push the current group (if it exists) and then
             // create a new group.
-            if let Some(group) = current_group.as_mut() {
-                grouped_swaps.push(group.clone());
+            if let Some(mut group) = current_group.take() {
+                group.estimated_gas = compute_group_gas(&group.swaps);
+                grouped_swaps.push(group);
             }
             current_group = Some(SwapGroup {
                 token_in: swap.token_in().address.clone(),
@@ -83,16 +85,43 @@ pub fn group_swaps(swaps: &[Swap]) -> Vec<SwapGroup> {
                 protocol_system: current_swap_protocol.clone(),
                 swaps: vec![swap.clone()],
                 split: swap.split(),
-                estimated_gas_usage: BigUint::ZERO, // TODO: figure out what to do here
+                estimated_gas: BigUint::ZERO,
             });
         }
         last_swap_protocol = current_swap_protocol;
         last_swap_out_token = swap.token_out().address.clone();
     }
-    if let Some(group) = current_group.as_mut() {
-        grouped_swaps.push(group.clone());
+    if let Some(mut group) = current_group.take() {
+        group.estimated_gas = compute_group_gas(&group.swaps);
+        grouped_swaps.push(group);
     }
     grouped_swaps
+}
+
+/// Aggregate per-swap gas estimates for a group, discounting transfers skipped by batching.
+///
+/// Each swap's `estimated_gas` is assumed to include its input and output token transfer
+/// costs. When swaps are batched (e.g. USV4's PoolManager flash accounting), intermediate
+/// transfers are saved: the first swap's output transfer, every middle swap's input and
+/// output transfers, and the last swap's input transfer. The group's external input and
+/// output transfers remain.
+fn compute_group_gas(swaps: &[Swap]) -> BigUint {
+    let mut total_gas: BigUint = swaps
+        .iter()
+        .map(|s| s.estimated_gas().clone())
+        .sum();
+    let n = swaps.len();
+    if n <= 1 {
+        return total_gas;
+    }
+    let safe_sub = |t: BigUint, v: BigUint| if t >= v { t - v } else { BigUint::ZERO };
+    total_gas = safe_sub(total_gas, swaps[0].token_out().gas_usage());
+    for swap in &swaps[1..n - 1] {
+        total_gas = safe_sub(total_gas, swap.token_in().gas_usage());
+        total_gas = safe_sub(total_gas, swap.token_out().gas_usage());
+    }
+    total_gas = safe_sub(total_gas, swaps[n - 1].token_in().gas_usage());
+    total_gas
 }
 
 #[cfg(test)]
@@ -100,13 +129,20 @@ mod tests {
     use std::str::FromStr;
 
     use alloy::primitives::hex;
-    use tycho_common::{models::protocol::ProtocolComponent, Bytes};
+    use tycho_common::{
+        models::{protocol::ProtocolComponent, token::Token},
+        Bytes,
+    };
 
     use super::*;
     use crate::encoding::models::{default_token, Swap};
 
     fn weth() -> Bytes {
         Bytes::from(hex!("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").to_vec())
+    }
+
+    fn token_with_gas(address: Bytes, gas: u64) -> Token {
+        Token::new(&address, "", 0, 0, &[Some(gas)], Default::default(), 100)
     }
 
     #[test]
@@ -125,14 +161,14 @@ mod tests {
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
             default_token(weth.clone()),
             default_token(wbtc.clone()),
-            BigUint::ZERO,
+            BigUint::from(200_000u64),
         );
 
         let swap_wbtc_usdc = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
             default_token(wbtc.clone()),
             default_token(usdc.clone()),
-            BigUint::ZERO,
+            BigUint::from(220_000u64),
         );
 
         let swap_usdc_dai = Swap::new(
@@ -153,7 +189,7 @@ mod tests {
                     token_out: usdc.clone(),
                     protocol_system: "uniswap_v4".to_string(),
                     split: 0f64,
-                    estimated_gas_usage: BigUint::ZERO,
+                    estimated_gas: BigUint::from(300_000u64),
                 },
                 SwapGroup {
                     swaps: vec![swap_usdc_dai],
@@ -161,7 +197,7 @@ mod tests {
                     token_out: dai,
                     protocol_system: "uniswap_v2".to_string(),
                     split: 0f64,
-                    estimated_gas_usage: BigUint::ZERO,
+                    estimated_gas: BigUint::ZERO,
                 }
             ]
         );
@@ -199,7 +235,7 @@ mod tests {
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
             default_token(weth.clone()),
             default_token(dai.clone()),
-            BigUint::ZERO,
+            BigUint::from(220_000u64),
         );
         // Split 0 represents the remaining 50%, but to avoid any rounding errors we set this to
         // 0 to signify "the remainder of the WETH value". It should still be very close to 50%
@@ -208,7 +244,7 @@ mod tests {
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
             default_token(dai.clone()),
             default_token(usdc.clone()),
-            BigUint::ZERO,
+            BigUint::from(250_000u64),
         );
         let swaps = vec![
             swap_wbtc_weth.clone(),
@@ -227,7 +263,7 @@ mod tests {
                     token_out: weth.clone(),
                     protocol_system: "uniswap_v4".to_string(),
                     split: 0f64,
-                    estimated_gas_usage: BigUint::ZERO,
+                    estimated_gas: BigUint::ZERO,
                 },
                 SwapGroup {
                     swaps: vec![swap_weth_usdc],
@@ -235,7 +271,7 @@ mod tests {
                     token_out: usdc.clone(),
                     protocol_system: "uniswap_v4".to_string(),
                     split: 0.5f64,
-                    estimated_gas_usage: BigUint::ZERO,
+                    estimated_gas: BigUint::ZERO,
                 },
                 SwapGroup {
                     swaps: vec![swap_weth_dai, swap_dai_usdc],
@@ -243,7 +279,7 @@ mod tests {
                     token_out: usdc,
                     protocol_system: "uniswap_v4".to_string(),
                     split: 0f64,
-                    estimated_gas_usage: BigUint::ZERO,
+                    estimated_gas: BigUint::from(350_000u64),
                 }
             ]
         );
@@ -270,7 +306,7 @@ mod tests {
             },
             default_token(weth.clone()),
             default_token(wbtc.clone()),
-            BigUint::ZERO,
+            BigUint::from(220_000u64),
         )
         .with_split(0.5f64);
 
@@ -281,19 +317,19 @@ mod tests {
             },
             default_token(wbtc.clone()),
             default_token(usdc.clone()),
-            BigUint::ZERO,
+            BigUint::from(220_000u64),
         );
         let swap_weth_dai = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
             default_token(weth.clone()),
             default_token(dai.clone()),
-            BigUint::ZERO,
+            BigUint::from(250_000u64),
         );
         let swap_dai_usdc = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
             default_token(dai.clone()),
             default_token(usdc.clone()),
-            BigUint::ZERO,
+            BigUint::from(250_000u64),
         );
 
         let swaps = vec![
@@ -313,7 +349,7 @@ mod tests {
                     token_out: usdc.clone(),
                     protocol_system: "vm:balancer_v3".to_string(),
                     split: 0.5f64,
-                    estimated_gas_usage: BigUint::ZERO,
+                    estimated_gas: BigUint::from(320_000u64),
                 },
                 SwapGroup {
                     swaps: vec![swap_weth_dai, swap_dai_usdc],
@@ -321,7 +357,7 @@ mod tests {
                     token_out: usdc,
                     protocol_system: "uniswap_v4".to_string(),
                     split: 0f64,
-                    estimated_gas_usage: BigUint::ZERO,
+                    estimated_gas: BigUint::from(380_000u64),
                 }
             ]
         );
@@ -346,13 +382,13 @@ mod tests {
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
             default_token(usdc.clone()),
             default_token(weth.clone()),
-            BigUint::ZERO,
+            BigUint::from(220_000u64),
         );
         let swap_weth_usdc = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
             default_token(weth.clone()),
             default_token(usdc.clone()),
-            BigUint::ZERO,
+            BigUint::from(220_000u64),
         );
 
         let grouped_swaps = group_swaps(&[swap_usdc_weth.clone(), swap_weth_usdc.clone()]);
@@ -366,7 +402,7 @@ mod tests {
                     token_out: weth.clone(),
                     protocol_system: "uniswap_v4".to_string(),
                     split: 0f64,
-                    estimated_gas_usage: BigUint::ZERO,
+                    estimated_gas: BigUint::from(220_000u64),
                 },
                 SwapGroup {
                     swaps: vec![swap_weth_usdc],
@@ -374,7 +410,7 @@ mod tests {
                     token_out: usdc,
                     protocol_system: "uniswap_v4".to_string(),
                     split: 0f64,
-                    estimated_gas_usage: BigUint::ZERO,
+                    estimated_gas: BigUint::from(220_000u64),
                 },
             ]
         );
@@ -399,13 +435,13 @@ mod tests {
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
             default_token(usdc.clone()),
             default_token(weth.clone()),
-            BigUint::ZERO,
+            BigUint::from(220_000u64),
         );
         let swap_weth_dai = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
             default_token(weth.clone()),
             default_token(dai.clone()),
-            BigUint::ZERO,
+            BigUint::from(250_000u64),
         );
         let swap_dai_usdc = Swap::new(
             ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
@@ -426,7 +462,7 @@ mod tests {
                     token_out: dai.clone(),
                     protocol_system: "uniswap_v4".to_string(),
                     split: 0f64,
-                    estimated_gas_usage: BigUint::ZERO,
+                    estimated_gas: BigUint::from(350_000u64),
                 },
                 SwapGroup {
                     swaps: vec![swap_dai_usdc],
@@ -434,7 +470,7 @@ mod tests {
                     token_out: usdc,
                     protocol_system: "uniswap_v4".to_string(),
                     split: 0f64,
-                    estimated_gas_usage: BigUint::ZERO,
+                    estimated_gas: BigUint::ZERO,
                 },
             ]
         );
@@ -491,5 +527,109 @@ mod tests {
         assert_eq!(grouped_swaps[1].token_in, usdc);
         assert_eq!(grouped_swaps[1].token_out, dai);
         assert_eq!(grouped_swaps[1].protocol_system, "uniswap_v2");
+    }
+
+    #[test]
+    fn test_group_swaps_estimated_gas() {
+        //   WETH ──(USV4)──> WBTC ──(USV4)──> USDC ──(USV4)──> DAI
+
+        let weth = token_with_gas(weth(), 10);
+        let wbtc = token_with_gas(
+            Bytes::from_str("0x2260fac5e5542a773aa44fbcfedf7c193bc2c599").unwrap(),
+            20,
+        );
+        let usdc = token_with_gas(
+            Bytes::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap(),
+            30,
+        );
+        let dai = token_with_gas(
+            Bytes::from_str("0x6b175474e89094c44da98b954eedeac495271d0f").unwrap(),
+            40,
+        );
+
+        let swap_weth_wbtc = Swap::new(
+            ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
+            weth,
+            wbtc.clone(),
+            BigUint::from(1000u64),
+        );
+        let swap_wbtc_usdc = Swap::new(
+            ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
+            wbtc,
+            usdc.clone(),
+            BigUint::from(1500u64),
+        );
+        let swap_usdc_dai = Swap::new(
+            ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
+            usdc,
+            dai,
+            BigUint::from(2000u64),
+        );
+
+        let grouped_swaps = group_swaps(&[swap_weth_wbtc, swap_wbtc_usdc, swap_usdc_dai]);
+
+        assert_eq!(grouped_swaps.len(), 1);
+        // Sum: 1000 + 1500 + 2000 = 4500
+        // - first.token_out (wbtc=20) = 4480
+        // - middle.token_in (wbtc=20) + middle.token_out (usdc=30) = 4430
+        // - last.token_in (usdc=30) = 4400
+        assert_eq!(grouped_swaps[0].estimated_gas, BigUint::from(4400u64));
+    }
+
+    #[test]
+    fn test_group_swaps_estimated_gas_single_swap_group() {
+        // A single-swap group has no batching benefit, so its estimated_gas equals the
+        // swap's own estimated_gas with no subtraction.
+        let weth = token_with_gas(weth(), 10);
+        let usdc = token_with_gas(
+            Bytes::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap(),
+            30,
+        );
+
+        let swap = Swap::new(
+            ProtocolComponent { protocol_system: "uniswap_v2".to_string(), ..Default::default() },
+            weth,
+            usdc,
+            BigUint::from(1234u64),
+        );
+
+        let grouped_swaps = group_swaps(&[swap]);
+
+        assert_eq!(grouped_swaps.len(), 1);
+        assert_eq!(grouped_swaps[0].estimated_gas, BigUint::from(1234u64));
+    }
+
+    #[test]
+    fn test_group_swaps_estimated_gas_saturates_to_zero() {
+        // If the per-swap gas estimates are smaller than the transfer costs we need to
+        // subtract, the result should saturate to zero rather than underflow.
+        // This should never happen though!!
+        let weth = token_with_gas(weth(), 10_000);
+        let wbtc = token_with_gas(
+            Bytes::from_str("0x2260fac5e5542a773aa44fbcfedf7c193bc2c599").unwrap(),
+            10_000,
+        );
+        let usdc = token_with_gas(
+            Bytes::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap(),
+            10_000,
+        );
+
+        let swap_weth_wbtc = Swap::new(
+            ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
+            weth,
+            wbtc.clone(),
+            BigUint::from(50u64),
+        );
+        let swap_wbtc_usdc = Swap::new(
+            ProtocolComponent { protocol_system: "uniswap_v4".to_string(), ..Default::default() },
+            wbtc,
+            usdc,
+            BigUint::from(50u64),
+        );
+
+        let grouped_swaps = group_swaps(&[swap_weth_wbtc, swap_wbtc_usdc]);
+
+        assert_eq!(grouped_swaps.len(), 1);
+        assert_eq!(grouped_swaps[0].estimated_gas, BigUint::ZERO);
     }
 }

--- a/crates/tycho-execution/src/encoding/evm/tycho_encoders.rs
+++ b/crates/tycho-execution/src/encoding/evm/tycho_encoders.rs
@@ -281,7 +281,7 @@ impl TychoExecutorEncoder {
             swap_encoder.executor_address().clone(),
             "".to_string(),
             0,
-            grouped_swap.estimated_gas_usage.clone(),
+            grouped_swap.estimated_gas.clone(),
         ))
     }
 }

--- a/crates/tycho-execution/src/encoding/models.rs
+++ b/crates/tycho-execution/src/encoding/models.rs
@@ -258,7 +258,8 @@ impl PartialEq for Swap {
             self.token_out().address == other.token_out().address &&
             self.split() == other.split() &&
             self.user_data() == other.user_data() &&
-            self.estimated_amount_in() == other.estimated_amount_in()
+            self.estimated_amount_in() == other.estimated_amount_in() &&
+            self.estimated_gas() == other.estimated_gas()
     }
 }
 
@@ -423,7 +424,7 @@ pub(crate) enum Strategy {
 /// Only available in tests and when the `test-utils` feature is enabled.
 #[cfg(any(test, feature = "test-utils"))]
 pub fn default_token(address: Bytes) -> Token {
-    Token::new(&address, "", 0, 0, &[], Default::default(), 100)
+    Token::new(&address, "", 0, 0, &[Some(60_000u64)], Default::default(), 100)
 }
 
 mod tests {


### PR DESCRIPTION
Assumes that all protocols that can be grouped include both token in and out transfer gas usage in the swap.estimated_gas (this is acceptable because all protocols that can group do so with a callback mechanism). If there is a group we need to remove the extra token transfers gas costs that now will be saved:
- for the first hop: remove the token out transfer gas
- for all in between hops: remove both token out and in transfer gas
- for the last hop: remove the token in transfer gas

Misc fixes:
- add vm:balancer_v3 to PROTOCOLS_CALLBACK list
- Rename estimated_gas_usage -> estimated_gas in SwapGroup
- Extend PartialEq for SwapGroup and Swap

TODO later in fynd:
- Actually measure that this is reasonable and we are not doing nonsense stuff here. Theoretically I think this should work but would like to verify!
