### PR TITLE
feat(indexer): use jemalloc and add memory profiling tools

### DIFF
--- a/.github/workflows/cd-deploy-dev.yaml
+++ b/.github/workflows/cd-deploy-dev.yaml
@@ -7,7 +7,7 @@ name: Dev; Build and deploy
 # Choosing "tycho-indexer" deploys to all indexer services; picking a specific
 # name (e.g. "base-tycho-indexer") targets only that one.
 #
-# For tycho-integration-test the app_name input is ignored.
+# For tycho-integration-test the app_name, cargo_profile, and extra_cargo_flags inputs are ignored.
 on:
   workflow_dispatch:
     inputs:
@@ -32,6 +32,23 @@ on:
           - ethereum-tycho-indexer-new-protocol
           - base-tycho-indexer
           - unichain-tycho-indexer
+      cargo_profile:
+        description: >
+          Cargo build profile. "profiling" includes debug symbols for
+          heap profiling with jeprof/pprof and doesn't affect performance.
+        required: false
+        type: choice
+        default: profiling
+        options:
+          - profiling
+          - release
+      extra_cargo_flags:
+        description: >
+          Extra flags passed to cargo build (e.g. --no-default-features
+          to disable jemalloc).
+        required: false
+        type: string
+        default: ""
 
 permissions:
   id-token: write
@@ -49,6 +66,9 @@ jobs:
       image_tag: ${{ github.sha }}
       image_name: tycho-indexer
       dockerfile: docker/tycho-indexer.Dockerfile
+      build_args: |
+        CARGO_PROFILE=${{ inputs.cargo_profile }}
+        EXTRA_CARGO_FLAGS=${{ inputs.extra_cargo_flags }}
     secrets:
       app_id: ${{ secrets.APP_ID }}
       app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -49,6 +49,7 @@ jobs:
       image_tag: ${{ needs.release.outputs.next_release_version }}
       image_name: tycho-indexer
       dockerfile: docker/tycho-indexer.Dockerfile
+      build_args: CARGO_PROFILE=profiling # Use profiling profile for heap profiling with jeprof/pprof. The cost is a bigger binary, no performance penalty.
     secrets:
       app_id: ${{ secrets.APP_ID }}
       app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6480,6 +6480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eea0cc524de808a6d98d192a3d99fe95617031ad4a52ec0a0f987ef4432e8fe1"
 dependencies = [
  "anyhow",
+ "backtrace",
  "flate2",
  "num",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5081,6 +5081,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jemalloc_pprof"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d44c349cfe2654897fadcb9de4f0bfbf48288ec344f700b2bd59f152dd209"
+dependencies = [
+ "anyhow",
+ "libc",
+ "mappings",
+ "once_cell",
+ "pprof_util",
+ "tempfile",
+ "tikv-jemalloc-ctl",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5412,6 +5429,19 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "mappings"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bab1e61a4b76757edb59cd81fcaa7f3ba9018d43b527d9abfad877b4c6c60f2"
+dependencies = [
+ "anyhow",
+ "libc",
+ "once_cell",
+ "pprof_util",
+ "tracing",
+]
 
 [[package]]
 name = "matchers"
@@ -6442,6 +6472,19 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "pprof_util"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea0cc524de808a6d98d192a3d99fe95617031ad4a52ec0a0f987ef4432e8fe1"
+dependencies = [
+ "anyhow",
+ "flate2",
+ "num",
+ "paste",
+ "prost 0.14.3",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -8917,6 +8960,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9806,6 +9880,7 @@ dependencies = [
  "float_eq",
  "futures 0.3.31",
  "hex",
+ "jemalloc_pprof",
  "metrics",
  "metrics-exporter-prometheus 0.16.2",
  "metrics-util 0.20.0",
@@ -9829,6 +9904,8 @@ dependencies = [
  "serde_yaml",
  "test-log",
  "thiserror 1.0.69",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "tokio-retry",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,5 +117,9 @@ strip = "debuginfo"
 lto = true
 codegen-units = 1
 
+[profile.profiling]
+inherits = "release"
+debug = 1  # line tables for jeprof — human-readable stacks without full debuginfo overhead
+
 [profile.dev]
 debug = 0

--- a/crates/tycho-indexer/Cargo.toml
+++ b/crates/tycho-indexer/Cargo.toml
@@ -14,6 +14,7 @@ categories.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["jemalloc"]
 jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl", "dep:jemalloc_pprof"]
 
 [[bin]]

--- a/crates/tycho-indexer/Cargo.toml
+++ b/crates/tycho-indexer/Cargo.toml
@@ -88,7 +88,7 @@ utoipa = { version = "4.2.0", features = ["chrono"] }
 utoipa-swagger-ui = { version = "6.0.0", features = ["actix-web"] }
 tikv-jemallocator = { version = "0.6", features = ["profiling"], optional = true }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats"], optional = true }
-jemalloc_pprof = { version = "0.8", optional = true }
+jemalloc_pprof = { version = "0.8", features = ["symbolize"], optional = true }
 zstd = "0.13"
 
 [dev-dependencies]

--- a/crates/tycho-indexer/Cargo.toml
+++ b/crates/tycho-indexer/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl", "dep:jemalloc_pprof"]
+
 [[bin]]
 name = "tycho-indexer"
 path = "src/main.rs"
@@ -83,6 +86,9 @@ tracing-opentelemetry = { version = "0.23", default-features = false }
 tycho-substreams = "0.6.0"
 utoipa = { version = "4.2.0", features = ["chrono"] }
 utoipa-swagger-ui = { version = "6.0.0", features = ["actix-web"] }
+tikv-jemallocator = { version = "0.6", features = ["profiling"], optional = true }
+tikv-jemalloc-ctl = { version = "0.6", features = ["stats"], optional = true }
+jemalloc_pprof = { version = "0.8", optional = true }
 zstd = "0.13"
 
 [dev-dependencies]

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -1,5 +1,9 @@
 #![doc = include_str!("../README.md")]
 
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 // TODO: We need to use `use pretty_assertions::{assert_eq, assert_ne}` per test module.
 #[cfg(test)]
 #[macro_use]
@@ -165,6 +169,33 @@ async fn metrics_handler(handle: PrometheusHandle) -> impl Responder {
         .body(metrics)
 }
 
+/// Spawns a background task that emits jemalloc allocator stats as Prometheus gauges every 60s.
+///
+/// Emits `jemalloc_allocated_bytes` (live allocations) and `jemalloc_resident_bytes` (RSS as seen
+/// by jemalloc).
+#[cfg(feature = "jemalloc")]
+fn spawn_jemalloc_stats_reporter() {
+    use metrics::gauge;
+    use tikv_jemalloc_ctl::{epoch, stats};
+
+    tokio::spawn(async {
+        let mut tick = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            tick.tick().await;
+            // Advance the epoch to refresh stats.
+            if epoch::advance().is_err() {
+                continue;
+            }
+            if let Ok(allocated) = stats::allocated::read() {
+                gauge!("jemalloc_allocated_bytes").set(allocated as f64);
+            }
+            if let Ok(resident) = stats::resident::read() {
+                gauge!("jemalloc_resident_bytes").set(resident as f64);
+            }
+        }
+    });
+}
+
 /// Executes all extractors configured in the extractor configuration file and starts the server.
 ///
 /// Note: This function utilizes two distinct runtimes: one for extraction tasks and another
@@ -201,6 +232,8 @@ fn run_indexer(global_args: GlobalArgs, index_args: IndexArgs) -> Result<(), Ext
         .block_on(async {
             create_tracing_subscriber();
             let _metrics_task = create_metrics_exporter();
+            #[cfg(feature = "jemalloc")]
+            spawn_jemalloc_stats_reporter();
 
             info!("Starting Tycho");
             debug!("{} CPUs detected", num_cpus::get());
@@ -268,6 +301,9 @@ fn run_indexer(global_args: GlobalArgs, index_args: IndexArgs) -> Result<(), Ext
 #[tokio::main]
 async fn run_spkg(global_args: GlobalArgs, run_args: RunSpkgArgs) -> Result<(), ExtractionError> {
     create_tracing_subscriber();
+    let _metrics_task = create_metrics_exporter();
+    #[cfg(feature = "jemalloc")]
+    spawn_jemalloc_stats_reporter();
     info!("Starting Tycho");
 
     let dci_plugin = run_args
@@ -325,6 +361,9 @@ async fn run_spkg(global_args: GlobalArgs, run_args: RunSpkgArgs) -> Result<(), 
 #[tokio::main]
 async fn run_rpc(global_args: GlobalArgs) -> Result<(), ExtractionError> {
     create_tracing_subscriber();
+    let _metrics_task = create_metrics_exporter();
+    #[cfg(feature = "jemalloc")]
+    spawn_jemalloc_stats_reporter();
 
     let rpc_client = global_args.rpc.build_client()?;
 

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -301,9 +301,6 @@ fn run_indexer(global_args: GlobalArgs, index_args: IndexArgs) -> Result<(), Ext
 #[tokio::main]
 async fn run_spkg(global_args: GlobalArgs, run_args: RunSpkgArgs) -> Result<(), ExtractionError> {
     create_tracing_subscriber();
-    let _metrics_task = create_metrics_exporter();
-    #[cfg(feature = "jemalloc")]
-    spawn_jemalloc_stats_reporter();
     info!("Starting Tycho");
 
     let dci_plugin = run_args
@@ -361,9 +358,6 @@ async fn run_spkg(global_args: GlobalArgs, run_args: RunSpkgArgs) -> Result<(), 
 #[tokio::main]
 async fn run_rpc(global_args: GlobalArgs) -> Result<(), ExtractionError> {
     create_tracing_subscriber();
-    let _metrics_task = create_metrics_exporter();
-    #[cfg(feature = "jemalloc")]
-    spawn_jemalloc_stats_reporter();
 
     let rpc_client = global_args.rpc.build_client()?;
 

--- a/crates/tycho-indexer/src/services/debug.rs
+++ b/crates/tycho-indexer/src/services/debug.rs
@@ -2,17 +2,17 @@ use actix_web::{HttpResponse, Responder};
 
 /// Returns a heap profile in gzipped pprof protobuf format.
 ///
-/// Requires: built with `--features jemalloc` and started with
-/// `MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19`.
+/// Requires: started with
+/// `_RJEM_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19`.
 ///
 /// Usage:
-///   curl -o heap.pb.gz localhost:4242/debug/pprof/heap
+///   curl -H "Authorization: $AUTH_API_KEY" -o heap.pb.gz localhost:4242/debug/pprof/heap
 ///   go tool pprof -http=:8080 heap.pb.gz
 #[cfg(feature = "jemalloc")]
 pub async fn heap_profile() -> impl Responder {
     let Some(ctl) = jemalloc_pprof::PROF_CTL.as_ref() else {
         return HttpResponse::InternalServerError().body(
-            "heap profiling not available — set MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19",
+            "heap profiling not available — set _RJEM_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19",
         );
     };
     let mut prof_ctl = ctl.lock().await;
@@ -26,9 +26,4 @@ pub async fn heap_profile() -> impl Responder {
             .body(pprof),
         Err(err) => HttpResponse::InternalServerError().body(format!("heap dump failed: {err}")),
     }
-}
-
-#[cfg(not(feature = "jemalloc"))]
-pub async fn heap_profile() -> impl Responder {
-    HttpResponse::NotFound().body("not built with jemalloc feature")
 }

--- a/crates/tycho-indexer/src/services/debug.rs
+++ b/crates/tycho-indexer/src/services/debug.rs
@@ -1,0 +1,34 @@
+use actix_web::{HttpResponse, Responder};
+
+/// Returns a heap profile in gzipped pprof protobuf format.
+///
+/// Requires: built with `--features jemalloc` and started with
+/// `MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19`.
+///
+/// Usage:
+///   curl -o heap.pb.gz localhost:4242/debug/pprof/heap
+///   go tool pprof -http=:8080 heap.pb.gz
+#[cfg(feature = "jemalloc")]
+pub async fn heap_profile() -> impl Responder {
+    let Some(ctl) = jemalloc_pprof::PROF_CTL.as_ref() else {
+        return HttpResponse::InternalServerError().body(
+            "heap profiling not available — set MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19",
+        );
+    };
+    let mut prof_ctl = ctl.lock().await;
+    if !prof_ctl.activated() {
+        return HttpResponse::Forbidden().body("heap profiling not activated");
+    }
+    match prof_ctl.dump_pprof() {
+        Ok(pprof) => HttpResponse::Ok()
+            .content_type("application/octet-stream")
+            .append_header(("Content-Disposition", "attachment; filename=\"heap.pb.gz\""))
+            .body(pprof),
+        Err(err) => HttpResponse::InternalServerError().body(format!("heap dump failed: {err}")),
+    }
+}
+
+#[cfg(not(feature = "jemalloc"))]
+pub async fn heap_profile() -> impl Responder {
+    HttpResponse::NotFound().body("not built with jemalloc feature")
+}

--- a/crates/tycho-indexer/src/services/mod.rs
+++ b/crates/tycho-indexer/src/services/mod.rs
@@ -32,6 +32,7 @@ use crate::{
 mod access_control;
 mod api_docs;
 mod cache;
+mod debug;
 mod deltas_buffer;
 mod middleware;
 mod rpc;
@@ -262,6 +263,10 @@ where
                 )
                 .service(
                     SwaggerUi::new("/docs/{_:.*}").url("/api-docs/openapi.json", openapi.clone()),
+                )
+                .service(
+                    web::resource("/debug/pprof/heap")
+                        .route(web::get().to(debug::heap_profile)),
                 );
 
             if let Some(ws_data) = ws_data.clone() {

--- a/crates/tycho-indexer/src/services/mod.rs
+++ b/crates/tycho-indexer/src/services/mod.rs
@@ -32,6 +32,7 @@ use crate::{
 mod access_control;
 mod api_docs;
 mod cache;
+#[cfg(feature = "jemalloc")]
 mod debug;
 mod deltas_buffer;
 mod middleware;
@@ -264,11 +265,16 @@ where
                 .service(
                     SwaggerUi::new("/docs/{_:.*}").url("/api-docs/openapi.json", openapi.clone()),
                 )
-                .service(
+                ;
+
+            #[cfg(feature = "jemalloc")]
+            {
+                app = app.service(
                     web::resource("/debug/pprof/heap")
                         .wrap(access_control::AccessControl::new(&self.api_key))
                         .route(web::get().to(debug::heap_profile)),
                 );
+            }
 
             if let Some(ws_data) = ws_data.clone() {
                 app = app.app_data(ws_data).service(

--- a/crates/tycho-indexer/src/services/mod.rs
+++ b/crates/tycho-indexer/src/services/mod.rs
@@ -266,6 +266,7 @@ where
                 )
                 .service(
                     web::resource("/debug/pprof/heap")
+                        .wrap(access_control::AccessControl::new(&self.api_key))
                         .route(web::get().to(debug::heap_profile)),
                 );
 

--- a/crates/tycho-indexer/src/services/mod.rs
+++ b/crates/tycho-indexer/src/services/mod.rs
@@ -264,8 +264,7 @@ where
                 )
                 .service(
                     SwaggerUi::new("/docs/{_:.*}").url("/api-docs/openapi.json", openapi.clone()),
-                )
-                ;
+                );
 
             #[cfg(feature = "jemalloc")]
             {

--- a/docker/tycho-indexer.Dockerfile
+++ b/docker/tycho-indexer.Dockerfile
@@ -15,17 +15,19 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 # ── Stage 3: build ───────────────────────────────────────────────────────────
 FROM chef AS builder
+ARG CARGO_PROFILE=profiling
+ARG EXTRA_CARGO_FLAGS=""
 COPY --from=planner /build/recipe.json recipe.json
 # Pre-build deps only (cached layer)
 RUN cargo chef cook --package tycho-indexer --release --recipe-path recipe.json
 # Full build
 COPY . .
-RUN RUSTFLAGS="--cfg tokio_unstable" cargo build --package tycho-indexer --profile profiling --features jemalloc
+RUN RUSTFLAGS="--cfg tokio_unstable" cargo build --package tycho-indexer --profile ${CARGO_PROFILE} ${EXTRA_CARGO_FLAGS}
 
 # ── Stage 4: minimal runtime ─────────────────────────────────────────────────
 FROM debian:bookworm-slim
 WORKDIR /opt/tycho-indexer
-COPY --from=builder /build/target/profiling/tycho-indexer ./tycho-indexer
+COPY --from=builder /build/target/${CARGO_PROFILE}/tycho-indexer ./tycho-indexer
 COPY crates/tycho-indexer/extractors.yaml ./extractors.yaml
 RUN apt-get update && apt-get install -y libpq5 libcurl4 ca-certificates && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/tycho-indexer.Dockerfile
+++ b/docker/tycho-indexer.Dockerfile
@@ -15,7 +15,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 # ── Stage 3: build ───────────────────────────────────────────────────────────
 FROM chef AS builder
-ARG CARGO_PROFILE=profiling
+ARG CARGO_PROFILE=release
 ARG EXTRA_CARGO_FLAGS=""
 COPY --from=planner /build/recipe.json recipe.json
 # Pre-build deps only (cached layer)

--- a/docker/tycho-indexer.Dockerfile
+++ b/docker/tycho-indexer.Dockerfile
@@ -20,12 +20,12 @@ COPY --from=planner /build/recipe.json recipe.json
 RUN cargo chef cook --package tycho-indexer --release --recipe-path recipe.json
 # Full build
 COPY . .
-RUN RUSTFLAGS="--cfg tokio_unstable" cargo build --package tycho-indexer --release
+RUN RUSTFLAGS="--cfg tokio_unstable" cargo build --package tycho-indexer --profile profiling --features jemalloc
 
 # ── Stage 4: minimal runtime ─────────────────────────────────────────────────
 FROM debian:bookworm-slim
 WORKDIR /opt/tycho-indexer
-COPY --from=builder /build/target/release/tycho-indexer ./tycho-indexer
+COPY --from=builder /build/target/profiling/tycho-indexer ./tycho-indexer
 COPY crates/tycho-indexer/extractors.yaml ./extractors.yaml
 RUN apt-get update && apt-get install -y libpq5 libcurl4 ca-certificates && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

Adds jemalloc as the default allocator with built-in heap profiling support. From our tests, Jemalloc works much better than default Linux malloc for tycho-indexer. We also have a way to easily get a heap profile dump if we are seeing unexpected memory usage in the future. 

- **jemalloc allocator** behind a `jemalloc` cargo feature (default). Emits `jemalloc_allocated_bytes` and `jemalloc_resident_bytes` Prometheus gauges every 60s.
- **Heap profiling endpoint** at `GET /debug/pprof/heap` — returns a gzipped pprof protobuf with pre-symbolized function names (if built with profile `profiling`).
- **Profiling is opt-in at runtime** — set `_RJEM_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19` on the pod to activate. Without it, zero overhead.
- **`profiling` cargo profile** — release optimizations + line tables for readable heap dumps. Default in the Dockerfile.
- **Flexible CI build** — `cd-deploy-dev` workflow exposes `cargo_profile` and `extra_cargo_flags` inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)