### PR TITLE
feat: add signed gas_error_ratio metric histogram for integration tests

### DIFF
--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -1366,10 +1366,12 @@ fn process_execution_result(
             metrics::record_execution_slippage(&execution_info.protocol_system, slippage);
 
             if let Some(estimated) = execution_info.estimated_gas.to_f64() {
-                metrics::record_gas_error_ratio(
+                let actual = *gas_used as f64;
+                metrics::record_gas_error_ratio(&execution_info.protocol_system, estimated, actual);
+                metrics::record_gas_signed_error_ratio(
                     &execution_info.protocol_system,
                     estimated,
-                    *gas_used as f64,
+                    actual,
                 );
             }
 

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -1367,7 +1367,6 @@ fn process_execution_result(
 
             if let Some(estimated) = execution_info.estimated_gas.to_f64() {
                 let actual = *gas_used as f64;
-                metrics::record_gas_error_ratio(&execution_info.protocol_system, estimated, actual);
                 metrics::record_gas_signed_error_ratio(
                     &execution_info.protocol_system,
                     estimated,

--- a/crates/tycho-integration-test/src/metrics.rs
+++ b/crates/tycho-integration-test/src/metrics.rs
@@ -68,6 +68,11 @@ pub fn initialize_metrics() {
         "tycho_integration_simulation_gas_error_ratio",
         "Absolute gas estimation error as a fraction of actual gas: |estimated - actual| / actual"
     );
+    describe_histogram!(
+        "tycho_integration_simulation_gas_signed_error_ratio",
+        "Signed gas estimation error as a fraction of actual gas: (estimated - actual) / actual. \
+         Positive = overestimate, negative = underestimate"
+    );
 }
 
 /// Record the duration between block timestamp and component receipt.
@@ -202,6 +207,18 @@ pub fn record_gas_error_ratio(protocol: &str, estimated_gas: f64, actual_gas: f6
     }
 }
 
+/// Record signed gas estimation deviation as (estimated - actual) / actual
+pub fn record_gas_signed_error_ratio(protocol: &str, estimated_gas: f64, actual_gas: f64) {
+    if actual_gas > 0.0 {
+        let deviation = (estimated_gas - actual_gas) / actual_gas;
+        histogram!(
+            "tycho_integration_simulation_gas_signed_error_ratio",
+            "protocol" => protocol.to_string(),
+        )
+        .record(deviation);
+    }
+}
+
 /// Record a failed validation
 pub fn record_validation_failure(protocol: &str) {
     counter!(
@@ -246,6 +263,14 @@ pub async fn create_metrics_exporter(port: u16) -> Result<tokio::task::JoinHandl
         .set_buckets_for_metric(
             Matcher::Full("tycho_integration_simulation_gas_error_ratio".to_string()),
             &[0.0, 0.02, 0.04, 0.06, 0.08, 0.1, 0.25, 0.5, 1.0],
+        )
+        .map_err(|e| miette::miette!("Failed to set buckets: {}", e))?
+        .set_buckets_for_metric(
+            Matcher::Full("tycho_integration_simulation_gas_signed_error_ratio".to_string()),
+            &[
+                -1.0, -0.75, -0.5, -0.25, -0.1, -0.08, -0.06, -0.04, -0.02, 0.0, 0.02, 0.04, 0.06,
+                0.08, 0.1, 0.25, 0.5, 0.75, 1.0,
+            ],
         )
         .map_err(|e| miette::miette!("Failed to set buckets: {}", e))?;
     let handle = exporter_builder

--- a/crates/tycho-integration-test/src/metrics.rs
+++ b/crates/tycho-integration-test/src/metrics.rs
@@ -65,10 +65,6 @@ pub fn initialize_metrics() {
         "Total number of failed state validations"
     );
     describe_histogram!(
-        "tycho_integration_simulation_gas_error_ratio",
-        "Absolute gas estimation error as a fraction of actual gas: |estimated - actual| / actual"
-    );
-    describe_histogram!(
         "tycho_integration_simulation_gas_signed_error_ratio",
         "Signed gas estimation error as a fraction of actual gas: (estimated - actual) / actual. \
          Positive = overestimate, negative = underestimate"
@@ -195,18 +191,6 @@ pub fn record_protocol_update_block_delay(block_delay: u64) {
     histogram!("tycho_integration_protocol_update_block_delay_blocks").record(block_delay as f64);
 }
 
-/// Record gas estimation error as |estimated - actual| / actual
-pub fn record_gas_error_ratio(protocol: &str, estimated_gas: f64, actual_gas: f64) {
-    if actual_gas > 0.0 {
-        let ratio = (estimated_gas - actual_gas).abs() / actual_gas;
-        histogram!(
-            "tycho_integration_simulation_gas_error_ratio",
-            "protocol" => protocol.to_string(),
-        )
-        .record(ratio);
-    }
-}
-
 /// Record signed gas estimation deviation as (estimated - actual) / actual
 pub fn record_gas_signed_error_ratio(protocol: &str, estimated_gas: f64, actual_gas: f64) {
     if actual_gas > 0.0 {
@@ -258,11 +242,6 @@ pub async fn create_metrics_exporter(port: u16) -> Result<tokio::task::JoinHandl
         .set_buckets_for_metric(
             Matcher::Full("tycho_integration_protocol_update_block_delay_blocks".to_string()),
             &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 7.0, 10.0, 15.0, 20.0, 25.0],
-        )
-        .map_err(|e| miette::miette!("Failed to set buckets: {}", e))?
-        .set_buckets_for_metric(
-            Matcher::Full("tycho_integration_simulation_gas_error_ratio".to_string()),
-            &[0.0, 0.02, 0.04, 0.06, 0.08, 0.1, 0.25, 0.5, 1.0],
         )
         .map_err(|e| miette::miette!("Failed to set buckets: {}", e))?
         .set_buckets_for_metric(


### PR DESCRIPTION
 - add gas_error_ratio and gas_signed_error_ratio histograms to the integration test metrics, measuring `estimated_gas - actual_gas / actual_gas`
- emit the gas_signed_error_ratio metric
- buckets: with symmetric buckets from -100% to +100%  dense up to 10% threshold (2% steps), then a few for outliers [0.0, 0.02, 0.04, 0.06, 0.08, 0.1, 0.25, 0.5, 0.75, 1.0]
  
 