### PR TITLE
docs: direct users to get a base key before requesting upgrades

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -107,7 +107,7 @@ The quickstart shows you how to:
 Run Tycho Indexer by setting up the following environment variables:
 
 * TYCHO\_URL (by default `"tycho-beta.propellerheads.xyz"`)
-* TYCHO\_API\_KEY key
+* TYCHO\_API\_KEY key ([get one from @fynd\_portal\_bot](https://t.me/fynd_portal_bot))
 * PRIVATE\_KEY if you wish to execute the swap against the Tycho Router
 
 The Indexer stream or the Simulation does not manage tokens; you manage them yourself.

--- a/docs/for-solvers/hosted-endpoints.md
+++ b/docs/for-solvers/hosted-endpoints.md
@@ -29,7 +29,9 @@ Each API key is assigned a plan that determines rate limits and endpoint access.
 <table><thead><tr><th>Plan</th><th>Requests/sec</th><th>Burst</th><th>Max WebSocket Connections</th><th>Allowed Endpoints</th></tr></thead><tbody><tr><td>basic</td><td>50</td><td>300/s (6x)</td><td>2</td><td>Tycho Indexer, Tycho Fynd</td></tr><tr><td>fynd-basic</td><td>50</td><td>300/s (6x)</td><td>2</td><td>Tycho Fynd only</td></tr></tbody></table>
 
 {% hint style="info" %}
-Need higher limits? Contact @tanay\_j on Telegram.
+Don't have a key yet? Get a base-tier key from [@fynd_portal_bot](https://t.me/fynd_portal_bot) on Telegram.
+
+Need higher limits or full Tycho Indexer access? DM `@tanay_j` on Telegram to request an upgrade.
 {% endhint %}
 
 ### Data Restrictions

--- a/docs/for-solvers/indexer/tycho-client/README.md
+++ b/docs/for-solvers/indexer/tycho-client/README.md
@@ -36,7 +36,10 @@ We welcome community contributions to expand language support. See our contribut
 
 ## Authentication
 
-Currently, interacting with the hosted Tycho Indexer requires a personalized API Key. Please contact `@tanay_j` on Telegram to get your API key.
+Interacting with the hosted Tycho Indexer requires a personalized API Key.
+
+1. **Get a base key**: Message [@fynd_portal_bot](https://t.me/fynd_portal_bot) on Telegram to receive a Tycho Fynd key. This gives you access to [Tycho Fynd endpoints](../../hosted-endpoints.md#tycho-fynd).
+2. **Need full Tycho Indexer access?** Once you have a base key, DM `@tanay_j` on Telegram to request an upgrade.
 
 ***
 


### PR DESCRIPTION
## Summary

- Updated Tycho Client authentication docs to guide users through a two-step flow: get a base key from `@fynd_portal_bot` first, then DM `@tanay_j` for an upgrade to full Tycho Indexer access.
- Added `@fynd_portal_bot` link to the hosted endpoints rate limits section for users who don't have a key yet.
- Added bot link next to `TYCHO_API_KEY` in the quickstart setup section.

## Test plan

- [ ] Verify links to `https://t.me/fynd_portal_bot` resolve correctly
- [ ] Verify the hosted-endpoints anchor `#tycho-fynd` works in GitBook

🤖 Generated with [Claude Code](https://claude.com/claude-code)