### PR TITLE
feat(tycho-client): replace dto types with model types in public API

### DIFF
--- a/crates/tycho-client/src/cli.rs
+++ b/crates/tycho-client/src/cli.rs
@@ -1,9 +1,9 @@
 use std::{path::Path, str::FromStr};
 
 use clap::Parser;
-use tracing::{error, info};
+use tracing::info;
 use tracing_appender::rolling;
-use tycho_common::dto::{Chain, TvlThresholdTier};
+use tycho_common::{dto::TvlThresholdTier, models::Chain};
 
 use crate::{feed::component_tracker::ComponentFilter, stream::TychoStreamBuilder};
 
@@ -282,12 +282,10 @@ async fn run(exchanges: Vec<(String, Option<String>)>, args: CliArgs) -> Result<
             let msg =
                 result.map_err(|e| format!("Message printer received synchronizer error: {e}"))?;
 
-            if let Ok(msg_json) = serde_json::to_string(&msg) {
-                println!("{msg_json}");
-            } else {
-                // Log the error but continue processing further messages.
-                error!("Failed to serialize FeedMessage");
-            };
+            // TODO: cli.rs needs to convert model types to dto types for serialization
+            // FeedMessage no longer implements Serialize because StateSyncMessage uses model types.
+            // Using Debug output as a temporary fallback until proper serialization is implemented.
+            println!("{msg:?}");
         }
 
         Ok::<(), String>(())

--- a/crates/tycho-client/src/cli.rs
+++ b/crates/tycho-client/src/cli.rs
@@ -6,7 +6,7 @@ use tracing_appender::rolling;
 use tycho_common::{dto::TvlThresholdTier, models::Chain};
 
 use crate::{
-    feed::{component_tracker::ComponentFilter, dto::FeedMessageDto},
+    feed::{component_tracker::ComponentFilter, dto::FeedMessage as FeedMessageDto},
     stream::TychoStreamBuilder,
 };
 

--- a/crates/tycho-client/src/cli.rs
+++ b/crates/tycho-client/src/cli.rs
@@ -5,7 +5,10 @@ use tracing::info;
 use tracing_appender::rolling;
 use tycho_common::{dto::TvlThresholdTier, models::Chain};
 
-use crate::{feed::component_tracker::ComponentFilter, stream::TychoStreamBuilder};
+use crate::{
+    feed::{component_tracker::ComponentFilter, dto::FeedMessageDto},
+    stream::TychoStreamBuilder,
+};
 
 /// Tycho Client CLI - A tool for indexing and tracking blockchain protocol data
 ///
@@ -282,10 +285,9 @@ async fn run(exchanges: Vec<(String, Option<String>)>, args: CliArgs) -> Result<
             let msg =
                 result.map_err(|e| format!("Message printer received synchronizer error: {e}"))?;
 
-            // TODO: cli.rs needs to convert model types to dto types for serialization
-            // FeedMessage no longer implements Serialize because StateSyncMessage uses model types.
-            // Using Debug output as a temporary fallback until proper serialization is implemented.
-            println!("{msg:?}");
+            let json = serde_json::to_string(&FeedMessageDto::from(msg))
+                .map_err(|e| format!("Message printer failed to serialize message: {e}"))?;
+            println!("{json}");
         }
 
         Ok::<(), String>(())

--- a/crates/tycho-client/src/deltas.rs
+++ b/crates/tycho-client/src/deltas.rs
@@ -58,8 +58,9 @@ use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream,
 };
 use tracing::{debug, error, info, instrument, trace, warn};
-use tycho_common::dto::{
-    BlockChanges, Command, ExtractorIdentity, Response, WebSocketMessage, WebsocketError,
+use tycho_common::{
+    dto::{BlockChanges, Command, Response, WebSocketMessage, WebsocketError},
+    models::{blockchain::BlockAggregatedChanges, ExtractorIdentity},
 };
 use uuid::Uuid;
 use zstd;
@@ -77,7 +78,7 @@ pub enum DeltasError {
     SubscriptionAlreadyPending,
 
     #[error("The server replied with an error: {0}")]
-    ServerError(String, #[source] WebsocketError),
+    ServerError(String),
 
     /// A message failed to send via an internal channel or through the websocket channel.
     /// This is typically a fatal error and might indicate a bug in the implementation.
@@ -157,7 +158,7 @@ pub trait DeltasClient {
         &self,
         extractor_id: ExtractorIdentity,
         options: SubscriptionOptions,
-    ) -> Result<(Uuid, Receiver<BlockChanges>), DeltasError>;
+    ) -> Result<(Uuid, Receiver<BlockAggregatedChanges>), DeltasError>;
 
     /// Unsubscribe from an subscription
     async fn unsubscribe(&self, subscription_id: Uuid) -> Result<(), DeltasError>;
@@ -210,7 +211,9 @@ type WebSocketSink =
 #[derive(Debug)]
 enum SubscriptionInfo {
     /// Subscription was requested we wait for server confirmation and uuid assignment.
-    RequestedSubscription(oneshot::Sender<Result<(Uuid, Receiver<BlockChanges>), DeltasError>>),
+    RequestedSubscription(
+        oneshot::Sender<Result<(Uuid, Receiver<BlockAggregatedChanges>), DeltasError>>,
+    ),
     /// Subscription is active.
     Active,
     /// Unsubscription was requested, we wait for server confirmation.
@@ -223,13 +226,13 @@ struct Inner {
     sink: WebSocketSink,
     /// Command channel sender handle.
     cmd_tx: Sender<()>,
-    /// Currently pending subscriptions.
+    /// Currently pending subscriptions, keyed by model-layer extractor identity.
     pending: HashMap<ExtractorIdentity, SubscriptionInfo>,
     /// Active subscriptions.
     subscriptions: HashMap<Uuid, SubscriptionInfo>,
     /// For eachs subscription we keep a sender handle, the receiver is returned to the caller of
     /// subscribe.
-    sender: HashMap<Uuid, Sender<BlockChanges>>,
+    sender: HashMap<Uuid, Sender<BlockAggregatedChanges>>,
     /// How many messages to buffer per subscription before starting to drop new messages.
     buffer_size: usize,
 }
@@ -254,7 +257,7 @@ impl Inner {
     fn new_subscription(
         &mut self,
         id: &ExtractorIdentity,
-        ready_tx: oneshot::Sender<Result<(Uuid, Receiver<BlockChanges>), DeltasError>>,
+        ready_tx: oneshot::Sender<Result<(Uuid, Receiver<BlockAggregatedChanges>), DeltasError>>,
     ) -> Result<(), DeltasError> {
         if self.pending.contains_key(id) {
             return Err(DeltasError::SubscriptionAlreadyPending);
@@ -267,8 +270,8 @@ impl Inner {
     /// Transitions a pending subscription to active.
     ///
     /// Will ignore any request to do so for subscriptions that are not pending.
-    fn mark_active(&mut self, extractor_id: &ExtractorIdentity, subscription_id: Uuid) {
-        if let Some(info) = self.pending.remove(extractor_id) {
+    fn mark_active(&mut self, extractor_id: ExtractorIdentity, subscription_id: Uuid) {
+        if let Some(info) = self.pending.remove(&extractor_id) {
             if let SubscriptionInfo::RequestedSubscription(ready_tx) = info {
                 let (tx, rx) = mpsc::channel(self.buffer_size);
                 self.sender.insert(subscription_id, tx);
@@ -302,7 +305,7 @@ impl Inner {
 
     /// Sends a message to a subscription's receiver.
     #[allow(clippy::result_large_err)]
-    fn send(&mut self, id: &Uuid, msg: BlockChanges) -> Result<(), DeltasError> {
+    fn send(&mut self, id: &Uuid, msg: BlockAggregatedChanges) -> Result<(), DeltasError> {
         if let Some(sender) = self.sender.get_mut(id) {
             sender
                 .try_send(msg)
@@ -373,15 +376,14 @@ impl Inner {
         Ok(())
     }
 
-    fn cancel_pending(&mut self, extractor_id: &ExtractorIdentity, error: &WebsocketError) {
-        if let Some(sub_info) = self.pending.remove(extractor_id) {
+    fn cancel_pending(&mut self, extractor_id: ExtractorIdentity, error: &WebsocketError) {
+        if let Some(sub_info) = self.pending.remove(&extractor_id) {
             match sub_info {
                 SubscriptionInfo::RequestedSubscription(tx) => {
                     let _ = tx
-                        .send(Err(DeltasError::ServerError(
-                            format!("Subscription failed: {error}"),
-                            error.clone(),
-                        )))
+                        .send(Err(DeltasError::ServerError(format!(
+                            "Subscription failed: {error}"
+                        ))))
                         .map_err(|_| debug!("Cancel pending failed: receiver deallocated!"));
                 }
                 _ => {
@@ -533,7 +535,8 @@ impl WsDeltasClient {
                 Ok(value) => match serde_json::from_value::<WebSocketMessage>(value) {
                     Ok(ws_message) => match ws_message {
                         WebSocketMessage::BlockChanges { subscription_id, deltas } => {
-                            Self::handle_block_changes_msg(&mut guard, subscription_id, deltas).await?;
+                            Self::handle_block_changes_msg(&mut guard, subscription_id, deltas)
+                                .await?;
                         }
                         WebSocketMessage::Response(Response::NewSubscription {
                             extractor_id,
@@ -543,7 +546,7 @@ impl WsDeltasClient {
                             let inner = guard
                                 .as_mut()
                                 .ok_or_else(|| DeltasError::NotConnected)?;
-                            inner.mark_active(&extractor_id, subscription_id);
+                            inner.mark_active(extractor_id.into(), subscription_id);
                         }
                         WebSocketMessage::Response(Response::SubscriptionEnded {
                             subscription_id,
@@ -559,7 +562,7 @@ impl WsDeltasClient {
                                 let inner = guard
                                     .as_mut()
                                     .ok_or_else(|| DeltasError::NotConnected)?;
-                                inner.cancel_pending(extractor_id, &error);
+                                inner.cancel_pending(extractor_id.clone().into(), &error);
                             }
                             WebsocketError::SubscriptionNotFound(subscription_id) => {
                                 debug!("Received subscription not found, removing subscription");
@@ -569,26 +572,21 @@ impl WsDeltasClient {
                                 inner.remove_subscription(*subscription_id)?;
                             }
                             WebsocketError::ParseError(raw, e) => {
-                                return Err(DeltasError::ServerError(
-                                    format!(
-                                        "Server failed to parse client message: {e}, msg: {raw}"
-                                    ),
-                                    error.clone(),
-                                ))
+                                return Err(DeltasError::ServerError(format!(
+                                    "Server failed to parse client message: {e}, msg: {raw}"
+                                )))
                             }
                             WebsocketError::CompressionError(subscription_id, e) => {
-                                return Err(DeltasError::ServerError(
-                                    format!(
-                                        "Server failed to compress message for subscription: {subscription_id}, error: {e}"
-                                    ),
-                                    error.clone(),
-                                ))
+                                return Err(DeltasError::ServerError(format!(
+                                    "Server failed to compress message for subscription: \
+                                     {subscription_id}, error: {e}"
+                                )))
                             }
                             WebsocketError::SubscribeError(extractor_id) => {
                                 let inner = guard
                                     .as_mut()
                                     .ok_or_else(|| DeltasError::NotConnected)?;
-                                inner.cancel_pending(extractor_id, &error);
+                                inner.cancel_pending(extractor_id.clone().into(), &error);
                             }
                         },
                     },
@@ -610,36 +608,47 @@ impl WsDeltasClient {
                 // Decompress the zstd-compressed data,
                 // Note that we only support compressed BlockChanges messages for now.
                 match zstd::decode_all(data.as_slice()) {
-                    Ok(decompressed) => match serde_json::from_slice::<serde_json::Value>(decompressed.as_slice()) {
-                                Ok(value) => match serde_json::from_value::<WebSocketMessage>(value.clone()) {
+                    Ok(decompressed) => {
+                        match serde_json::from_slice::<serde_json::Value>(decompressed.as_slice()) {
+                            Ok(value) => {
+                                match serde_json::from_value::<WebSocketMessage>(value.clone()) {
                                     Ok(ws_message) => match ws_message {
-                                        WebSocketMessage::BlockChanges { subscription_id, deltas } => {
-                                            Self::handle_block_changes_msg(&mut guard, subscription_id, deltas).await?;
+                                        WebSocketMessage::BlockChanges {
+                                            subscription_id,
+                                            deltas,
+                                        } => {
+                                            Self::handle_block_changes_msg(
+                                                &mut guard,
+                                                subscription_id,
+                                                deltas,
+                                            )
+                                            .await?;
                                         }
                                         _ => {
                                             error!(
                                                 "Received unsupported compressed WebSocketMessage variant. \nMessage: {ws_message:?}",
                                             );
                                         }
-
                                     },
                                     Err(e) => {
                                         error!(
                                             "Failed to deserialize compressed WebSocketMessage: {e}. \nMessage: {value:?}",
                                         );
                                     }
-                                },
-                                Err(e) => {
-                                    error!(
-                                        "Failed to deserialize compressed message: invalid JSON. {e}",
-                                    );
                                 }
-                            },
+                            }
+                            Err(e) => {
+                                error!(
+                                    "Failed to deserialize compressed message: invalid JSON. {e}",
+                                );
+                            }
+                        }
+                    }
                     Err(e) => {
                         error!("Failed to decompress zstd data: {}", e);
                     }
                 }
-            },
+            }
             Ok(tungstenite::protocol::Message::Ping(_)) => {
                 // Respond to pings with pongs.
                 let inner = guard
@@ -692,7 +701,7 @@ impl WsDeltasClient {
         let inner = guard
             .as_mut()
             .ok_or_else(|| DeltasError::NotConnected)?;
-        match inner.send(&subscription_id, deltas) {
+        match inner.send(&subscription_id, BlockAggregatedChanges::from(deltas)) {
             Err(DeltasError::BufferFull) => {
                 error!(?subscription_id, "Buffer full, unsubscribing!");
                 Self::force_unsubscribe(subscription_id, inner).await;
@@ -768,7 +777,7 @@ impl DeltasClient for WsDeltasClient {
         &self,
         extractor_id: ExtractorIdentity,
         options: SubscriptionOptions,
-    ) -> Result<(Uuid, Receiver<BlockChanges>), DeltasError> {
+    ) -> Result<(Uuid, Receiver<BlockAggregatedChanges>), DeltasError> {
         trace!("Starting subscribe");
         self.ensure_connection().await?;
         let (ready_tx, ready_rx) = oneshot::channel();
@@ -780,7 +789,7 @@ impl DeltasClient for WsDeltasClient {
             trace!("Sending subscribe command");
             inner.new_subscription(&extractor_id, ready_tx)?;
             let cmd = Command::Subscribe {
-                extractor_id,
+                extractor_id: extractor_id.into(),
                 include_state: options.include_state,
                 compression: options.compression,
                 partial_blocks: options.partial_blocks,
@@ -1037,7 +1046,7 @@ mod tests {
     use std::{net::SocketAddr, str::FromStr};
 
     use tokio::{net::TcpListener, time::timeout};
-    use tycho_common::dto::Chain;
+    use tycho_common::models::Chain;
 
     use super::*;
 
@@ -1819,7 +1828,7 @@ mod tests {
 
         // Test ExtractorNotFound error
         let error_response = WebSocketMessage::Response(Response::Error(
-            WebsocketError::ExtractorNotFound(extractor_id.clone()),
+            WebsocketError::ExtractorNotFound(extractor_id.clone().into()),
         ));
         let error_json = serde_json::to_string(&error_response).unwrap();
 
@@ -1845,7 +1854,7 @@ mod tests {
 
         // Verify that we get a ServerError
         assert!(result.is_err());
-        if let Err(DeltasError::ServerError(msg, _)) = result {
+        if let Err(DeltasError::ServerError(msg)) = result {
             assert!(msg.contains("Subscription failed"));
             assert!(msg.contains("Extractor not found"));
         } else {
@@ -1963,7 +1972,7 @@ mod tests {
             .await
             .expect("ws loop should complete");
         assert!(result.is_err());
-        if let Err(DeltasError::ServerError(message, _)) = result {
+        if let Err(DeltasError::ServerError(message)) = result {
             assert!(message.contains("Server failed to parse client message"));
         } else {
             panic!("Expected DeltasError::ServerError, got: {:?}", result);
@@ -2013,7 +2022,7 @@ mod tests {
             .await
             .expect("ws loop should complete");
         assert!(result.is_err());
-        if let Err(DeltasError::ServerError(message, _)) = result {
+        if let Err(DeltasError::ServerError(message)) = result {
             assert!(message.contains("Server failed to compress message for subscription"));
         } else {
             panic!("Expected DeltasError::ServerError, got: {:?}", result);
@@ -2029,7 +2038,7 @@ mod tests {
         let extractor_id = ExtractorIdentity::new(Chain::Ethereum, "vm:ambient");
 
         let error_response = WebSocketMessage::Response(Response::Error(
-            WebsocketError::SubscribeError(extractor_id.clone()),
+            WebsocketError::SubscribeError(extractor_id.clone().into()),
         ));
         let error_json = serde_json::to_string(&error_response).unwrap();
 
@@ -2055,7 +2064,7 @@ mod tests {
 
         // Verify that we get a ServerError for subscribe failure
         assert!(result.is_err());
-        if let Err(DeltasError::ServerError(msg, _)) = result {
+        if let Err(DeltasError::ServerError(msg)) = result {
             assert!(msg.contains("Subscription failed"));
             assert!(msg.contains("Failed to subscribe to extractor"));
         } else {
@@ -2080,7 +2089,7 @@ mod tests {
         let extractor_id = ExtractorIdentity::new(Chain::Ethereum, "vm:ambient");
 
         let error_response = WebSocketMessage::Response(Response::Error(
-            WebsocketError::ExtractorNotFound(extractor_id.clone()),
+            WebsocketError::ExtractorNotFound(extractor_id.clone().into()),
         ));
         let error_json = serde_json::to_string(&error_response).unwrap();
 
@@ -2128,7 +2137,7 @@ mod tests {
 
         if let Err(DeltasError::SubscriptionAlreadyPending) = result2 {
             // This is expected for the second subscription
-        } else if let Err(DeltasError::ServerError(_, _)) = result1 {
+        } else if let Err(DeltasError::ServerError(_)) = result1 {
             // This is expected for the first subscription that gets the server error
         } else {
             panic!("Expected one SubscriptionAlreadyPending and one ServerError");

--- a/crates/tycho-client/src/deltas.rs
+++ b/crates/tycho-client/src/deltas.rs
@@ -59,7 +59,7 @@ use tokio_tungstenite::{
 };
 use tracing::{debug, error, info, instrument, trace, warn};
 use tycho_common::{
-    dto::{BlockChanges, Command, Response, WebSocketMessage, WebsocketError},
+    dto::{BlockAggregatedChanges as DtoBlockAggregatedChanges, Command, Response, WebSocketMessage, WebsocketError},
     models::{blockchain::BlockAggregatedChanges, ExtractorIdentity},
 };
 use uuid::Uuid;
@@ -534,7 +534,7 @@ impl WsDeltasClient {
             {
                 Ok(value) => match serde_json::from_value::<WebSocketMessage>(value) {
                     Ok(ws_message) => match ws_message {
-                        WebSocketMessage::BlockChanges { subscription_id, deltas } => {
+                        WebSocketMessage::BlockAggregatedChanges { subscription_id, deltas } => {
                             Self::handle_block_changes_msg(&mut guard, subscription_id, deltas)
                                 .await?;
                         }
@@ -606,14 +606,14 @@ impl WsDeltasClient {
             },
             Ok(tungstenite::protocol::Message::Binary(data)) => {
                 // Decompress the zstd-compressed data,
-                // Note that we only support compressed BlockChanges messages for now.
+                // Note that we only support compressed BlockAggregatedChanges messages for now.
                 match zstd::decode_all(data.as_slice()) {
                     Ok(decompressed) => {
                         match serde_json::from_slice::<serde_json::Value>(decompressed.as_slice()) {
                             Ok(value) => {
                                 match serde_json::from_value::<WebSocketMessage>(value.clone()) {
                                     Ok(ws_message) => match ws_message {
-                                        WebSocketMessage::BlockChanges {
+                                        WebSocketMessage::BlockAggregatedChanges {
                                             subscription_id,
                                             deltas,
                                         } => {
@@ -695,7 +695,7 @@ impl WsDeltasClient {
     async fn handle_block_changes_msg(
         guard: &mut MutexGuard<'_, Option<Inner>>,
         subscription_id: Uuid,
-        deltas: BlockChanges,
+        deltas: DtoBlockAggregatedChanges,
     ) -> Result<(), DeltasError> {
         trace!(?deltas, "Received a block state change, sending to channel");
         let inner = guard

--- a/crates/tycho-client/src/deltas.rs
+++ b/crates/tycho-client/src/deltas.rs
@@ -59,10 +59,7 @@ use tokio_tungstenite::{
 };
 use tracing::{debug, error, info, instrument, trace, warn};
 use tycho_common::{
-    dto::{
-        BlockAggregatedChanges as DtoBlockAggregatedChanges, Command, Response, WebSocketMessage,
-        WebsocketError,
-    },
+    dto::{self, Command, Response, WebSocketMessage, WebsocketError},
     models::{blockchain::BlockAggregatedChanges, ExtractorIdentity},
 };
 use uuid::Uuid;
@@ -700,7 +697,7 @@ impl WsDeltasClient {
     async fn handle_block_changes_msg(
         guard: &mut MutexGuard<'_, Option<Inner>>,
         subscription_id: Uuid,
-        deltas: DtoBlockAggregatedChanges,
+        deltas: dto::BlockAggregatedChanges,
     ) -> Result<(), DeltasError> {
         trace!(?deltas, "Received a block state change, sending to channel");
         let inner = guard

--- a/crates/tycho-client/src/deltas.rs
+++ b/crates/tycho-client/src/deltas.rs
@@ -59,7 +59,10 @@ use tokio_tungstenite::{
 };
 use tracing::{debug, error, info, instrument, trace, warn};
 use tycho_common::{
-    dto::{BlockAggregatedChanges as DtoBlockAggregatedChanges, Command, Response, WebSocketMessage, WebsocketError},
+    dto::{
+        BlockAggregatedChanges as DtoBlockAggregatedChanges, Command, Response, WebSocketMessage,
+        WebsocketError,
+    },
     models::{blockchain::BlockAggregatedChanges, ExtractorIdentity},
 };
 use uuid::Uuid;
@@ -666,7 +669,9 @@ impl WsDeltasClient {
             }
             Ok(tungstenite::protocol::Message::Close(frame)) => {
                 match &frame {
-                    Some(f) => warn!(code = ?f.code, reason = %f.reason, "WebSocket closed by server"),
+                    Some(f) => {
+                        warn!(code = ?f.code, reason = %f.reason, "WebSocket closed by server")
+                    }
                     None => warn!("WebSocket closed by server (no close frame)"),
                 }
                 return Err(DeltasError::ConnectionClosed);

--- a/crates/tycho-client/src/feed/component_tracker.rs
+++ b/crates/tycho-client/src/feed/component_tracker.rs
@@ -1,9 +1,10 @@
 use std::collections::{HashMap, HashSet};
 
 use tracing::{debug, instrument, warn};
-use tycho_common::{
-    dto::{BlockChanges, Chain, DCIUpdate, ProtocolComponent, ProtocolComponentsRequestBody},
-    models::{Address, ComponentId, ProtocolSystem},
+use tycho_common::models::{
+    blockchain::{BlockAggregatedChanges, DCIUpdate},
+    protocol::ProtocolComponent,
+    Address, Chain, ComponentId, ProtocolSystem,
 };
 
 use crate::{
@@ -172,27 +173,25 @@ where
     /// Retrieves all components that belong to the system we are streaming that have sufficient
     /// tvl. Also detects which contracts are relevant for simulating on those components.
     pub async fn initialise_components(&mut self) -> Result<(), RPCError> {
-        let body = match &self.filter.variant {
-            ComponentFilterVariant::Ids(ids) => ProtocolComponentsRequestBody::id_filtered(
-                &self.protocol_system,
-                ids.clone(),
-                self.chain,
-            ),
+        let (component_ids, tvl_gt) = match &self.filter.variant {
+            ComponentFilterVariant::Ids(ids) => (Some(ids.clone()), None),
             ComponentFilterVariant::MinimumTVLRange { range: (_, upper_tvl_threshold), .. } => {
-                ProtocolComponentsRequestBody::system_filtered(
-                    &self.protocol_system,
-                    Some(*upper_tvl_threshold),
-                    self.chain,
-                )
+                (None, Some(*upper_tvl_threshold))
             }
         };
         self.components = self
             .rpc_client
-            .get_protocol_components_paginated(&body, None, RPC_CLIENT_CONCURRENCY)
+            .get_protocol_components_paginated(
+                self.chain,
+                self.protocol_system.clone(),
+                component_ids,
+                tvl_gt,
+                None,
+                RPC_CLIENT_CONCURRENCY,
+            )
             .await?
-            .protocol_components
             .into_iter()
-            .map(|pc| (pc.id.clone(), pc))
+            .map(|comp| (comp.id.clone(), comp))
             .filter(|(id, _)| !self.filter.is_blocklisted(id))
             .collect::<HashMap<_, _>>();
 
@@ -207,7 +206,7 @@ where
         self.contracts = self
             .components
             .values()
-            .flat_map(|comp| comp.contract_ids.iter().cloned())
+            .flat_map(|comp| comp.contract_addresses.iter().cloned())
             .collect();
 
         // Add contracts from entrypoints that are linked to tracked components
@@ -235,8 +234,12 @@ where
         // Add contracts from the components
         for comp in components {
             if let Some(component) = self.components.get(&comp) {
-                self.contracts
-                    .extend(component.contract_ids.iter().cloned());
+                self.contracts.extend(
+                    component
+                        .contract_addresses
+                        .iter()
+                        .cloned(),
+                );
                 tracked_component_ids.insert(comp);
             }
         }
@@ -270,21 +273,22 @@ where
         }
 
         // Fetch the components
-        let request = ProtocolComponentsRequestBody::id_filtered(
-            &self.protocol_system,
-            new_components
-                .iter()
-                .map(|&id| id.to_string())
-                .collect(),
-            self.chain,
-        );
+        let ids_as_component_ids: Vec<ComponentId> = new_components
+            .iter()
+            .map(|&id| id.to_string())
+            .collect();
         let components = self
             .rpc_client
-            .get_protocol_components(&request)
+            .get_protocol_components(
+                crate::rpc::ProtocolComponentsParams::new(
+                    self.chain,
+                    self.protocol_system.as_str(),
+                )
+                .with_component_ids(ids_as_component_ids),
+            )
             .await?
-            .protocol_components
             .into_iter()
-            .map(|pc| (pc.id.clone(), pc))
+            .map(|comp| (comp.id.clone(), comp))
             .collect::<HashMap<_, _>>();
 
         // Update components and contracts
@@ -378,7 +382,7 @@ where
                         .flat_map(|ep| ep.contracts.iter().cloned())
                         .collect();
                     Some(
-                        comp.contract_ids
+                        comp.contract_addresses
                             .clone()
                             .into_iter()
                             .chain(dci_contracts)
@@ -406,7 +410,7 @@ where
     /// components that need to be added or removed.
     pub fn filter_updated_components(
         &self,
-        deltas: &BlockChanges,
+        deltas: &BlockAggregatedChanges,
     ) -> (Vec<ComponentId>, Vec<ComponentId>) {
         match &self.filter.variant {
             ComponentFilterVariant::Ids(_) => (Default::default(), Default::default()),
@@ -436,10 +440,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use tycho_common::{
-        dto::{PaginationResponse, ProtocolComponentRequestResponse},
-        Bytes,
-    };
+    use tycho_common::Bytes;
 
     use super::*;
     use crate::rpc::MockRPCClient;
@@ -455,29 +456,25 @@ mod test {
     }
 
     fn components_response() -> (Vec<Address>, ProtocolComponent) {
-        let contract_ids = vec![Bytes::from("0x1234"), Bytes::from("0xbabe")];
+        let contract_addresses = vec![Bytes::from("0x1234"), Bytes::from("0xbabe")];
         let component = ProtocolComponent {
             id: "Component1".to_string(),
-            contract_ids: contract_ids.clone(),
+            contract_addresses: contract_addresses.clone(),
             ..Default::default()
         };
-        (contract_ids, component)
+        (contract_addresses, component)
     }
 
     #[tokio::test]
     async fn test_initialise_components() {
         let mut tracker = with_mocked_rpc();
-        let (contract_ids, component) = components_response();
-        let exp_component = component.clone();
+        let (contract_ids, model_component) = components_response();
+        let exp_component = model_component.clone();
+        let model_for_mock = model_component.clone();
         tracker
             .rpc_client
             .expect_get_protocol_components_paginated()
-            .returning(move |_, _, _| {
-                Ok(ProtocolComponentRequestResponse {
-                    protocol_components: vec![component.clone()],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
-                })
-            });
+            .returning(move |_, _, _, _, _, _| Ok(vec![model_for_mock.clone()]));
 
         tracker
             .initialise_components()
@@ -497,19 +494,15 @@ mod test {
     #[tokio::test]
     async fn test_start_tracking() {
         let mut tracker = with_mocked_rpc();
-        let (contract_ids, component) = components_response();
+        let (contract_ids, model_component) = components_response();
         let exp_contracts = contract_ids.into_iter().collect();
-        let component_id = component.id.clone();
+        let component_id = model_component.id.clone();
         let components_arg = [&component_id];
+        let model_for_mock = model_component.clone();
         tracker
             .rpc_client
             .expect_get_protocol_components()
-            .returning(move |_| {
-                Ok(ProtocolComponentRequestResponse {
-                    protocol_components: vec![component.clone()],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
-                })
-            });
+            .returning(move |_| Ok(vec![model_for_mock.clone()]));
 
         tracker
             .start_tracking(&components_arg)
@@ -525,13 +518,13 @@ mod test {
     #[test]
     fn test_stop_tracking() {
         let mut tracker = with_mocked_rpc();
-        let (contract_ids, component) = components_response();
+        let (contract_ids, model_component) = components_response();
         tracker
             .components
-            .insert("Component1".to_string(), component.clone());
+            .insert("Component1".to_string(), model_component.clone());
         tracker.contracts.extend(contract_ids);
         let components_arg = ["Component1".to_string(), "Component2".to_string()];
-        let exp = [("Component1".to_string(), component)]
+        let exp = [("Component1".to_string(), model_component)]
             .into_iter()
             .collect();
 
@@ -544,10 +537,10 @@ mod test {
     #[test]
     fn test_get_contracts_by_component() {
         let mut tracker = with_mocked_rpc();
-        let (exp_contracts, component) = components_response();
+        let (exp_contracts, model_component) = components_response();
         tracker
             .components
-            .insert("Component1".to_string(), component);
+            .insert("Component1".to_string(), model_component);
         let components_arg = ["Component1".to_string()];
 
         let res = tracker.get_contracts_by_component(&components_arg);
@@ -558,10 +551,10 @@ mod test {
     #[test]
     fn test_get_tracked_component_ids() {
         let mut tracker = with_mocked_rpc();
-        let (_, component) = components_response();
+        let (_, model_component) = components_response();
         tracker
             .components
-            .insert("Component1".to_string(), component);
+            .insert("Component1".to_string(), model_component);
         let exp = vec!["Component1".to_string()];
 
         let res = tracker.get_tracked_component_ids();
@@ -582,16 +575,11 @@ mod test {
     #[tokio::test]
     async fn test_initialise_skips_blocklisted_components() {
         let mut tracker = with_mocked_rpc_and_blocklist(vec!["component1"]);
-        let (_, component) = components_response();
+        let (_, model_component) = components_response();
         tracker
             .rpc_client
             .expect_get_protocol_components_paginated()
-            .returning(move |_, _, _| {
-                Ok(ProtocolComponentRequestResponse {
-                    protocol_components: vec![component.clone()],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
-                })
-            });
+            .returning(move |_, _, _, _, _, _| Ok(vec![model_component.clone()]));
 
         tracker
             .initialise_components()
@@ -621,7 +609,7 @@ mod test {
         tracker.filter = ComponentFilter::with_tvl_range(5.0, 10.0)
             .blocklist(vec!["blocklisted_pool".to_string()]);
 
-        let deltas = BlockChanges {
+        let deltas = BlockAggregatedChanges {
             component_tvl: HashMap::from([
                 ("blocklisted_pool".to_string(), 100.0),
                 ("allowed_pool".to_string(), 100.0),

--- a/crates/tycho-client/src/feed/component_tracker.rs
+++ b/crates/tycho-client/src/feed/component_tracker.rs
@@ -8,7 +8,7 @@ use tycho_common::models::{
 };
 
 use crate::{
-    rpc::{RPCClient, RPC_CLIENT_CONCURRENCY},
+    rpc::{ProtocolComponentsPaginatedParams, RPCClient, RPC_CLIENT_CONCURRENCY},
     RPCError,
 };
 
@@ -179,16 +179,21 @@ where
                 (None, Some(*upper_tvl_threshold))
             }
         };
+        let mut paginated_params = ProtocolComponentsPaginatedParams::new(
+            self.chain,
+            self.protocol_system.as_str(),
+            RPC_CLIENT_CONCURRENCY,
+        );
+        if let Some(ids) = component_ids {
+            paginated_params = paginated_params.with_component_ids(ids);
+        }
+        if let Some(tvl) = tvl_gt {
+            paginated_params = paginated_params.with_tvl_gt(tvl);
+        }
+
         self.components = self
             .rpc_client
-            .get_protocol_components_paginated(
-                self.chain,
-                self.protocol_system.clone(),
-                component_ids,
-                tvl_gt,
-                None,
-                RPC_CLIENT_CONCURRENCY,
-            )
+            .get_protocol_components_paginated(paginated_params)
             .await?
             .into_iter()
             .map(|comp| (comp.id.clone(), comp))
@@ -406,7 +411,7 @@ where
             .collect()
     }
 
-    /// Given BlockChanges, filter out components that are no longer relevant and return the
+    /// Given BlockAggregatedChanges, filter out components that are no longer relevant and return the
     /// components that need to be added or removed.
     pub fn filter_updated_components(
         &self,
@@ -474,7 +479,7 @@ mod test {
         tracker
             .rpc_client
             .expect_get_protocol_components_paginated()
-            .returning(move |_, _, _, _, _, _| Ok(vec![model_for_mock.clone()]));
+            .returning(move |_| Ok(vec![model_for_mock.clone()]));
 
         tracker
             .initialise_components()
@@ -502,7 +507,7 @@ mod test {
         tracker
             .rpc_client
             .expect_get_protocol_components()
-            .returning(move |_| Ok(vec![model_for_mock.clone()]));
+            .returning(move |_| Ok(crate::rpc::Page::new(vec![model_for_mock.clone()], 1, 0, 100)));
 
         tracker
             .start_tracking(&components_arg)
@@ -579,7 +584,7 @@ mod test {
         tracker
             .rpc_client
             .expect_get_protocol_components_paginated()
-            .returning(move |_, _, _, _, _, _| Ok(vec![model_component.clone()]));
+            .returning(move |_| Ok(vec![model_component.clone()]));
 
         tracker
             .initialise_components()

--- a/crates/tycho-client/src/feed/component_tracker.rs
+++ b/crates/tycho-client/src/feed/component_tracker.rs
@@ -411,8 +411,8 @@ where
             .collect()
     }
 
-    /// Given BlockAggregatedChanges, filter out components that are no longer relevant and return the
-    /// components that need to be added or removed.
+    /// Given BlockAggregatedChanges, filter out components that are no longer relevant and return
+    /// the components that need to be added or removed.
     pub fn filter_updated_components(
         &self,
         deltas: &BlockAggregatedChanges,

--- a/crates/tycho-client/src/feed/component_tracker.rs
+++ b/crates/tycho-client/src/feed/component_tracker.rs
@@ -272,11 +272,6 @@ where
             return Ok(());
         }
 
-        // Fetch the components
-        let ids_as_component_ids: Vec<ComponentId> = new_components
-            .iter()
-            .map(|&id| id.to_string())
-            .collect();
         let components = self
             .rpc_client
             .get_protocol_components(
@@ -284,7 +279,12 @@ where
                     self.chain,
                     self.protocol_system.as_str(),
                 )
-                .with_component_ids(ids_as_component_ids),
+                .with_component_ids(
+                    new_components
+                        .into_iter()
+                        .cloned()
+                        .collect(),
+                ),
             )
             .await?
             .into_iter()

--- a/crates/tycho-client/src/feed/dto.rs
+++ b/crates/tycho-client/src/feed/dto.rs
@@ -1,6 +1,6 @@
 //! Serializable wrappers for the client feed pipeline types.
 //!
-//! [`FeedMessageDto`], [`StateSyncMessageDto`], etc. mirror the structures of their
+//! [`FeedMessage`], [`StateSyncMessage`], etc. mirror the structures of their
 //! model-based counterparts but use [`tycho_common::dto`] types that carry full
 //! `Serialize` / `Deserialize` support. The JSON format produced here matches the
 //! wire format (dto field names such as `contract_ids` and `state_updates`), which
@@ -8,6 +8,8 @@
 //! existing test fixture files.
 //!
 //! Conversion to and from the model-based pipeline types is provided via `From` impls.
+//! When both names are in scope use the module path to disambiguate, e.g.
+//! `feed::dto::ComponentWithState` vs `feed::synchronizer::ComponentWithState`.
 
 use std::collections::HashMap;
 
@@ -22,108 +24,49 @@ use tycho_common::{
 };
 
 use crate::feed::{
-    synchronizer::{ComponentWithState, Snapshot, StateSyncMessage},
-    BlockHeader, FeedMessage, HeaderLike, SynchronizerState,
+    synchronizer::{
+        ComponentWithState as ModelComponentWithState, Snapshot as ModelSnapshot,
+        StateSyncMessage as ModelStateSyncMessage,
+    },
+    BlockHeader, FeedMessage as ModelFeedMessage, HeaderLike, SynchronizerState,
 };
 
-/// Serializable counterpart of [`ComponentWithState`].
+/// Serializable counterpart of [`crate::feed::synchronizer::ComponentWithState`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ComponentWithStateDto {
+pub struct ComponentWithState {
     pub state: ResponseProtocolState,
     pub component: DtoProtocolComponent,
     pub component_tvl: Option<f64>,
     pub entrypoints: Vec<(DtoEntryPointWithTracingParams, DtoTracingResult)>,
 }
 
-/// Serializable counterpart of [`Snapshot`].
+/// Serializable counterpart of [`crate::feed::synchronizer::Snapshot`].
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct SnapshotDto {
-    pub states: HashMap<String, ComponentWithStateDto>,
+pub struct Snapshot {
+    pub states: HashMap<String, ComponentWithState>,
     #[serde(with = "tycho_common::serde_primitives::hex_hashmap_key")]
     pub vm_storage: HashMap<Bytes, ResponseAccount>,
 }
 
-/// Serializable counterpart of [`StateSyncMessage`].
+/// Serializable counterpart of [`crate::feed::synchronizer::StateSyncMessage`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StateSyncMessageDto<H = BlockHeader> {
+pub struct StateSyncMessage<H = BlockHeader> {
     pub header: H,
-    pub snapshots: SnapshotDto,
+    pub snapshots: Snapshot,
     pub deltas: Option<BlockChanges>,
     pub removed_components: HashMap<String, DtoProtocolComponent>,
 }
 
-/// Serializable counterpart of [`FeedMessage`].
+/// Serializable counterpart of [`crate::feed::FeedMessage`].
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct FeedMessageDto<H = BlockHeader> {
-    pub state_msgs: HashMap<String, StateSyncMessageDto<H>>,
+pub struct FeedMessage<H = BlockHeader> {
+    pub state_msgs: HashMap<String, StateSyncMessage<H>>,
     pub sync_states: HashMap<String, SynchronizerState>,
 }
 
-// ── FeedMessageDto → model types ──────────────────────────────────────────────
+// ── dto types → model types ───────────────────────────────────────────────────
 
-impl From<ComponentWithStateDto> for ComponentWithState {
-    fn from(value: ComponentWithStateDto) -> Self {
-        Self {
-            state: value.state.into(),
-            component: value.component.into(),
-            component_tvl: value.component_tvl,
-            entrypoints: value
-                .entrypoints
-                .into_iter()
-                .map(|(ep, tr)| (ep.into(), tr.into()))
-                .collect(),
-        }
-    }
-}
-
-impl From<SnapshotDto> for Snapshot {
-    fn from(value: SnapshotDto) -> Self {
-        Self {
-            states: value
-                .states
-                .into_iter()
-                .map(|(k, v)| (k, v.into()))
-                .collect(),
-            vm_storage: value
-                .vm_storage
-                .into_iter()
-                .map(|(k, v)| (k, v.into()))
-                .collect(),
-        }
-    }
-}
-
-impl<H: HeaderLike> From<StateSyncMessageDto<H>> for StateSyncMessage<H> {
-    fn from(value: StateSyncMessageDto<H>) -> Self {
-        Self {
-            header: value.header,
-            snapshots: value.snapshots.into(),
-            deltas: value.deltas.map(Into::into),
-            removed_components: value
-                .removed_components
-                .into_iter()
-                .map(|(k, v)| (k, v.into()))
-                .collect(),
-        }
-    }
-}
-
-impl<H: HeaderLike> From<FeedMessageDto<H>> for FeedMessage<H> {
-    fn from(value: FeedMessageDto<H>) -> Self {
-        Self {
-            state_msgs: value
-                .state_msgs
-                .into_iter()
-                .map(|(k, v)| (k, v.into()))
-                .collect(),
-            sync_states: value.sync_states,
-        }
-    }
-}
-
-// ── model types → FeedMessageDto ──────────────────────────────────────────────
-
-impl From<ComponentWithState> for ComponentWithStateDto {
+impl From<ComponentWithState> for ModelComponentWithState {
     fn from(value: ComponentWithState) -> Self {
         Self {
             state: value.state.into(),
@@ -138,7 +81,7 @@ impl From<ComponentWithState> for ComponentWithStateDto {
     }
 }
 
-impl From<Snapshot> for SnapshotDto {
+impl From<Snapshot> for ModelSnapshot {
     fn from(value: Snapshot) -> Self {
         Self {
             states: value
@@ -155,7 +98,7 @@ impl From<Snapshot> for SnapshotDto {
     }
 }
 
-impl<H: HeaderLike> From<StateSyncMessage<H>> for StateSyncMessageDto<H> {
+impl<H: HeaderLike> From<StateSyncMessage<H>> for ModelStateSyncMessage<H> {
     fn from(value: StateSyncMessage<H>) -> Self {
         Self {
             header: value.header,
@@ -170,8 +113,70 @@ impl<H: HeaderLike> From<StateSyncMessage<H>> for StateSyncMessageDto<H> {
     }
 }
 
-impl<H: HeaderLike> From<FeedMessage<H>> for FeedMessageDto<H> {
+impl<H: HeaderLike> From<FeedMessage<H>> for ModelFeedMessage<H> {
     fn from(value: FeedMessage<H>) -> Self {
+        Self {
+            state_msgs: value
+                .state_msgs
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+            sync_states: value.sync_states,
+        }
+    }
+}
+
+// ── model types → dto types ───────────────────────────────────────────────────
+
+impl From<ModelComponentWithState> for ComponentWithState {
+    fn from(value: ModelComponentWithState) -> Self {
+        Self {
+            state: value.state.into(),
+            component: value.component.into(),
+            component_tvl: value.component_tvl,
+            entrypoints: value
+                .entrypoints
+                .into_iter()
+                .map(|(ep, tr)| (ep.into(), tr.into()))
+                .collect(),
+        }
+    }
+}
+
+impl From<ModelSnapshot> for Snapshot {
+    fn from(value: ModelSnapshot) -> Self {
+        Self {
+            states: value
+                .states
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+            vm_storage: value
+                .vm_storage
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+        }
+    }
+}
+
+impl<H: HeaderLike> From<ModelStateSyncMessage<H>> for StateSyncMessage<H> {
+    fn from(value: ModelStateSyncMessage<H>) -> Self {
+        Self {
+            header: value.header,
+            snapshots: value.snapshots.into(),
+            deltas: value.deltas.map(Into::into),
+            removed_components: value
+                .removed_components
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+        }
+    }
+}
+
+impl<H: HeaderLike> From<ModelFeedMessage<H>> for FeedMessage<H> {
+    fn from(value: ModelFeedMessage<H>) -> Self {
         Self {
             state_msgs: value
                 .state_msgs

--- a/crates/tycho-client/src/feed/dto.rs
+++ b/crates/tycho-client/src/feed/dto.rs
@@ -15,29 +15,19 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use tycho_common::{
-    dto::{
-        BlockAggregatedChanges, EntryPointWithTracingParams as DtoEntryPointWithTracingParams,
-        ProtocolComponent as DtoProtocolComponent, ResponseAccount, ResponseProtocolState,
-        TracingResult as DtoTracingResult,
-    },
+    dto::{self, BlockAggregatedChanges, ResponseAccount, ResponseProtocolState},
     Bytes,
 };
 
-use crate::feed::{
-    synchronizer::{
-        ComponentWithState as ModelComponentWithState, Snapshot as ModelSnapshot,
-        StateSyncMessage as ModelStateSyncMessage,
-    },
-    BlockHeader, FeedMessage as ModelFeedMessage, HeaderLike, SynchronizerState,
-};
+use crate::feed::{self as feed_model, synchronizer, BlockHeader, HeaderLike, SynchronizerState};
 
 /// Serializable counterpart of [`crate::feed::synchronizer::ComponentWithState`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComponentWithState {
     pub state: ResponseProtocolState,
-    pub component: DtoProtocolComponent,
+    pub component: dto::ProtocolComponent,
     pub component_tvl: Option<f64>,
-    pub entrypoints: Vec<(DtoEntryPointWithTracingParams, DtoTracingResult)>,
+    pub entrypoints: Vec<(dto::EntryPointWithTracingParams, dto::TracingResult)>,
 }
 
 /// Serializable counterpart of [`crate::feed::synchronizer::Snapshot`].
@@ -54,7 +44,7 @@ pub struct StateSyncMessage<H = BlockHeader> {
     pub header: H,
     pub snapshots: Snapshot,
     pub deltas: Option<BlockAggregatedChanges>,
-    pub removed_components: HashMap<String, DtoProtocolComponent>,
+    pub removed_components: HashMap<String, dto::ProtocolComponent>,
 }
 
 /// Serializable counterpart of [`crate::feed::FeedMessage`].
@@ -66,7 +56,7 @@ pub struct FeedMessage<H = BlockHeader> {
 
 // ── dto types → model types ───────────────────────────────────────────────────
 
-impl From<ComponentWithState> for ModelComponentWithState {
+impl From<ComponentWithState> for synchronizer::ComponentWithState {
     fn from(value: ComponentWithState) -> Self {
         Self {
             state: value.state.into(),
@@ -81,7 +71,7 @@ impl From<ComponentWithState> for ModelComponentWithState {
     }
 }
 
-impl From<Snapshot> for ModelSnapshot {
+impl From<Snapshot> for synchronizer::Snapshot {
     fn from(value: Snapshot) -> Self {
         Self {
             states: value
@@ -98,7 +88,7 @@ impl From<Snapshot> for ModelSnapshot {
     }
 }
 
-impl<H: HeaderLike> From<StateSyncMessage<H>> for ModelStateSyncMessage<H> {
+impl<H: HeaderLike> From<StateSyncMessage<H>> for synchronizer::StateSyncMessage<H> {
     fn from(value: StateSyncMessage<H>) -> Self {
         Self {
             header: value.header,
@@ -113,7 +103,7 @@ impl<H: HeaderLike> From<StateSyncMessage<H>> for ModelStateSyncMessage<H> {
     }
 }
 
-impl<H: HeaderLike> From<FeedMessage<H>> for ModelFeedMessage<H> {
+impl<H: HeaderLike> From<FeedMessage<H>> for feed_model::FeedMessage<H> {
     fn from(value: FeedMessage<H>) -> Self {
         Self {
             state_msgs: value
@@ -128,8 +118,8 @@ impl<H: HeaderLike> From<FeedMessage<H>> for ModelFeedMessage<H> {
 
 // ── model types → dto types ───────────────────────────────────────────────────
 
-impl From<ModelComponentWithState> for ComponentWithState {
-    fn from(value: ModelComponentWithState) -> Self {
+impl From<synchronizer::ComponentWithState> for ComponentWithState {
+    fn from(value: synchronizer::ComponentWithState) -> Self {
         Self {
             state: value.state.into(),
             component: value.component.into(),
@@ -143,8 +133,8 @@ impl From<ModelComponentWithState> for ComponentWithState {
     }
 }
 
-impl From<ModelSnapshot> for Snapshot {
-    fn from(value: ModelSnapshot) -> Self {
+impl From<synchronizer::Snapshot> for Snapshot {
+    fn from(value: synchronizer::Snapshot) -> Self {
         Self {
             states: value
                 .states
@@ -160,8 +150,8 @@ impl From<ModelSnapshot> for Snapshot {
     }
 }
 
-impl<H: HeaderLike> From<ModelStateSyncMessage<H>> for StateSyncMessage<H> {
-    fn from(value: ModelStateSyncMessage<H>) -> Self {
+impl<H: HeaderLike> From<synchronizer::StateSyncMessage<H>> for StateSyncMessage<H> {
+    fn from(value: synchronizer::StateSyncMessage<H>) -> Self {
         Self {
             header: value.header,
             snapshots: value.snapshots.into(),
@@ -175,8 +165,8 @@ impl<H: HeaderLike> From<ModelStateSyncMessage<H>> for StateSyncMessage<H> {
     }
 }
 
-impl<H: HeaderLike> From<ModelFeedMessage<H>> for FeedMessage<H> {
-    fn from(value: ModelFeedMessage<H>) -> Self {
+impl<H: HeaderLike> From<feed_model::FeedMessage<H>> for FeedMessage<H> {
+    fn from(value: feed_model::FeedMessage<H>) -> Self {
         Self {
             state_msgs: value
                 .state_msgs

--- a/crates/tycho-client/src/feed/dto.rs
+++ b/crates/tycho-client/src/feed/dto.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use tycho_common::{
     dto::{
-        BlockChanges, EntryPointWithTracingParams as DtoEntryPointWithTracingParams,
+        BlockAggregatedChanges, EntryPointWithTracingParams as DtoEntryPointWithTracingParams,
         ProtocolComponent as DtoProtocolComponent, ResponseAccount, ResponseProtocolState,
         TracingResult as DtoTracingResult,
     },
@@ -53,7 +53,7 @@ pub struct Snapshot {
 pub struct StateSyncMessage<H = BlockHeader> {
     pub header: H,
     pub snapshots: Snapshot,
-    pub deltas: Option<BlockChanges>,
+    pub deltas: Option<BlockAggregatedChanges>,
     pub removed_components: HashMap<String, DtoProtocolComponent>,
 }
 

--- a/crates/tycho-client/src/feed/dto.rs
+++ b/crates/tycho-client/src/feed/dto.rs
@@ -1,0 +1,184 @@
+//! Serializable wrappers for the client feed pipeline types.
+//!
+//! [`FeedMessageDto`], [`StateSyncMessageDto`], etc. mirror the structures of their
+//! model-based counterparts but use [`tycho_common::dto`] types that carry full
+//! `Serialize` / `Deserialize` support. The JSON format produced here matches the
+//! wire format (dto field names such as `contract_ids` and `state_updates`), which
+//! keeps the CLI output backwards-compatible with existing tooling and preserves the
+//! existing test fixture files.
+//!
+//! Conversion to and from the model-based pipeline types is provided via `From` impls.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use tycho_common::{
+    dto::{
+        BlockChanges, EntryPointWithTracingParams as DtoEntryPointWithTracingParams,
+        ProtocolComponent as DtoProtocolComponent, ResponseAccount, ResponseProtocolState,
+        TracingResult as DtoTracingResult,
+    },
+    Bytes,
+};
+
+use crate::feed::{
+    synchronizer::{ComponentWithState, Snapshot, StateSyncMessage},
+    BlockHeader, FeedMessage, HeaderLike, SynchronizerState,
+};
+
+/// Serializable counterpart of [`ComponentWithState`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComponentWithStateDto {
+    pub state: ResponseProtocolState,
+    pub component: DtoProtocolComponent,
+    pub component_tvl: Option<f64>,
+    pub entrypoints: Vec<(DtoEntryPointWithTracingParams, DtoTracingResult)>,
+}
+
+/// Serializable counterpart of [`Snapshot`].
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SnapshotDto {
+    pub states: HashMap<String, ComponentWithStateDto>,
+    #[serde(with = "tycho_common::serde_primitives::hex_hashmap_key")]
+    pub vm_storage: HashMap<Bytes, ResponseAccount>,
+}
+
+/// Serializable counterpart of [`StateSyncMessage`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateSyncMessageDto<H = BlockHeader> {
+    pub header: H,
+    pub snapshots: SnapshotDto,
+    pub deltas: Option<BlockChanges>,
+    pub removed_components: HashMap<String, DtoProtocolComponent>,
+}
+
+/// Serializable counterpart of [`FeedMessage`].
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct FeedMessageDto<H = BlockHeader> {
+    pub state_msgs: HashMap<String, StateSyncMessageDto<H>>,
+    pub sync_states: HashMap<String, SynchronizerState>,
+}
+
+// ── FeedMessageDto → model types ──────────────────────────────────────────────
+
+impl From<ComponentWithStateDto> for ComponentWithState {
+    fn from(value: ComponentWithStateDto) -> Self {
+        Self {
+            state: value.state.into(),
+            component: value.component.into(),
+            component_tvl: value.component_tvl,
+            entrypoints: value
+                .entrypoints
+                .into_iter()
+                .map(|(ep, tr)| (ep.into(), tr.into()))
+                .collect(),
+        }
+    }
+}
+
+impl From<SnapshotDto> for Snapshot {
+    fn from(value: SnapshotDto) -> Self {
+        Self {
+            states: value
+                .states
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+            vm_storage: value
+                .vm_storage
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+        }
+    }
+}
+
+impl<H: HeaderLike> From<StateSyncMessageDto<H>> for StateSyncMessage<H> {
+    fn from(value: StateSyncMessageDto<H>) -> Self {
+        Self {
+            header: value.header,
+            snapshots: value.snapshots.into(),
+            deltas: value.deltas.map(Into::into),
+            removed_components: value
+                .removed_components
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+        }
+    }
+}
+
+impl<H: HeaderLike> From<FeedMessageDto<H>> for FeedMessage<H> {
+    fn from(value: FeedMessageDto<H>) -> Self {
+        Self {
+            state_msgs: value
+                .state_msgs
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+            sync_states: value.sync_states,
+        }
+    }
+}
+
+// ── model types → FeedMessageDto ──────────────────────────────────────────────
+
+impl From<ComponentWithState> for ComponentWithStateDto {
+    fn from(value: ComponentWithState) -> Self {
+        Self {
+            state: value.state.into(),
+            component: value.component.into(),
+            component_tvl: value.component_tvl,
+            entrypoints: value
+                .entrypoints
+                .into_iter()
+                .map(|(ep, tr)| (ep.into(), tr.into()))
+                .collect(),
+        }
+    }
+}
+
+impl From<Snapshot> for SnapshotDto {
+    fn from(value: Snapshot) -> Self {
+        Self {
+            states: value
+                .states
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+            vm_storage: value
+                .vm_storage
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+        }
+    }
+}
+
+impl<H: HeaderLike> From<StateSyncMessage<H>> for StateSyncMessageDto<H> {
+    fn from(value: StateSyncMessage<H>) -> Self {
+        Self {
+            header: value.header,
+            snapshots: value.snapshots.into(),
+            deltas: value.deltas.map(Into::into),
+            removed_components: value
+                .removed_components
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+        }
+    }
+}
+
+impl<H: HeaderLike> From<FeedMessage<H>> for FeedMessageDto<H> {
+    fn from(value: FeedMessage<H>) -> Self {
+        Self {
+            state_msgs: value
+                .state_msgs
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+            sync_states: value.sync_states,
+        }
+    }
+}

--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -30,6 +30,7 @@ use crate::feed::{
 
 mod block_history;
 pub mod component_tracker;
+pub mod dto;
 pub mod synchronizer;
 
 /// A trait representing a minimal interface for types that behave like a block header.

--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -19,7 +19,7 @@ use tokio::{
 use tracing::{debug, error, info, trace, warn};
 use tycho_common::{
     display::opt,
-    dto::{BlockChanges, ExtractorIdentity},
+    models::{blockchain::BlockAggregatedChanges, ExtractorIdentity},
     Bytes,
 };
 
@@ -75,8 +75,8 @@ impl Display for BlockHeader {
     }
 }
 
-impl From<&BlockChanges> for BlockHeader {
-    fn from(block_changes: &BlockChanges) -> Self {
+impl From<&BlockAggregatedChanges> for BlockHeader {
+    fn from(block_changes: &BlockAggregatedChanges) -> Self {
         let block = &block_changes.block;
         Self {
             hash: block.hash.clone(),
@@ -557,7 +557,7 @@ impl SynchronizerStream {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct FeedMessage<H = BlockHeader>
 where
     H: HeaderLike,
@@ -1057,7 +1057,7 @@ mod tests {
     use async_trait::async_trait;
     use test_log::test;
     use tokio::sync::{oneshot, Mutex};
-    use tycho_common::dto::Chain;
+    use tycho_common::models::Chain;
 
     use super::*;
     use crate::feed::synchronizer::{SyncResult, SynchronizerTaskHandle};

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -864,8 +864,7 @@ mod test {
     use tycho_common::models::{
         blockchain::{
             AddressStorageLocation, Block, BlockAggregatedChanges, DCIUpdate, EntryPoint,
-            EntryPointWithTracingParams as ModelEntryPointWithTracingParams, RPCTracerParams,
-            TracingParams, TracingResult as ModelTracingResult,
+            EntryPointWithTracingParams, RPCTracerParams, TracingParams, TracingResult,
         },
         protocol::{ProtocolComponent, ProtocolComponentState},
         token::Token,
@@ -1217,31 +1216,27 @@ mod test {
     }
 
     fn traced_entry_point_response(
-    ) -> HashMap<String, Vec<(ModelEntryPointWithTracingParams, ModelTracingResult)>> {
-        use tycho_common::models::blockchain::{
-            AddressStorageLocation as ModelASL, EntryPoint as ModelEntryPoint,
-            RPCTracerParams as ModelRPCTP, TracingParams as ModelTP,
-        };
+    ) -> HashMap<String, Vec<(EntryPointWithTracingParams, TracingResult)>> {
         HashMap::from([(
             "Component1".to_string(),
             vec![(
-                ModelEntryPointWithTracingParams {
-                    entry_point: ModelEntryPoint {
+                EntryPointWithTracingParams {
+                    entry_point: EntryPoint {
                         external_id: "entrypoint_a".to_string(),
                         target: Bytes::from("0x0badc0ffee"),
                         signature: "sig()".to_string(),
                     },
-                    params: ModelTP::RPCTracer(ModelRPCTP {
+                    params: TracingParams::RPCTracer(RPCTracerParams {
                         caller: Some(Bytes::from("0x0badc0ffee")),
                         calldata: Bytes::from("0x0badc0ffee"),
                         state_overrides: None,
                         prune_addresses: None,
                     }),
                 },
-                ModelTracingResult {
+                TracingResult {
                     retriggers: HashSet::from([(
                         Bytes::from("0x0badc0ffee"),
-                        ModelASL::new(Bytes::from("0x0badc0ffee"), 12),
+                        AddressStorageLocation::new(Bytes::from("0x0badc0ffee"), 12),
                     )]),
                     accessed_slots: HashMap::from([(
                         Bytes::from("0x0badc0ffee"),

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -28,7 +28,7 @@ use crate::{
         component_tracker::{ComponentFilter, ComponentTracker},
         BlockHeader, HeaderLike,
     },
-    rpc::{RPCClient, RPCError, SnapshotParameters, RPC_CLIENT_CONCURRENCY},
+    rpc::{RPCClient, RPCError, SnapshotParameters, TracedEntryPointsPaginatedParams, RPC_CLIENT_CONCURRENCY},
     DeltasError,
 };
 
@@ -339,11 +339,12 @@ where
             let result = self
                 .rpc_client
                 .get_traced_entry_points_paginated(
-                    self.extractor_id.chain,
-                    &self.extractor_id.name,
-                    &component_ids,
-                    None,
-                    RPC_CLIENT_CONCURRENCY,
+                    TracedEntryPointsPaginatedParams::new(
+                        self.extractor_id.chain,
+                        self.extractor_id.name.as_str(),
+                        component_ids.clone(),
+                        RPC_CLIENT_CONCURRENCY,
+                    ),
                 )
                 .await?;
             self.component_tracker
@@ -859,9 +860,10 @@ mod test {
 
     use tycho_common::{
         dto::{
-            AddressStorageLocation, Block, BlockChanges, Chain, DCIUpdate, EntryPoint,
-            PaginationResponse, ProtocolStateRequestResponse, RPCTracerParams, ResponseAccount,
-            ResponseProtocolState, StateRequestResponse, TracingParams,
+            AddressStorageLocation, Block, BlockAggregatedChanges as DtoBlockAggregatedChanges,
+            Chain, DCIUpdate, EntryPoint, PaginationResponse, ProtocolStateRequestResponse,
+            RPCTracerParams, ResponseAccount, ResponseProtocolState, StateRequestResponse,
+            TracingParams,
         },
         models::{
             blockchain::{
@@ -876,7 +878,7 @@ mod test {
     use uuid::Uuid;
 
     use super::*;
-    use crate::{deltas::MockDeltasClient, rpc::MockRPCClient, DeltasError, RPCError};
+    use crate::{deltas::MockDeltasClient, rpc::{MockRPCClient, Page}, DeltasError, RPCError};
 
     // Required for mock client to implement clone
     struct ArcRPCClient<T>(Arc<T>);
@@ -896,21 +898,21 @@ mod test {
         async fn get_tokens(
             &self,
             params: crate::rpc::TokensParams,
-        ) -> Result<Vec<Token>, RPCError> {
+        ) -> Result<crate::rpc::Page<Vec<Token>>, RPCError> {
             self.0.get_tokens(params).await
         }
 
         async fn get_contract_state(
             &self,
             params: crate::rpc::ContractStateParams,
-        ) -> Result<Vec<Account>, RPCError> {
+        ) -> Result<crate::rpc::Page<Vec<Account>>, RPCError> {
             self.0.get_contract_state(params).await
         }
 
         async fn get_protocol_components(
             &self,
             params: crate::rpc::ProtocolComponentsParams,
-        ) -> Result<Vec<ProtocolComponent>, RPCError> {
+        ) -> Result<crate::rpc::Page<Vec<ProtocolComponent>>, RPCError> {
             self.0
                 .get_protocol_components(params)
                 .await
@@ -919,14 +921,14 @@ mod test {
         async fn get_protocol_states(
             &self,
             params: crate::rpc::ProtocolStatesParams,
-        ) -> Result<Vec<ProtocolComponentState>, RPCError> {
+        ) -> Result<crate::rpc::Page<Vec<ProtocolComponentState>>, RPCError> {
             self.0.get_protocol_states(params).await
         }
 
         async fn get_protocol_systems(
             &self,
             params: crate::rpc::ProtocolSystemsParams,
-        ) -> Result<crate::rpc::ProtocolSystemsResponse, RPCError> {
+        ) -> Result<crate::rpc::Page<crate::rpc::ProtocolSystems>, RPCError> {
             self.0
                 .get_protocol_systems(params)
                 .await
@@ -935,14 +937,14 @@ mod test {
         async fn get_component_tvl(
             &self,
             params: crate::rpc::ComponentTvlParams,
-        ) -> Result<HashMap<String, f64>, RPCError> {
+        ) -> Result<crate::rpc::Page<HashMap<String, f64>>, RPCError> {
             self.0.get_component_tvl(params).await
         }
 
         async fn get_traced_entry_points(
             &self,
             params: crate::rpc::TracedEntryPointsParams,
-        ) -> Result<HashMap<String, Vec<(EntryPointWithTracingParams, TracingResult)>>, RPCError>
+        ) -> Result<crate::rpc::Page<HashMap<String, Vec<(EntryPointWithTracingParams, TracingResult)>>>, RPCError>
         {
             self.0
                 .get_traced_entry_points(params)
@@ -1077,7 +1079,7 @@ mod test {
             });
 
         rpc.expect_get_traced_entry_points()
-            .returning(|_| Ok(HashMap::new()));
+            .returning(|_| Ok(Page::new(HashMap::new(), 0, 0, 0)));
 
         let mut state_sync = with_mocked_clients(true, false, Some(rpc), None);
         state_sync
@@ -1147,7 +1149,7 @@ mod test {
             });
 
         rpc.expect_get_traced_entry_points()
-            .returning(|_| Ok(HashMap::new()));
+            .returning(|_| Ok(Page::new(HashMap::new(), 0, 0, 0)));
 
         let mut state_sync = with_mocked_clients(true, true, Some(rpc), None);
         state_sync
@@ -1280,7 +1282,7 @@ mod test {
             });
 
         rpc.expect_get_traced_entry_points()
-            .returning(move |_| Ok(traced_entry_point_response()));
+            .returning(move |_| Ok(Page::new(traced_entry_point_response(), 1, 0, 100)));
 
         let mut state_sync = with_mocked_clients(false, false, Some(rpc), None);
         let component = ProtocolComponent {
@@ -1370,7 +1372,7 @@ mod test {
             });
 
         rpc.expect_get_traced_entry_points()
-            .returning(|_| Ok(HashMap::new()));
+            .returning(|_| Ok(Page::new(HashMap::new(), 0, 0, 0)));
 
         let mut state_sync = with_mocked_clients(false, true, Some(rpc), None);
         state_sync
@@ -1465,7 +1467,7 @@ mod test {
             });
 
         rpc.expect_get_traced_entry_points()
-            .returning(|_| Ok(HashMap::new()));
+            .returning(|_| Ok(Page::new(HashMap::new(), 0, 0, 0)));
 
         let mut state_sync = with_mocked_clients(true, false, Some(rpc), None);
 
@@ -1521,10 +1523,15 @@ mod test {
             })
             .returning(|_| {
                 // return Component3
-                Ok(vec![
-                    // this component shall have a tvl update above threshold
-                    ProtocolComponent { id: "Component3".to_string(), ..Default::default() },
-                ])
+                Ok(Page::new(
+                    vec![
+                        // this component shall have a tvl update above threshold
+                        ProtocolComponent { id: "Component3".to_string(), ..Default::default() },
+                    ],
+                    1,
+                    0,
+                    100,
+                ))
             });
         // Mock get_snapshots for Component3
         rpc_client
@@ -1567,13 +1574,18 @@ mod test {
             .expect_get_protocol_components()
             .returning(|_| {
                 // Initial sync of components
-                Ok(vec![
-                    // this component shall have a tvl update above threshold
-                    ProtocolComponent { id: "Component1".to_string(), ..Default::default() },
-                    // this component shall have a tvl update below threshold.
-                    ProtocolComponent { id: "Component2".to_string(), ..Default::default() },
-                    // a third component will have a tvl update above threshold
-                ])
+                Ok(Page::new(
+                    vec![
+                        // this component shall have a tvl update above threshold
+                        ProtocolComponent { id: "Component1".to_string(), ..Default::default() },
+                        // this component shall have a tvl update below threshold.
+                        ProtocolComponent { id: "Component2".to_string(), ..Default::default() },
+                        // a third component will have a tvl update above threshold
+                    ],
+                    2,
+                    0,
+                    100,
+                ))
             });
 
         rpc_client
@@ -1623,7 +1635,7 @@ mod test {
         // Mock get_traced_entry_points for Ethereum chain
         rpc_client
             .expect_get_traced_entry_points()
-            .returning(|_| Ok(HashMap::new()));
+            .returning(|_| Ok(Page::new(HashMap::new(), 0, 0, 0)));
 
         // Mock deltas client and messages
         let mut deltas_client = MockDeltasClient::new();
@@ -1653,7 +1665,7 @@ mod test {
     async fn test_state_sync() {
         let (rpc_client, deltas_client, tx) = mock_clients_for_state_sync();
         let deltas = [
-            BlockAggregatedChanges::from(BlockChanges {
+            BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -1701,7 +1713,7 @@ mod test {
                 },
                 ..Default::default()
             }),
-            BlockAggregatedChanges::from(BlockChanges {
+            BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -1835,7 +1847,7 @@ mod test {
             },
             // Our deltas are empty and since merge methods are
             // tested in tycho-common we don't have much to do here.
-            deltas: Some(BlockAggregatedChanges::from(BlockChanges {
+            deltas: Some(BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -1884,7 +1896,12 @@ mod test {
                     .is_some_and(|ids| ids.contains(&"Component3".to_string()))
             })
             .returning(|_| {
-                Ok(vec![ProtocolComponent { id: "Component3".to_string(), ..Default::default() }])
+                Ok(Page::new(
+                    vec![ProtocolComponent { id: "Component3".to_string(), ..Default::default() }],
+                    1,
+                    0,
+                    100,
+                ))
             });
         // Mock get_snapshots for Component3
         rpc_client
@@ -1926,10 +1943,15 @@ mod test {
         rpc_client
             .expect_get_protocol_components()
             .returning(|_| {
-                Ok(vec![
-                    ProtocolComponent { id: "Component1".to_string(), ..Default::default() },
-                    ProtocolComponent { id: "Component2".to_string(), ..Default::default() },
-                ])
+                Ok(Page::new(
+                    vec![
+                        ProtocolComponent { id: "Component1".to_string(), ..Default::default() },
+                        ProtocolComponent { id: "Component2".to_string(), ..Default::default() },
+                    ],
+                    2,
+                    0,
+                    100,
+                ))
             });
 
         // Mock get_snapshots for initial snapshot
@@ -1980,7 +2002,7 @@ mod test {
         // Mock get_traced_entry_points for Ethereum chain
         rpc_client
             .expect_get_traced_entry_points()
-            .returning(|_| Ok(HashMap::new()));
+            .returning(|_| Ok(Page::new(HashMap::new(), 0, 0, 0)));
 
         let (tx, rx) = channel(1);
         deltas_client
@@ -2010,9 +2032,9 @@ mod test {
             .await
             .expect("Init failed");
 
-        // Simulate the incoming BlockChanges
+        // Simulate the incoming BlockAggregatedChanges
         let deltas = [
-            BlockAggregatedChanges::from(BlockChanges {
+            BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -2025,7 +2047,7 @@ mod test {
                 revert: false,
                 ..Default::default()
             }),
-            BlockAggregatedChanges::from(BlockChanges {
+            BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -2104,7 +2126,7 @@ mod test {
                 .collect(),
                 vm_storage: HashMap::new(),
             },
-            deltas: Some(BlockAggregatedChanges::from(BlockChanges {
+            deltas: Some(BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -2148,7 +2170,7 @@ mod test {
         // Mock the initial components call
         rpc_client
             .expect_get_protocol_components()
-            .returning(|_| Ok(vec![]));
+            .returning(|_| Ok(Page::new(vec![], 0, 0, 0)));
 
         // Set up deltas client that will wait for messages (blocking in state_sync)
         let (_tx, rx) = channel(1);
@@ -2207,7 +2229,7 @@ mod test {
         // Mock the initial components call
         rpc_client
             .expect_get_protocol_components()
-            .returning(|_| Ok(vec![]));
+            .returning(|_| Ok(Page::new(vec![], 0, 0, 0)));
 
         // Mock to fail during snapshot retrieval (this will cause an error during processing)
         rpc_client
@@ -2222,7 +2244,7 @@ mod test {
             .expect_subscribe()
             .return_once(move |_, _| {
                 // Send a delta message that will require a snapshot
-                let delta = BlockAggregatedChanges::from(BlockChanges {
+                let delta = BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
                     extractor: "test".to_string(),
                     chain: Chain::Ethereum,
                     block: Block {
@@ -2318,7 +2340,7 @@ mod test {
 
         rpc_client
             .expect_get_protocol_components()
-            .returning(|_| Ok(vec![]));
+            .returning(|_| Ok(Page::new(vec![], 0, 0, 0)));
 
         let (_tx, rx) = channel(1);
         deltas_client
@@ -2386,20 +2408,20 @@ mod test {
         // Mock the initial components call
         rpc_client
             .expect_get_protocol_components()
-            .returning(|_| Ok(vec![]));
+            .returning(|_| Ok(Page::new(vec![], 0, 0, 0)));
 
         // Mock the snapshot retrieval that happens after first message
         rpc_client
             .expect_get_protocol_states()
-            .returning(|_| Ok(vec![]));
+            .returning(|_| Ok(Page::new(vec![], 0, 0, 0)));
 
         rpc_client
             .expect_get_component_tvl()
-            .returning(|_| Ok(HashMap::new()));
+            .returning(|_| Ok(Page::new(HashMap::new(), 0, 0, 0)));
 
         rpc_client
             .expect_get_traced_entry_points()
-            .returning(|_| Ok(HashMap::new()));
+            .returning(|_| Ok(Page::new(HashMap::new(), 0, 0, 0)));
 
         // Set up deltas client to send one message, then keep channel open
         let (tx, rx) = channel(10);
@@ -2407,7 +2429,7 @@ mod test {
             .expect_subscribe()
             .return_once(move |_, _| {
                 // Send first message immediately
-                let first_delta = BlockAggregatedChanges::from(BlockChanges {
+                let first_delta = BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
                     extractor: "test".to_string(),
                     chain: Chain::Ethereum,
                     block: Block {
@@ -2503,7 +2525,7 @@ mod test {
         // Mock the initial components call to succeed
         rpc_client
             .expect_get_protocol_components()
-            .returning(|_| Ok(vec![]));
+            .returning(|_| Ok(Page::new(vec![], 0, 0, 0)));
 
         // Set up deltas client to consistently fail after subscription
         // This will cause connection errors and trigger retries
@@ -2635,7 +2657,12 @@ mod test {
         rpc_client
             .expect_get_protocol_components()
             .returning(|_| {
-                Ok(vec![ProtocolComponent { id: "Component1".to_string(), ..Default::default() }])
+                Ok(Page::new(
+                    vec![ProtocolComponent { id: "Component1".to_string(), ..Default::default() }],
+                    1,
+                    0,
+                    100,
+                ))
             });
 
         // Set up deltas client to send a message that is the next expected block
@@ -2643,7 +2670,7 @@ mod test {
         deltas_client
             .expect_subscribe()
             .return_once(move |_, _| {
-                let expected_next_delta = BlockAggregatedChanges::from(BlockChanges {
+                let expected_next_delta = BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
                     extractor: "uniswap-v2".to_string(),
                     chain: Chain::Ethereum,
                     block: Block {
@@ -2765,31 +2792,46 @@ mod test {
         rpc_client
             .expect_get_protocol_components()
             .returning(|_| {
-                Ok(vec![ProtocolComponent { id: "Component1".to_string(), ..Default::default() }])
+                Ok(Page::new(
+                    vec![ProtocolComponent { id: "Component1".to_string(), ..Default::default() }],
+                    1,
+                    0,
+                    100,
+                ))
             });
 
         // Mock snapshot calls for when we process the expected next block (block 6)
         rpc_client
             .expect_get_protocol_states()
             .returning(|_| {
-                Ok(vec![ProtocolComponentState::new(
-                    "Component1",
-                    Default::default(),
-                    Default::default(),
-                )])
+                Ok(Page::new(
+                    vec![ProtocolComponentState::new(
+                        "Component1",
+                        Default::default(),
+                        Default::default(),
+                    )],
+                    1,
+                    0,
+                    100,
+                ))
             });
 
         rpc_client
             .expect_get_component_tvl()
             .returning(|_| {
-                Ok([("Component1".to_string(), 100.0)]
-                    .into_iter()
-                    .collect())
+                Ok(Page::new(
+                    [("Component1".to_string(), 100.0)]
+                        .into_iter()
+                        .collect(),
+                    1,
+                    0,
+                    100,
+                ))
             });
 
         rpc_client
             .expect_get_traced_entry_points()
-            .returning(|_| Ok(HashMap::new()));
+            .returning(|_| Ok(Page::new(HashMap::new(), 0, 0, 0)));
 
         // Set up deltas client to send old messages first, then the expected next block
         let (tx, rx) = channel(10);
@@ -2798,7 +2840,7 @@ mod test {
             .return_once(move |_, _| {
                 // Send messages for blocks 3, 4, 5 (already processed), then block 6 (expected)
                 let old_messages = vec![
-                    BlockAggregatedChanges::from(BlockChanges {
+                    BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
                         extractor: "uniswap-v2".to_string(),
                         chain: Chain::Ethereum,
                         block: Block {
@@ -2811,7 +2853,7 @@ mod test {
                         revert: false,
                         ..Default::default()
                     }),
-                    BlockAggregatedChanges::from(BlockChanges {
+                    BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
                         extractor: "uniswap-v2".to_string(),
                         chain: Chain::Ethereum,
                         block: Block {
@@ -2824,7 +2866,7 @@ mod test {
                         revert: false,
                         ..Default::default()
                     }),
-                    BlockAggregatedChanges::from(BlockChanges {
+                    BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
                         extractor: "uniswap-v2".to_string(),
                         chain: Chain::Ethereum,
                         block: Block {
@@ -2838,7 +2880,7 @@ mod test {
                         ..Default::default()
                     }),
                     // This is the expected next block (block 6)
-                    BlockAggregatedChanges::from(BlockChanges {
+                    BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
                         extractor: "uniswap-v2".to_string(),
                         chain: Chain::Ethereum,
                         block: Block {
@@ -2958,7 +3000,7 @@ mod test {
         // Use vec to create Bytes from block number
         let hash = Bytes::from(vec![block_num as u8; 32]);
         let parent_hash = Bytes::from(vec![block_num.saturating_sub(1) as u8; 32]);
-        BlockAggregatedChanges::from(BlockChanges {
+        BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
             extractor: "uniswap-v2".to_string(),
             chain: Chain::Ethereum,
             block: Block {
@@ -3201,7 +3243,7 @@ mod test {
         // get_traced_entry_points SHOULD be called for a DCI protocol
         rpc.expect_get_traced_entry_points()
             .times(1)
-            .returning(|_| Ok(HashMap::new()));
+            .returning(|_| Ok(Page::new(HashMap::new(), 0, 0, 0)));
 
         let mut state_sync = with_mocked_clients(true, false, Some(rpc), None).with_dci(true);
         state_sync
@@ -3243,19 +3285,29 @@ mod test {
                     .is_some_and(|ids| ids.contains(&"BrandNew".to_string()))
             })
             .returning(|_| {
-                Ok(vec![
-                    ProtocolComponent { id: "BrandNew".to_string(), ..Default::default() },
-                    ProtocolComponent { id: "Preexisting".to_string(), ..Default::default() },
-                ])
+                Ok(Page::new(
+                    vec![
+                        ProtocolComponent { id: "BrandNew".to_string(), ..Default::default() },
+                        ProtocolComponent { id: "Preexisting".to_string(), ..Default::default() },
+                    ],
+                    2,
+                    0,
+                    100,
+                ))
             });
         // get_protocol_components for initial sync (via get_protocol_components_paginated)
         rpc_client
             .expect_get_protocol_components()
             .returning(|_| {
-                Ok(vec![
-                    ProtocolComponent { id: "Component1".to_string(), ..Default::default() },
-                    ProtocolComponent { id: "Component2".to_string(), ..Default::default() },
-                ])
+                Ok(Page::new(
+                    vec![
+                        ProtocolComponent { id: "Component1".to_string(), ..Default::default() },
+                        ProtocolComponent { id: "Component2".to_string(), ..Default::default() },
+                    ],
+                    2,
+                    0,
+                    100,
+                ))
             });
         // get_snapshots: more specific expectations first so init (block 0, all components)
         // does not match the block 1/2 ones.
@@ -3377,7 +3429,7 @@ mod test {
             });
         rpc_client
             .expect_get_traced_entry_points()
-            .returning(|_| Ok(HashMap::new()));
+            .returning(|_| Ok(Page::new(HashMap::new(), 0, 0, 0)));
 
         let mut deltas_client = MockDeltasClient::new();
         let (tx, rx) = channel(1);

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -1704,7 +1704,7 @@ mod test {
                     )]),
                     trace_results: HashMap::from([(
                         "entrypoint_a".to_string(),
-                        ModelTracingResult {
+                        TracingResult {
                             retriggers: HashSet::from([(
                                 Bytes::from("0x0badc0ffee"),
                                 AddressStorageLocation::new(Bytes::from("0x0badc0ffee"), 12),

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    time::Duration,
-};
+use std::{collections::HashMap, time::Duration};
 
 use async_trait::async_trait;
 use thiserror::Error;
@@ -17,10 +14,7 @@ use tokio::{
 use tracing::{debug, error, info, instrument, trace, warn};
 use tycho_common::{
     models::{
-        blockchain::{
-            BlockAggregatedChanges, DCIUpdate, EntryPoint, EntryPointWithTracingParams,
-            TracingParams, TracingResult,
-        },
+        blockchain::{BlockAggregatedChanges, DCIUpdate, EntryPointWithTracingParams, TracingResult},
         contract::Account,
         protocol::{ProtocolComponent, ProtocolComponentState},
         ExtractorIdentity,
@@ -352,48 +346,8 @@ where
                     RPC_CLIENT_CONCURRENCY,
                 )
                 .await?;
-            let mut new_entrypoints: HashMap<String, HashSet<EntryPoint>> = HashMap::new();
-            let mut new_entrypoint_params: HashMap<String, HashSet<(TracingParams, String)>> =
-                HashMap::new();
-            let mut trace_results: HashMap<String, TracingResult> = HashMap::new();
-            for (component, traces) in &result {
-                let mut eps: HashSet<EntryPoint> = HashSet::new();
-                for (ep_with_params, trace) in traces {
-                    let ep_id = ep_with_params
-                        .entry_point
-                        .external_id
-                        .clone();
-                    eps.insert(ep_with_params.entry_point.clone());
-                    new_entrypoint_params
-                        .entry(ep_id.clone())
-                        .or_default()
-                        .insert((ep_with_params.params.clone(), component.clone()));
-                    trace_results
-                        .entry(ep_id)
-                        .and_modify(|existing| {
-                            existing
-                                .retriggers
-                                .extend(trace.retriggers.clone());
-                            for (address, slots) in trace.accessed_slots.clone() {
-                                existing
-                                    .accessed_slots
-                                    .entry(address)
-                                    .or_default()
-                                    .extend(slots);
-                            }
-                        })
-                        .or_insert_with(|| trace.clone());
-                }
-                if !eps.is_empty() {
-                    new_entrypoints.insert(component.clone(), eps);
-                }
-            }
             self.component_tracker
-                .process_entrypoints(&DCIUpdate {
-                    new_entrypoints,
-                    new_entrypoint_params,
-                    trace_results,
-                });
+                .process_entrypoints(&DCIUpdate::from(result.clone()));
             result
         } else {
             HashMap::new()

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -1,7 +1,9 @@
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::{
     select,
@@ -14,9 +16,14 @@ use tokio::{
 };
 use tracing::{debug, error, info, instrument, trace, warn};
 use tycho_common::{
-    dto::{
-        BlockChanges, EntryPointWithTracingParams, ExtractorIdentity, ProtocolComponent,
-        ResponseAccount, ResponseProtocolState, TracingResult,
+    models::{
+        blockchain::{
+            BlockAggregatedChanges, DCIUpdate, EntryPoint, EntryPointWithTracingParams,
+            TracingParams, TracingResult,
+        },
+        contract::Account,
+        protocol::{ProtocolComponent, ProtocolComponentState},
+        ExtractorIdentity,
     },
     Bytes,
 };
@@ -99,18 +106,18 @@ pub struct ProtocolStateSynchronizer<R: RPCClient, D: DeltasClient> {
     deferred_snapshot_components: Vec<String>,
 }
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct ComponentWithState {
-    pub state: ResponseProtocolState,
+    pub state: ProtocolComponentState,
     pub component: ProtocolComponent,
     pub component_tvl: Option<f64>,
     pub entrypoints: Vec<(EntryPointWithTracingParams, TracingResult)>,
 }
 
-#[derive(Clone, PartialEq, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Default)]
 pub struct Snapshot {
     pub states: HashMap<String, ComponentWithState>,
-    pub vm_storage: HashMap<Bytes, ResponseAccount>,
+    pub vm_storage: HashMap<Bytes, Account>,
 }
 
 impl Snapshot {
@@ -123,12 +130,12 @@ impl Snapshot {
         &self.states
     }
 
-    pub fn get_vm_storage(&self) -> &HashMap<Bytes, ResponseAccount> {
+    pub fn get_vm_storage(&self) -> &HashMap<Bytes, Account> {
         &self.vm_storage
     }
 }
 
-#[derive(Clone, PartialEq, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Default)]
 pub struct StateSyncMessage<H>
 where
     H: HeaderLike,
@@ -140,7 +147,7 @@ where
     /// A single delta contains state updates for all tracked components, as well as additional
     /// information about the system components e.g. newly added components (even below tvl), tvl
     /// updates, balance updates.
-    pub deltas: Option<BlockChanges>,
+    pub deltas: Option<BlockAggregatedChanges>,
     /// Components that stopped being tracked.
     pub removed_components: HashMap<String, ProtocolComponent>,
 }
@@ -328,7 +335,13 @@ where
             return Ok(StateSyncMessage { header, ..Default::default() });
         }
 
-        let entrypoints_result = if self.uses_dci {
+        let entrypoints_result: HashMap<
+            String,
+            Vec<(
+                tycho_common::models::blockchain::EntryPointWithTracingParams,
+                tycho_common::models::blockchain::TracingResult,
+            )>,
+        > = if self.uses_dci {
             let result = self
                 .rpc_client
                 .get_traced_entry_points_paginated(
@@ -339,9 +352,49 @@ where
                     RPC_CLIENT_CONCURRENCY,
                 )
                 .await?;
+            let mut new_entrypoints: HashMap<String, HashSet<EntryPoint>> = HashMap::new();
+            let mut new_entrypoint_params: HashMap<String, HashSet<(TracingParams, String)>> =
+                HashMap::new();
+            let mut trace_results: HashMap<String, TracingResult> = HashMap::new();
+            for (component, traces) in &result {
+                let mut eps: HashSet<EntryPoint> = HashSet::new();
+                for (ep_with_params, trace) in traces {
+                    let ep_id = ep_with_params
+                        .entry_point
+                        .external_id
+                        .clone();
+                    eps.insert(ep_with_params.entry_point.clone());
+                    new_entrypoint_params
+                        .entry(ep_id.clone())
+                        .or_default()
+                        .insert((ep_with_params.params.clone(), component.clone()));
+                    trace_results
+                        .entry(ep_id)
+                        .and_modify(|existing| {
+                            existing
+                                .retriggers
+                                .extend(trace.retriggers.clone());
+                            for (address, slots) in trace.accessed_slots.clone() {
+                                existing
+                                    .accessed_slots
+                                    .entry(address)
+                                    .or_default()
+                                    .extend(slots);
+                            }
+                        })
+                        .or_insert_with(|| trace.clone());
+                }
+                if !eps.is_empty() {
+                    new_entrypoints.insert(component.clone(), eps);
+                }
+            }
             self.component_tracker
-                .process_entrypoints(&result.clone().into());
-            result.traced_entry_points.clone()
+                .process_entrypoints(&DCIUpdate {
+                    new_entrypoints,
+                    new_entrypoint_params,
+                    trace_results,
+                });
+            result
         } else {
             HashMap::new()
         };
@@ -708,7 +761,7 @@ where
         }
         false
     }
-    fn filter_deltas(&self, deltas: &mut BlockChanges) {
+    fn filter_deltas(&self, deltas: &mut BlockAggregatedChanges) {
         deltas.filter_by_component(|id| {
             self.component_tracker
                 .components
@@ -850,13 +903,21 @@ mod test {
 
     use std::{collections::HashSet, sync::Arc};
 
-    use tycho_common::dto::{
-        AddressStorageLocation, Block, Chain, ComponentTvlRequestBody, ComponentTvlRequestResponse,
-        DCIUpdate, EntryPoint, PaginationResponse, ProtocolComponentRequestResponse,
-        ProtocolComponentsRequestBody, ProtocolStateRequestBody, ProtocolStateRequestResponse,
-        ProtocolSystemsRequestBody, ProtocolSystemsRequestResponse, RPCTracerParams,
-        StateRequestBody, StateRequestResponse, TokensRequestBody, TokensRequestResponse,
-        TracedEntryPointRequestBody, TracedEntryPointRequestResponse, TracingParams,
+    use tycho_common::{
+        dto::{
+            AddressStorageLocation, Block, BlockChanges, Chain, DCIUpdate, EntryPoint,
+            PaginationResponse, ProtocolStateRequestResponse, RPCTracerParams, ResponseAccount,
+            ResponseProtocolState, StateRequestResponse, TracingParams,
+        },
+        models::{
+            blockchain::{
+                BlockAggregatedChanges,
+                EntryPointWithTracingParams as ModelEntryPointWithTracingParams,
+                TracingResult as ModelTracingResult,
+            },
+            protocol::{ProtocolComponent, ProtocolComponentState},
+            token::Token,
+        },
     };
     use uuid::Uuid;
 
@@ -880,58 +941,57 @@ mod test {
     {
         async fn get_tokens(
             &self,
-            request: &TokensRequestBody,
-        ) -> Result<TokensRequestResponse, RPCError> {
-            self.0.get_tokens(request).await
+            params: crate::rpc::TokensParams,
+        ) -> Result<Vec<Token>, RPCError> {
+            self.0.get_tokens(params).await
         }
 
         async fn get_contract_state(
             &self,
-            request: &StateRequestBody,
-        ) -> Result<StateRequestResponse, RPCError> {
-            self.0.get_contract_state(request).await
+            params: crate::rpc::ContractStateParams,
+        ) -> Result<Vec<Account>, RPCError> {
+            self.0.get_contract_state(params).await
         }
 
         async fn get_protocol_components(
             &self,
-            request: &ProtocolComponentsRequestBody,
-        ) -> Result<ProtocolComponentRequestResponse, RPCError> {
+            params: crate::rpc::ProtocolComponentsParams,
+        ) -> Result<Vec<ProtocolComponent>, RPCError> {
             self.0
-                .get_protocol_components(request)
+                .get_protocol_components(params)
                 .await
         }
 
         async fn get_protocol_states(
             &self,
-            request: &ProtocolStateRequestBody,
-        ) -> Result<ProtocolStateRequestResponse, RPCError> {
-            self.0
-                .get_protocol_states(request)
-                .await
+            params: crate::rpc::ProtocolStatesParams,
+        ) -> Result<Vec<ProtocolComponentState>, RPCError> {
+            self.0.get_protocol_states(params).await
         }
 
         async fn get_protocol_systems(
             &self,
-            request: &ProtocolSystemsRequestBody,
-        ) -> Result<ProtocolSystemsRequestResponse, RPCError> {
+            params: crate::rpc::ProtocolSystemsParams,
+        ) -> Result<crate::rpc::ProtocolSystemsResponse, RPCError> {
             self.0
-                .get_protocol_systems(request)
+                .get_protocol_systems(params)
                 .await
         }
 
         async fn get_component_tvl(
             &self,
-            request: &ComponentTvlRequestBody,
-        ) -> Result<ComponentTvlRequestResponse, RPCError> {
-            self.0.get_component_tvl(request).await
+            params: crate::rpc::ComponentTvlParams,
+        ) -> Result<HashMap<String, f64>, RPCError> {
+            self.0.get_component_tvl(params).await
         }
 
         async fn get_traced_entry_points(
             &self,
-            request: &TracedEntryPointRequestBody,
-        ) -> Result<TracedEntryPointRequestResponse, RPCError> {
+            params: crate::rpc::TracedEntryPointsParams,
+        ) -> Result<HashMap<String, Vec<(EntryPointWithTracingParams, TracingResult)>>, RPCError>
+        {
             self.0
-                .get_traced_entry_points(request)
+                .get_traced_entry_points(params)
                 .await
         }
 
@@ -968,9 +1028,9 @@ mod test {
     {
         async fn subscribe(
             &self,
-            extractor_id: ExtractorIdentity,
+            extractor_id: tycho_common::models::ExtractorIdentity,
             options: SubscriptionOptions,
-        ) -> Result<(Uuid, Receiver<BlockChanges>), DeltasError> {
+        ) -> Result<(Uuid, Receiver<BlockAggregatedChanges>), DeltasError> {
             self.0
                 .subscribe(extractor_id, options)
                 .await
@@ -1002,7 +1062,7 @@ mod test {
         let deltas_client = ArcDeltasClient(Arc::new(deltas_client.unwrap_or_default()));
 
         ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum, "uniswap-v2"),
+            ExtractorIdentity::new(Chain::Ethereum.into(), "uniswap-v2"),
             native,
             ComponentFilter::with_tvl_range(50.0, 50.0),
             1,
@@ -1050,7 +1110,7 @@ mod test {
                             (
                                 state.component_id.clone(),
                                 ComponentWithState {
-                                    state,
+                                    state: state.into(),
                                     component: component_clone.clone(),
                                     entrypoints: vec![],
                                     component_tvl: None,
@@ -1063,12 +1123,7 @@ mod test {
             });
 
         rpc.expect_get_traced_entry_points()
-            .returning(|_| {
-                Ok(TracedEntryPointRequestResponse {
-                    traced_entry_points: HashMap::new(),
-                    pagination: PaginationResponse::new(0, 20, 0),
-                })
-            });
+            .returning(|_| Ok(HashMap::new()));
 
         let mut state_sync = with_mocked_clients(true, false, Some(rpc), None);
         state_sync
@@ -1086,7 +1141,7 @@ mod test {
                         (
                             state.component_id.clone(),
                             ComponentWithState {
-                                state,
+                                state: state.into(),
                                 component: component.clone(),
                                 entrypoints: vec![],
                                 component_tvl: None,
@@ -1125,7 +1180,7 @@ mod test {
                             (
                                 state.component_id.clone(),
                                 ComponentWithState {
-                                    state,
+                                    state: state.into(),
                                     component: component_clone.clone(),
                                     component_tvl: Some(100.0),
                                     entrypoints: vec![],
@@ -1138,12 +1193,7 @@ mod test {
             });
 
         rpc.expect_get_traced_entry_points()
-            .returning(|_| {
-                Ok(TracedEntryPointRequestResponse {
-                    traced_entry_points: HashMap::new(),
-                    pagination: PaginationResponse::new(0, 20, 0),
-                })
-            });
+            .returning(|_| Ok(HashMap::new()));
 
         let mut state_sync = with_mocked_clients(true, true, Some(rpc), None);
         state_sync
@@ -1161,7 +1211,7 @@ mod test {
                         (
                             state.component_id.clone(),
                             ComponentWithState {
-                                state,
+                                state: state.into(),
                                 component: component.clone(),
                                 component_tvl: Some(100.0),
                                 entrypoints: vec![],
@@ -1193,38 +1243,40 @@ mod test {
         }
     }
 
-    fn traced_entry_point_response() -> TracedEntryPointRequestResponse {
-        TracedEntryPointRequestResponse {
-            traced_entry_points: HashMap::from([(
-                "Component1".to_string(),
-                vec![(
-                    EntryPointWithTracingParams {
-                        entry_point: EntryPoint {
-                            external_id: "entrypoint_a".to_string(),
-                            target: Bytes::from("0x0badc0ffee"),
-                            signature: "sig()".to_string(),
-                        },
-                        params: TracingParams::RPCTracer(RPCTracerParams {
-                            caller: Some(Bytes::from("0x0badc0ffee")),
-                            calldata: Bytes::from("0x0badc0ffee"),
-                            state_overrides: None,
-                            prune_addresses: None,
-                        }),
+    fn traced_entry_point_response(
+    ) -> HashMap<String, Vec<(ModelEntryPointWithTracingParams, ModelTracingResult)>> {
+        use tycho_common::models::blockchain::{
+            AddressStorageLocation as ModelASL, EntryPoint as ModelEntryPoint,
+            RPCTracerParams as ModelRPCTP, TracingParams as ModelTP,
+        };
+        HashMap::from([(
+            "Component1".to_string(),
+            vec![(
+                ModelEntryPointWithTracingParams {
+                    entry_point: ModelEntryPoint {
+                        external_id: "entrypoint_a".to_string(),
+                        target: Bytes::from("0x0badc0ffee"),
+                        signature: "sig()".to_string(),
                     },
-                    TracingResult {
-                        retriggers: HashSet::from([(
-                            Bytes::from("0x0badc0ffee"),
-                            AddressStorageLocation::new(Bytes::from("0x0badc0ffee"), 12),
-                        )]),
-                        accessed_slots: HashMap::from([(
-                            Bytes::from("0x0badc0ffee"),
-                            HashSet::from([Bytes::from("0xbadbeef0")]),
-                        )]),
-                    },
-                )],
-            )]),
-            pagination: PaginationResponse::new(0, 20, 0),
-        }
+                    params: ModelTP::RPCTracer(ModelRPCTP {
+                        caller: Some(Bytes::from("0x0badc0ffee")),
+                        calldata: Bytes::from("0x0badc0ffee"),
+                        state_overrides: None,
+                        prune_addresses: None,
+                    }),
+                },
+                ModelTracingResult {
+                    retriggers: HashSet::from([(
+                        Bytes::from("0x0badc0ffee"),
+                        ModelASL::new(Bytes::from("0x0badc0ffee"), 12),
+                    )]),
+                    accessed_slots: HashMap::from([(
+                        Bytes::from("0x0badc0ffee"),
+                        HashSet::from([Bytes::from("0xbadbeef0")]),
+                    )]),
+                },
+            )],
+        )])
     }
 
     #[test_log::test(tokio::test)]
@@ -1243,10 +1295,11 @@ mod test {
                             state: ResponseProtocolState {
                                 component_id: "Component1".to_string(),
                                 ..Default::default()
-                            },
+                            }
+                            .into(),
                             component: ProtocolComponent {
                                 id: "Component1".to_string(),
-                                contract_ids: vec![
+                                contract_addresses: vec![
                                     Bytes::from("0x0badc0ffee"),
                                     Bytes::from("0xbabe42"),
                                 ],
@@ -1254,7 +1307,6 @@ mod test {
                             },
                             component_tvl: None,
                             entrypoints: traced_ep_response
-                                .traced_entry_points
                                 .get("Component1")
                                 .cloned()
                                 .unwrap_or_default(),
@@ -1265,18 +1317,21 @@ mod test {
                     vm_storage: vm_storage_accounts
                         .accounts
                         .into_iter()
-                        .map(|state| (state.address.clone(), state))
+                        .map(|state| {
+                            let addr = state.address.clone();
+                            (addr, Account::from(state))
+                        })
                         .collect(),
                 })
             });
 
         rpc.expect_get_traced_entry_points()
-            .returning(|_| Ok(traced_entry_point_response()));
+            .returning(move |_| Ok(traced_entry_point_response()));
 
         let mut state_sync = with_mocked_clients(false, false, Some(rpc), None);
         let component = ProtocolComponent {
             id: "Component1".to_string(),
-            contract_ids: vec![Bytes::from("0x0badc0ffee"), Bytes::from("0xbabe42")],
+            contract_addresses: vec![Bytes::from("0x0badc0ffee"), Bytes::from("0xbabe42")],
             ..Default::default()
         };
         state_sync
@@ -1293,34 +1348,13 @@ mod test {
                         state: ResponseProtocolState {
                             component_id: "Component1".to_string(),
                             ..Default::default()
-                        },
+                        }
+                        .into(),
                         component: component.clone(),
                         component_tvl: None,
-                        entrypoints: vec![(
-                            EntryPointWithTracingParams {
-                                entry_point: EntryPoint {
-                                    external_id: "entrypoint_a".to_string(),
-                                    target: Bytes::from("0x0badc0ffee"),
-                                    signature: "sig()".to_string(),
-                                },
-                                params: TracingParams::RPCTracer(RPCTracerParams {
-                                    caller: Some(Bytes::from("0x0badc0ffee")),
-                                    calldata: Bytes::from("0x0badc0ffee"),
-                                    state_overrides: None,
-                                    prune_addresses: None,
-                                }),
-                            },
-                            TracingResult {
-                                retriggers: HashSet::from([(
-                                    Bytes::from("0x0badc0ffee"),
-                                    AddressStorageLocation::new(Bytes::from("0x0badc0ffee"), 12),
-                                )]),
-                                accessed_slots: HashMap::from([(
-                                    Bytes::from("0x0badc0ffee"),
-                                    HashSet::from([Bytes::from("0xbadbeef0")]),
-                                )]),
-                            },
-                        )],
+                        entrypoints: traced_entry_point_response()
+                            .remove("Component1")
+                            .unwrap_or_default(),
                     },
                 )]
                 .into_iter()
@@ -1328,7 +1362,7 @@ mod test {
                 vm_storage: state_snapshot_vm()
                     .accounts
                     .into_iter()
-                    .map(|state| (state.address.clone(), state))
+                    .map(|state| (state.address.clone(), Account::from(state)))
                     .collect(),
             },
             deltas: None,
@@ -1349,7 +1383,7 @@ mod test {
         let mut rpc = make_mock_client();
         let component = ProtocolComponent {
             id: "Component1".to_string(),
-            contract_ids: vec![Bytes::from("0x0badc0ffee"), Bytes::from("0xbabe42")],
+            contract_addresses: vec![Bytes::from("0x0badc0ffee"), Bytes::from("0xbabe42")],
             ..Default::default()
         };
 
@@ -1364,7 +1398,8 @@ mod test {
                             state: ResponseProtocolState {
                                 component_id: "Component1".to_string(),
                                 ..Default::default()
-                            },
+                            }
+                            .into(),
                             component: component_clone.clone(),
                             component_tvl: Some(100.0),
                             entrypoints: vec![],
@@ -1375,18 +1410,13 @@ mod test {
                     vm_storage: vm_storage_accounts
                         .accounts
                         .into_iter()
-                        .map(|state| (state.address.clone(), state))
+                        .map(|state| (state.address.clone(), Account::from(state)))
                         .collect(),
                 })
             });
 
         rpc.expect_get_traced_entry_points()
-            .returning(|_| {
-                Ok(TracedEntryPointRequestResponse {
-                    traced_entry_points: HashMap::new(),
-                    pagination: PaginationResponse::new(0, 20, 0),
-                })
-            });
+            .returning(|_| Ok(HashMap::new()));
 
         let mut state_sync = with_mocked_clients(false, true, Some(rpc), None);
         state_sync
@@ -1403,7 +1433,8 @@ mod test {
                         state: ResponseProtocolState {
                             component_id: "Component1".to_string(),
                             ..Default::default()
-                        },
+                        }
+                        .into(),
                         component: component.clone(),
                         component_tvl: Some(100.0),
                         entrypoints: vec![],
@@ -1414,7 +1445,7 @@ mod test {
                 vm_storage: state_snapshot_vm()
                     .accounts
                     .into_iter()
-                    .map(|state| (state.address.clone(), state))
+                    .map(|state| (state.address.clone(), Account::from(state)))
                     .collect(),
             },
             deltas: None,
@@ -1466,7 +1497,8 @@ mod test {
                             state: ResponseProtocolState {
                                 component_id: "Component2".to_string(),
                                 ..Default::default()
-                            },
+                            }
+                            .into(),
                             component: component2_clone.clone(),
                             entrypoints: vec![],
                             component_tvl: None,
@@ -1479,12 +1511,7 @@ mod test {
             });
 
         rpc.expect_get_traced_entry_points()
-            .returning(|_| {
-                Ok(TracedEntryPointRequestResponse {
-                    traced_entry_points: HashMap::new(),
-                    pagination: PaginationResponse::new(0, 20, 0),
-                })
-            });
+            .returning(|_| Ok(HashMap::new()));
 
         let mut state_sync = with_mocked_clients(true, false, Some(rpc), None);
 
@@ -1526,30 +1553,24 @@ mod test {
             .contains_key("Component3"));
     }
 
-    fn mock_clients_for_state_sync() -> (MockRPCClient, MockDeltasClient, Sender<BlockChanges>) {
+    fn mock_clients_for_state_sync(
+    ) -> (MockRPCClient, MockDeltasClient, Sender<BlockAggregatedChanges>) {
         let mut rpc_client = make_mock_client();
         // Mocks for the start_tracking call, these need to come first because they are more
         // specific, see: https://docs.rs/mockall/latest/mockall/#matching-multiple-calls
         rpc_client
             .expect_get_protocol_components()
-            .with(mockall::predicate::function(
-                move |request_params: &ProtocolComponentsRequestBody| {
-                    if let Some(ids) = request_params.component_ids.as_ref() {
-                        ids.contains(&"Component3".to_string())
-                    } else {
-                        false
-                    }
-                },
-            ))
+            .withf(|params: &crate::rpc::ProtocolComponentsParams| {
+                params
+                    .component_ids()
+                    .is_some_and(|ids| ids.contains(&"Component3".to_string()))
+            })
             .returning(|_| {
                 // return Component3
-                Ok(ProtocolComponentRequestResponse {
-                    protocol_components: vec![
-                        // this component shall have a tvl update above threshold
-                        ProtocolComponent { id: "Component3".to_string(), ..Default::default() },
-                    ],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
-                })
+                Ok(vec![
+                    // this component shall have a tvl update above threshold
+                    ProtocolComponent { id: "Component3".to_string(), ..Default::default() },
+                ])
             });
         // Mock get_snapshots for Component3
         rpc_client
@@ -1568,10 +1589,11 @@ mod test {
                     states: [(
                         "Component3".to_string(),
                         ComponentWithState {
-                            state: ResponseProtocolState {
-                                component_id: "Component3".to_string(),
-                                ..Default::default()
-                            },
+                            state: ProtocolComponentState::new(
+                                "Component3",
+                                Default::default(),
+                                Default::default(),
+                            ),
                             component: ProtocolComponent {
                                 id: "Component3".to_string(),
                                 ..Default::default()
@@ -1591,16 +1613,13 @@ mod test {
             .expect_get_protocol_components()
             .returning(|_| {
                 // Initial sync of components
-                Ok(ProtocolComponentRequestResponse {
-                    protocol_components: vec![
-                        // this component shall have a tvl update above threshold
-                        ProtocolComponent { id: "Component1".to_string(), ..Default::default() },
-                        // this component shall have a tvl update below threshold.
-                        ProtocolComponent { id: "Component2".to_string(), ..Default::default() },
-                        // a third component will have a tvl update above threshold
-                    ],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
-                })
+                Ok(vec![
+                    // this component shall have a tvl update above threshold
+                    ProtocolComponent { id: "Component1".to_string(), ..Default::default() },
+                    // this component shall have a tvl update below threshold.
+                    ProtocolComponent { id: "Component2".to_string(), ..Default::default() },
+                    // a third component will have a tvl update above threshold
+                ])
             });
 
         rpc_client
@@ -1611,10 +1630,11 @@ mod test {
                         (
                             "Component1".to_string(),
                             ComponentWithState {
-                                state: ResponseProtocolState {
-                                    component_id: "Component1".to_string(),
-                                    ..Default::default()
-                                },
+                                state: ProtocolComponentState::new(
+                                    "Component1",
+                                    Default::default(),
+                                    Default::default(),
+                                ),
                                 component: ProtocolComponent {
                                     id: "Component1".to_string(),
                                     ..Default::default()
@@ -1626,10 +1646,11 @@ mod test {
                         (
                             "Component2".to_string(),
                             ComponentWithState {
-                                state: ResponseProtocolState {
-                                    component_id: "Component2".to_string(),
-                                    ..Default::default()
-                                },
+                                state: ProtocolComponentState::new(
+                                    "Component2",
+                                    Default::default(),
+                                    Default::default(),
+                                ),
                                 component: ProtocolComponent {
                                     id: "Component2".to_string(),
                                     ..Default::default()
@@ -1648,12 +1669,7 @@ mod test {
         // Mock get_traced_entry_points for Ethereum chain
         rpc_client
             .expect_get_traced_entry_points()
-            .returning(|_| {
-                Ok(TracedEntryPointRequestResponse {
-                    traced_entry_points: HashMap::new(),
-                    pagination: PaginationResponse { page: 0, page_size: 100, total: 0 },
-                })
-            });
+            .returning(|_| Ok(HashMap::new()));
 
         // Mock deltas client and messages
         let mut deltas_client = MockDeltasClient::new();
@@ -1683,7 +1699,7 @@ mod test {
     async fn test_state_sync() {
         let (rpc_client, deltas_client, tx) = mock_clients_for_state_sync();
         let deltas = [
-            BlockChanges {
+            BlockAggregatedChanges::from(BlockChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -1717,7 +1733,7 @@ mod test {
                     )]),
                     trace_results: HashMap::from([(
                         "entrypoint_a".to_string(),
-                        TracingResult {
+                        tycho_common::dto::TracingResult {
                             retriggers: HashSet::from([(
                                 Bytes::from("0x0badc0ffee"),
                                 AddressStorageLocation::new(Bytes::from("0x0badc0ffee"), 12),
@@ -1730,8 +1746,8 @@ mod test {
                     )]),
                 },
                 ..Default::default()
-            },
-            BlockChanges {
+            }),
+            BlockAggregatedChanges::from(BlockChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -1750,7 +1766,7 @@ mod test {
                 .into_iter()
                 .collect(),
                 ..Default::default()
-            },
+            }),
         ];
         let mut state_sync = with_mocked_clients(true, true, Some(rpc_client), Some(deltas_client));
         state_sync
@@ -1793,10 +1809,11 @@ mod test {
                     (
                         "Component1".to_string(),
                         ComponentWithState {
-                            state: ResponseProtocolState {
-                                component_id: "Component1".to_string(),
-                                ..Default::default()
-                            },
+                            state: ProtocolComponentState::new(
+                                "Component1",
+                                Default::default(),
+                                Default::default(),
+                            ),
                             component: ProtocolComponent {
                                 id: "Component1".to_string(),
                                 ..Default::default()
@@ -1808,10 +1825,11 @@ mod test {
                     (
                         "Component2".to_string(),
                         ComponentWithState {
-                            state: ResponseProtocolState {
-                                component_id: "Component2".to_string(),
-                                ..Default::default()
-                            },
+                            state: ProtocolComponentState::new(
+                                "Component2",
+                                Default::default(),
+                                Default::default(),
+                            ),
                             component: ProtocolComponent {
                                 id: "Component2".to_string(),
                                 ..Default::default()
@@ -1843,10 +1861,11 @@ mod test {
                     (
                         "Component3".to_string(),
                         ComponentWithState {
-                            state: ResponseProtocolState {
-                                component_id: "Component3".to_string(),
-                                ..Default::default()
-                            },
+                            state: ProtocolComponentState::new(
+                                "Component3",
+                                Default::default(),
+                                Default::default(),
+                            ),
                             component: ProtocolComponent {
                                 id: "Component3".to_string(),
                                 ..Default::default()
@@ -1862,7 +1881,7 @@ mod test {
             },
             // Our deltas are empty and since merge methods are
             // tested in tycho-common we don't have much to do here.
-            deltas: Some(BlockChanges {
+            deltas: Some(BlockAggregatedChanges::from(BlockChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -1881,7 +1900,7 @@ mod test {
                 .into_iter()
                 .collect(),
                 ..Default::default()
-            }),
+            })),
             // "Component2" was removed, because its tvl changed to 0.
             removed_components: [(
                 "Component2".to_string(),
@@ -1905,23 +1924,13 @@ mod test {
 
         rpc_client
             .expect_get_protocol_components()
-            .with(mockall::predicate::function(
-                move |request_params: &ProtocolComponentsRequestBody| {
-                    if let Some(ids) = request_params.component_ids.as_ref() {
-                        ids.contains(&"Component3".to_string())
-                    } else {
-                        false
-                    }
-                },
-            ))
+            .withf(|params: &crate::rpc::ProtocolComponentsParams| {
+                params
+                    .component_ids()
+                    .is_some_and(|ids| ids.contains(&"Component3".to_string()))
+            })
             .returning(|_| {
-                Ok(ProtocolComponentRequestResponse {
-                    protocol_components: vec![ProtocolComponent {
-                        id: "Component3".to_string(),
-                        ..Default::default()
-                    }],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
-                })
+                Ok(vec![ProtocolComponent { id: "Component3".to_string(), ..Default::default() }])
             });
         // Mock get_snapshots for Component3
         rpc_client
@@ -1940,10 +1949,11 @@ mod test {
                     states: [(
                         "Component3".to_string(),
                         ComponentWithState {
-                            state: ResponseProtocolState {
-                                component_id: "Component3".to_string(),
-                                ..Default::default()
-                            },
+                            state: ProtocolComponentState::new(
+                                "Component3",
+                                Default::default(),
+                                Default::default(),
+                            ),
                             component: ProtocolComponent {
                                 id: "Component3".to_string(),
                                 ..Default::default()
@@ -1962,13 +1972,10 @@ mod test {
         rpc_client
             .expect_get_protocol_components()
             .returning(|_| {
-                Ok(ProtocolComponentRequestResponse {
-                    protocol_components: vec![
-                        ProtocolComponent { id: "Component1".to_string(), ..Default::default() },
-                        ProtocolComponent { id: "Component2".to_string(), ..Default::default() },
-                    ],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
-                })
+                Ok(vec![
+                    ProtocolComponent { id: "Component1".to_string(), ..Default::default() },
+                    ProtocolComponent { id: "Component2".to_string(), ..Default::default() },
+                ])
             });
 
         // Mock get_snapshots for initial snapshot
@@ -1980,10 +1987,11 @@ mod test {
                         (
                             "Component1".to_string(),
                             ComponentWithState {
-                                state: ResponseProtocolState {
-                                    component_id: "Component1".to_string(),
-                                    ..Default::default()
-                                },
+                                state: ProtocolComponentState::new(
+                                    "Component1",
+                                    Default::default(),
+                                    Default::default(),
+                                ),
                                 component: ProtocolComponent {
                                     id: "Component1".to_string(),
                                     ..Default::default()
@@ -1995,10 +2003,11 @@ mod test {
                         (
                             "Component2".to_string(),
                             ComponentWithState {
-                                state: ResponseProtocolState {
-                                    component_id: "Component2".to_string(),
-                                    ..Default::default()
-                                },
+                                state: ProtocolComponentState::new(
+                                    "Component2",
+                                    Default::default(),
+                                    Default::default(),
+                                ),
                                 component: ProtocolComponent {
                                     id: "Component2".to_string(),
                                     ..Default::default()
@@ -2017,12 +2026,7 @@ mod test {
         // Mock get_traced_entry_points for Ethereum chain
         rpc_client
             .expect_get_traced_entry_points()
-            .returning(|_| {
-                Ok(TracedEntryPointRequestResponse {
-                    traced_entry_points: HashMap::new(),
-                    pagination: PaginationResponse { page: 0, page_size: 100, total: 0 },
-                })
-            });
+            .returning(|_| Ok(HashMap::new()));
 
         let (tx, rx) = channel(1);
         deltas_client
@@ -2035,7 +2039,7 @@ mod test {
             .return_once(|_| Ok(()));
 
         let mut state_sync = ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum, "uniswap-v2"),
+            ExtractorIdentity::new(Chain::Ethereum.into(), "uniswap-v2"),
             true,
             ComponentFilter::with_tvl_range(remove_tvl_threshold, add_tvl_threshold),
             1,
@@ -2054,7 +2058,7 @@ mod test {
 
         // Simulate the incoming BlockChanges
         let deltas = [
-            BlockChanges {
+            BlockAggregatedChanges::from(BlockChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -2066,8 +2070,8 @@ mod test {
                 },
                 revert: false,
                 ..Default::default()
-            },
-            BlockChanges {
+            }),
+            BlockAggregatedChanges::from(BlockChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -2086,7 +2090,7 @@ mod test {
                 .into_iter()
                 .collect(),
                 ..Default::default()
-            },
+            }),
         ];
 
         let (handle, mut rx) = state_sync.start().await;
@@ -2129,10 +2133,11 @@ mod test {
                 states: [(
                     "Component3".to_string(),
                     ComponentWithState {
-                        state: ResponseProtocolState {
-                            component_id: "Component3".to_string(),
-                            ..Default::default()
-                        },
+                        state: ProtocolComponentState::new(
+                            "Component3",
+                            Default::default(),
+                            Default::default(),
+                        ),
                         component: ProtocolComponent {
                             id: "Component3".to_string(),
                             ..Default::default()
@@ -2145,7 +2150,7 @@ mod test {
                 .collect(),
                 vm_storage: HashMap::new(),
             },
-            deltas: Some(BlockChanges {
+            deltas: Some(BlockAggregatedChanges::from(BlockChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -2163,7 +2168,7 @@ mod test {
                 .into_iter()
                 .collect(),
                 ..Default::default()
-            }),
+            })),
             removed_components: [(
                 "Component2".to_string(),
                 ProtocolComponent { id: "Component2".to_string(), ..Default::default() },
@@ -2189,12 +2194,7 @@ mod test {
         // Mock the initial components call
         rpc_client
             .expect_get_protocol_components()
-            .returning(|_| {
-                Ok(ProtocolComponentRequestResponse {
-                    protocol_components: vec![],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 0 },
-                })
-            });
+            .returning(|_| Ok(vec![]));
 
         // Set up deltas client that will wait for messages (blocking in state_sync)
         let (_tx, rx) = channel(1);
@@ -2208,7 +2208,7 @@ mod test {
             .return_once(|_| Ok(()));
 
         let mut state_sync = ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum, "test-protocol"),
+            ExtractorIdentity::new(Chain::Ethereum.into(), "test-protocol"),
             true,
             ComponentFilter::with_tvl_range(0.0, 0.0),
             5, // Enough retries
@@ -2253,12 +2253,7 @@ mod test {
         // Mock the initial components call
         rpc_client
             .expect_get_protocol_components()
-            .returning(|_| {
-                Ok(ProtocolComponentRequestResponse {
-                    protocol_components: vec![],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 0 },
-                })
-            });
+            .returning(|_| Ok(vec![]));
 
         // Mock to fail during snapshot retrieval (this will cause an error during processing)
         rpc_client
@@ -2273,7 +2268,7 @@ mod test {
             .expect_subscribe()
             .return_once(move |_, _| {
                 // Send a delta message that will require a snapshot
-                let delta = BlockChanges {
+                let delta = BlockAggregatedChanges::from(BlockChanges {
                     extractor: "test".to_string(),
                     chain: Chain::Ethereum,
                     block: Block {
@@ -2289,17 +2284,9 @@ mod test {
                     // Add a new component to trigger snapshot request
                     new_protocol_components: [(
                         "new_component".to_string(),
-                        ProtocolComponent {
+                        tycho_common::dto::ProtocolComponent {
                             id: "new_component".to_string(),
-                            protocol_system: "test_protocol".to_string(),
-                            protocol_type_name: "test".to_string(),
-                            chain: Chain::Ethereum,
-                            tokens: vec![Bytes::from("0x0badc0ffee")],
-                            contract_ids: vec![Bytes::from("0x0badc0ffee")],
-                            static_attributes: Default::default(),
-                            creation_tx: Default::default(),
-                            created_at: Default::default(),
-                            change: Default::default(),
+                            ..Default::default()
                         },
                     )]
                     .into_iter()
@@ -2308,7 +2295,7 @@ mod test {
                         .into_iter()
                         .collect(),
                     ..Default::default()
-                };
+                });
 
                 tokio::spawn(async move {
                     let _ = tx.send(delta).await;
@@ -2324,7 +2311,7 @@ mod test {
             .return_once(|_| Ok(()));
 
         let mut state_sync = ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum, "test-protocol"),
+            ExtractorIdentity::new(Chain::Ethereum.into(), "test-protocol"),
             true,
             ComponentFilter::with_tvl_range(0.0, 1000.0), // Include the component
             1,
@@ -2377,12 +2364,7 @@ mod test {
 
         rpc_client
             .expect_get_protocol_components()
-            .returning(|_| {
-                Ok(ProtocolComponentRequestResponse {
-                    protocol_components: vec![],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 0 },
-                })
-            });
+            .returning(|_| Ok(vec![]));
 
         let (_tx, rx) = channel(1);
         deltas_client
@@ -2394,7 +2376,7 @@ mod test {
             .return_once(|_| Ok(()));
 
         let mut state_sync = ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum, "test-protocol"),
+            ExtractorIdentity::new(Chain::Ethereum.into(), "test-protocol"),
             true,
             ComponentFilter::with_tvl_range(0.0, 0.0),
             1,
@@ -2450,40 +2432,20 @@ mod test {
         // Mock the initial components call
         rpc_client
             .expect_get_protocol_components()
-            .returning(|_| {
-                Ok(ProtocolComponentRequestResponse {
-                    protocol_components: vec![],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 0 },
-                })
-            });
+            .returning(|_| Ok(vec![]));
 
         // Mock the snapshot retrieval that happens after first message
         rpc_client
             .expect_get_protocol_states()
-            .returning(|_| {
-                Ok(ProtocolStateRequestResponse {
-                    states: vec![],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 0 },
-                })
-            });
+            .returning(|_| Ok(vec![]));
 
         rpc_client
             .expect_get_component_tvl()
-            .returning(|_| {
-                Ok(ComponentTvlRequestResponse {
-                    tvl: HashMap::new(),
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 0 },
-                })
-            });
+            .returning(|_| Ok(HashMap::new()));
 
         rpc_client
             .expect_get_traced_entry_points()
-            .returning(|_| {
-                Ok(TracedEntryPointRequestResponse {
-                    traced_entry_points: HashMap::new(),
-                    pagination: PaginationResponse::new(0, 20, 0),
-                })
-            });
+            .returning(|_| Ok(HashMap::new()));
 
         // Set up deltas client to send one message, then keep channel open
         let (tx, rx) = channel(10);
@@ -2491,7 +2453,7 @@ mod test {
             .expect_subscribe()
             .return_once(move |_, _| {
                 // Send first message immediately
-                let first_delta = BlockChanges {
+                let first_delta = BlockAggregatedChanges::from(BlockChanges {
                     extractor: "test".to_string(),
                     chain: Chain::Ethereum,
                     block: Block {
@@ -2505,7 +2467,7 @@ mod test {
                     },
                     revert: false,
                     ..Default::default()
-                };
+                });
 
                 tokio::spawn(async move {
                     let _ = tx.send(first_delta).await;
@@ -2522,7 +2484,7 @@ mod test {
             .return_once(|_| Ok(()));
 
         let mut state_sync = ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum, "test-protocol"),
+            ExtractorIdentity::new(Chain::Ethereum.into(), "test-protocol"),
             true,
             ComponentFilter::with_tvl_range(0.0, 1000.0),
             1,
@@ -2587,12 +2549,7 @@ mod test {
         // Mock the initial components call to succeed
         rpc_client
             .expect_get_protocol_components()
-            .returning(|_| {
-                Ok(ProtocolComponentRequestResponse {
-                    protocol_components: vec![],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 0 },
-                })
-            });
+            .returning(|_| Ok(vec![]));
 
         // Set up deltas client to consistently fail after subscription
         // This will cause connection errors and trigger retries
@@ -2611,7 +2568,7 @@ mod test {
 
         // Create synchronizer with only 2 retries and short cooldown
         let mut state_sync = ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum, "test-protocol"),
+            ExtractorIdentity::new(Chain::Ethereum.into(), "test-protocol"),
             true,
             ComponentFilter::with_tvl_range(0.0, 1000.0),
             2,                         // max_retries = 2
@@ -2724,13 +2681,7 @@ mod test {
         rpc_client
             .expect_get_protocol_components()
             .returning(|_| {
-                Ok(ProtocolComponentRequestResponse {
-                    protocol_components: vec![ProtocolComponent {
-                        id: "Component1".to_string(),
-                        ..Default::default()
-                    }],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
-                })
+                Ok(vec![ProtocolComponent { id: "Component1".to_string(), ..Default::default() }])
             });
 
         // Set up deltas client to send a message that is the next expected block
@@ -2738,7 +2689,7 @@ mod test {
         deltas_client
             .expect_subscribe()
             .return_once(move |_, _| {
-                let expected_next_delta = BlockChanges {
+                let expected_next_delta = BlockAggregatedChanges::from(BlockChanges {
                     extractor: "uniswap-v2".to_string(),
                     chain: Chain::Ethereum,
                     block: Block {
@@ -2756,7 +2707,7 @@ mod test {
                     },
                     revert: false,
                     ..Default::default()
-                };
+                });
 
                 tokio::spawn(async move {
                     let _ = tx.send(expected_next_delta).await;
@@ -2770,7 +2721,7 @@ mod test {
             .return_once(|_| Ok(()));
 
         let mut state_sync = ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum, "uniswap-v2"),
+            ExtractorIdentity::new(Chain::Ethereum.into(), "uniswap-v2"),
             true,
             ComponentFilter::with_tvl_range(0.0, 1000.0),
             1,
@@ -2860,47 +2811,31 @@ mod test {
         rpc_client
             .expect_get_protocol_components()
             .returning(|_| {
-                Ok(ProtocolComponentRequestResponse {
-                    protocol_components: vec![ProtocolComponent {
-                        id: "Component1".to_string(),
-                        ..Default::default()
-                    }],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
-                })
+                Ok(vec![ProtocolComponent { id: "Component1".to_string(), ..Default::default() }])
             });
 
         // Mock snapshot calls for when we process the expected next block (block 6)
         rpc_client
             .expect_get_protocol_states()
             .returning(|_| {
-                Ok(ProtocolStateRequestResponse {
-                    states: vec![ResponseProtocolState {
-                        component_id: "Component1".to_string(),
-                        ..Default::default()
-                    }],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
-                })
+                Ok(vec![ProtocolComponentState::new(
+                    "Component1",
+                    Default::default(),
+                    Default::default(),
+                )])
             });
 
         rpc_client
             .expect_get_component_tvl()
             .returning(|_| {
-                Ok(ComponentTvlRequestResponse {
-                    tvl: [("Component1".to_string(), 100.0)]
-                        .into_iter()
-                        .collect(),
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
-                })
+                Ok([("Component1".to_string(), 100.0)]
+                    .into_iter()
+                    .collect())
             });
 
         rpc_client
             .expect_get_traced_entry_points()
-            .returning(|_| {
-                Ok(TracedEntryPointRequestResponse {
-                    traced_entry_points: HashMap::new(),
-                    pagination: PaginationResponse::new(0, 20, 0),
-                })
-            });
+            .returning(|_| Ok(HashMap::new()));
 
         // Set up deltas client to send old messages first, then the expected next block
         let (tx, rx) = channel(10);
@@ -2909,7 +2844,7 @@ mod test {
             .return_once(move |_, _| {
                 // Send messages for blocks 3, 4, 5 (already processed), then block 6 (expected)
                 let old_messages = vec![
-                    BlockChanges {
+                    BlockAggregatedChanges::from(BlockChanges {
                         extractor: "uniswap-v2".to_string(),
                         chain: Chain::Ethereum,
                         block: Block {
@@ -2921,8 +2856,8 @@ mod test {
                         },
                         revert: false,
                         ..Default::default()
-                    },
-                    BlockChanges {
+                    }),
+                    BlockAggregatedChanges::from(BlockChanges {
                         extractor: "uniswap-v2".to_string(),
                         chain: Chain::Ethereum,
                         block: Block {
@@ -2934,8 +2869,8 @@ mod test {
                         },
                         revert: false,
                         ..Default::default()
-                    },
-                    BlockChanges {
+                    }),
+                    BlockAggregatedChanges::from(BlockChanges {
                         extractor: "uniswap-v2".to_string(),
                         chain: Chain::Ethereum,
                         block: Block {
@@ -2947,9 +2882,9 @@ mod test {
                         },
                         revert: false,
                         ..Default::default()
-                    },
+                    }),
                     // This is the expected next block (block 6)
-                    BlockChanges {
+                    BlockAggregatedChanges::from(BlockChanges {
                         extractor: "uniswap-v2".to_string(),
                         chain: Chain::Ethereum,
                         block: Block {
@@ -2961,7 +2896,7 @@ mod test {
                         },
                         revert: false,
                         ..Default::default()
-                    },
+                    }),
                 ];
 
                 tokio::spawn(async move {
@@ -2979,7 +2914,7 @@ mod test {
             .return_once(|_| Ok(()));
 
         let mut state_sync = ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum, "uniswap-v2"),
+            ExtractorIdentity::new(Chain::Ethereum.into(), "uniswap-v2"),
             true,
             ComponentFilter::with_tvl_range(0.0, 1000.0),
             1,
@@ -3065,11 +3000,11 @@ mod test {
         }
     }
 
-    fn make_block_changes(block_num: u64, partial_idx: Option<u32>) -> BlockChanges {
+    fn make_block_changes(block_num: u64, partial_idx: Option<u32>) -> BlockAggregatedChanges {
         // Use vec to create Bytes from block number
         let hash = Bytes::from(vec![block_num as u8; 32]);
         let parent_hash = Bytes::from(vec![block_num.saturating_sub(1) as u8; 32]);
-        BlockChanges {
+        BlockAggregatedChanges::from(BlockChanges {
             extractor: "uniswap-v2".to_string(),
             chain: Chain::Ethereum,
             block: Block {
@@ -3082,7 +3017,7 @@ mod test {
             revert: false,
             partial_block_index: partial_idx,
             ..Default::default()
-        }
+        })
     }
 
     /// Test that full block as first message in partial mode is accepted
@@ -3241,10 +3176,11 @@ mod test {
                     states: [(
                         "Component1".to_string(),
                         ComponentWithState {
-                            state: ResponseProtocolState {
-                                component_id: "Component1".to_string(),
-                                ..Default::default()
-                            },
+                            state: ProtocolComponentState::new(
+                                "Component1",
+                                Default::default(),
+                                Default::default(),
+                            ),
                             component: component_clone.clone(),
                             entrypoints: vec![],
                             component_tvl: None,
@@ -3292,10 +3228,11 @@ mod test {
                     states: [(
                         "Component1".to_string(),
                         ComponentWithState {
-                            state: ResponseProtocolState {
-                                component_id: "Component1".to_string(),
-                                ..Default::default()
-                            },
+                            state: ProtocolComponentState::new(
+                                "Component1",
+                                Default::default(),
+                                Default::default(),
+                            ),
                             component: component_clone.clone(),
                             entrypoints: vec![],
                             component_tvl: None,
@@ -3310,12 +3247,7 @@ mod test {
         // get_traced_entry_points SHOULD be called for a DCI protocol
         rpc.expect_get_traced_entry_points()
             .times(1)
-            .returning(|_| {
-                Ok(TracedEntryPointRequestResponse {
-                    traced_entry_points: HashMap::new(),
-                    pagination: PaginationResponse::new(0, 20, 0),
-                })
-            });
+            .returning(|_| Ok(HashMap::new()));
 
         let mut state_sync = with_mocked_clients(true, false, Some(rpc), None).with_dci(true);
         state_sync
@@ -3351,31 +3283,25 @@ mod test {
         // 2)
         rpc_client
             .expect_get_protocol_components()
-            .with(mockall::predicate::function(|req: &ProtocolComponentsRequestBody| {
-                req.component_ids
-                    .as_ref()
+            .withf(|params: &crate::rpc::ProtocolComponentsParams| {
+                params
+                    .component_ids()
                     .is_some_and(|ids| ids.contains(&"BrandNew".to_string()))
-            }))
+            })
             .returning(|_| {
-                Ok(ProtocolComponentRequestResponse {
-                    protocol_components: vec![
-                        ProtocolComponent { id: "BrandNew".to_string(), ..Default::default() },
-                        ProtocolComponent { id: "Preexisting".to_string(), ..Default::default() },
-                    ],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 2 },
-                })
+                Ok(vec![
+                    ProtocolComponent { id: "BrandNew".to_string(), ..Default::default() },
+                    ProtocolComponent { id: "Preexisting".to_string(), ..Default::default() },
+                ])
             });
         // get_protocol_components for initial sync (via get_protocol_components_paginated)
         rpc_client
             .expect_get_protocol_components()
             .returning(|_| {
-                Ok(ProtocolComponentRequestResponse {
-                    protocol_components: vec![
-                        ProtocolComponent { id: "Component1".to_string(), ..Default::default() },
-                        ProtocolComponent { id: "Component2".to_string(), ..Default::default() },
-                    ],
-                    pagination: PaginationResponse { page: 0, page_size: 20, total: 2 },
-                })
+                Ok(vec![
+                    ProtocolComponent { id: "Component1".to_string(), ..Default::default() },
+                    ProtocolComponent { id: "Component2".to_string(), ..Default::default() },
+                ])
             });
         // get_snapshots: more specific expectations first so init (block 0, all components)
         // does not match the block 1/2 ones.
@@ -3397,10 +3323,11 @@ mod test {
                     states: [(
                         "BrandNew".to_string(),
                         ComponentWithState {
-                            state: ResponseProtocolState {
-                                component_id: "BrandNew".to_string(),
-                                ..Default::default()
-                            },
+                            state: ProtocolComponentState::new(
+                                "BrandNew",
+                                Default::default(),
+                                Default::default(),
+                            ),
                             component: ProtocolComponent {
                                 id: "BrandNew".to_string(),
                                 ..Default::default()
@@ -3432,10 +3359,11 @@ mod test {
                     states: [(
                         "Preexisting".to_string(),
                         ComponentWithState {
-                            state: ResponseProtocolState {
-                                component_id: "Preexisting".to_string(),
-                                ..Default::default()
-                            },
+                            state: ProtocolComponentState::new(
+                                "Preexisting",
+                                Default::default(),
+                                Default::default(),
+                            ),
                             component: ProtocolComponent {
                                 id: "Preexisting".to_string(),
                                 ..Default::default()
@@ -3458,10 +3386,11 @@ mod test {
                         (
                             "Component1".to_string(),
                             ComponentWithState {
-                                state: ResponseProtocolState {
-                                    component_id: "Component1".to_string(),
-                                    ..Default::default()
-                                },
+                                state: ProtocolComponentState::new(
+                                    "Component1",
+                                    Default::default(),
+                                    Default::default(),
+                                ),
                                 component: ProtocolComponent {
                                     id: "Component1".to_string(),
                                     ..Default::default()
@@ -3473,10 +3402,11 @@ mod test {
                         (
                             "Component2".to_string(),
                             ComponentWithState {
-                                state: ResponseProtocolState {
-                                    component_id: "Component2".to_string(),
-                                    ..Default::default()
-                                },
+                                state: ProtocolComponentState::new(
+                                    "Component2",
+                                    Default::default(),
+                                    Default::default(),
+                                ),
                                 component: ProtocolComponent {
                                     id: "Component2".to_string(),
                                     ..Default::default()
@@ -3493,12 +3423,7 @@ mod test {
             });
         rpc_client
             .expect_get_traced_entry_points()
-            .returning(|_| {
-                Ok(TracedEntryPointRequestResponse {
-                    traced_entry_points: HashMap::new(),
-                    pagination: PaginationResponse::new(0, 100, 0),
-                })
-            });
+            .returning(|_| Ok(HashMap::new()));
 
         let mut deltas_client = MockDeltasClient::new();
         let (tx, rx) = channel(1);

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -861,22 +861,15 @@ mod test {
 
     use std::{collections::HashSet, sync::Arc};
 
-    use tycho_common::{
-        dto::{
-            AddressStorageLocation, Block, BlockAggregatedChanges as DtoBlockAggregatedChanges,
-            Chain, DCIUpdate, EntryPoint, PaginationResponse, ProtocolStateRequestResponse,
-            RPCTracerParams, ResponseAccount, ResponseProtocolState, StateRequestResponse,
-            TracingParams,
+    use tycho_common::models::{
+        blockchain::{
+            AddressStorageLocation, Block, BlockAggregatedChanges, DCIUpdate, EntryPoint,
+            EntryPointWithTracingParams as ModelEntryPointWithTracingParams, RPCTracerParams,
+            TracingParams, TracingResult as ModelTracingResult,
         },
-        models::{
-            blockchain::{
-                BlockAggregatedChanges,
-                EntryPointWithTracingParams as ModelEntryPointWithTracingParams,
-                TracingResult as ModelTracingResult,
-            },
-            protocol::{ProtocolComponent, ProtocolComponentState},
-            token::Token,
-        },
+        protocol::{ProtocolComponent, ProtocolComponentState},
+        token::Token,
+        Chain,
     };
     use uuid::Uuid;
 
@@ -1027,7 +1020,7 @@ mod test {
         let deltas_client = ArcDeltasClient(Arc::new(deltas_client.unwrap_or_default()));
 
         ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum.into(), "uniswap-v2"),
+            ExtractorIdentity::new(Chain::Ethereum, "uniswap-v2"),
             native,
             ComponentFilter::with_tvl_range(50.0, 50.0),
             1,
@@ -1041,14 +1034,12 @@ mod test {
         )
     }
 
-    fn state_snapshot_native() -> ProtocolStateRequestResponse {
-        ProtocolStateRequestResponse {
-            states: vec![ResponseProtocolState {
-                component_id: "Component1".to_string(),
-                ..Default::default()
-            }],
-            pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
-        }
+    fn state_snapshot_native() -> Vec<ProtocolComponentState> {
+        vec![ProtocolComponentState {
+            component_id: "Component1".to_string(),
+            attributes: HashMap::new(),
+            balances: HashMap::new(),
+        }]
     }
 
     fn make_mock_client() -> MockRPCClient {
@@ -1069,13 +1060,12 @@ mod test {
             .returning(move |_request, _chunk_size, _concurrency| {
                 Ok(Snapshot {
                     states: state_snapshot_native()
-                        .states
                         .into_iter()
                         .map(|state| {
                             (
                                 state.component_id.clone(),
                                 ComponentWithState {
-                                    state: state.into(),
+                                    state,
                                     component: component_clone.clone(),
                                     entrypoints: vec![],
                                     component_tvl: None,
@@ -1100,13 +1090,12 @@ mod test {
             header: header.clone(),
             snapshots: Snapshot {
                 states: state_snapshot_native()
-                    .states
                     .into_iter()
                     .map(|state| {
                         (
                             state.component_id.clone(),
                             ComponentWithState {
-                                state: state.into(),
+                                state,
                                 component: component.clone(),
                                 entrypoints: vec![],
                                 component_tvl: None,
@@ -1139,13 +1128,12 @@ mod test {
             .returning(move |_request, _chunk_size, _concurrency| {
                 Ok(Snapshot {
                     states: state_snapshot_native()
-                        .states
                         .into_iter()
                         .map(|state| {
                             (
                                 state.component_id.clone(),
                                 ComponentWithState {
-                                    state: state.into(),
+                                    state,
                                     component: component_clone.clone(),
                                     component_tvl: Some(100.0),
                                     entrypoints: vec![],
@@ -1170,13 +1158,12 @@ mod test {
             header: header.clone(),
             snapshots: Snapshot {
                 states: state_snapshot_native()
-                    .states
                     .into_iter()
                     .map(|state| {
                         (
                             state.component_id.clone(),
                             ComponentWithState {
-                                state: state.into(),
+                                state,
                                 component: component.clone(),
                                 component_tvl: Some(100.0),
                                 entrypoints: vec![],
@@ -1198,14 +1185,35 @@ mod test {
         assert_eq!(snap, exp);
     }
 
-    fn state_snapshot_vm() -> StateRequestResponse {
-        StateRequestResponse {
-            accounts: vec![
-                ResponseAccount { address: Bytes::from("0x0badc0ffee"), ..Default::default() },
-                ResponseAccount { address: Bytes::from("0xbabe42"), ..Default::default() },
-            ],
-            pagination: PaginationResponse { page: 0, page_size: 20, total: 1 },
-        }
+    fn state_snapshot_vm() -> Vec<Account> {
+        vec![
+            Account::new(
+                Chain::default(),
+                Bytes::from("0x0badc0ffee"),
+                String::new(),
+                HashMap::new(),
+                Bytes::default(),
+                HashMap::new(),
+                Bytes::default(),
+                Bytes::default(),
+                Bytes::default(),
+                Bytes::default(),
+                None,
+            ),
+            Account::new(
+                Chain::default(),
+                Bytes::from("0xbabe42"),
+                String::new(),
+                HashMap::new(),
+                Bytes::default(),
+                HashMap::new(),
+                Bytes::default(),
+                Bytes::default(),
+                Bytes::default(),
+                Bytes::default(),
+                None,
+            ),
+        ]
     }
 
     fn traced_entry_point_response(
@@ -1257,11 +1265,11 @@ mod test {
                     states: [(
                         "Component1".to_string(),
                         ComponentWithState {
-                            state: ResponseProtocolState {
+                            state: ProtocolComponentState {
                                 component_id: "Component1".to_string(),
-                                ..Default::default()
-                            }
-                            .into(),
+                                attributes: HashMap::new(),
+                                balances: HashMap::new(),
+                            },
                             component: ProtocolComponent {
                                 id: "Component1".to_string(),
                                 contract_addresses: vec![
@@ -1280,12 +1288,8 @@ mod test {
                     .into_iter()
                     .collect(),
                     vm_storage: vm_storage_accounts
-                        .accounts
                         .into_iter()
-                        .map(|state| {
-                            let addr = state.address.clone();
-                            (addr, Account::from(state))
-                        })
+                        .map(|account| (account.address.clone(), account))
                         .collect(),
                 })
             });
@@ -1310,11 +1314,11 @@ mod test {
                 states: [(
                     component.id.clone(),
                     ComponentWithState {
-                        state: ResponseProtocolState {
+                        state: ProtocolComponentState {
                             component_id: "Component1".to_string(),
-                            ..Default::default()
-                        }
-                        .into(),
+                            attributes: HashMap::new(),
+                            balances: HashMap::new(),
+                        },
                         component: component.clone(),
                         component_tvl: None,
                         entrypoints: traced_entry_point_response()
@@ -1325,9 +1329,8 @@ mod test {
                 .into_iter()
                 .collect(),
                 vm_storage: state_snapshot_vm()
-                    .accounts
                     .into_iter()
-                    .map(|state| (state.address.clone(), Account::from(state)))
+                    .map(|account| (account.address.clone(), account))
                     .collect(),
             },
             deltas: None,
@@ -1360,11 +1363,11 @@ mod test {
                     states: [(
                         "Component1".to_string(),
                         ComponentWithState {
-                            state: ResponseProtocolState {
+                            state: ProtocolComponentState {
                                 component_id: "Component1".to_string(),
-                                ..Default::default()
-                            }
-                            .into(),
+                                attributes: HashMap::new(),
+                                balances: HashMap::new(),
+                            },
                             component: component_clone.clone(),
                             component_tvl: Some(100.0),
                             entrypoints: vec![],
@@ -1373,9 +1376,8 @@ mod test {
                     .into_iter()
                     .collect(),
                     vm_storage: vm_storage_accounts
-                        .accounts
                         .into_iter()
-                        .map(|state| (state.address.clone(), Account::from(state)))
+                        .map(|account| (account.address.clone(), account))
                         .collect(),
                 })
             });
@@ -1395,11 +1397,11 @@ mod test {
                 states: [(
                     component.id.clone(),
                     ComponentWithState {
-                        state: ResponseProtocolState {
+                        state: ProtocolComponentState {
                             component_id: "Component1".to_string(),
-                            ..Default::default()
-                        }
-                        .into(),
+                            attributes: HashMap::new(),
+                            balances: HashMap::new(),
+                        },
                         component: component.clone(),
                         component_tvl: Some(100.0),
                         entrypoints: vec![],
@@ -1408,9 +1410,8 @@ mod test {
                 .into_iter()
                 .collect(),
                 vm_storage: state_snapshot_vm()
-                    .accounts
                     .into_iter()
-                    .map(|state| (state.address.clone(), Account::from(state)))
+                    .map(|account| (account.address.clone(), account))
                     .collect(),
             },
             deltas: None,
@@ -1459,11 +1460,11 @@ mod test {
                     states: [(
                         "Component2".to_string(),
                         ComponentWithState {
-                            state: ResponseProtocolState {
+                            state: ProtocolComponentState {
                                 component_id: "Component2".to_string(),
-                                ..Default::default()
-                            }
-                            .into(),
+                                attributes: HashMap::new(),
+                                balances: HashMap::new(),
+                            },
                             component: component2_clone.clone(),
                             entrypoints: vec![],
                             component_tvl: None,
@@ -1674,7 +1675,7 @@ mod test {
     async fn test_state_sync() {
         let (rpc_client, deltas_client, tx) = mock_clients_for_state_sync();
         let deltas = [
-            BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
+            BlockAggregatedChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -1708,7 +1709,7 @@ mod test {
                     )]),
                     trace_results: HashMap::from([(
                         "entrypoint_a".to_string(),
-                        tycho_common::dto::TracingResult {
+                        ModelTracingResult {
                             retriggers: HashSet::from([(
                                 Bytes::from("0x0badc0ffee"),
                                 AddressStorageLocation::new(Bytes::from("0x0badc0ffee"), 12),
@@ -1721,8 +1722,8 @@ mod test {
                     )]),
                 },
                 ..Default::default()
-            }),
-            BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
+            },
+            BlockAggregatedChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -1741,7 +1742,7 @@ mod test {
                 .into_iter()
                 .collect(),
                 ..Default::default()
-            }),
+            },
         ];
         let mut state_sync = with_mocked_clients(true, true, Some(rpc_client), Some(deltas_client));
         state_sync
@@ -1856,7 +1857,7 @@ mod test {
             },
             // Our deltas are empty and since merge methods are
             // tested in tycho-common we don't have much to do here.
-            deltas: Some(BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
+            deltas: Some(BlockAggregatedChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -1875,7 +1876,7 @@ mod test {
                 .into_iter()
                 .collect(),
                 ..Default::default()
-            })),
+            }),
             // "Component2" was removed, because its tvl changed to 0.
             removed_components: [(
                 "Component2".to_string(),
@@ -2024,7 +2025,7 @@ mod test {
             .return_once(|_| Ok(()));
 
         let mut state_sync = ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum.into(), "uniswap-v2"),
+            ExtractorIdentity::new(Chain::Ethereum, "uniswap-v2"),
             true,
             ComponentFilter::with_tvl_range(remove_tvl_threshold, add_tvl_threshold),
             1,
@@ -2043,7 +2044,7 @@ mod test {
 
         // Simulate the incoming BlockAggregatedChanges
         let deltas = [
-            BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
+            BlockAggregatedChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -2055,8 +2056,8 @@ mod test {
                 },
                 revert: false,
                 ..Default::default()
-            }),
-            BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
+            },
+            BlockAggregatedChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -2075,7 +2076,7 @@ mod test {
                 .into_iter()
                 .collect(),
                 ..Default::default()
-            }),
+            },
         ];
 
         let (handle, mut rx) = state_sync.start().await;
@@ -2135,7 +2136,7 @@ mod test {
                 .collect(),
                 vm_storage: HashMap::new(),
             },
-            deltas: Some(BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
+            deltas: Some(BlockAggregatedChanges {
                 extractor: "uniswap-v2".to_string(),
                 chain: Chain::Ethereum,
                 block: Block {
@@ -2153,7 +2154,7 @@ mod test {
                 .into_iter()
                 .collect(),
                 ..Default::default()
-            })),
+            }),
             removed_components: [(
                 "Component2".to_string(),
                 ProtocolComponent { id: "Component2".to_string(), ..Default::default() },
@@ -2193,7 +2194,7 @@ mod test {
             .return_once(|_| Ok(()));
 
         let mut state_sync = ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum.into(), "test-protocol"),
+            ExtractorIdentity::new(Chain::Ethereum, "test-protocol"),
             true,
             ComponentFilter::with_tvl_range(0.0, 0.0),
             5, // Enough retries
@@ -2253,7 +2254,7 @@ mod test {
             .expect_subscribe()
             .return_once(move |_, _| {
                 // Send a delta message that will require a snapshot
-                let delta = BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
+                let delta = BlockAggregatedChanges {
                     extractor: "test".to_string(),
                     chain: Chain::Ethereum,
                     block: Block {
@@ -2269,10 +2270,7 @@ mod test {
                     // Add a new component to trigger snapshot request
                     new_protocol_components: [(
                         "new_component".to_string(),
-                        tycho_common::dto::ProtocolComponent {
-                            id: "new_component".to_string(),
-                            ..Default::default()
-                        },
+                        ProtocolComponent { id: "new_component".to_string(), ..Default::default() },
                     )]
                     .into_iter()
                     .collect(),
@@ -2280,7 +2278,7 @@ mod test {
                         .into_iter()
                         .collect(),
                     ..Default::default()
-                });
+                };
 
                 tokio::spawn(async move {
                     let _ = tx.send(delta).await;
@@ -2296,7 +2294,7 @@ mod test {
             .return_once(|_| Ok(()));
 
         let mut state_sync = ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum.into(), "test-protocol"),
+            ExtractorIdentity::new(Chain::Ethereum, "test-protocol"),
             true,
             ComponentFilter::with_tvl_range(0.0, 1000.0), // Include the component
             1,
@@ -2361,7 +2359,7 @@ mod test {
             .return_once(|_| Ok(()));
 
         let mut state_sync = ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum.into(), "test-protocol"),
+            ExtractorIdentity::new(Chain::Ethereum, "test-protocol"),
             true,
             ComponentFilter::with_tvl_range(0.0, 0.0),
             1,
@@ -2438,7 +2436,7 @@ mod test {
             .expect_subscribe()
             .return_once(move |_, _| {
                 // Send first message immediately
-                let first_delta = BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
+                let first_delta = BlockAggregatedChanges {
                     extractor: "test".to_string(),
                     chain: Chain::Ethereum,
                     block: Block {
@@ -2452,7 +2450,7 @@ mod test {
                     },
                     revert: false,
                     ..Default::default()
-                });
+                };
 
                 tokio::spawn(async move {
                     let _ = tx.send(first_delta).await;
@@ -2469,7 +2467,7 @@ mod test {
             .return_once(|_| Ok(()));
 
         let mut state_sync = ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum.into(), "test-protocol"),
+            ExtractorIdentity::new(Chain::Ethereum, "test-protocol"),
             true,
             ComponentFilter::with_tvl_range(0.0, 1000.0),
             1,
@@ -2553,7 +2551,7 @@ mod test {
 
         // Create synchronizer with only 2 retries and short cooldown
         let mut state_sync = ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum.into(), "test-protocol"),
+            ExtractorIdentity::new(Chain::Ethereum, "test-protocol"),
             true,
             ComponentFilter::with_tvl_range(0.0, 1000.0),
             2,                         // max_retries = 2
@@ -2679,7 +2677,7 @@ mod test {
         deltas_client
             .expect_subscribe()
             .return_once(move |_, _| {
-                let expected_next_delta = BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
+                let expected_next_delta = BlockAggregatedChanges {
                     extractor: "uniswap-v2".to_string(),
                     chain: Chain::Ethereum,
                     block: Block {
@@ -2697,7 +2695,7 @@ mod test {
                     },
                     revert: false,
                     ..Default::default()
-                });
+                };
 
                 tokio::spawn(async move {
                     let _ = tx.send(expected_next_delta).await;
@@ -2711,7 +2709,7 @@ mod test {
             .return_once(|_| Ok(()));
 
         let mut state_sync = ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum.into(), "uniswap-v2"),
+            ExtractorIdentity::new(Chain::Ethereum, "uniswap-v2"),
             true,
             ComponentFilter::with_tvl_range(0.0, 1000.0),
             1,
@@ -2849,7 +2847,7 @@ mod test {
             .return_once(move |_, _| {
                 // Send messages for blocks 3, 4, 5 (already processed), then block 6 (expected)
                 let old_messages = vec![
-                    BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
+                    BlockAggregatedChanges {
                         extractor: "uniswap-v2".to_string(),
                         chain: Chain::Ethereum,
                         block: Block {
@@ -2861,8 +2859,8 @@ mod test {
                         },
                         revert: false,
                         ..Default::default()
-                    }),
-                    BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
+                    },
+                    BlockAggregatedChanges {
                         extractor: "uniswap-v2".to_string(),
                         chain: Chain::Ethereum,
                         block: Block {
@@ -2874,8 +2872,8 @@ mod test {
                         },
                         revert: false,
                         ..Default::default()
-                    }),
-                    BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
+                    },
+                    BlockAggregatedChanges {
                         extractor: "uniswap-v2".to_string(),
                         chain: Chain::Ethereum,
                         block: Block {
@@ -2887,9 +2885,9 @@ mod test {
                         },
                         revert: false,
                         ..Default::default()
-                    }),
+                    },
                     // This is the expected next block (block 6)
-                    BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
+                    BlockAggregatedChanges {
                         extractor: "uniswap-v2".to_string(),
                         chain: Chain::Ethereum,
                         block: Block {
@@ -2901,7 +2899,7 @@ mod test {
                         },
                         revert: false,
                         ..Default::default()
-                    }),
+                    },
                 ];
 
                 tokio::spawn(async move {
@@ -2919,7 +2917,7 @@ mod test {
             .return_once(|_| Ok(()));
 
         let mut state_sync = ProtocolStateSynchronizer::new(
-            ExtractorIdentity::new(Chain::Ethereum.into(), "uniswap-v2"),
+            ExtractorIdentity::new(Chain::Ethereum, "uniswap-v2"),
             true,
             ComponentFilter::with_tvl_range(0.0, 1000.0),
             1,
@@ -3009,7 +3007,7 @@ mod test {
         // Use vec to create Bytes from block number
         let hash = Bytes::from(vec![block_num as u8; 32]);
         let parent_hash = Bytes::from(vec![block_num.saturating_sub(1) as u8; 32]);
-        BlockAggregatedChanges::from(DtoBlockAggregatedChanges {
+        BlockAggregatedChanges {
             extractor: "uniswap-v2".to_string(),
             chain: Chain::Ethereum,
             block: Block {
@@ -3022,7 +3020,7 @@ mod test {
             revert: false,
             partial_block_index: partial_idx,
             ..Default::default()
-        })
+        }
     }
 
     /// Test that full block as first message in partial mode is accepted

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -14,7 +14,9 @@ use tokio::{
 use tracing::{debug, error, info, instrument, trace, warn};
 use tycho_common::{
     models::{
-        blockchain::{BlockAggregatedChanges, DCIUpdate, EntryPointWithTracingParams, TracingResult},
+        blockchain::{
+            BlockAggregatedChanges, DCIUpdate, EntryPointWithTracingParams, TracingResult,
+        },
         contract::Account,
         protocol::{ProtocolComponent, ProtocolComponentState},
         ExtractorIdentity,
@@ -28,7 +30,10 @@ use crate::{
         component_tracker::{ComponentFilter, ComponentTracker},
         BlockHeader, HeaderLike,
     },
-    rpc::{RPCClient, RPCError, SnapshotParameters, TracedEntryPointsPaginatedParams, RPC_CLIENT_CONCURRENCY},
+    rpc::{
+        RPCClient, RPCError, SnapshotParameters, TracedEntryPointsPaginatedParams,
+        RPC_CLIENT_CONCURRENCY,
+    },
     DeltasError,
 };
 
@@ -338,14 +343,12 @@ where
         > = if self.uses_dci {
             let result = self
                 .rpc_client
-                .get_traced_entry_points_paginated(
-                    TracedEntryPointsPaginatedParams::new(
-                        self.extractor_id.chain,
-                        self.extractor_id.name.as_str(),
-                        component_ids.clone(),
-                        RPC_CLIENT_CONCURRENCY,
-                    ),
-                )
+                .get_traced_entry_points_paginated(TracedEntryPointsPaginatedParams::new(
+                    self.extractor_id.chain,
+                    self.extractor_id.name.as_str(),
+                    component_ids.clone(),
+                    RPC_CLIENT_CONCURRENCY,
+                ))
                 .await?;
             self.component_tracker
                 .process_entrypoints(&DCIUpdate::from(result.clone()));
@@ -878,7 +881,11 @@ mod test {
     use uuid::Uuid;
 
     use super::*;
-    use crate::{deltas::MockDeltasClient, rpc::{MockRPCClient, Page}, DeltasError, RPCError};
+    use crate::{
+        deltas::MockDeltasClient,
+        rpc::{MockRPCClient, Page},
+        DeltasError, RPCError,
+    };
 
     // Required for mock client to implement clone
     struct ArcRPCClient<T>(Arc<T>);
@@ -944,8 +951,10 @@ mod test {
         async fn get_traced_entry_points(
             &self,
             params: crate::rpc::TracedEntryPointsParams,
-        ) -> Result<crate::rpc::Page<HashMap<String, Vec<(EntryPointWithTracingParams, TracingResult)>>>, RPCError>
-        {
+        ) -> Result<
+            crate::rpc::Page<HashMap<String, Vec<(EntryPointWithTracingParams, TracingResult)>>>,
+            RPCError,
+        > {
             self.0
                 .get_traced_entry_points(params)
                 .await

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -620,13 +620,7 @@ pub struct ComponentTvlPaginatedParams {
 
 impl ComponentTvlPaginatedParams {
     pub fn new(chain: Chain, concurrency: usize) -> Self {
-        Self {
-            chain,
-            protocol_system: None,
-            component_ids: None,
-            chunk_size: None,
-            concurrency,
-        }
+        Self { chain, protocol_system: None, component_ids: None, chunk_size: None, concurrency }
     }
 
     pub fn with_protocol_system(mut self, protocol_system: impl Into<String>) -> Self {
@@ -863,7 +857,8 @@ pub trait RPCClient: Send + Sync {
                     .acquire()
                     .await
                     .map_err(|_| RPCError::Fatal("Semaphore dropped".to_string()))?;
-                self.get_contract_state(base_params).await
+                self.get_contract_state(base_params)
+                    .await
             });
         }
 
@@ -932,12 +927,7 @@ pub trait RPCClient: Send + Sync {
 
                 try_join_all(tasks)
                     .await
-                    .map(|pages| {
-                        pages
-                            .into_iter()
-                            .flatten()
-                            .collect()
-                    })
+                    .map(|pages| pages.into_iter().flatten().collect())
             }
             None => {
                 // If no component ids are specified, we need to make requests based on the total
@@ -961,8 +951,7 @@ pub trait RPCClient: Send + Sync {
 
                 let mut page = 1;
                 while page < total_pages {
-                    let requests_in_this_iteration =
-                        (total_pages - page).min(concurrency as i64);
+                    let requests_in_this_iteration = (total_pages - page).min(concurrency as i64);
 
                     let tasks: Vec<_> = (0..requests_in_this_iteration)
                         .map(|iter| {
@@ -1012,9 +1001,12 @@ pub trait RPCClient: Send + Sync {
     ) -> Result<Vec<ProtocolComponentState>, RPCError> {
         let semaphore = Arc::new(Semaphore::new(params.concurrency));
 
-        let chunk_size = params.chunk_size.unwrap_or(
-            ProtocolStateRequestBody::effective_max_page_size(self.compression()) as usize,
-        );
+        let chunk_size =
+            params
+                .chunk_size
+                .unwrap_or(
+                    ProtocolStateRequestBody::effective_max_page_size(self.compression()) as usize
+                );
 
         let tasks: Vec<_> = params
             .protocol_ids
@@ -1050,9 +1042,9 @@ pub trait RPCClient: Send + Sync {
     ///
     /// If `chunk_size` is `None`, it defaults to the maximum page size.
     async fn get_all_tokens(&self, params: AllTokensParams) -> Result<Vec<Token>, RPCError> {
-        let chunk_size = params.chunk_size.unwrap_or(
-            TokensRequestBody::effective_max_page_size(self.compression()) as usize,
-        );
+        let chunk_size = params
+            .chunk_size
+            .unwrap_or(TokensRequestBody::effective_max_page_size(self.compression()) as usize);
 
         let semaphore = Arc::new(Semaphore::new(params.concurrency));
 
@@ -1128,31 +1120,34 @@ pub trait RPCClient: Send + Sync {
     ) -> Result<HashMap<String, f64>, RPCError> {
         let semaphore = Arc::new(Semaphore::new(params.concurrency));
 
-        let chunk_size = params.chunk_size.unwrap_or(
-            ComponentTvlRequestBody::effective_max_page_size(self.compression()) as usize,
-        );
+        let chunk_size =
+            params
+                .chunk_size
+                .unwrap_or(
+                    ComponentTvlRequestBody::effective_max_page_size(self.compression()) as usize
+                );
 
         match params.component_ids {
             Some(ids) => {
-                let tasks: Vec<_> = ids
-                    .chunks(chunk_size)
-                    .enumerate()
-                    .map(|(index, chunk)| {
-                        let sem = semaphore.clone();
-                        let mut p = ComponentTvlParams::new(params.chain)
-                            .with_component_ids(chunk.to_vec())
-                            .with_pagination(index as i64, chunk_size as i64);
-                        if let Some(ref ps) = params.protocol_system {
-                            p = p.with_protocol_system(ps.as_str());
-                        }
-                        async move {
-                            let _permit = sem.acquire().await.map_err(|_| {
-                                RPCError::Fatal("Semaphore dropped".to_string())
-                            })?;
-                            self.get_component_tvl(p).await
-                        }
-                    })
-                    .collect();
+                let tasks: Vec<_> =
+                    ids.chunks(chunk_size)
+                        .enumerate()
+                        .map(|(index, chunk)| {
+                            let sem = semaphore.clone();
+                            let mut p = ComponentTvlParams::new(params.chain)
+                                .with_component_ids(chunk.to_vec())
+                                .with_pagination(index as i64, chunk_size as i64);
+                            if let Some(ref ps) = params.protocol_system {
+                                p = p.with_protocol_system(ps.as_str());
+                            }
+                            async move {
+                                let _permit = sem.acquire().await.map_err(|_| {
+                                    RPCError::Fatal("Semaphore dropped".to_string())
+                                })?;
+                                self.get_component_tvl(p).await
+                            }
+                        })
+                        .collect();
 
                 let pages = try_join_all(tasks).await?;
 
@@ -1263,12 +1258,7 @@ pub trait RPCClient: Send + Sync {
 
         try_join_all(tasks)
             .await
-            .map(|pages| {
-                pages
-                    .into_iter()
-                    .flatten()
-                    .collect()
-            })
+            .map(|pages| pages.into_iter().flatten().collect())
     }
 
     async fn get_snapshots<'a>(
@@ -1515,7 +1505,6 @@ fn parse_retry_value(val: &str) -> Option<SystemTime> {
     }
     None
 }
-
 
 #[async_trait]
 impl RPCClient for HttpRPCClient {

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -25,17 +25,35 @@ use tokio::{
 use tracing::{debug, error, instrument, trace, warn};
 use tycho_common::{
     dto::{
-        BlockParam, Chain, ComponentTvlRequestBody, ComponentTvlRequestResponse,
-        EntryPointWithTracingParams, PaginationLimits, PaginationParams, PaginationResponse,
-        ProtocolComponent, ProtocolComponentRequestResponse, ProtocolComponentsRequestBody,
+        BlockParam, ComponentTvlRequestBody, ComponentTvlRequestResponse, PaginationLimits,
+        PaginationParams, ProtocolComponentRequestResponse, ProtocolComponentsRequestBody,
         ProtocolStateRequestBody, ProtocolStateRequestResponse, ProtocolSystemsRequestBody,
-        ProtocolSystemsRequestResponse, ResponseToken, StateRequestBody, StateRequestResponse,
-        TokensRequestBody, TokensRequestResponse, TracedEntryPointRequestBody,
-        TracedEntryPointRequestResponse, TracingResult, VersionParam,
+        ProtocolSystemsRequestResponse, StateRequestBody, StateRequestResponse, TokensRequestBody,
+        TokensRequestResponse, TracedEntryPointRequestBody, TracedEntryPointRequestResponse,
+        VersionParam,
     },
-    models::ComponentId,
+    models::{
+        blockchain::{EntryPointWithTracingParams, TracedEntryPoints, TracingResult},
+        contract::Account,
+        protocol::{ProtocolComponent, ProtocolComponentState},
+        token::Token,
+        Chain, ComponentId,
+    },
     Bytes,
 };
+
+/// Response from `RPCClient::get_protocol_systems`.
+///
+/// Carries the raw lists returned by the server without wrapping dto types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProtocolSystemsResponse {
+    /// All protocol systems known to the server.
+    pub protocol_systems: Vec<String>,
+    /// Subset of `protocol_systems` that use Dynamic Contract Indexing.
+    pub dci_protocols: Vec<String>,
+    /// Total number of protocol systems on the server (may exceed what was fetched).
+    pub total: i64,
+}
 
 use crate::{
     feed::synchronizer::{ComponentWithState, Snapshot},
@@ -44,6 +62,267 @@ use crate::{
 
 /// Suggested concurrency level for RPC clients.
 pub const RPC_CLIENT_CONCURRENCY: usize = 4;
+
+/// Parameters for [`RPCClient::get_contract_state`].
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContractStateParams {
+    chain: Chain,
+    protocol_system: String,
+    contract_ids: Option<Vec<Bytes>>,
+    block_number: Option<u64>,
+    page: i64,
+    page_size: i64,
+}
+
+impl ContractStateParams {
+    pub fn new(chain: Chain, protocol_system: impl Into<String>) -> Self {
+        Self {
+            chain,
+            protocol_system: protocol_system.into(),
+            contract_ids: None,
+            block_number: None,
+            page: 0,
+            page_size: StateRequestBody::MAX_PAGE_SIZE_COMPRESSED,
+        }
+    }
+
+    pub fn with_contract_ids(mut self, ids: Vec<Bytes>) -> Self {
+        self.contract_ids = Some(ids);
+        self
+    }
+
+    pub fn with_block_number(mut self, block_number: u64) -> Self {
+        self.block_number = Some(block_number);
+        self
+    }
+
+    pub(crate) fn with_pagination(mut self, page: i64, page_size: i64) -> Self {
+        self.page = page;
+        self.page_size = page_size;
+        self
+    }
+}
+
+/// Parameters for [`RPCClient::get_protocol_components`].
+#[derive(Clone, PartialEq, Debug)]
+pub struct ProtocolComponentsParams {
+    chain: Chain,
+    protocol_system: String,
+    component_ids: Option<Vec<ComponentId>>,
+    tvl_gt: Option<f64>,
+    page: i64,
+    page_size: i64,
+}
+
+impl ProtocolComponentsParams {
+    pub fn new(chain: Chain, protocol_system: impl Into<String>) -> Self {
+        Self {
+            chain,
+            protocol_system: protocol_system.into(),
+            component_ids: None,
+            tvl_gt: None,
+            page: 0,
+            page_size: ProtocolComponentsRequestBody::MAX_PAGE_SIZE_COMPRESSED,
+        }
+    }
+
+    pub fn with_component_ids(mut self, ids: Vec<ComponentId>) -> Self {
+        self.component_ids = Some(ids);
+        self
+    }
+
+    pub fn with_tvl_gt(mut self, tvl_gt: f64) -> Self {
+        self.tvl_gt = Some(tvl_gt);
+        self
+    }
+
+    pub(crate) fn with_pagination(mut self, page: i64, page_size: i64) -> Self {
+        self.page = page;
+        self.page_size = page_size;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn component_ids(&self) -> Option<&Vec<ComponentId>> {
+        self.component_ids.as_ref()
+    }
+}
+
+/// Parameters for [`RPCClient::get_protocol_states`].
+#[derive(Clone, PartialEq, Debug)]
+pub struct ProtocolStatesParams {
+    chain: Chain,
+    protocol_system: String,
+    protocol_ids: Option<Vec<String>>,
+    include_balances: bool,
+    block_number: Option<u64>,
+    page: i64,
+    page_size: i64,
+}
+
+impl ProtocolStatesParams {
+    pub fn new(chain: Chain, protocol_system: impl Into<String>) -> Self {
+        Self {
+            chain,
+            protocol_system: protocol_system.into(),
+            protocol_ids: None,
+            include_balances: false,
+            block_number: None,
+            page: 0,
+            page_size: ProtocolStateRequestBody::MAX_PAGE_SIZE_COMPRESSED,
+        }
+    }
+
+    pub fn with_protocol_ids(mut self, ids: Vec<String>) -> Self {
+        self.protocol_ids = Some(ids);
+        self
+    }
+
+    pub fn with_include_balances(mut self, include_balances: bool) -> Self {
+        self.include_balances = include_balances;
+        self
+    }
+
+    pub fn with_block_number(mut self, block_number: u64) -> Self {
+        self.block_number = Some(block_number);
+        self
+    }
+
+    pub(crate) fn with_pagination(mut self, page: i64, page_size: i64) -> Self {
+        self.page = page;
+        self.page_size = page_size;
+        self
+    }
+}
+
+/// Parameters for [`RPCClient::get_tokens`].
+#[derive(Clone, PartialEq, Debug)]
+pub struct TokensParams {
+    chain: Chain,
+    min_quality: Option<i32>,
+    traded_n_days_ago: Option<u64>,
+    page: i64,
+    page_size: i64,
+}
+
+impl TokensParams {
+    pub fn new(chain: Chain) -> Self {
+        Self {
+            chain,
+            min_quality: None,
+            traded_n_days_ago: None,
+            page: 0,
+            page_size: TokensRequestBody::MAX_PAGE_SIZE_COMPRESSED,
+        }
+    }
+
+    pub fn with_min_quality(mut self, min_quality: i32) -> Self {
+        self.min_quality = Some(min_quality);
+        self
+    }
+
+    pub fn with_traded_n_days_ago(mut self, days: u64) -> Self {
+        self.traded_n_days_ago = Some(days);
+        self
+    }
+
+    pub(crate) fn with_pagination(mut self, page: i64, page_size: i64) -> Self {
+        self.page = page;
+        self.page_size = page_size;
+        self
+    }
+}
+
+/// Parameters for [`RPCClient::get_protocol_systems`].
+#[derive(Clone, PartialEq, Debug)]
+pub struct ProtocolSystemsParams {
+    chain: Chain,
+    page: i64,
+    page_size: i64,
+}
+
+impl ProtocolSystemsParams {
+    pub fn new(chain: Chain) -> Self {
+        Self { chain, page: 0, page_size: ProtocolSystemsRequestBody::MAX_PAGE_SIZE_COMPRESSED }
+    }
+
+    pub(crate) fn with_pagination(mut self, page: i64, page_size: i64) -> Self {
+        self.page = page;
+        self.page_size = page_size;
+        self
+    }
+}
+
+/// Parameters for [`RPCClient::get_component_tvl`].
+#[derive(Clone, PartialEq, Debug)]
+pub struct ComponentTvlParams {
+    chain: Chain,
+    protocol_system: Option<String>,
+    component_ids: Option<Vec<String>>,
+    page: i64,
+    page_size: i64,
+}
+
+impl ComponentTvlParams {
+    pub fn new(chain: Chain) -> Self {
+        Self {
+            chain,
+            protocol_system: None,
+            component_ids: None,
+            page: 0,
+            page_size: ComponentTvlRequestBody::MAX_PAGE_SIZE_COMPRESSED,
+        }
+    }
+
+    pub fn with_protocol_system(mut self, protocol_system: impl Into<String>) -> Self {
+        self.protocol_system = Some(protocol_system.into());
+        self
+    }
+
+    pub fn with_component_ids(mut self, ids: Vec<String>) -> Self {
+        self.component_ids = Some(ids);
+        self
+    }
+
+    pub(crate) fn with_pagination(mut self, page: i64, page_size: i64) -> Self {
+        self.page = page;
+        self.page_size = page_size;
+        self
+    }
+}
+
+/// Parameters for [`RPCClient::get_traced_entry_points`].
+#[derive(Clone, PartialEq, Debug)]
+pub struct TracedEntryPointsParams {
+    chain: Chain,
+    protocol_system: String,
+    component_ids: Option<Vec<String>>,
+    page: i64,
+    page_size: i64,
+}
+
+impl TracedEntryPointsParams {
+    pub fn new(chain: Chain, protocol_system: impl Into<String>) -> Self {
+        Self {
+            chain,
+            protocol_system: protocol_system.into(),
+            component_ids: None,
+            page: 0,
+            page_size: TracedEntryPointRequestBody::MAX_PAGE_SIZE_COMPRESSED,
+        }
+    }
+
+    pub fn with_component_ids(mut self, ids: Vec<String>) -> Self {
+        self.component_ids = Some(ids);
+        self
+    }
+
+    pub(crate) fn with_pagination(mut self, page: i64, page_size: i64) -> Self {
+        self.page = page;
+        self.page_size = page_size;
+        self
+    }
+}
 
 /// Request body for fetching a snapshot of protocol states and VM storage.
 ///
@@ -57,8 +336,8 @@ pub struct SnapshotParameters<'a> {
     pub protocol_system: &'a str,
     /// Components to fetch protocol states for
     pub components: &'a HashMap<ComponentId, ProtocolComponent>,
-    /// Traced entry points data mapped by component id
-    pub entrypoints: Option<&'a HashMap<String, Vec<(EntryPointWithTracingParams, TracingResult)>>>,
+    /// Traced entry points data mapped by component id (model types)
+    pub entrypoints: Option<&'a TracedEntryPoints>,
     /// Contract addresses to fetch VM storage for
     pub contract_ids: &'a [Bytes],
     /// Block number for versioning
@@ -101,10 +380,7 @@ impl<'a> SnapshotParameters<'a> {
         self
     }
 
-    pub fn entrypoints(
-        mut self,
-        entrypoints: &'a HashMap<String, Vec<(EntryPointWithTracingParams, TracingResult)>>,
-    ) -> Self {
+    pub fn entrypoints(mut self, entrypoints: &'a TracedEntryPoints) -> Self {
         self.entrypoints = Some(entrypoints);
         self
     }
@@ -174,23 +450,26 @@ pub trait RPCClient: Send + Sync {
     /// Returns whether compression is enabled for requests.
     fn compression(&self) -> bool;
 
-    /// Retrieves a snapshot of contract state.
+    /// Retrieves a snapshot of contract state for the given contract addresses.
+    ///
+    /// `block_number` pins the query to a specific block; pass `None` to use the latest state.
     async fn get_contract_state(
         &self,
-        request: &StateRequestBody,
-    ) -> Result<StateRequestResponse, RPCError>;
+        params: ContractStateParams,
+    ) -> Result<Vec<Account>, RPCError>;
 
     /// Retrieves a snapshot of contract state for a set of contract IDs.
-    /// If the `chunk_size` is `None`, it defaults to the maximum page size
+    ///
+    /// If `chunk_size` is `None`, it defaults to the maximum page size.
     async fn get_contract_state_paginated(
         &self,
         chain: Chain,
         ids: &[Bytes],
         protocol_system: &str,
-        version: &VersionParam,
+        block_number: Option<u64>,
         chunk_size: Option<usize>,
         concurrency: usize,
-    ) -> Result<StateRequestResponse, RPCError> {
+    ) -> Result<Vec<Account>, RPCError> {
         let semaphore = Arc::new(Semaphore::new(concurrency));
 
         // Sort the ids to maximize server-side cache hits
@@ -200,26 +479,25 @@ pub trait RPCClient: Send + Sync {
         let chunk_size = chunk_size
             .unwrap_or(StateRequestBody::effective_max_page_size(self.compression()) as usize);
 
-        let chunked_bodies = sorted_ids
-            .chunks(chunk_size)
-            .map(|chunk| StateRequestBody {
-                contract_ids: Some(chunk.to_vec()),
-                protocol_system: protocol_system.to_string(),
-                chain,
-                version: version.clone(),
-                pagination: PaginationParams { page: 0, page_size: chunk_size as i64 },
-            })
-            .collect::<Vec<_>>();
-
         let mut tasks = Vec::new();
-        for body in chunked_bodies.iter() {
+        for chunk in sorted_ids.chunks(chunk_size) {
             let sem = semaphore.clone();
+            let chunk = chunk.to_vec();
+            let base_params = ContractStateParams::new(chain, protocol_system)
+                .with_contract_ids(chunk)
+                .with_pagination(0, chunk_size as i64);
+            let base_params = if let Some(bn) = block_number {
+                base_params.with_block_number(bn)
+            } else {
+                base_params
+            };
             tasks.push(async move {
                 let _permit = sem
                     .acquire()
                     .await
                     .map_err(|_| RPCError::Fatal("Semaphore dropped".to_string()))?;
-                self.get_contract_state(body).await
+                self.get_contract_state(base_params)
+                    .await
             });
         }
 
@@ -228,33 +506,33 @@ pub trait RPCClient: Send + Sync {
 
         // Aggregate the responses into a single result.
         let accounts = responses
-            .iter()
-            .flat_map(|r| r.accounts.clone())
+            .into_iter()
+            .flat_map(|r| r.into_iter())
             .collect();
-        let total: i64 = responses
-            .iter()
-            .map(|r| r.pagination.total)
-            .sum();
 
-        Ok(StateRequestResponse {
-            accounts,
-            pagination: PaginationResponse { page: 0, page_size: chunk_size as i64, total },
-        })
+        Ok(accounts)
     }
 
+    /// Retrieves protocol components matching the given filters.
+    ///
+    /// Pass `component_ids` to filter by specific IDs, or `tvl_gt` to filter by minimum TVL.
     async fn get_protocol_components(
         &self,
-        request: &ProtocolComponentsRequestBody,
-    ) -> Result<ProtocolComponentRequestResponse, RPCError>;
+        params: ProtocolComponentsParams,
+    ) -> Result<Vec<ProtocolComponent>, RPCError>;
 
-    /// Retrieves protocol components.
-    /// If the `chunk_size` is `None`, it defaults to the maximum page size.
+    /// Retrieves protocol components, fetching all pages automatically.
+    ///
+    /// If `chunk_size` is `None`, it defaults to the maximum page size.
     async fn get_protocol_components_paginated(
         &self,
-        request: &ProtocolComponentsRequestBody,
+        chain: Chain,
+        protocol_system: String,
+        component_ids: Option<Vec<ComponentId>>,
+        tvl_gt: Option<f64>,
         chunk_size: Option<usize>,
         concurrency: usize,
-    ) -> Result<ProtocolComponentRequestResponse, RPCError> {
+    ) -> Result<Vec<ProtocolComponent>, RPCError> {
         let semaphore = Arc::new(Semaphore::new(concurrency));
 
         let chunk_size = chunk_size.unwrap_or(
@@ -263,150 +541,109 @@ pub trait RPCClient: Send + Sync {
 
         // If a set of component IDs is specified, the maximum return size is already known,
         // allowing us to pre-compute the number of requests to be made.
-        match request.component_ids {
-            Some(ref ids) => {
-                // We can divide the component_ids into chunks of size chunk_size
-                let chunked_bodies = ids
-                    .chunks(chunk_size)
-                    .enumerate()
-                    .map(|(index, _)| ProtocolComponentsRequestBody {
-                        protocol_system: request.protocol_system.clone(),
-                        component_ids: request.component_ids.clone(),
-                        tvl_gt: request.tvl_gt,
-                        chain: request.chain,
-                        pagination: PaginationParams {
-                            page: index as i64,
-                            page_size: chunk_size as i64,
-                        },
-                    })
-                    .collect::<Vec<_>>();
-
-                let mut tasks = Vec::new();
-                for body in chunked_bodies.iter() {
-                    let sem = semaphore.clone();
-                    tasks.push(async move {
-                        let _permit = sem
-                            .acquire()
-                            .await
-                            .map_err(|_| RPCError::Fatal("Semaphore dropped".to_string()))?;
-                        self.get_protocol_components(body).await
-                    });
-                }
-
-                try_join_all(tasks)
-                    .await
-                    .map(|responses| ProtocolComponentRequestResponse {
-                        protocol_components: responses
-                            .into_iter()
-                            .flat_map(|r| r.protocol_components.into_iter())
-                            .collect(),
-                        pagination: PaginationResponse {
-                            page: 0,
-                            page_size: chunk_size as i64,
-                            total: ids.len() as i64,
-                        },
-                    })
-            }
-            _ => {
-                // If no component ids are specified, we need to make requests based on the total
-                // number of results from the first response.
-
-                let initial_request = ProtocolComponentsRequestBody {
-                    protocol_system: request.protocol_system.clone(),
-                    component_ids: request.component_ids.clone(),
-                    tvl_gt: request.tvl_gt,
-                    chain: request.chain,
-                    pagination: PaginationParams { page: 0, page_size: chunk_size as i64 },
-                };
-                let first_response = self
-                    .get_protocol_components(&initial_request)
-                    .await?;
-
-                let total_items = first_response.pagination.total;
-                let total_pages = (total_items as f64 / chunk_size as f64).ceil() as i64;
-
-                // Initialize the final response accumulator
-                let mut accumulated_response = ProtocolComponentRequestResponse {
-                    protocol_components: first_response.protocol_components,
-                    pagination: PaginationResponse {
-                        page: 0,
-                        page_size: chunk_size as i64,
-                        total: total_items,
-                    },
-                };
-
-                let mut page = 1;
-                while page < total_pages {
-                    let requests_in_this_iteration = (total_pages - page).min(concurrency as i64);
-
-                    // Create request bodies for parallel requests, respecting the concurrency limit
-                    let chunked_bodies = (0..requests_in_this_iteration)
-                        .map(|iter| ProtocolComponentsRequestBody {
-                            protocol_system: request.protocol_system.clone(),
-                            component_ids: request.component_ids.clone(),
-                            tvl_gt: request.tvl_gt,
-                            chain: request.chain,
-                            pagination: PaginationParams {
-                                page: page + iter,
-                                page_size: chunk_size as i64,
-                            },
-                        })
-                        .collect::<Vec<_>>();
-
-                    let tasks: Vec<_> = chunked_bodies
-                        .iter()
-                        .map(|body| {
+        match component_ids {
+            Some(ids) => {
+                let tasks: Vec<_> =
+                    ids.chunks(chunk_size)
+                        .enumerate()
+                        .map(|(index, chunk)| {
                             let sem = semaphore.clone();
+                            let mut base =
+                                ProtocolComponentsParams::new(chain, protocol_system.as_str())
+                                    .with_component_ids(chunk.to_vec())
+                                    .with_pagination(index as i64, chunk_size as i64);
+                            if let Some(tvl) = tvl_gt {
+                                base = base.with_tvl_gt(tvl);
+                            }
                             async move {
                                 let _permit = sem.acquire().await.map_err(|_| {
                                     RPCError::Fatal("Semaphore dropped".to_string())
                                 })?;
-                                self.get_protocol_components(body).await
+                                self.get_protocol_components(base).await
                             }
                         })
                         .collect();
 
-                    let responses = try_join_all(tasks)
-                        .await
-                        .map(|responses| {
-                            let total = responses[0].pagination.total;
-                            ProtocolComponentRequestResponse {
-                                protocol_components: responses
-                                    .into_iter()
-                                    .flat_map(|r| r.protocol_components.into_iter())
-                                    .collect(),
-                                pagination: PaginationResponse {
-                                    page,
-                                    page_size: chunk_size as i64,
-                                    total,
-                                },
-                            }
-                        });
+                try_join_all(tasks)
+                    .await
+                    .map(|responses| {
+                        responses
+                            .into_iter()
+                            .flatten()
+                            .collect()
+                    })
+            }
+            None => {
+                // If no component ids are specified, we need to make requests based on the total
+                // number of results from the first response.
+                let mut base_params =
+                    ProtocolComponentsParams::new(chain, protocol_system.as_str())
+                        .with_pagination(0, chunk_size as i64);
+                if let Some(tvl) = tvl_gt {
+                    base_params = base_params.with_tvl_gt(tvl);
+                }
 
-                    // Update the accumulated response or set the initial response
-                    match responses {
-                        Ok(mut resp) => {
-                            accumulated_response
-                                .protocol_components
-                                .append(&mut resp.protocol_components);
+                let first_result = self
+                    .get_protocol_components(base_params)
+                    .await
+                    .map_err(|err| RPCError::Fatal(err.to_string()))?;
+
+                if first_result.len() < chunk_size {
+                    return Ok(first_result);
+                }
+
+                let mut all = first_result;
+                let mut page = 1i64;
+                loop {
+                    let tasks: Vec<_> = (0..concurrency as i64)
+                        .map(|iter| {
+                            let sem = semaphore.clone();
+                            let mut p =
+                                ProtocolComponentsParams::new(chain, protocol_system.as_str())
+                                    .with_pagination(page + iter, chunk_size as i64);
+                            if let Some(tvl) = tvl_gt {
+                                p = p.with_tvl_gt(tvl);
+                            }
+                            async move {
+                                let _permit = sem.acquire().await.map_err(|_| {
+                                    RPCError::Fatal("Semaphore dropped".to_string())
+                                })?;
+                                self.get_protocol_components(p).await
+                            }
+                        })
+                        .collect();
+
+                    let batch = try_join_all(tasks).await?;
+
+                    let mut done = false;
+                    for r in batch {
+                        if r.len() < chunk_size {
+                            done = true;
                         }
-                        Err(e) => return Err(e),
+                        all.extend(r);
                     }
 
                     page += concurrency as i64;
+                    if done {
+                        break;
+                    }
                 }
-                Ok(accumulated_response)
+                Ok(all)
             }
         }
     }
 
+    /// Retrieves a page of protocol component states.
+    ///
+    /// `block_number` pins the query to a specific block; pass `None` to use the latest state.
     async fn get_protocol_states(
         &self,
-        request: &ProtocolStateRequestBody,
-    ) -> Result<ProtocolStateRequestResponse, RPCError>;
+        params: ProtocolStatesParams,
+    ) -> Result<Vec<ProtocolComponentState>, RPCError>;
 
-    /// Retrieves protocol states for a set of protocol IDs.
-    /// If the `chunk_size` is `None`, it defaults to the maximum page size.
+    /// Retrieves protocol states for a set of protocol IDs, fetching all pages automatically.
+    ///
+    /// If `chunk_size` is `None`, it defaults to the maximum page size.
     #[allow(clippy::too_many_arguments)]
     async fn get_protocol_states_paginated<T>(
         &self,
@@ -414,10 +651,10 @@ pub trait RPCClient: Send + Sync {
         ids: &[T],
         protocol_system: &str,
         include_balances: bool,
-        version: &VersionParam,
+        block_number: Option<u64>,
         chunk_size: Option<usize>,
         concurrency: usize,
-    ) -> Result<ProtocolStateRequestResponse, RPCError>
+    ) -> Result<Vec<ProtocolComponentState>, RPCError>
     where
         T: AsRef<str> + Sync + 'static,
     {
@@ -427,62 +664,49 @@ pub trait RPCClient: Send + Sync {
             self.compression(),
         ) as usize);
 
-        let chunked_bodies = ids
+        let tasks: Vec<_> = ids
             .chunks(chunk_size)
-            .map(|c| ProtocolStateRequestBody {
-                protocol_ids: Some(
-                    c.iter()
-                        .map(|id| id.as_ref().to_string())
-                        .collect(),
-                ),
-                protocol_system: protocol_system.to_string(),
-                chain,
-                include_balances,
-                version: version.clone(),
-                pagination: PaginationParams { page: 0, page_size: chunk_size as i64 },
+            .map(|c| {
+                let sem = semaphore.clone();
+                let chunk: Vec<String> = c
+                    .iter()
+                    .map(|id| id.as_ref().to_string())
+                    .collect();
+                let mut params = ProtocolStatesParams::new(chain, protocol_system)
+                    .with_protocol_ids(chunk)
+                    .with_include_balances(include_balances)
+                    .with_pagination(0, chunk_size as i64);
+                if let Some(bn) = block_number {
+                    params = params.with_block_number(bn);
+                }
+                async move {
+                    let _permit = sem
+                        .acquire()
+                        .await
+                        .map_err(|_| RPCError::Fatal("Semaphore dropped".to_string()))?;
+                    self.get_protocol_states(params).await
+                }
             })
-            .collect::<Vec<_>>();
-
-        let mut tasks = Vec::new();
-        for body in chunked_bodies.iter() {
-            let sem = semaphore.clone();
-            tasks.push(async move {
-                let _permit = sem
-                    .acquire()
-                    .await
-                    .map_err(|_| RPCError::Fatal("Semaphore dropped".to_string()))?;
-                self.get_protocol_states(body).await
-            });
-        }
+            .collect();
 
         try_join_all(tasks)
             .await
             .map(|responses| {
-                let states = responses
-                    .clone()
+                responses
                     .into_iter()
-                    .flat_map(|r| r.states)
-                    .collect();
-                let total = responses
-                    .iter()
-                    .map(|r| r.pagination.total)
-                    .sum();
-                ProtocolStateRequestResponse {
-                    states,
-                    pagination: PaginationResponse { page: 0, page_size: chunk_size as i64, total },
-                }
+                    .flatten()
+                    .collect()
             })
     }
 
-    /// This function returns only one chunk of tokens. To get all tokens please call
-    /// get_all_tokens.
-    async fn get_tokens(
-        &self,
-        request: &TokensRequestBody,
-    ) -> Result<TokensRequestResponse, RPCError>;
+    /// Retrieves a page of tokens.
+    ///
+    /// Use `get_all_tokens` to fetch all matching tokens automatically.
+    async fn get_tokens(&self, params: TokensParams) -> Result<Vec<Token>, RPCError>;
 
-    /// Retrieves all tokens matching the given criteria.
-    /// If the `chunk_size` is `None`, it defaults to the maximum page size.
+    /// Retrieves all tokens matching the given criteria, fetching all pages automatically.
+    ///
+    /// If `chunk_size` is `None`, it defaults to the maximum page size.
     async fn get_all_tokens(
         &self,
         chain: Chain,
@@ -490,7 +714,7 @@ pub trait RPCClient: Send + Sync {
         traded_n_days_ago: Option<u64>,
         chunk_size: Option<usize>,
         concurrency: usize,
-    ) -> Result<Vec<ResponseToken>, RPCError> {
+    ) -> Result<Vec<Token>, RPCError> {
         let chunk_size = chunk_size
             .unwrap_or(TokensRequestBody::effective_max_page_size(self.compression()) as usize);
 
@@ -501,209 +725,194 @@ pub trait RPCClient: Send + Sync {
             RPCError::FormatRequest("Failed to convert chunk_size into i64".to_string())
         })?;
 
-        let initial_request = TokensRequestBody {
-            token_addresses: None,
-            min_quality,
-            traded_n_days_ago,
-            pagination: PaginationParams { page: 0, page_size },
-            chain,
-        };
-
-        let first_response = self
-            .get_tokens(&initial_request)
-            .await?;
-        let total_items = first_response.pagination.total;
-        let total_pages = (total_items as f64 / chunk_size as f64).ceil() as i64;
-
-        let mut all_tokens = first_response.tokens;
-
-        // If only one page, return immediately
-        if total_pages <= 1 {
-            return Ok(all_tokens);
+        let mut base_params = TokensParams::new(chain).with_pagination(0, page_size);
+        if let Some(q) = min_quality {
+            base_params = base_params.with_min_quality(q);
+        }
+        if let Some(d) = traded_n_days_ago {
+            base_params = base_params.with_traded_n_days_ago(d);
         }
 
-        // Create a task for each remaining page
-        let tasks: Vec<_> = (1..total_pages)
-            .map(|page| {
-                let sem = semaphore.clone();
-                let request = TokensRequestBody {
-                    token_addresses: None,
-                    min_quality,
-                    traded_n_days_ago,
-                    pagination: PaginationParams { page, page_size },
-                    chain,
-                };
+        let first_response = self.get_tokens(base_params).await?;
 
-                async move {
-                    // Semaphore controls how many requests are actually in-flight
-                    let _permit = sem
-                        .acquire()
-                        .await
-                        .map_err(|_| RPCError::Fatal("Semaphore dropped".to_string()))?;
-                    self.get_tokens(&request).await
+        if first_response.len() < chunk_size {
+            return Ok(first_response);
+        }
+
+        let mut all_tokens = first_response;
+        let mut page = 1i64;
+
+        loop {
+            // Create a task for each page in this batch
+            let tasks: Vec<_> = (0..concurrency as i64)
+                .map(|i| {
+                    let sem = semaphore.clone();
+                    let mut p = TokensParams::new(chain).with_pagination(page + i, page_size);
+                    if let Some(q) = min_quality {
+                        p = p.with_min_quality(q);
+                    }
+                    if let Some(d) = traded_n_days_ago {
+                        p = p.with_traded_n_days_ago(d);
+                    }
+                    async move {
+                        // Semaphore controls how many requests are actually in-flight
+                        let _permit = sem
+                            .acquire()
+                            .await
+                            .map_err(|_| RPCError::Fatal("Semaphore dropped".to_string()))?;
+                        self.get_tokens(p).await
+                    }
+                })
+                .collect();
+
+            let responses = try_join_all(tasks).await?;
+
+            let mut done = false;
+            for response in responses {
+                if response.len() < chunk_size {
+                    done = true;
                 }
-            })
-            .collect();
+                all_tokens.extend(response);
+            }
 
-        // Join all tasks - semaphore ensures only 'concurrency' execute at once
-        let responses = try_join_all(tasks).await?;
-
-        // Aggregate all tokens from all pages
-        for mut response in responses {
-            all_tokens.append(&mut response.tokens);
+            page += concurrency as i64;
+            if done {
+                break;
+            }
         }
 
         Ok(all_tokens)
     }
 
+    /// Retrieves the protocol systems known to the server.
     async fn get_protocol_systems(
         &self,
-        request: &ProtocolSystemsRequestBody,
-    ) -> Result<ProtocolSystemsRequestResponse, RPCError>;
+        params: ProtocolSystemsParams,
+    ) -> Result<ProtocolSystemsResponse, RPCError>;
 
+    /// Retrieves component TVL values.
+    ///
+    /// Filter by `component_ids` or by `protocol_system`; both are optional.
     async fn get_component_tvl(
         &self,
-        request: &ComponentTvlRequestBody,
-    ) -> Result<ComponentTvlRequestResponse, RPCError>;
+        params: ComponentTvlParams,
+    ) -> Result<HashMap<String, f64>, RPCError>;
 
-    /// Retrieves component TVL for a set of component IDs.
-    /// If the `chunk_size` is `None`, it defaults to the maximum page size.
+    /// Retrieves component TVL values, fetching all pages automatically.
+    ///
+    /// If `chunk_size` is `None`, it defaults to the maximum page size.
     async fn get_component_tvl_paginated(
         &self,
-        request: &ComponentTvlRequestBody,
+        chain: Chain,
+        protocol_system: Option<String>,
+        component_ids: Option<Vec<String>>,
         chunk_size: Option<usize>,
         concurrency: usize,
-    ) -> Result<ComponentTvlRequestResponse, RPCError> {
+    ) -> Result<HashMap<String, f64>, RPCError> {
         let semaphore = Arc::new(Semaphore::new(concurrency));
 
         let chunk_size = chunk_size.unwrap_or(ComponentTvlRequestBody::effective_max_page_size(
             self.compression(),
         ) as usize);
 
-        match request.component_ids {
-            Some(ref ids) => {
-                let chunked_requests = ids
-                    .chunks(chunk_size)
-                    .enumerate()
-                    .map(|(index, _)| ComponentTvlRequestBody {
-                        chain: request.chain,
-                        protocol_system: request.protocol_system.clone(),
-                        component_ids: Some(ids.clone()),
-                        pagination: PaginationParams {
-                            page: index as i64,
-                            page_size: chunk_size as i64,
-                        },
-                    })
-                    .collect::<Vec<_>>();
-
-                let tasks: Vec<_> = chunked_requests
-                    .into_iter()
-                    .map(|req| {
-                        let sem = semaphore.clone();
-                        async move {
-                            let _permit = sem
-                                .acquire()
-                                .await
-                                .map_err(|_| RPCError::Fatal("Semaphore dropped".to_string()))?;
-                            self.get_component_tvl(&req).await
-                        }
-                    })
-                    .collect();
+        match component_ids {
+            Some(ids) => {
+                let tasks: Vec<_> =
+                    ids.chunks(chunk_size)
+                        .enumerate()
+                        .map(|(index, chunk)| {
+                            let sem = semaphore.clone();
+                            let mut p = ComponentTvlParams::new(chain)
+                                .with_component_ids(chunk.to_vec())
+                                .with_pagination(index as i64, chunk_size as i64);
+                            if let Some(ref ps) = protocol_system {
+                                p = p.with_protocol_system(ps.as_str());
+                            }
+                            async move {
+                                let _permit = sem.acquire().await.map_err(|_| {
+                                    RPCError::Fatal("Semaphore dropped".to_string())
+                                })?;
+                                self.get_component_tvl(p).await
+                            }
+                        })
+                        .collect();
 
                 let responses = try_join_all(tasks).await?;
 
                 let mut merged_tvl = HashMap::new();
                 for resp in responses {
-                    for (key, value) in resp.tvl {
+                    for (key, value) in resp {
                         *merged_tvl.entry(key).or_insert(0.0) = value;
                     }
                 }
 
-                Ok(ComponentTvlRequestResponse {
-                    tvl: merged_tvl,
-                    pagination: PaginationResponse {
-                        page: 0,
-                        page_size: chunk_size as i64,
-                        total: ids.len() as i64,
-                    },
-                })
+                Ok(merged_tvl)
             }
-            _ => {
-                let first_request = ComponentTvlRequestBody {
-                    chain: request.chain,
-                    protocol_system: request.protocol_system.clone(),
-                    component_ids: request.component_ids.clone(),
-                    pagination: PaginationParams { page: 0, page_size: chunk_size as i64 },
-                };
+            None => {
+                let mut base = ComponentTvlParams::new(chain).with_pagination(0, chunk_size as i64);
+                if let Some(ref ps) = protocol_system {
+                    base = base.with_protocol_system(ps.as_str());
+                }
 
-                let first_response = self
-                    .get_component_tvl(&first_request)
-                    .await?;
-                let total_items = first_response.pagination.total;
-                let total_pages = (total_items as f64 / chunk_size as f64).ceil() as i64;
+                let first = self.get_component_tvl(base).await?;
 
-                let mut merged_tvl = first_response.tvl;
+                if first.len() < chunk_size {
+                    return Ok(first);
+                }
 
-                let mut page = 1;
-                while page < total_pages {
-                    let requests_in_this_iteration = (total_pages - page).min(concurrency as i64);
+                let mut merged_tvl = first;
+                let mut page = 1i64;
 
-                    let chunked_requests: Vec<_> = (0..requests_in_this_iteration)
-                        .map(|i| ComponentTvlRequestBody {
-                            chain: request.chain,
-                            protocol_system: request.protocol_system.clone(),
-                            component_ids: request.component_ids.clone(),
-                            pagination: PaginationParams {
-                                page: page + i,
-                                page_size: chunk_size as i64,
-                            },
-                        })
-                        .collect();
-
-                    let tasks: Vec<_> = chunked_requests
-                        .into_iter()
-                        .map(|req| {
+                loop {
+                    let tasks: Vec<_> = (0..concurrency as i64)
+                        .map(|i| {
                             let sem = semaphore.clone();
+                            let mut p = ComponentTvlParams::new(chain)
+                                .with_pagination(page + i, chunk_size as i64);
+                            if let Some(ref ps) = protocol_system {
+                                p = p.with_protocol_system(ps.as_str());
+                            }
                             async move {
                                 let _permit = sem.acquire().await.map_err(|_| {
                                     RPCError::Fatal("Semaphore dropped".to_string())
                                 })?;
-                                self.get_component_tvl(&req).await
+                                self.get_component_tvl(p).await
                             }
                         })
                         .collect();
 
-                    let responses = try_join_all(tasks).await?;
+                    let batch = try_join_all(tasks).await?;
 
-                    // merge hashmap
-                    for resp in responses {
-                        for (key, value) in resp.tvl {
-                            *merged_tvl.entry(key).or_insert(0.0) += value;
+                    let mut done = false;
+                    for resp in batch {
+                        if resp.len() < chunk_size {
+                            done = true;
                         }
+                        merged_tvl.extend(resp);
                     }
 
                     page += concurrency as i64;
+                    if done {
+                        break;
+                    }
                 }
 
-                Ok(ComponentTvlRequestResponse {
-                    tvl: merged_tvl,
-                    pagination: PaginationResponse {
-                        page: 0,
-                        page_size: chunk_size as i64,
-                        total: total_items,
-                    },
-                })
+                Ok(merged_tvl)
             }
         }
     }
 
+    /// Retrieves a page of traced entry points.
+    ///
+    /// Use `get_traced_entry_points_paginated` to fetch all pages automatically.
     async fn get_traced_entry_points(
         &self,
-        request: &TracedEntryPointRequestBody,
-    ) -> Result<TracedEntryPointRequestResponse, RPCError>;
+        params: TracedEntryPointsParams,
+    ) -> Result<TracedEntryPoints, RPCError>;
 
-    /// Retrieves traced entry points for a set of component IDs.
-    /// If the `chunk_size` is `None`, it defaults to the maximum page size.
+    /// Retrieves traced entry points for a set of component IDs, fetching all pages automatically.
+    ///
+    /// If `chunk_size` is `None`, it defaults to the maximum page size.
     async fn get_traced_entry_points_paginated(
         &self,
         chain: Chain,
@@ -711,51 +920,38 @@ pub trait RPCClient: Send + Sync {
         component_ids: &[String],
         chunk_size: Option<usize>,
         concurrency: usize,
-    ) -> Result<TracedEntryPointRequestResponse, RPCError> {
+    ) -> Result<TracedEntryPoints, RPCError> {
         let semaphore = Arc::new(Semaphore::new(concurrency));
 
         let chunk_size = chunk_size.unwrap_or(
             TracedEntryPointRequestBody::effective_max_page_size(self.compression()) as usize,
         );
 
-        let chunked_bodies = component_ids
+        let tasks: Vec<_> = component_ids
             .chunks(chunk_size)
-            .map(|c| TracedEntryPointRequestBody {
-                chain,
-                protocol_system: protocol_system.to_string(),
-                component_ids: Some(c.to_vec()),
-                pagination: PaginationParams { page: 0, page_size: chunk_size as i64 },
+            .map(|c| {
+                let sem = semaphore.clone();
+                let params = TracedEntryPointsParams::new(chain, protocol_system)
+                    .with_component_ids(c.to_vec())
+                    .with_pagination(0, chunk_size as i64);
+                async move {
+                    let _permit = sem
+                        .acquire()
+                        .await
+                        .map_err(|_| RPCError::Fatal("Semaphore dropped".to_string()))?;
+                    self.get_traced_entry_points(params)
+                        .await
+                }
             })
-            .collect::<Vec<_>>();
-
-        let mut tasks = Vec::new();
-        for body in chunked_bodies.iter() {
-            let sem = semaphore.clone();
-            tasks.push(async move {
-                let _permit = sem
-                    .acquire()
-                    .await
-                    .map_err(|_| RPCError::Fatal("Semaphore dropped".to_string()))?;
-                self.get_traced_entry_points(body).await
-            });
-        }
+            .collect();
 
         try_join_all(tasks)
             .await
             .map(|responses| {
-                let traced_entry_points = responses
-                    .clone()
+                responses
                     .into_iter()
-                    .flat_map(|r| r.traced_entry_points)
-                    .collect();
-                let total = responses
-                    .iter()
-                    .map(|r| r.pagination.total)
-                    .sum();
-                TracedEntryPointRequestResponse {
-                    traced_entry_points,
-                    pagination: PaginationResponse { page: 0, page_size: chunk_size as i64, total },
-                }
+                    .flatten()
+                    .collect()
             })
     }
 
@@ -1004,25 +1200,49 @@ fn parse_retry_value(val: &str) -> Option<SystemTime> {
     None
 }
 
+/// Builds a `VersionParam` pinned to a block number on the given chain.
+///
+/// When `block_number` is `None`, returns the default (current-time timestamp).
+fn build_version_param(chain: Chain, block_number: Option<u64>) -> VersionParam {
+    match block_number {
+        Some(n) => VersionParam::new(
+            None,
+            Some({
+                #[allow(deprecated)]
+                BlockParam { hash: None, chain: Some(chain.into()), number: Some(n as i64) }
+            }),
+        ),
+        None => VersionParam::default(),
+    }
+}
+
 #[async_trait]
 impl RPCClient for HttpRPCClient {
     fn compression(&self) -> bool {
         self.compression
     }
 
-    #[instrument(skip(self, request))]
+    #[instrument(skip(self))]
     async fn get_contract_state(
         &self,
-        request: &StateRequestBody,
-    ) -> Result<StateRequestResponse, RPCError> {
-        // Check if contract ids are specified
-        if request
+        params: ContractStateParams,
+    ) -> Result<Vec<Account>, RPCError> {
+        if params
             .contract_ids
             .as_ref()
             .is_none_or(|ids| ids.is_empty())
         {
             warn!("No contract ids specified in request.");
         }
+
+        let version = build_version_param(params.chain, params.block_number);
+        let request = StateRequestBody {
+            contract_ids: params.contract_ids,
+            protocol_system: params.protocol_system,
+            chain: params.chain.into(),
+            version,
+            pagination: PaginationParams { page: params.page, page_size: params.page_size },
+        };
 
         let uri = format!(
             "{}/{}/contract_state",
@@ -1034,7 +1254,7 @@ impl RPCClient for HttpRPCClient {
         debug!(%uri, "Sending contract_state request to Tycho server");
         trace!(?request, "Sending request to Tycho server");
         let response = self
-            .make_post_request(request, &uri)
+            .make_post_request(&request, &uri)
             .await?;
         trace!(?response, "Received response from Tycho server");
 
@@ -1044,27 +1264,32 @@ impl RPCClient for HttpRPCClient {
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
         if body.is_empty() {
             // Pure native protocols will return empty contract states
-            return Ok(StateRequestResponse {
-                accounts: vec![],
-                pagination: PaginationResponse {
-                    page: request.pagination.page,
-                    page_size: request.pagination.page,
-                    total: 0,
-                },
-            });
+            return Ok(vec![]);
         }
 
-        let accounts = serde_json::from_str::<StateRequestResponse>(&body)
+        let dto_response = serde_json::from_str::<StateRequestResponse>(&body)
             .map_err(|err| RPCError::from_parse_error(err, &body))?;
-        trace!(?accounts, "Received contract_state response from Tycho server");
+        trace!(?dto_response, "Received contract_state response from Tycho server");
 
-        Ok(accounts)
+        Ok(dto_response
+            .accounts
+            .into_iter()
+            .map(Account::from)
+            .collect())
     }
 
     async fn get_protocol_components(
         &self,
-        request: &ProtocolComponentsRequestBody,
-    ) -> Result<ProtocolComponentRequestResponse, RPCError> {
+        params: ProtocolComponentsParams,
+    ) -> Result<Vec<ProtocolComponent>, RPCError> {
+        let request = ProtocolComponentsRequestBody {
+            protocol_system: params.protocol_system,
+            component_ids: params.component_ids,
+            tvl_gt: params.tvl_gt,
+            chain: params.chain.into(),
+            pagination: PaginationParams { page: params.page, page_size: params.page_size },
+        };
+
         let uri = format!(
             "{}/{}/protocol_components",
             self.url
@@ -1076,7 +1301,7 @@ impl RPCClient for HttpRPCClient {
         trace!(?request, "Sending request to Tycho server");
 
         let response = self
-            .make_post_request(request, &uri)
+            .make_post_request(&request, &uri)
             .await?;
 
         trace!(?response, "Received response from Tycho server");
@@ -1085,25 +1310,38 @@ impl RPCClient for HttpRPCClient {
             .text()
             .await
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
-        let components = serde_json::from_str::<ProtocolComponentRequestResponse>(&body)
+        let dto_response = serde_json::from_str::<ProtocolComponentRequestResponse>(&body)
             .map_err(|err| RPCError::from_parse_error(err, &body))?;
-        trace!(?components, "Received protocol_components response from Tycho server");
+        trace!(?dto_response, "Received protocol_components response from Tycho server");
 
-        Ok(components)
+        Ok(dto_response
+            .protocol_components
+            .into_iter()
+            .map(ProtocolComponent::from)
+            .collect())
     }
 
     async fn get_protocol_states(
         &self,
-        request: &ProtocolStateRequestBody,
-    ) -> Result<ProtocolStateRequestResponse, RPCError> {
-        // Check if protocol ids are specified
-        if request
+        params: ProtocolStatesParams,
+    ) -> Result<Vec<ProtocolComponentState>, RPCError> {
+        if params
             .protocol_ids
             .as_ref()
             .is_none_or(|ids| ids.is_empty())
         {
             warn!("No protocol ids specified in request.");
         }
+
+        let version = build_version_param(params.chain, params.block_number);
+        let request = ProtocolStateRequestBody {
+            protocol_ids: params.protocol_ids,
+            protocol_system: params.protocol_system,
+            chain: params.chain.into(),
+            include_balances: params.include_balances,
+            version,
+            pagination: PaginationParams { page: params.page, page_size: params.page_size },
+        };
 
         let uri = format!(
             "{}/{}/protocol_state",
@@ -1116,7 +1354,7 @@ impl RPCClient for HttpRPCClient {
         trace!(?request, "Sending request to Tycho server");
 
         let response = self
-            .make_post_request(request, &uri)
+            .make_post_request(&request, &uri)
             .await?;
         trace!(?response, "Received response from Tycho server");
 
@@ -1127,27 +1365,29 @@ impl RPCClient for HttpRPCClient {
 
         if body.is_empty() {
             // Pure VM protocols will return empty states
-            return Ok(ProtocolStateRequestResponse {
-                states: vec![],
-                pagination: PaginationResponse {
-                    page: request.pagination.page,
-                    page_size: request.pagination.page_size,
-                    total: 0,
-                },
-            });
+            return Ok(vec![]);
         }
 
-        let states = serde_json::from_str::<ProtocolStateRequestResponse>(&body)
+        let dto_response = serde_json::from_str::<ProtocolStateRequestResponse>(&body)
             .map_err(|err| RPCError::from_parse_error(err, &body))?;
-        trace!(?states, "Received protocol_states response from Tycho server");
+        trace!(?dto_response, "Received protocol_states response from Tycho server");
 
-        Ok(states)
+        Ok(dto_response
+            .states
+            .into_iter()
+            .map(ProtocolComponentState::from)
+            .collect())
     }
 
-    async fn get_tokens(
-        &self,
-        request: &TokensRequestBody,
-    ) -> Result<TokensRequestResponse, RPCError> {
+    async fn get_tokens(&self, params: TokensParams) -> Result<Vec<Token>, RPCError> {
+        let request = TokensRequestBody {
+            token_addresses: None,
+            min_quality: params.min_quality,
+            traded_n_days_ago: params.traded_n_days_ago,
+            pagination: PaginationParams { page: params.page, page_size: params.page_size },
+            chain: params.chain.into(),
+        };
+
         let uri = format!(
             "{}/{}/tokens",
             self.url
@@ -1158,23 +1398,32 @@ impl RPCClient for HttpRPCClient {
         debug!(%uri, "Sending tokens request to Tycho server");
 
         let response = self
-            .make_post_request(request, &uri)
+            .make_post_request(&request, &uri)
             .await?;
 
         let body = response
             .text()
             .await
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
-        let tokens = serde_json::from_str::<TokensRequestResponse>(&body)
+        let dto_response = serde_json::from_str::<TokensRequestResponse>(&body)
             .map_err(|err| RPCError::ParseResponse(format!("Error: {err}, Body: {body}")))?;
 
-        Ok(tokens)
+        Ok(dto_response
+            .tokens
+            .into_iter()
+            .map(Token::from)
+            .collect())
     }
 
     async fn get_protocol_systems(
         &self,
-        request: &ProtocolSystemsRequestBody,
-    ) -> Result<ProtocolSystemsRequestResponse, RPCError> {
+        params: ProtocolSystemsParams,
+    ) -> Result<ProtocolSystemsResponse, RPCError> {
+        let request = ProtocolSystemsRequestBody {
+            chain: params.chain.into(),
+            pagination: PaginationParams { page: params.page, page_size: params.page_size },
+        };
+
         let uri = format!(
             "{}/{}/protocol_systems",
             self.url
@@ -1185,23 +1434,34 @@ impl RPCClient for HttpRPCClient {
         debug!(%uri, "Sending protocol_systems request to Tycho server");
         trace!(?request, "Sending request to Tycho server");
         let response = self
-            .make_post_request(request, &uri)
+            .make_post_request(&request, &uri)
             .await?;
         trace!(?response, "Received response from Tycho server");
         let body = response
             .text()
             .await
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
-        let protocol_systems = serde_json::from_str::<ProtocolSystemsRequestResponse>(&body)
+        let dto = serde_json::from_str::<ProtocolSystemsRequestResponse>(&body)
             .map_err(|err| RPCError::ParseResponse(format!("Error: {err}, Body: {body}")))?;
-        trace!(?protocol_systems, "Received protocol_systems response from Tycho server");
-        Ok(protocol_systems)
+        trace!(?dto, "Received protocol_systems response from Tycho server");
+        Ok(ProtocolSystemsResponse {
+            protocol_systems: dto.protocol_systems,
+            dci_protocols: dto.dci_protocols,
+            total: dto.pagination.total,
+        })
     }
 
     async fn get_component_tvl(
         &self,
-        request: &ComponentTvlRequestBody,
-    ) -> Result<ComponentTvlRequestResponse, RPCError> {
+        params: ComponentTvlParams,
+    ) -> Result<HashMap<String, f64>, RPCError> {
+        let request = ComponentTvlRequestBody {
+            chain: params.chain.into(),
+            protocol_system: params.protocol_system,
+            component_ids: params.component_ids,
+            pagination: PaginationParams { page: params.page, page_size: params.page_size },
+        };
+
         let uri = format!(
             "{}/{}/component_tvl",
             self.url
@@ -1212,26 +1472,33 @@ impl RPCClient for HttpRPCClient {
         debug!(%uri, "Sending get_component_tvl request to Tycho server");
         trace!(?request, "Sending request to Tycho server");
         let response = self
-            .make_post_request(request, &uri)
+            .make_post_request(&request, &uri)
             .await?;
         trace!(?response, "Received response from Tycho server");
         let body = response
             .text()
             .await
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
-        let component_tvl =
+        let dto_response =
             serde_json::from_str::<ComponentTvlRequestResponse>(&body).map_err(|err| {
                 error!("Failed to parse component_tvl response: {:?}", &body);
                 RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
             })?;
-        trace!(?component_tvl, "Received component_tvl response from Tycho server");
-        Ok(component_tvl)
+        trace!(?dto_response, "Received component_tvl response from Tycho server");
+        Ok(dto_response.tvl)
     }
 
     async fn get_traced_entry_points(
         &self,
-        request: &TracedEntryPointRequestBody,
-    ) -> Result<TracedEntryPointRequestResponse, RPCError> {
+        params: TracedEntryPointsParams,
+    ) -> Result<TracedEntryPoints, RPCError> {
+        let request = TracedEntryPointRequestBody {
+            chain: params.chain.into(),
+            protocol_system: params.protocol_system,
+            component_ids: params.component_ids,
+            pagination: PaginationParams { page: params.page, page_size: params.page_size },
+        };
+
         let uri = format!(
             "{}/{TYCHO_SERVER_VERSION}/traced_entry_points",
             self.url
@@ -1242,7 +1509,7 @@ impl RPCClient for HttpRPCClient {
         trace!(?request, "Sending request to Tycho server");
 
         let response = self
-            .make_post_request(request, &uri)
+            .make_post_request(&request, &uri)
             .await?;
 
         trace!(?response, "Received response from Tycho server");
@@ -1251,13 +1518,26 @@ impl RPCClient for HttpRPCClient {
             .text()
             .await
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
-        let entrypoints =
+        let dto_response =
             serde_json::from_str::<TracedEntryPointRequestResponse>(&body).map_err(|err| {
                 error!("Failed to parse traced_entry_points response: {:?}", &body);
                 RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
             })?;
-        trace!(?entrypoints, "Received traced_entry_points response from Tycho server");
-        Ok(entrypoints)
+        trace!(?dto_response, "Received traced_entry_points response from Tycho server");
+        Ok(dto_response
+            .traced_entry_points
+            .into_iter()
+            .map(|(k, v)| {
+                (
+                    k,
+                    v.into_iter()
+                        .map(|(ep, tr)| {
+                            (EntryPointWithTracingParams::from(ep), TracingResult::from(tr))
+                        })
+                        .collect(),
+                )
+            })
+            .collect())
     }
 
     async fn get_snapshots<'a>(
@@ -1272,23 +1552,15 @@ impl RPCClient for HttpRPCClient {
             .cloned()
             .collect();
 
-        let version = VersionParam::new(
-            None,
-            Some({
-                #[allow(deprecated)]
-                BlockParam {
-                    hash: None,
-                    chain: Some(request.chain),
-                    number: Some(request.block_number as i64),
-                }
-            }),
-        );
-
         let component_tvl = if request.include_tvl && !component_ids.is_empty() {
-            let body = ComponentTvlRequestBody::id_filtered(component_ids.clone(), request.chain);
-            self.get_component_tvl_paginated(&body, chunk_size, concurrency)
-                .await?
-                .tvl
+            self.get_component_tvl_paginated(
+                request.chain,
+                None,
+                Some(component_ids.clone()),
+                chunk_size,
+                concurrency,
+            )
+            .await?
         } else {
             HashMap::new()
         };
@@ -1299,12 +1571,11 @@ impl RPCClient for HttpRPCClient {
                 &component_ids,
                 request.protocol_system,
                 request.include_balances,
-                &version,
+                Some(request.block_number),
                 chunk_size,
                 concurrency,
             )
             .await?
-            .states
             .into_iter()
             .map(|state| (state.component_id.clone(), state))
             .collect()
@@ -1351,12 +1622,11 @@ impl RPCClient for HttpRPCClient {
                     request.chain,
                     request.contract_ids,
                     request.protocol_system,
-                    &version,
+                    Some(request.block_number),
                     chunk_size,
                     concurrency,
                 )
                 .await?
-                .accounts
                 .into_iter()
                 .map(|acc| (acc.address.clone(), acc))
                 .collect::<HashMap<_, _>>();
@@ -1369,7 +1639,7 @@ impl RPCClient for HttpRPCClient {
                 .filter_map(|(id, comp)| {
                     if component_ids.contains(id) {
                         Some(
-                            comp.contract_ids
+                            comp.contract_addresses
                                 .iter()
                                 .map(|address| (address.clone(), comp.id.clone())),
                         )
@@ -1419,10 +1689,7 @@ mod tests {
 
     use mockito::Server;
     use rstest::rstest;
-    // TODO: remove once deprecated ProtocolId struct is removed
-    #[allow(deprecated)]
-    use tycho_common::dto::ProtocolId;
-    use tycho_common::dto::{AddressStorageLocation, TracingParams};
+    use tycho_common::models::blockchain::AddressStorageLocation;
 
     use super::*;
 
@@ -1436,26 +1703,26 @@ mod tests {
             ids: &[T],
             protocol_system: &str,
             include_balances: bool,
-            version: &VersionParam,
+            block_number: Option<u64>,
             chunk_size: usize,
             _concurrency: usize,
-        ) -> Vec<ProtocolStateRequestBody>
+        ) -> Vec<(Chain, Vec<String>, String, bool, Option<u64>, PaginationParams)>
         where
             T: AsRef<str> + Clone + Send + Sync + 'static,
         {
             ids.chunks(chunk_size)
-                .map(|chunk| ProtocolStateRequestBody {
-                    protocol_ids: Some(
+                .map(|chunk| {
+                    (
+                        chain,
                         chunk
                             .iter()
                             .map(|id| id.as_ref().to_string())
                             .collect(),
-                    ),
-                    protocol_system: protocol_system.to_string(),
-                    chain,
-                    include_balances,
-                    version: version.clone(),
-                    pagination: PaginationParams { page: 0, page_size: chunk_size as i64 },
+                        protocol_system.to_string(),
+                        include_balances,
+                        block_number,
+                        PaginationParams { page: 0, page_size: chunk_size as i64 },
+                    )
                 })
                 .collect()
         }
@@ -1486,46 +1753,33 @@ mod tests {
         }
         "#;
 
-    // TODO: remove once deprecated ProtocolId struct is removed
-    #[allow(deprecated)]
     #[rstest]
-    #[case::protocol_id_input(vec![
-        ProtocolId { id: "id1".to_string(), chain: Chain::Ethereum },
-        ProtocolId { id: "id2".to_string(), chain: Chain::Ethereum }
-    ])]
     #[case::string_input(vec![
         "id1".to_string(),
         "id2".to_string()
     ])]
     #[tokio::test]
-    async fn test_get_protocol_states_paginated_backwards_compatibility<T>(#[case] ids: Vec<T>)
+    async fn test_get_protocol_states_paginated<T>(#[case] ids: Vec<T>)
     where
         T: AsRef<str> + Clone + Send + Sync + 'static,
     {
         let mock_client = MockRPCClient::new();
 
-        let request_bodies = mock_client
+        let request_args = mock_client
             .test_get_protocol_states_paginated(
                 Chain::Ethereum,
                 &ids,
                 "test_system",
                 true,
-                &VersionParam::default(),
+                None,
                 2,
                 2,
             )
             .await;
 
-        // Verify that the request bodies have been created correctly
-        assert_eq!(request_bodies.len(), 1);
-        assert_eq!(
-            request_bodies[0]
-                .protocol_ids
-                .as_ref()
-                .unwrap()
-                .len(),
-            2
-        );
+        // Verify that the request args have been split into chunks correctly
+        assert_eq!(request_args.len(), 1);
+        assert_eq!(request_args[0].1.len(), 2);
     }
 
     #[tokio::test]
@@ -1545,11 +1799,10 @@ mod tests {
         let client = HttpRPCClient::new(server.url().as_str(), HttpRPCClientOptions::default())
             .expect("create client");
 
-        let response = client
-            .get_contract_state(&Default::default())
+        let accounts = client
+            .get_contract_state(ContractStateParams::new(Chain::Ethereum, ""))
             .await
             .expect("get state");
-        let accounts = response.accounts;
 
         mocked_server.assert();
         assert_eq!(accounts.len(), 1);
@@ -1609,11 +1862,10 @@ mod tests {
         let client = HttpRPCClient::new(server.url().as_str(), HttpRPCClientOptions::default())
             .expect("create client");
 
-        let response = client
-            .get_protocol_components(&Default::default())
+        let components = client
+            .get_protocol_components(ProtocolComponentsParams::new(Chain::Ethereum, ""))
             .await
             .expect("get state");
-        let components = response.protocol_components;
 
         mocked_server.assert();
         assert_eq!(components.len(), 1);
@@ -1664,11 +1916,12 @@ mod tests {
         let client = HttpRPCClient::new(server.url().as_str(), HttpRPCClientOptions::default())
             .expect("create client");
 
-        let response = client
-            .get_protocol_states(&Default::default())
+        let states = client
+            .get_protocol_states(
+                ProtocolStatesParams::new(Chain::Ethereum, "").with_include_balances(true),
+            )
             .await
             .expect("get state");
-        let states = response.states;
 
         mocked_server.assert();
         assert_eq!(states.len(), 1);
@@ -1738,14 +1991,14 @@ mod tests {
         let client = HttpRPCClient::new(server.url().as_str(), HttpRPCClientOptions::default())
             .expect("create client");
 
-        let response = client
-            .get_tokens(&Default::default())
+        let tokens = client
+            .get_tokens(TokensParams::new(Chain::Ethereum))
             .await
             .expect("get tokens");
 
         let expected = vec![
-            ResponseToken {
-                chain: Chain::Ethereum,
+            Token {
+                chain: tycho_common::models::Chain::Ethereum,
                 address: Bytes::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap(),
                 symbol: "WETH".to_string(),
                 decimals: 18,
@@ -1753,8 +2006,8 @@ mod tests {
                 gas: vec![Some(29962)],
                 quality: 100,
             },
-            ResponseToken {
-                chain: Chain::Ethereum,
+            Token {
+                chain: tycho_common::models::Chain::Ethereum,
                 address: Bytes::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap(),
                 symbol: "USDC".to_string(),
                 decimals: 6,
@@ -1765,8 +2018,7 @@ mod tests {
         ];
 
         mocked_server.assert();
-        assert_eq!(response.tokens, expected);
-        assert_eq!(response.pagination, PaginationResponse { page: 0, page_size: 20, total: 10 });
+        assert_eq!(tokens, expected);
     }
 
     #[rstest]
@@ -1799,7 +2051,7 @@ mod tests {
             .expect("create client");
 
         let response = client
-            .get_protocol_systems(&Default::default())
+            .get_protocol_systems(ProtocolSystemsParams::new(Chain::Ethereum))
             .await
             .expect("get protocol systems");
 
@@ -1835,11 +2087,10 @@ mod tests {
         let client = HttpRPCClient::new(server.url().as_str(), HttpRPCClientOptions::default())
             .expect("create client");
 
-        let response = client
-            .get_component_tvl(&Default::default())
+        let component_tvl = client
+            .get_component_tvl(ComponentTvlParams::new(Chain::Ethereum))
             .await
-            .expect("get protocol systems");
-        let component_tvl = response.tvl;
+            .expect("get component tvl");
 
         mocked_server.assert();
         assert_eq!(component_tvl.get("component1"), Some(&100.0));
@@ -1900,11 +2151,10 @@ mod tests {
         let client = HttpRPCClient::new(server.url().as_str(), HttpRPCClientOptions::default())
             .expect("create client");
 
-        let response = client
-            .get_traced_entry_points(&Default::default())
+        let entrypoints = client
+            .get_traced_entry_points(TracedEntryPointsParams::new(Chain::Ethereum, ""))
             .await
             .expect("get traced entry points");
-        let entrypoints = response.traced_entry_points;
 
         mocked_server.assert();
         assert_eq!(entrypoints.len(), 1);
@@ -1920,7 +2170,8 @@ mod tests {
             Bytes::from_str("0x0000000000000000000000000000000000000001").unwrap()
         );
         assert_eq!(entrypoint.entry_point.signature, "sig()");
-        let TracingParams::RPCTracer(rpc_params) = &entrypoint.params;
+        let tycho_common::models::blockchain::TracingParams::RPCTracer(rpc_params) =
+            &entrypoint.params;
         assert_eq!(
             rpc_params.caller,
             Some(Bytes::from("0x000000000000000000000000000000000000000a"))
@@ -2605,23 +2856,25 @@ mod tests {
             .expect("create client");
 
         #[allow(deprecated)]
-        let component = tycho_common::dto::ProtocolComponent {
-            id: "component1".to_string(),
-            protocol_system: "test_protocol".to_string(),
-            protocol_type_name: "test_type".to_string(),
-            chain: Chain::Ethereum,
-            tokens: vec![],
-            contract_ids: vec![
-                Bytes::from_str("0x1111111111111111111111111111111111111111").unwrap()
-            ],
-            static_attributes: HashMap::new(),
-            change: tycho_common::dto::ChangeType::Creation,
-            creation_tx: Bytes::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000000",
-            )
-            .unwrap(),
-            created_at: chrono::Utc::now().naive_utc(),
-        };
+        let component = tycho_common::models::protocol::ProtocolComponent::from(
+            tycho_common::dto::ProtocolComponent {
+                id: "component1".to_string(),
+                protocol_system: "test_protocol".to_string(),
+                protocol_type_name: "test_type".to_string(),
+                chain: Chain::Ethereum.into(),
+                tokens: vec![],
+                contract_ids: vec![
+                    Bytes::from_str("0x1111111111111111111111111111111111111111").unwrap()
+                ],
+                static_attributes: HashMap::new(),
+                change: tycho_common::dto::ChangeType::Creation,
+                creation_tx: Bytes::from_str(
+                    "0x0000000000000000000000000000000000000000000000000000000000000000",
+                )
+                .unwrap(),
+                created_at: chrono::Utc::now().naive_utc(),
+            },
+        );
 
         let mut components = HashMap::new();
         components.insert("component1".to_string(), component);
@@ -2728,21 +2981,23 @@ mod tests {
 
         // Create test component
         #[allow(deprecated)]
-        let component = tycho_common::dto::ProtocolComponent {
-            id: "component1".to_string(),
-            protocol_system: "test_protocol".to_string(),
-            protocol_type_name: "test_type".to_string(),
-            chain: Chain::Ethereum,
-            tokens: vec![],
-            contract_ids: vec![],
-            static_attributes: HashMap::new(),
-            change: tycho_common::dto::ChangeType::Creation,
-            creation_tx: Bytes::from_str(
-                "0x0000000000000000000000000000000000000000000000000000000000000000",
-            )
-            .unwrap(),
-            created_at: chrono::Utc::now().naive_utc(),
-        };
+        let component = tycho_common::models::protocol::ProtocolComponent::from(
+            tycho_common::dto::ProtocolComponent {
+                id: "component1".to_string(),
+                protocol_system: "test_protocol".to_string(),
+                protocol_type_name: "test_type".to_string(),
+                chain: Chain::Ethereum.into(),
+                tokens: vec![],
+                contract_ids: vec![],
+                static_attributes: HashMap::new(),
+                change: tycho_common::dto::ChangeType::Creation,
+                creation_tx: Bytes::from_str(
+                    "0x0000000000000000000000000000000000000000000000000000000000000000",
+                )
+                .unwrap(),
+                created_at: chrono::Utc::now().naive_utc(),
+            },
+        );
 
         let mut components = HashMap::new();
         components.insert("component1".to_string(), component);
@@ -2802,10 +3057,10 @@ mod tests {
         .expect("create client");
 
         let response = client
-            .get_contract_state(&Default::default())
+            .get_contract_state(ContractStateParams::new(Chain::Ethereum, ""))
             .await
             .expect("get state");
-        let accounts = response.accounts;
+        let accounts = response;
 
         mocked_server.assert();
         assert_eq!(accounts.len(), 1);
@@ -2836,10 +3091,10 @@ mod tests {
         .expect("create client");
 
         let response = client
-            .get_contract_state(&Default::default())
+            .get_contract_state(ContractStateParams::new(Chain::Ethereum, ""))
             .await
             .expect("get state");
-        let accounts = response.accounts;
+        let accounts = response;
 
         // Verify the mock was called (client sent request without Accept-Encoding header)
         mocked_server.assert();

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -3136,26 +3136,23 @@ mod tests {
         let client = HttpRPCClient::new(server.url().as_str(), HttpRPCClientOptions::default())
             .expect("create client");
 
-        #[allow(deprecated)]
-        let component = tycho_common::models::protocol::ProtocolComponent::from(
-            tycho_common::dto::ProtocolComponent {
-                id: "component1".to_string(),
-                protocol_system: "test_protocol".to_string(),
-                protocol_type_name: "test_type".to_string(),
-                chain: Chain::Ethereum.into(),
-                tokens: vec![],
-                contract_ids: vec![
-                    Bytes::from_str("0x1111111111111111111111111111111111111111").unwrap()
-                ],
-                static_attributes: HashMap::new(),
-                change: tycho_common::dto::ChangeType::Creation,
-                creation_tx: Bytes::from_str(
-                    "0x0000000000000000000000000000000000000000000000000000000000000000",
-                )
-                .unwrap(),
-                created_at: chrono::Utc::now().naive_utc(),
-            },
-        );
+        let component = tycho_common::models::protocol::ProtocolComponent {
+            id: "component1".to_string(),
+            protocol_system: "test_protocol".to_string(),
+            protocol_type_name: "test_type".to_string(),
+            chain: Chain::Ethereum,
+            tokens: vec![],
+            contract_addresses: vec![
+                Bytes::from_str("0x1111111111111111111111111111111111111111").unwrap()
+            ],
+            static_attributes: HashMap::new(),
+            change: tycho_common::models::ChangeType::Creation,
+            creation_tx: Bytes::from_str(
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            created_at: chrono::Utc::now().naive_utc(),
+        };
 
         let mut components = HashMap::new();
         components.insert("component1".to_string(), component);
@@ -3261,24 +3258,21 @@ mod tests {
             .expect("create client");
 
         // Create test component
-        #[allow(deprecated)]
-        let component = tycho_common::models::protocol::ProtocolComponent::from(
-            tycho_common::dto::ProtocolComponent {
-                id: "component1".to_string(),
-                protocol_system: "test_protocol".to_string(),
-                protocol_type_name: "test_type".to_string(),
-                chain: Chain::Ethereum.into(),
-                tokens: vec![],
-                contract_ids: vec![],
-                static_attributes: HashMap::new(),
-                change: tycho_common::dto::ChangeType::Creation,
-                creation_tx: Bytes::from_str(
-                    "0x0000000000000000000000000000000000000000000000000000000000000000",
-                )
-                .unwrap(),
-                created_at: chrono::Utc::now().naive_utc(),
-            },
-        );
+        let component = tycho_common::models::protocol::ProtocolComponent {
+            id: "component1".to_string(),
+            protocol_system: "test_protocol".to_string(),
+            protocol_type_name: "test_type".to_string(),
+            chain: Chain::Ethereum,
+            tokens: vec![],
+            contract_addresses: vec![],
+            static_attributes: HashMap::new(),
+            change: tycho_common::models::ChangeType::Creation,
+            creation_tx: Bytes::from_str(
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            created_at: chrono::Utc::now().naive_utc(),
+        };
 
         let mut components = HashMap::new();
         components.insert("component1".to_string(), component);

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -72,22 +72,6 @@ pub struct Page<T> {
     page_size: i64,
 }
 
-pub(crate) trait CollectionLen {
-    fn len(&self) -> usize;
-}
-
-impl<T> CollectionLen for Vec<T> {
-    fn len(&self) -> usize {
-        Vec::len(self)
-    }
-}
-
-impl<K, V, S: std::hash::BuildHasher> CollectionLen for HashMap<K, V, S> {
-    fn len(&self) -> usize {
-        HashMap::len(self)
-    }
-}
-
 impl<T> Page<T> {
     pub fn new(data: T, total: i64, page: i64, page_size: i64) -> Self {
         Page { data, total, page, page_size }
@@ -114,14 +98,23 @@ impl<T> Page<T> {
     }
 }
 
-#[allow(private_bounds)]
-impl<T: CollectionLen> Page<T> {
+impl<T> Page<Vec<T>> {
     pub fn len(&self) -> usize {
         self.data.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.data.len() == 0
+        self.data.is_empty()
+    }
+}
+
+impl<K, V, S: std::hash::BuildHasher> Page<HashMap<K, V, S>> {
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
     }
 }
 
@@ -188,17 +181,7 @@ impl ContractStateParams {
     }
 
     pub fn with_block_number(mut self, block_number: u64) -> Self {
-        self.version = VersionParam::new(
-            None,
-            Some({
-                #[allow(deprecated)]
-                BlockParam {
-                    hash: None,
-                    chain: Some(self.chain.into()),
-                    number: Some(block_number as i64),
-                }
-            }),
-        );
+        self.version = VersionParam::at_block(self.chain.into(), block_number);
         self
     }
 
@@ -295,17 +278,7 @@ impl ProtocolStatesParams {
     }
 
     pub fn with_block_number(mut self, block_number: u64) -> Self {
-        self.version = VersionParam::new(
-            None,
-            Some({
-                #[allow(deprecated)]
-                BlockParam {
-                    hash: None,
-                    chain: Some(self.chain.into()),
-                    number: Some(block_number as i64),
-                }
-            }),
-        );
+        self.version = VersionParam::at_block(self.chain.into(), block_number);
         self
     }
 
@@ -448,12 +421,12 @@ impl TracedEntryPointsParams {
 /// Parameters for [`RPCClient::get_protocol_components_paginated`].
 #[derive(Clone, PartialEq, Debug)]
 pub struct ProtocolComponentsPaginatedParams {
-    pub(crate) chain: Chain,
-    pub(crate) protocol_system: String,
-    pub(crate) component_ids: Option<Vec<ComponentId>>,
-    pub(crate) tvl_gt: Option<f64>,
-    pub(crate) chunk_size: Option<usize>,
-    pub(crate) concurrency: usize,
+    chain: Chain,
+    protocol_system: String,
+    component_ids: Option<Vec<ComponentId>>,
+    tvl_gt: Option<f64>,
+    chunk_size: Option<usize>,
+    concurrency: usize,
 }
 
 impl ProtocolComponentsPaginatedParams {
@@ -487,11 +460,11 @@ impl ProtocolComponentsPaginatedParams {
 /// Parameters for [`RPCClient::get_traced_entry_points_paginated`].
 #[derive(Clone, PartialEq, Debug)]
 pub struct TracedEntryPointsPaginatedParams {
-    pub(crate) chain: Chain,
-    pub(crate) protocol_system: String,
-    pub(crate) component_ids: Vec<String>,
-    pub(crate) chunk_size: Option<usize>,
-    pub(crate) concurrency: usize,
+    chain: Chain,
+    protocol_system: String,
+    component_ids: Vec<String>,
+    chunk_size: Option<usize>,
+    concurrency: usize,
 }
 
 impl TracedEntryPointsPaginatedParams {
@@ -557,17 +530,7 @@ impl ProtocolStatesPaginatedParams {
     }
 
     pub fn with_block_number(mut self, block_number: u64) -> Self {
-        self.version = VersionParam::new(
-            None,
-            Some({
-                #[allow(deprecated)]
-                BlockParam {
-                    hash: None,
-                    chain: Some(self.chain.into()),
-                    number: Some(block_number as i64),
-                }
-            }),
-        );
+        self.version = VersionParam::at_block(self.chain.into(), block_number);
         self
     }
 
@@ -673,17 +636,7 @@ impl ContractStatePaginatedParams {
     }
 
     pub fn with_block_number(mut self, block_number: u64) -> Self {
-        self.version = VersionParam::new(
-            None,
-            Some({
-                #[allow(deprecated)]
-                BlockParam {
-                    hash: None,
-                    chain: Some(self.chain.into()),
-                    number: Some(block_number as i64),
-                }
-            }),
-        );
+        self.version = VersionParam::at_block(self.chain.into(), block_number);
         self
     }
 
@@ -1199,7 +1152,7 @@ pub trait RPCClient: Send + Sync {
 
                     for resp in responses {
                         for (key, value) in resp {
-                            *merged_tvl.entry(key).or_insert(0.0) += value;
+                            *merged_tvl.entry(key).or_insert(0.0) = value;
                         }
                     }
 
@@ -1886,17 +1839,7 @@ impl RPCClient for HttpRPCClient {
             HashMap::new()
         };
 
-        let version = VersionParam::new(
-            None,
-            Some({
-                #[allow(deprecated)]
-                BlockParam {
-                    hash: None,
-                    chain: Some(request.chain.into()),
-                    number: Some(request.block_number as i64),
-                }
-            }),
-        );
+        let version = VersionParam::at_block(request.chain.into(), request.block_number);
 
         let mut protocol_states = if !component_ids.is_empty() {
             self.get_protocol_states_paginated(

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -25,12 +25,11 @@ use tokio::{
 use tracing::{debug, error, instrument, trace, warn};
 use tycho_common::{
     dto::{
-        BlockParam, ComponentTvlRequestBody, ComponentTvlRequestResponse, PaginationLimits,
-        PaginationParams, ProtocolComponentRequestResponse, ProtocolComponentsRequestBody,
-        ProtocolStateRequestBody, ProtocolStateRequestResponse, ProtocolSystemsRequestBody,
-        ProtocolSystemsRequestResponse, StateRequestBody, StateRequestResponse, TokensRequestBody,
-        TokensRequestResponse, TracedEntryPointRequestBody, TracedEntryPointRequestResponse,
-        VersionParam,
+        ComponentTvlRequestBody, ComponentTvlRequestResponse, PaginationLimits, PaginationParams,
+        ProtocolComponentRequestResponse, ProtocolComponentsRequestBody, ProtocolStateRequestBody,
+        ProtocolStateRequestResponse, ProtocolSystemsRequestBody, ProtocolSystemsRequestResponse,
+        StateRequestBody, StateRequestResponse, TokensRequestBody, TokensRequestResponse,
+        TracedEntryPointRequestBody, TracedEntryPointRequestResponse, VersionParam,
     },
     models::{
         blockchain::{EntryPointWithTracingParams, TracedEntryPoints, TracingResult},

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -42,17 +42,108 @@ use tycho_common::{
     Bytes,
 };
 
-/// Response from `RPCClient::get_protocol_systems`.
-///
-/// Carries the raw lists returned by the server without wrapping dto types.
+/// Data payload returned by `RPCClient::get_protocol_systems`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProtocolSystemsResponse {
-    /// All protocol systems known to the server.
-    pub protocol_systems: Vec<String>,
-    /// Subset of `protocol_systems` that use Dynamic Contract Indexing.
-    pub dci_protocols: Vec<String>,
-    /// Total number of protocol systems on the server (may exceed what was fetched).
-    pub total: i64,
+pub struct ProtocolSystems {
+    protocol_systems: Vec<String>,
+    dci_protocols: Vec<String>,
+}
+
+impl ProtocolSystems {
+    pub(crate) fn new(protocol_systems: Vec<String>, dci_protocols: Vec<String>) -> Self {
+        Self { protocol_systems, dci_protocols }
+    }
+
+    pub fn protocol_systems(&self) -> &[String] {
+        &self.protocol_systems
+    }
+
+    pub fn dci_protocols(&self) -> &[String] {
+        &self.dci_protocols
+    }
+}
+
+/// An RPC response page, bundling data with the pagination metadata the server returned.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Page<T> {
+    data: T,
+    total: i64,
+    page: i64,
+    page_size: i64,
+}
+
+pub(crate) trait CollectionLen {
+    fn len(&self) -> usize;
+}
+
+impl<T> CollectionLen for Vec<T> {
+    fn len(&self) -> usize {
+        Vec::len(self)
+    }
+}
+
+impl<K, V, S: std::hash::BuildHasher> CollectionLen for HashMap<K, V, S> {
+    fn len(&self) -> usize {
+        HashMap::len(self)
+    }
+}
+
+impl<T> Page<T> {
+    pub fn new(data: T, total: i64, page: i64, page_size: i64) -> Self {
+        Page { data, total, page, page_size }
+    }
+
+    pub fn data(&self) -> &T {
+        &self.data
+    }
+
+    pub fn into_data(self) -> T {
+        self.data
+    }
+
+    pub fn total(&self) -> i64 {
+        self.total
+    }
+
+    pub fn page(&self) -> i64 {
+        self.page
+    }
+
+    pub fn page_size(&self) -> i64 {
+        self.page_size
+    }
+}
+
+#[allow(private_bounds)]
+impl<T: CollectionLen> Page<T> {
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.data.len() == 0
+    }
+}
+
+impl<T: IntoIterator> IntoIterator for Page<T> {
+    type Item = T::Item;
+    type IntoIter = T::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a Page<T>
+where
+    &'a T: IntoIterator,
+{
+    type Item = <&'a T as IntoIterator>::Item;
+    type IntoIter = <&'a T as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        (&self.data).into_iter()
+    }
 }
 
 use crate::{
@@ -69,7 +160,7 @@ pub struct ContractStateParams {
     chain: Chain,
     protocol_system: String,
     contract_ids: Option<Vec<Bytes>>,
-    block_number: Option<u64>,
+    version: VersionParam,
     page: i64,
     page_size: i64,
 }
@@ -80,7 +171,7 @@ impl ContractStateParams {
             chain,
             protocol_system: protocol_system.into(),
             contract_ids: None,
-            block_number: None,
+            version: VersionParam::default(),
             page: 0,
             page_size: StateRequestBody::MAX_PAGE_SIZE_COMPRESSED,
         }
@@ -91,8 +182,23 @@ impl ContractStateParams {
         self
     }
 
+    pub fn with_version(mut self, version: VersionParam) -> Self {
+        self.version = version;
+        self
+    }
+
     pub fn with_block_number(mut self, block_number: u64) -> Self {
-        self.block_number = Some(block_number);
+        self.version = VersionParam::new(
+            None,
+            Some({
+                #[allow(deprecated)]
+                BlockParam {
+                    hash: None,
+                    chain: Some(self.chain.into()),
+                    number: Some(block_number as i64),
+                }
+            }),
+        );
         self
     }
 
@@ -155,7 +261,7 @@ pub struct ProtocolStatesParams {
     protocol_system: String,
     protocol_ids: Option<Vec<String>>,
     include_balances: bool,
-    block_number: Option<u64>,
+    version: VersionParam,
     page: i64,
     page_size: i64,
 }
@@ -167,7 +273,7 @@ impl ProtocolStatesParams {
             protocol_system: protocol_system.into(),
             protocol_ids: None,
             include_balances: false,
-            block_number: None,
+            version: VersionParam::default(),
             page: 0,
             page_size: ProtocolStateRequestBody::MAX_PAGE_SIZE_COMPRESSED,
         }
@@ -183,8 +289,23 @@ impl ProtocolStatesParams {
         self
     }
 
+    pub fn with_version(mut self, version: VersionParam) -> Self {
+        self.version = version;
+        self
+    }
+
     pub fn with_block_number(mut self, block_number: u64) -> Self {
-        self.block_number = Some(block_number);
+        self.version = VersionParam::new(
+            None,
+            Some({
+                #[allow(deprecated)]
+                BlockParam {
+                    hash: None,
+                    chain: Some(self.chain.into()),
+                    number: Some(block_number as i64),
+                }
+            }),
+        );
         self
     }
 
@@ -324,6 +445,260 @@ impl TracedEntryPointsParams {
     }
 }
 
+/// Parameters for [`RPCClient::get_protocol_components_paginated`].
+#[derive(Clone, PartialEq, Debug)]
+pub struct ProtocolComponentsPaginatedParams {
+    pub(crate) chain: Chain,
+    pub(crate) protocol_system: String,
+    pub(crate) component_ids: Option<Vec<ComponentId>>,
+    pub(crate) tvl_gt: Option<f64>,
+    pub(crate) chunk_size: Option<usize>,
+    pub(crate) concurrency: usize,
+}
+
+impl ProtocolComponentsPaginatedParams {
+    pub fn new(chain: Chain, protocol_system: impl Into<String>, concurrency: usize) -> Self {
+        Self {
+            chain,
+            protocol_system: protocol_system.into(),
+            component_ids: None,
+            tvl_gt: None,
+            chunk_size: None,
+            concurrency,
+        }
+    }
+
+    pub fn with_component_ids(mut self, ids: Vec<ComponentId>) -> Self {
+        self.component_ids = Some(ids);
+        self
+    }
+
+    pub fn with_tvl_gt(mut self, tvl_gt: f64) -> Self {
+        self.tvl_gt = Some(tvl_gt);
+        self
+    }
+
+    pub fn with_chunk_size(mut self, chunk_size: usize) -> Self {
+        self.chunk_size = Some(chunk_size);
+        self
+    }
+}
+
+/// Parameters for [`RPCClient::get_traced_entry_points_paginated`].
+#[derive(Clone, PartialEq, Debug)]
+pub struct TracedEntryPointsPaginatedParams {
+    pub(crate) chain: Chain,
+    pub(crate) protocol_system: String,
+    pub(crate) component_ids: Vec<String>,
+    pub(crate) chunk_size: Option<usize>,
+    pub(crate) concurrency: usize,
+}
+
+impl TracedEntryPointsPaginatedParams {
+    pub fn new(
+        chain: Chain,
+        protocol_system: impl Into<String>,
+        component_ids: Vec<String>,
+        concurrency: usize,
+    ) -> Self {
+        Self {
+            chain,
+            protocol_system: protocol_system.into(),
+            component_ids,
+            chunk_size: None,
+            concurrency,
+        }
+    }
+
+    pub fn with_chunk_size(mut self, chunk_size: usize) -> Self {
+        self.chunk_size = Some(chunk_size);
+        self
+    }
+}
+
+/// Parameters for [`RPCClient::get_protocol_states_paginated`].
+#[derive(Clone, PartialEq, Debug)]
+pub struct ProtocolStatesPaginatedParams {
+    chain: Chain,
+    protocol_system: String,
+    protocol_ids: Vec<String>,
+    include_balances: bool,
+    version: VersionParam,
+    chunk_size: Option<usize>,
+    concurrency: usize,
+}
+
+impl ProtocolStatesPaginatedParams {
+    pub fn new(chain: Chain, protocol_system: impl Into<String>, concurrency: usize) -> Self {
+        Self {
+            chain,
+            protocol_system: protocol_system.into(),
+            protocol_ids: Vec::new(),
+            include_balances: true,
+            version: VersionParam::default(),
+            chunk_size: None,
+            concurrency,
+        }
+    }
+
+    pub fn with_protocol_ids(mut self, ids: Vec<String>) -> Self {
+        self.protocol_ids = ids;
+        self
+    }
+
+    pub fn with_include_balances(mut self, include_balances: bool) -> Self {
+        self.include_balances = include_balances;
+        self
+    }
+
+    pub fn with_version(mut self, version: VersionParam) -> Self {
+        self.version = version;
+        self
+    }
+
+    pub fn with_block_number(mut self, block_number: u64) -> Self {
+        self.version = VersionParam::new(
+            None,
+            Some({
+                #[allow(deprecated)]
+                BlockParam {
+                    hash: None,
+                    chain: Some(self.chain.into()),
+                    number: Some(block_number as i64),
+                }
+            }),
+        );
+        self
+    }
+
+    pub fn with_chunk_size(mut self, chunk_size: usize) -> Self {
+        self.chunk_size = Some(chunk_size);
+        self
+    }
+}
+
+/// Parameters for [`RPCClient::get_all_tokens`].
+#[derive(Clone, PartialEq, Debug)]
+pub struct AllTokensParams {
+    chain: Chain,
+    min_quality: Option<i32>,
+    traded_n_days_ago: Option<u64>,
+    chunk_size: Option<usize>,
+    concurrency: usize,
+}
+
+impl AllTokensParams {
+    pub fn new(chain: Chain, concurrency: usize) -> Self {
+        Self { chain, min_quality: None, traded_n_days_ago: None, chunk_size: None, concurrency }
+    }
+
+    pub fn with_min_quality(mut self, min_quality: i32) -> Self {
+        self.min_quality = Some(min_quality);
+        self
+    }
+
+    pub fn with_traded_n_days_ago(mut self, days: u64) -> Self {
+        self.traded_n_days_ago = Some(days);
+        self
+    }
+
+    pub fn with_chunk_size(mut self, chunk_size: usize) -> Self {
+        self.chunk_size = Some(chunk_size);
+        self
+    }
+}
+
+/// Parameters for [`RPCClient::get_component_tvl_paginated`].
+#[derive(Clone, PartialEq, Debug)]
+pub struct ComponentTvlPaginatedParams {
+    chain: Chain,
+    protocol_system: Option<String>,
+    component_ids: Option<Vec<String>>,
+    chunk_size: Option<usize>,
+    concurrency: usize,
+}
+
+impl ComponentTvlPaginatedParams {
+    pub fn new(chain: Chain, concurrency: usize) -> Self {
+        Self {
+            chain,
+            protocol_system: None,
+            component_ids: None,
+            chunk_size: None,
+            concurrency,
+        }
+    }
+
+    pub fn with_protocol_system(mut self, protocol_system: impl Into<String>) -> Self {
+        self.protocol_system = Some(protocol_system.into());
+        self
+    }
+
+    pub fn with_component_ids(mut self, ids: Vec<String>) -> Self {
+        self.component_ids = Some(ids);
+        self
+    }
+
+    pub fn with_chunk_size(mut self, chunk_size: usize) -> Self {
+        self.chunk_size = Some(chunk_size);
+        self
+    }
+}
+
+/// Parameters for [`RPCClient::get_contract_state_paginated`].
+#[derive(Clone, PartialEq, Debug)]
+pub struct ContractStatePaginatedParams {
+    chain: Chain,
+    protocol_system: String,
+    contract_ids: Vec<Bytes>,
+    version: VersionParam,
+    chunk_size: Option<usize>,
+    concurrency: usize,
+}
+
+impl ContractStatePaginatedParams {
+    pub fn new(chain: Chain, protocol_system: impl Into<String>, concurrency: usize) -> Self {
+        Self {
+            chain,
+            protocol_system: protocol_system.into(),
+            contract_ids: Vec::new(),
+            version: VersionParam::default(),
+            chunk_size: None,
+            concurrency,
+        }
+    }
+
+    pub fn with_contract_ids(mut self, ids: Vec<Bytes>) -> Self {
+        self.contract_ids = ids;
+        self
+    }
+
+    pub fn with_version(mut self, version: VersionParam) -> Self {
+        self.version = version;
+        self
+    }
+
+    pub fn with_block_number(mut self, block_number: u64) -> Self {
+        self.version = VersionParam::new(
+            None,
+            Some({
+                #[allow(deprecated)]
+                BlockParam {
+                    hash: None,
+                    chain: Some(self.chain.into()),
+                    number: Some(block_number as i64),
+                }
+            }),
+        );
+        self
+    }
+
+    pub fn with_chunk_size(mut self, chunk_size: usize) -> Self {
+        self.chunk_size = Some(chunk_size);
+        self
+    }
+}
+
 /// Request body for fetching a snapshot of protocol states and VM storage.
 ///
 /// This struct helps to coordinate fetching  multiple pieces of related data
@@ -456,58 +831,47 @@ pub trait RPCClient: Send + Sync {
     async fn get_contract_state(
         &self,
         params: ContractStateParams,
-    ) -> Result<Vec<Account>, RPCError>;
+    ) -> Result<Page<Vec<Account>>, RPCError>;
 
     /// Retrieves a snapshot of contract state for a set of contract IDs.
     ///
     /// If `chunk_size` is `None`, it defaults to the maximum page size.
     async fn get_contract_state_paginated(
         &self,
-        chain: Chain,
-        ids: &[Bytes],
-        protocol_system: &str,
-        block_number: Option<u64>,
-        chunk_size: Option<usize>,
-        concurrency: usize,
+        params: ContractStatePaginatedParams,
     ) -> Result<Vec<Account>, RPCError> {
-        let semaphore = Arc::new(Semaphore::new(concurrency));
+        let semaphore = Arc::new(Semaphore::new(params.concurrency));
 
         // Sort the ids to maximize server-side cache hits
-        let mut sorted_ids = ids.to_vec();
+        let mut sorted_ids = params.contract_ids;
         sorted_ids.sort();
 
-        let chunk_size = chunk_size
+        let chunk_size = params
+            .chunk_size
             .unwrap_or(StateRequestBody::effective_max_page_size(self.compression()) as usize);
 
         let mut tasks = Vec::new();
         for chunk in sorted_ids.chunks(chunk_size) {
             let sem = semaphore.clone();
-            let chunk = chunk.to_vec();
-            let base_params = ContractStateParams::new(chain, protocol_system)
-                .with_contract_ids(chunk)
-                .with_pagination(0, chunk_size as i64);
-            let base_params = if let Some(bn) = block_number {
-                base_params.with_block_number(bn)
-            } else {
-                base_params
-            };
+            let base_params =
+                ContractStateParams::new(params.chain, params.protocol_system.as_str())
+                    .with_contract_ids(chunk.to_vec())
+                    .with_version(params.version.clone())
+                    .with_pagination(0, chunk_size as i64);
             tasks.push(async move {
                 let _permit = sem
                     .acquire()
                     .await
                     .map_err(|_| RPCError::Fatal("Semaphore dropped".to_string()))?;
-                self.get_contract_state(base_params)
-                    .await
+                self.get_contract_state(base_params).await
             });
         }
 
-        // Execute all tasks concurrently with the defined concurrency limit.
-        let responses = try_join_all(tasks).await?;
+        let pages = try_join_all(tasks).await?;
 
-        // Aggregate the responses into a single result.
-        let accounts = responses
+        let accounts = pages
             .into_iter()
-            .flat_map(|r| r.into_iter())
+            .flat_map(|p| p.into_iter())
             .collect();
 
         Ok(accounts)
@@ -519,20 +883,22 @@ pub trait RPCClient: Send + Sync {
     async fn get_protocol_components(
         &self,
         params: ProtocolComponentsParams,
-    ) -> Result<Vec<ProtocolComponent>, RPCError>;
+    ) -> Result<Page<Vec<ProtocolComponent>>, RPCError>;
 
     /// Retrieves protocol components, fetching all pages automatically.
     ///
     /// If `chunk_size` is `None`, it defaults to the maximum page size.
     async fn get_protocol_components_paginated(
         &self,
-        chain: Chain,
-        protocol_system: String,
-        component_ids: Option<Vec<ComponentId>>,
-        tvl_gt: Option<f64>,
-        chunk_size: Option<usize>,
-        concurrency: usize,
+        params: ProtocolComponentsPaginatedParams,
     ) -> Result<Vec<ProtocolComponent>, RPCError> {
+        let chain = params.chain;
+        let protocol_system = params.protocol_system;
+        let component_ids = params.component_ids;
+        let tvl_gt = params.tvl_gt;
+        let chunk_size = params.chunk_size;
+        let concurrency = params.concurrency;
+
         let semaphore = Arc::new(Semaphore::new(concurrency));
 
         let chunk_size = chunk_size.unwrap_or(
@@ -566,8 +932,8 @@ pub trait RPCClient: Send + Sync {
 
                 try_join_all(tasks)
                     .await
-                    .map(|responses| {
-                        responses
+                    .map(|pages| {
+                        pages
                             .into_iter()
                             .flatten()
                             .collect()
@@ -583,19 +949,22 @@ pub trait RPCClient: Send + Sync {
                     base_params = base_params.with_tvl_gt(tvl);
                 }
 
-                let first_result = self
+                let first_page = self
                     .get_protocol_components(base_params)
                     .await
                     .map_err(|err| RPCError::Fatal(err.to_string()))?;
 
-                if first_result.len() < chunk_size {
-                    return Ok(first_result);
-                }
+                let total_items = first_page.total();
+                let total_pages = (total_items as f64 / chunk_size as f64).ceil() as i64;
 
-                let mut all = first_result;
-                let mut page = 1i64;
-                loop {
-                    let tasks: Vec<_> = (0..concurrency as i64)
+                let mut all: Vec<ProtocolComponent> = first_page.into_data();
+
+                let mut page = 1;
+                while page < total_pages {
+                    let requests_in_this_iteration =
+                        (total_pages - page).min(concurrency as i64);
+
+                    let tasks: Vec<_> = (0..requests_in_this_iteration)
                         .map(|iter| {
                             let sem = semaphore.clone();
                             let mut p =
@@ -613,20 +982,13 @@ pub trait RPCClient: Send + Sync {
                         })
                         .collect();
 
-                    let batch = try_join_all(tasks).await?;
+                    let responses = try_join_all(tasks).await?;
 
-                    let mut done = false;
-                    for r in batch {
-                        if r.len() < chunk_size {
-                            done = true;
-                        }
-                        all.extend(r);
+                    for resp in responses {
+                        all.extend(resp);
                     }
 
-                    page += concurrency as i64;
-                    if done {
-                        break;
-                    }
+                    page += requests_in_this_iteration;
                 }
                 Ok(all)
             }
@@ -639,146 +1001,105 @@ pub trait RPCClient: Send + Sync {
     async fn get_protocol_states(
         &self,
         params: ProtocolStatesParams,
-    ) -> Result<Vec<ProtocolComponentState>, RPCError>;
+    ) -> Result<Page<Vec<ProtocolComponentState>>, RPCError>;
 
     /// Retrieves protocol states for a set of protocol IDs, fetching all pages automatically.
     ///
     /// If `chunk_size` is `None`, it defaults to the maximum page size.
-    #[allow(clippy::too_many_arguments)]
-    async fn get_protocol_states_paginated<T>(
+    async fn get_protocol_states_paginated(
         &self,
-        chain: Chain,
-        ids: &[T],
-        protocol_system: &str,
-        include_balances: bool,
-        block_number: Option<u64>,
-        chunk_size: Option<usize>,
-        concurrency: usize,
-    ) -> Result<Vec<ProtocolComponentState>, RPCError>
-    where
-        T: AsRef<str> + Sync + 'static,
-    {
-        let semaphore = Arc::new(Semaphore::new(concurrency));
+        params: ProtocolStatesPaginatedParams,
+    ) -> Result<Vec<ProtocolComponentState>, RPCError> {
+        let semaphore = Arc::new(Semaphore::new(params.concurrency));
 
-        let chunk_size = chunk_size.unwrap_or(ProtocolStateRequestBody::effective_max_page_size(
-            self.compression(),
-        ) as usize);
+        let chunk_size = params.chunk_size.unwrap_or(
+            ProtocolStateRequestBody::effective_max_page_size(self.compression()) as usize,
+        );
 
-        let tasks: Vec<_> = ids
+        let tasks: Vec<_> = params
+            .protocol_ids
             .chunks(chunk_size)
             .map(|c| {
                 let sem = semaphore.clone();
-                let chunk: Vec<String> = c
-                    .iter()
-                    .map(|id| id.as_ref().to_string())
-                    .collect();
-                let mut params = ProtocolStatesParams::new(chain, protocol_system)
-                    .with_protocol_ids(chunk)
-                    .with_include_balances(include_balances)
+                let p = ProtocolStatesParams::new(params.chain, params.protocol_system.as_str())
+                    .with_protocol_ids(c.to_vec())
+                    .with_include_balances(params.include_balances)
+                    .with_version(params.version.clone())
                     .with_pagination(0, chunk_size as i64);
-                if let Some(bn) = block_number {
-                    params = params.with_block_number(bn);
-                }
                 async move {
                     let _permit = sem
                         .acquire()
                         .await
                         .map_err(|_| RPCError::Fatal("Semaphore dropped".to_string()))?;
-                    self.get_protocol_states(params).await
+                    self.get_protocol_states(p).await
                 }
             })
             .collect();
 
         try_join_all(tasks)
             .await
-            .map(|responses| {
-                responses
-                    .into_iter()
-                    .flatten()
-                    .collect()
-            })
+            .map(|pages| pages.into_iter().flatten().collect())
     }
 
     /// Retrieves a page of tokens.
     ///
     /// Use `get_all_tokens` to fetch all matching tokens automatically.
-    async fn get_tokens(&self, params: TokensParams) -> Result<Vec<Token>, RPCError>;
+    async fn get_tokens(&self, params: TokensParams) -> Result<Page<Vec<Token>>, RPCError>;
 
     /// Retrieves all tokens matching the given criteria, fetching all pages automatically.
     ///
     /// If `chunk_size` is `None`, it defaults to the maximum page size.
-    async fn get_all_tokens(
-        &self,
-        chain: Chain,
-        min_quality: Option<i32>,
-        traded_n_days_ago: Option<u64>,
-        chunk_size: Option<usize>,
-        concurrency: usize,
-    ) -> Result<Vec<Token>, RPCError> {
-        let chunk_size = chunk_size
-            .unwrap_or(TokensRequestBody::effective_max_page_size(self.compression()) as usize);
+    async fn get_all_tokens(&self, params: AllTokensParams) -> Result<Vec<Token>, RPCError> {
+        let chunk_size = params.chunk_size.unwrap_or(
+            TokensRequestBody::effective_max_page_size(self.compression()) as usize,
+        );
 
-        let semaphore = Arc::new(Semaphore::new(concurrency));
+        let semaphore = Arc::new(Semaphore::new(params.concurrency));
 
-        // Make initial request to get total count
-        let page_size = chunk_size.try_into().map_err(|_| {
+        let page_size: i64 = chunk_size.try_into().map_err(|_| {
             RPCError::FormatRequest("Failed to convert chunk_size into i64".to_string())
         })?;
 
-        let mut base_params = TokensParams::new(chain).with_pagination(0, page_size);
-        if let Some(q) = min_quality {
+        let mut base_params = TokensParams::new(params.chain).with_pagination(0, page_size);
+        if let Some(q) = params.min_quality {
             base_params = base_params.with_min_quality(q);
         }
-        if let Some(d) = traded_n_days_ago {
+        if let Some(d) = params.traded_n_days_ago {
             base_params = base_params.with_traded_n_days_ago(d);
         }
 
-        let first_response = self.get_tokens(base_params).await?;
+        let first_page = self.get_tokens(base_params).await?;
+        let total_pages = (first_page.total() as f64 / chunk_size as f64).ceil() as i64;
 
-        if first_response.len() < chunk_size {
-            return Ok(first_response);
+        let mut all_tokens: Vec<Token> = first_page.into_data();
+
+        if total_pages <= 1 {
+            return Ok(all_tokens);
         }
 
-        let mut all_tokens = first_response;
-        let mut page = 1i64;
-
-        loop {
-            // Create a task for each page in this batch
-            let tasks: Vec<_> = (0..concurrency as i64)
-                .map(|i| {
-                    let sem = semaphore.clone();
-                    let mut p = TokensParams::new(chain).with_pagination(page + i, page_size);
-                    if let Some(q) = min_quality {
-                        p = p.with_min_quality(q);
-                    }
-                    if let Some(d) = traded_n_days_ago {
-                        p = p.with_traded_n_days_ago(d);
-                    }
-                    async move {
-                        // Semaphore controls how many requests are actually in-flight
-                        let _permit = sem
-                            .acquire()
-                            .await
-                            .map_err(|_| RPCError::Fatal("Semaphore dropped".to_string()))?;
-                        self.get_tokens(p).await
-                    }
-                })
-                .collect();
-
-            let responses = try_join_all(tasks).await?;
-
-            let mut done = false;
-            for response in responses {
-                if response.len() < chunk_size {
-                    done = true;
+        let tasks: Vec<_> = (1..total_pages)
+            .map(|page| {
+                let sem = semaphore.clone();
+                let mut p = TokensParams::new(params.chain).with_pagination(page, page_size);
+                if let Some(q) = params.min_quality {
+                    p = p.with_min_quality(q);
                 }
-                all_tokens.extend(response);
-            }
+                if let Some(d) = params.traded_n_days_ago {
+                    p = p.with_traded_n_days_ago(d);
+                }
+                async move {
+                    let _permit = sem
+                        .acquire()
+                        .await
+                        .map_err(|_| RPCError::Fatal("Semaphore dropped".to_string()))?;
+                    self.get_tokens(p).await
+                }
+            })
+            .collect();
 
-            page += concurrency as i64;
-            if done {
-                break;
-            }
+        let pages = try_join_all(tasks).await?;
+        for page in pages {
+            all_tokens.extend(page);
         }
 
         Ok(all_tokens)
@@ -788,7 +1109,7 @@ pub trait RPCClient: Send + Sync {
     async fn get_protocol_systems(
         &self,
         params: ProtocolSystemsParams,
-    ) -> Result<ProtocolSystemsResponse, RPCError>;
+    ) -> Result<Page<ProtocolSystems>, RPCError>;
 
     /// Retrieves component TVL values.
     ///
@@ -796,52 +1117,48 @@ pub trait RPCClient: Send + Sync {
     async fn get_component_tvl(
         &self,
         params: ComponentTvlParams,
-    ) -> Result<HashMap<String, f64>, RPCError>;
+    ) -> Result<Page<HashMap<String, f64>>, RPCError>;
 
     /// Retrieves component TVL values, fetching all pages automatically.
     ///
     /// If `chunk_size` is `None`, it defaults to the maximum page size.
     async fn get_component_tvl_paginated(
         &self,
-        chain: Chain,
-        protocol_system: Option<String>,
-        component_ids: Option<Vec<String>>,
-        chunk_size: Option<usize>,
-        concurrency: usize,
+        params: ComponentTvlPaginatedParams,
     ) -> Result<HashMap<String, f64>, RPCError> {
-        let semaphore = Arc::new(Semaphore::new(concurrency));
+        let semaphore = Arc::new(Semaphore::new(params.concurrency));
 
-        let chunk_size = chunk_size.unwrap_or(ComponentTvlRequestBody::effective_max_page_size(
-            self.compression(),
-        ) as usize);
+        let chunk_size = params.chunk_size.unwrap_or(
+            ComponentTvlRequestBody::effective_max_page_size(self.compression()) as usize,
+        );
 
-        match component_ids {
+        match params.component_ids {
             Some(ids) => {
-                let tasks: Vec<_> =
-                    ids.chunks(chunk_size)
-                        .enumerate()
-                        .map(|(index, chunk)| {
-                            let sem = semaphore.clone();
-                            let mut p = ComponentTvlParams::new(chain)
-                                .with_component_ids(chunk.to_vec())
-                                .with_pagination(index as i64, chunk_size as i64);
-                            if let Some(ref ps) = protocol_system {
-                                p = p.with_protocol_system(ps.as_str());
-                            }
-                            async move {
-                                let _permit = sem.acquire().await.map_err(|_| {
-                                    RPCError::Fatal("Semaphore dropped".to_string())
-                                })?;
-                                self.get_component_tvl(p).await
-                            }
-                        })
-                        .collect();
+                let tasks: Vec<_> = ids
+                    .chunks(chunk_size)
+                    .enumerate()
+                    .map(|(index, chunk)| {
+                        let sem = semaphore.clone();
+                        let mut p = ComponentTvlParams::new(params.chain)
+                            .with_component_ids(chunk.to_vec())
+                            .with_pagination(index as i64, chunk_size as i64);
+                        if let Some(ref ps) = params.protocol_system {
+                            p = p.with_protocol_system(ps.as_str());
+                        }
+                        async move {
+                            let _permit = sem.acquire().await.map_err(|_| {
+                                RPCError::Fatal("Semaphore dropped".to_string())
+                            })?;
+                            self.get_component_tvl(p).await
+                        }
+                    })
+                    .collect();
 
-                let responses = try_join_all(tasks).await?;
+                let pages = try_join_all(tasks).await?;
 
                 let mut merged_tvl = HashMap::new();
-                for resp in responses {
-                    for (key, value) in resp {
+                for page in pages {
+                    for (key, value) in page {
                         *merged_tvl.entry(key).or_insert(0.0) = value;
                     }
                 }
@@ -849,27 +1166,29 @@ pub trait RPCClient: Send + Sync {
                 Ok(merged_tvl)
             }
             None => {
-                let mut base = ComponentTvlParams::new(chain).with_pagination(0, chunk_size as i64);
-                if let Some(ref ps) = protocol_system {
+                let mut base =
+                    ComponentTvlParams::new(params.chain).with_pagination(0, chunk_size as i64);
+                if let Some(ref ps) = params.protocol_system {
                     base = base.with_protocol_system(ps.as_str());
                 }
 
-                let first = self.get_component_tvl(base).await?;
+                let first_page = self.get_component_tvl(base).await?;
+                let total_items = first_page.total();
+                let total_pages = (total_items as f64 / chunk_size as f64).ceil() as i64;
 
-                if first.len() < chunk_size {
-                    return Ok(first);
-                }
+                let mut merged_tvl: HashMap<String, f64> = first_page.into_data();
 
-                let mut merged_tvl = first;
-                let mut page = 1i64;
+                let mut page = 1;
+                while page < total_pages {
+                    let requests_in_this_iteration =
+                        (total_pages - page).min(params.concurrency as i64);
 
-                loop {
-                    let tasks: Vec<_> = (0..concurrency as i64)
+                    let tasks: Vec<_> = (0..requests_in_this_iteration)
                         .map(|i| {
                             let sem = semaphore.clone();
-                            let mut p = ComponentTvlParams::new(chain)
+                            let mut p = ComponentTvlParams::new(params.chain)
                                 .with_pagination(page + i, chunk_size as i64);
-                            if let Some(ref ps) = protocol_system {
+                            if let Some(ref ps) = params.protocol_system {
                                 p = p.with_protocol_system(ps.as_str());
                             }
                             async move {
@@ -881,20 +1200,15 @@ pub trait RPCClient: Send + Sync {
                         })
                         .collect();
 
-                    let batch = try_join_all(tasks).await?;
+                    let responses = try_join_all(tasks).await?;
 
-                    let mut done = false;
-                    for resp in batch {
-                        if resp.len() < chunk_size {
-                            done = true;
+                    for resp in responses {
+                        for (key, value) in resp {
+                            *merged_tvl.entry(key).or_insert(0.0) += value;
                         }
-                        merged_tvl.extend(resp);
                     }
 
-                    page += concurrency as i64;
-                    if done {
-                        break;
-                    }
+                    page += requests_in_this_iteration;
                 }
 
                 Ok(merged_tvl)
@@ -908,19 +1222,21 @@ pub trait RPCClient: Send + Sync {
     async fn get_traced_entry_points(
         &self,
         params: TracedEntryPointsParams,
-    ) -> Result<TracedEntryPoints, RPCError>;
+    ) -> Result<Page<TracedEntryPoints>, RPCError>;
 
     /// Retrieves traced entry points for a set of component IDs, fetching all pages automatically.
     ///
     /// If `chunk_size` is `None`, it defaults to the maximum page size.
     async fn get_traced_entry_points_paginated(
         &self,
-        chain: Chain,
-        protocol_system: &str,
-        component_ids: &[String],
-        chunk_size: Option<usize>,
-        concurrency: usize,
+        params: TracedEntryPointsPaginatedParams,
     ) -> Result<TracedEntryPoints, RPCError> {
+        let chain = params.chain;
+        let protocol_system = params.protocol_system;
+        let component_ids = params.component_ids;
+        let chunk_size = params.chunk_size;
+        let concurrency = params.concurrency;
+
         let semaphore = Arc::new(Semaphore::new(concurrency));
 
         let chunk_size = chunk_size.unwrap_or(
@@ -931,7 +1247,7 @@ pub trait RPCClient: Send + Sync {
             .chunks(chunk_size)
             .map(|c| {
                 let sem = semaphore.clone();
-                let params = TracedEntryPointsParams::new(chain, protocol_system)
+                let params = TracedEntryPointsParams::new(chain, protocol_system.as_str())
                     .with_component_ids(c.to_vec())
                     .with_pagination(0, chunk_size as i64);
                 async move {
@@ -947,8 +1263,8 @@ pub trait RPCClient: Send + Sync {
 
         try_join_all(tasks)
             .await
-            .map(|responses| {
-                responses
+            .map(|pages| {
+                pages
                     .into_iter()
                     .flatten()
                     .collect()
@@ -1200,21 +1516,6 @@ fn parse_retry_value(val: &str) -> Option<SystemTime> {
     None
 }
 
-/// Builds a `VersionParam` pinned to a block number on the given chain.
-///
-/// When `block_number` is `None`, returns the default (current-time timestamp).
-fn build_version_param(chain: Chain, block_number: Option<u64>) -> VersionParam {
-    match block_number {
-        Some(n) => VersionParam::new(
-            None,
-            Some({
-                #[allow(deprecated)]
-                BlockParam { hash: None, chain: Some(chain.into()), number: Some(n as i64) }
-            }),
-        ),
-        None => VersionParam::default(),
-    }
-}
 
 #[async_trait]
 impl RPCClient for HttpRPCClient {
@@ -1226,7 +1527,7 @@ impl RPCClient for HttpRPCClient {
     async fn get_contract_state(
         &self,
         params: ContractStateParams,
-    ) -> Result<Vec<Account>, RPCError> {
+    ) -> Result<Page<Vec<Account>>, RPCError> {
         if params
             .contract_ids
             .as_ref()
@@ -1235,12 +1536,11 @@ impl RPCClient for HttpRPCClient {
             warn!("No contract ids specified in request.");
         }
 
-        let version = build_version_param(params.chain, params.block_number);
         let request = StateRequestBody {
             contract_ids: params.contract_ids,
             protocol_system: params.protocol_system,
             chain: params.chain.into(),
-            version,
+            version: params.version,
             pagination: PaginationParams { page: params.page, page_size: params.page_size },
         };
 
@@ -1264,24 +1564,30 @@ impl RPCClient for HttpRPCClient {
             .map_err(|e| RPCError::ParseResponse(e.to_string()))?;
         if body.is_empty() {
             // Pure native protocols will return empty contract states
-            return Ok(vec![]);
+            return Ok(Page::new(vec![], 0, 0, 0));
         }
 
         let dto_response = serde_json::from_str::<StateRequestResponse>(&body)
             .map_err(|err| RPCError::from_parse_error(err, &body))?;
         trace!(?dto_response, "Received contract_state response from Tycho server");
 
-        Ok(dto_response
+        let data: Vec<Account> = dto_response
             .accounts
             .into_iter()
             .map(Account::from)
-            .collect())
+            .collect();
+        Ok(Page::new(
+            data,
+            dto_response.pagination.total,
+            dto_response.pagination.page,
+            dto_response.pagination.page_size,
+        ))
     }
 
     async fn get_protocol_components(
         &self,
         params: ProtocolComponentsParams,
-    ) -> Result<Vec<ProtocolComponent>, RPCError> {
+    ) -> Result<Page<Vec<ProtocolComponent>>, RPCError> {
         let request = ProtocolComponentsRequestBody {
             protocol_system: params.protocol_system,
             component_ids: params.component_ids,
@@ -1314,17 +1620,23 @@ impl RPCClient for HttpRPCClient {
             .map_err(|err| RPCError::from_parse_error(err, &body))?;
         trace!(?dto_response, "Received protocol_components response from Tycho server");
 
-        Ok(dto_response
+        let data: Vec<ProtocolComponent> = dto_response
             .protocol_components
             .into_iter()
             .map(ProtocolComponent::from)
-            .collect())
+            .collect();
+        Ok(Page::new(
+            data,
+            dto_response.pagination.total,
+            dto_response.pagination.page,
+            dto_response.pagination.page_size,
+        ))
     }
 
     async fn get_protocol_states(
         &self,
         params: ProtocolStatesParams,
-    ) -> Result<Vec<ProtocolComponentState>, RPCError> {
+    ) -> Result<Page<Vec<ProtocolComponentState>>, RPCError> {
         if params
             .protocol_ids
             .as_ref()
@@ -1333,13 +1645,12 @@ impl RPCClient for HttpRPCClient {
             warn!("No protocol ids specified in request.");
         }
 
-        let version = build_version_param(params.chain, params.block_number);
         let request = ProtocolStateRequestBody {
             protocol_ids: params.protocol_ids,
             protocol_system: params.protocol_system,
             chain: params.chain.into(),
             include_balances: params.include_balances,
-            version,
+            version: params.version,
             pagination: PaginationParams { page: params.page, page_size: params.page_size },
         };
 
@@ -1365,21 +1676,27 @@ impl RPCClient for HttpRPCClient {
 
         if body.is_empty() {
             // Pure VM protocols will return empty states
-            return Ok(vec![]);
+            return Ok(Page::new(vec![], 0, 0, 0));
         }
 
         let dto_response = serde_json::from_str::<ProtocolStateRequestResponse>(&body)
             .map_err(|err| RPCError::from_parse_error(err, &body))?;
         trace!(?dto_response, "Received protocol_states response from Tycho server");
 
-        Ok(dto_response
+        let data: Vec<ProtocolComponentState> = dto_response
             .states
             .into_iter()
             .map(ProtocolComponentState::from)
-            .collect())
+            .collect();
+        Ok(Page::new(
+            data,
+            dto_response.pagination.total,
+            dto_response.pagination.page,
+            dto_response.pagination.page_size,
+        ))
     }
 
-    async fn get_tokens(&self, params: TokensParams) -> Result<Vec<Token>, RPCError> {
+    async fn get_tokens(&self, params: TokensParams) -> Result<Page<Vec<Token>>, RPCError> {
         let request = TokensRequestBody {
             token_addresses: None,
             min_quality: params.min_quality,
@@ -1408,17 +1725,23 @@ impl RPCClient for HttpRPCClient {
         let dto_response = serde_json::from_str::<TokensRequestResponse>(&body)
             .map_err(|err| RPCError::ParseResponse(format!("Error: {err}, Body: {body}")))?;
 
-        Ok(dto_response
+        let data: Vec<Token> = dto_response
             .tokens
             .into_iter()
             .map(Token::from)
-            .collect())
+            .collect();
+        Ok(Page::new(
+            data,
+            dto_response.pagination.total,
+            dto_response.pagination.page,
+            dto_response.pagination.page_size,
+        ))
     }
 
     async fn get_protocol_systems(
         &self,
         params: ProtocolSystemsParams,
-    ) -> Result<ProtocolSystemsResponse, RPCError> {
+    ) -> Result<Page<ProtocolSystems>, RPCError> {
         let request = ProtocolSystemsRequestBody {
             chain: params.chain.into(),
             pagination: PaginationParams { page: params.page, page_size: params.page_size },
@@ -1444,17 +1767,18 @@ impl RPCClient for HttpRPCClient {
         let dto = serde_json::from_str::<ProtocolSystemsRequestResponse>(&body)
             .map_err(|err| RPCError::ParseResponse(format!("Error: {err}, Body: {body}")))?;
         trace!(?dto, "Received protocol_systems response from Tycho server");
-        Ok(ProtocolSystemsResponse {
-            protocol_systems: dto.protocol_systems,
-            dci_protocols: dto.dci_protocols,
-            total: dto.pagination.total,
-        })
+        Ok(Page::new(
+            ProtocolSystems::new(dto.protocol_systems, dto.dci_protocols),
+            dto.pagination.total,
+            dto.pagination.page,
+            dto.pagination.page_size,
+        ))
     }
 
     async fn get_component_tvl(
         &self,
         params: ComponentTvlParams,
-    ) -> Result<HashMap<String, f64>, RPCError> {
+    ) -> Result<Page<HashMap<String, f64>>, RPCError> {
         let request = ComponentTvlRequestBody {
             chain: params.chain.into(),
             protocol_system: params.protocol_system,
@@ -1485,13 +1809,18 @@ impl RPCClient for HttpRPCClient {
                 RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
             })?;
         trace!(?dto_response, "Received component_tvl response from Tycho server");
-        Ok(dto_response.tvl)
+        Ok(Page::new(
+            dto_response.tvl,
+            dto_response.pagination.total,
+            dto_response.pagination.page,
+            dto_response.pagination.page_size,
+        ))
     }
 
     async fn get_traced_entry_points(
         &self,
         params: TracedEntryPointsParams,
-    ) -> Result<TracedEntryPoints, RPCError> {
+    ) -> Result<Page<TracedEntryPoints>, RPCError> {
         let request = TracedEntryPointRequestBody {
             chain: params.chain.into(),
             protocol_system: params.protocol_system,
@@ -1524,7 +1853,7 @@ impl RPCClient for HttpRPCClient {
                 RPCError::ParseResponse(format!("Error: {err}, Body: {body}"))
             })?;
         trace!(?dto_response, "Received traced_entry_points response from Tycho server");
-        Ok(dto_response
+        let data: TracedEntryPoints = dto_response
             .traced_entry_points
             .into_iter()
             .map(|(k, v)| {
@@ -1537,7 +1866,13 @@ impl RPCClient for HttpRPCClient {
                         .collect(),
                 )
             })
-            .collect())
+            .collect();
+        Ok(Page::new(
+            data,
+            dto_response.pagination.total,
+            dto_response.pagination.page,
+            dto_response.pagination.page_size,
+        ))
     }
 
     async fn get_snapshots<'a>(
@@ -1554,26 +1889,36 @@ impl RPCClient for HttpRPCClient {
 
         let component_tvl = if request.include_tvl && !component_ids.is_empty() {
             self.get_component_tvl_paginated(
-                request.chain,
-                None,
-                Some(component_ids.clone()),
-                chunk_size,
-                concurrency,
+                ComponentTvlPaginatedParams::new(request.chain, concurrency)
+                    .with_component_ids(component_ids.clone()),
             )
             .await?
         } else {
             HashMap::new()
         };
 
+        let version = VersionParam::new(
+            None,
+            Some({
+                #[allow(deprecated)]
+                BlockParam {
+                    hash: None,
+                    chain: Some(request.chain.into()),
+                    number: Some(request.block_number as i64),
+                }
+            }),
+        );
+
         let mut protocol_states = if !component_ids.is_empty() {
             self.get_protocol_states_paginated(
-                request.chain,
-                &component_ids,
-                request.protocol_system,
-                request.include_balances,
-                Some(request.block_number),
-                chunk_size,
-                concurrency,
+                ProtocolStatesPaginatedParams::new(
+                    request.chain,
+                    request.protocol_system,
+                    concurrency,
+                )
+                .with_protocol_ids(component_ids.clone())
+                .with_include_balances(request.include_balances)
+                .with_version(version.clone()),
             )
             .await?
             .into_iter()
@@ -1617,15 +1962,18 @@ impl RPCClient for HttpRPCClient {
             .collect();
 
         let vm_storage = if !request.contract_ids.is_empty() {
+            let mut cp_params = ContractStatePaginatedParams::new(
+                request.chain,
+                request.protocol_system,
+                concurrency,
+            )
+            .with_contract_ids(request.contract_ids.to_vec())
+            .with_version(version.clone());
+            if let Some(cs) = chunk_size {
+                cp_params = cp_params.with_chunk_size(cs);
+            }
             let contract_states = self
-                .get_contract_state_paginated(
-                    request.chain,
-                    request.contract_ids,
-                    request.protocol_system,
-                    Some(request.block_number),
-                    chunk_size,
-                    concurrency,
-                )
+                .get_contract_state_paginated(cp_params)
                 .await?
                 .into_iter()
                 .map(|acc| (acc.address.clone(), acc))
@@ -1805,12 +2153,12 @@ mod tests {
             .expect("get state");
 
         mocked_server.assert();
-        assert_eq!(accounts.len(), 1);
-        assert_eq!(accounts[0].slots, HashMap::new());
-        assert_eq!(accounts[0].native_balance, Bytes::from(500u16.to_be_bytes()));
-        assert_eq!(accounts[0].code, [0].to_vec());
+        assert_eq!(accounts.data().len(), 1);
+        assert_eq!(accounts.data()[0].slots, HashMap::new());
+        assert_eq!(accounts.data()[0].native_balance, Bytes::from(500u16.to_be_bytes()));
+        assert_eq!(accounts.data()[0].code, [0].to_vec());
         assert_eq!(
-            accounts[0].code_hash,
+            accounts.data()[0].code_hash,
             hex::decode("5c06b7c5b3d910fd33bc2229846f9ddaf91d584d9b196e16636901ac3a77077e")
                 .unwrap()
         );
@@ -1868,17 +2216,17 @@ mod tests {
             .expect("get state");
 
         mocked_server.assert();
-        assert_eq!(components.len(), 1);
-        assert_eq!(components[0].id, "State1");
-        assert_eq!(components[0].protocol_system, "ambient");
-        assert_eq!(components[0].protocol_type_name, "Pool");
-        assert_eq!(components[0].tokens.len(), 2);
+        assert_eq!(components.data().len(), 1);
+        assert_eq!(components.data()[0].id, "State1");
+        assert_eq!(components.data()[0].protocol_system, "ambient");
+        assert_eq!(components.data()[0].protocol_type_name, "Pool");
+        assert_eq!(components.data()[0].tokens.len(), 2);
         let expected_attributes =
             [("attribute_1".to_string(), Bytes::from(1000_u64.to_be_bytes()))]
                 .iter()
                 .cloned()
                 .collect::<HashMap<String, Bytes>>();
-        assert_eq!(components[0].static_attributes, expected_attributes);
+        assert_eq!(components.data()[0].static_attributes, expected_attributes);
     }
 
     #[tokio::test]
@@ -1924,14 +2272,14 @@ mod tests {
             .expect("get state");
 
         mocked_server.assert();
-        assert_eq!(states.len(), 1);
-        assert_eq!(states[0].component_id, "State1");
+        assert_eq!(states.data().len(), 1);
+        assert_eq!(states.data()[0].component_id, "State1");
         let expected_attributes =
             [("attribute_1".to_string(), Bytes::from(1000_u64.to_be_bytes()))]
                 .iter()
                 .cloned()
                 .collect::<HashMap<String, Bytes>>();
-        assert_eq!(states[0].attributes, expected_attributes);
+        assert_eq!(states.data()[0].attributes, expected_attributes);
         let expected_balances = [(
             Bytes::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
                 .expect("Unsupported address format"),
@@ -1940,7 +2288,7 @@ mod tests {
         .iter()
         .cloned()
         .collect::<HashMap<Bytes, Bytes>>();
-        assert_eq!(states[0].balances, expected_balances);
+        assert_eq!(states.data()[0].balances, expected_balances);
     }
 
     #[tokio::test]
@@ -2018,7 +2366,7 @@ mod tests {
         ];
 
         mocked_server.assert();
-        assert_eq!(tokens, expected);
+        assert_eq!(*tokens.data(), expected);
     }
 
     #[rstest]
@@ -2056,8 +2404,8 @@ mod tests {
             .expect("get protocol systems");
 
         mocked_server.assert();
-        assert_eq!(response.protocol_systems, vec!["system1", "system2"]);
-        assert_eq!(response.dci_protocols, expected_dci);
+        assert_eq!(response.data().protocol_systems(), ["system1", "system2"]);
+        assert_eq!(response.data().dci_protocols(), expected_dci.as_slice());
     }
 
     #[tokio::test]
@@ -2093,7 +2441,7 @@ mod tests {
             .expect("get component tvl");
 
         mocked_server.assert();
-        assert_eq!(component_tvl.get("component1"), Some(&100.0));
+        assert_eq!(component_tvl.data().get("component1"), Some(&100.0));
     }
 
     #[tokio::test]
@@ -2157,8 +2505,9 @@ mod tests {
             .expect("get traced entry points");
 
         mocked_server.assert();
-        assert_eq!(entrypoints.len(), 1);
+        assert_eq!(entrypoints.data().len(), 1);
         let comp1_entrypoints = entrypoints
+            .data()
             .get("component_1")
             .expect("component_1 entrypoints should exist");
         assert_eq!(comp1_entrypoints.len(), 1);
@@ -3063,8 +3412,8 @@ mod tests {
         let accounts = response;
 
         mocked_server.assert();
-        assert_eq!(accounts.len(), 1);
-        assert_eq!(accounts[0].native_balance, Bytes::from(500u16.to_be_bytes()));
+        assert_eq!(accounts.data().len(), 1);
+        assert_eq!(accounts.data()[0].native_balance, Bytes::from(500u16.to_be_bytes()));
     }
 
     #[tokio::test]
@@ -3098,8 +3447,8 @@ mod tests {
 
         // Verify the mock was called (client sent request without Accept-Encoding header)
         mocked_server.assert();
-        assert_eq!(accounts.len(), 1);
-        assert_eq!(accounts[0].native_balance, Bytes::from(500u16.to_be_bytes()));
+        assert_eq!(accounts.data().len(), 1);
+        assert_eq!(accounts.data()[0].native_balance, Bytes::from(500u16.to_be_bytes()));
     }
 
     #[rstest]
@@ -3182,7 +3531,10 @@ mod tests {
             .expect("create client");
 
         let tokens = client
-            .get_all_tokens(Chain::Ethereum, None, None, Some(page_size), allowed_concurrency)
+            .get_all_tokens(
+                AllTokensParams::new(Chain::Ethereum, allowed_concurrency)
+                    .with_chunk_size(page_size),
+            )
             .await
             .expect("get all tokens");
 

--- a/crates/tycho-client/src/stream.rs
+++ b/crates/tycho-client/src/stream.rs
@@ -408,26 +408,30 @@ impl ProtocolSystemsInfo {
             return Self { dci_protocols: HashSet::new(), other_available: HashSet::new() };
         };
 
-        if response.total > page_size {
+        if response.total() > page_size {
             warn!(
                 "Server has {} protocol systems but only {} were fetched (page_size={page_size}). \
                  Availability info may be incomplete.",
-                response.total,
-                response.protocol_systems.len(),
+                response.total(),
+                response.data().protocol_systems().len(),
             );
         }
 
         let available: HashSet<_> = response
-            .protocol_systems
-            .into_iter()
+            .data()
+            .protocol_systems()
+            .iter()
+            .cloned()
             .collect();
         let other_available = available
             .difference(requested_exchanges)
             .cloned()
             .collect();
         let mut dci_protocols: HashSet<String> = response
-            .dci_protocols
-            .into_iter()
+            .data()
+            .dci_protocols()
+            .iter()
+            .cloned()
             .collect();
 
         // TODO(ENG-5302): Remove this fallback once all environments serve

--- a/crates/tycho-client/src/stream.rs
+++ b/crates/tycho-client/src/stream.rs
@@ -8,8 +8,9 @@ use std::{
 use thiserror::Error;
 use tokio::{sync::mpsc::Receiver, task::JoinHandle};
 use tracing::{info, warn};
-use tycho_common::dto::{
-    Chain, ExtractorIdentity, PaginationLimits, PaginationParams, ProtocolSystemsRequestBody,
+use tycho_common::{
+    dto::{PaginationLimits, ProtocolSystemsRequestBody},
+    models::{Chain, ExtractorIdentity},
 };
 
 use crate::{
@@ -18,7 +19,7 @@ use crate::{
         component_tracker::ComponentFilter, synchronizer::ProtocolStateSynchronizer, BlockHeader,
         BlockSynchronizer, BlockSynchronizerError, FeedMessage,
     },
-    rpc::{HttpRPCClientOptions, RPCClient},
+    rpc::{HttpRPCClientOptions, ProtocolSystemsParams, RPCClient},
     HttpRPCClient, WsDeltasClient,
 };
 
@@ -391,11 +392,9 @@ impl ProtocolSystemsInfo {
     ) -> Self {
         let page_size =
             ProtocolSystemsRequestBody::effective_max_page_size(rpc_client.compression());
+        let params = ProtocolSystemsParams::new(chain).with_pagination(0, page_size);
         let response = rpc_client
-            .get_protocol_systems(&ProtocolSystemsRequestBody {
-                chain,
-                pagination: PaginationParams { page: 0, page_size },
-            })
+            .get_protocol_systems(params)
             .await
             .map_err(|e| {
                 warn!(
@@ -409,11 +408,11 @@ impl ProtocolSystemsInfo {
             return Self { dci_protocols: HashSet::new(), other_available: HashSet::new() };
         };
 
-        if response.pagination.total > page_size {
+        if response.total > page_size {
             warn!(
                 "Server has {} protocol systems but only {} were fetched (page_size={page_size}). \
                  Availability info may be incomplete.",
-                response.pagination.total,
+                response.total,
                 response.protocol_systems.len(),
             );
         }

--- a/crates/tycho-common/src/dto.rs
+++ b/crates/tycho-common/src/dto.rs
@@ -20,10 +20,7 @@ use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
 use crate::{
-    models::{
-        self, blockchain::BlockAggregatedChanges as ModelBlockAggregatedChanges, Address, Balance,
-        Code, ComponentId, StoreKey, StoreVal,
-    },
+    models::{self, Address, Balance, Code, ComponentId, StoreKey, StoreVal},
     serde_primitives::{
         hex_bytes, hex_bytes_option, hex_hashmap_key, hex_hashmap_key_value, hex_hashmap_value,
     },
@@ -520,8 +517,8 @@ impl From<models::contract::AccountBalance> for AccountBalance {
     }
 }
 
-impl From<ModelBlockAggregatedChanges> for BlockAggregatedChanges {
-    fn from(value: ModelBlockAggregatedChanges) -> Self {
+impl From<models::blockchain::BlockAggregatedChanges> for BlockAggregatedChanges {
+    fn from(value: models::blockchain::BlockAggregatedChanges) -> Self {
         Self {
             extractor: value.extractor,
             chain: value.chain.into(),
@@ -3219,42 +3216,43 @@ mod test {
 
     #[test]
     fn test_websocket_error_conversion_from_models() {
-        use crate::models::error::WebsocketError as ModelsError;
+        use crate::models::error;
 
         let extractor_id =
             crate::models::ExtractorIdentity::new(crate::models::Chain::Ethereum, "test");
         let subscription_id = Uuid::new_v4();
 
         // Test ExtractorNotFound conversion
-        let models_error = ModelsError::ExtractorNotFound(extractor_id.clone());
+        let models_error = error::WebsocketError::ExtractorNotFound(extractor_id.clone());
         let dto_error: WebsocketError = models_error.into();
         assert_eq!(dto_error, WebsocketError::ExtractorNotFound(extractor_id.clone().into()));
 
         // Test SubscriptionNotFound conversion
-        let models_error = ModelsError::SubscriptionNotFound(subscription_id);
+        let models_error = error::WebsocketError::SubscriptionNotFound(subscription_id);
         let dto_error: WebsocketError = models_error.into();
         assert_eq!(dto_error, WebsocketError::SubscriptionNotFound(subscription_id));
 
         // Test ParseError conversion - create a real JSON parse error
         let json_result: Result<serde_json::Value, _> = serde_json::from_str("{invalid json");
         let json_error = json_result.unwrap_err();
-        let models_error = ModelsError::ParseError("{invalid json".to_string(), json_error);
+        let models_error =
+            error::WebsocketError::ParseError("{invalid json".to_string(), json_error);
         let dto_error: WebsocketError = models_error.into();
-        if let WebsocketError::ParseError(msg, error) = dto_error {
+        if let WebsocketError::ParseError(msg, error_msg) = dto_error {
             // Just check that we have a non-empty error message
-            assert!(!error.is_empty(), "Error message should not be empty, got: '{}'", msg);
+            assert!(!error_msg.is_empty(), "Error message should not be empty, got: '{}'", msg);
         } else {
             panic!("Expected ParseError variant");
         }
 
         // Test SubscribeError conversion
-        let models_error = ModelsError::SubscribeError(extractor_id.clone());
+        let models_error = error::WebsocketError::SubscribeError(extractor_id.clone());
         let dto_error: WebsocketError = models_error.into();
         assert_eq!(dto_error, WebsocketError::SubscribeError(extractor_id.into()));
 
         // Test CompressionError conversion
         let io_error = std::io::Error::other("Compression failed");
-        let models_error = ModelsError::CompressionError(subscription_id, io_error);
+        let models_error = error::WebsocketError::CompressionError(subscription_id, io_error);
         let dto_error: WebsocketError = models_error.into();
         if let WebsocketError::CompressionError(sub_id, msg) = &dto_error {
             assert_eq!(*sub_id, subscription_id);

--- a/crates/tycho-common/src/dto.rs
+++ b/crates/tycho-common/src/dto.rs
@@ -1120,6 +1120,16 @@ impl VersionParam {
     pub fn new(timestamp: Option<NaiveDateTime>, block: Option<BlockParam>) -> Self {
         Self { timestamp, block }
     }
+
+    pub fn at_block(chain: Chain, block_number: u64) -> Self {
+        Self::new(
+            None,
+            Some({
+                #[allow(deprecated)]
+                BlockParam { hash: None, chain: Some(chain), number: Some(block_number as i64) }
+            }),
+        )
+    }
 }
 
 impl Default for VersionParam {

--- a/crates/tycho-common/src/dto.rs
+++ b/crates/tycho-common/src/dto.rs
@@ -21,8 +21,9 @@ use uuid::Uuid;
 
 use crate::{
     models::{
-        self, blockchain::BlockAggregatedChanges, Address, Balance, Code, ComponentId, StoreKey,
-        StoreVal,
+        self,
+        blockchain::BlockAggregatedChanges as ModelBlockAggregatedChanges,
+        Address, Balance, Code, ComponentId, StoreKey, StoreVal,
     },
     serde_primitives::{
         hex_bytes, hex_bytes_option, hex_hashmap_key, hex_hashmap_key_value, hex_hashmap_value,
@@ -247,7 +248,7 @@ pub enum Response {
 #[derive(Serialize, Deserialize, Debug, Display, Clone)]
 #[serde(untagged)]
 pub enum WebSocketMessage {
-    BlockChanges { subscription_id: Uuid, deltas: BlockChanges },
+    BlockAggregatedChanges { subscription_id: Uuid, deltas: BlockAggregatedChanges },
     Response(Response),
 }
 
@@ -314,7 +315,7 @@ impl Transaction {
 
 /// A container for updates grouped by account/component.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
-pub struct BlockChanges {
+pub struct BlockAggregatedChanges {
     pub extractor: String,
     pub chain: Chain,
     pub block: Block,
@@ -337,7 +338,7 @@ pub struct BlockChanges {
     pub partial_block_index: Option<u32>,
 }
 
-impl BlockChanges {
+impl BlockAggregatedChanges {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         extractor: &str,
@@ -353,7 +354,7 @@ impl BlockChanges {
         account_balances: HashMap<Bytes, HashMap<Bytes, AccountBalance>>,
         dci_update: DCIUpdate,
     ) -> Self {
-        BlockChanges {
+        BlockAggregatedChanges {
             extractor: extractor.to_owned(),
             chain,
             block,
@@ -520,8 +521,8 @@ impl From<models::contract::AccountBalance> for AccountBalance {
     }
 }
 
-impl From<BlockAggregatedChanges> for BlockChanges {
-    fn from(value: BlockAggregatedChanges) -> Self {
+impl From<ModelBlockAggregatedChanges> for BlockAggregatedChanges {
+    fn from(value: ModelBlockAggregatedChanges) -> Self {
         Self {
             extractor: value.extractor,
             chain: value.chain.into(),
@@ -2264,8 +2265,8 @@ mod test {
             json_value["partial_block_index"] = json!(partial_value);
         }
 
-        let block_changes: BlockChanges =
-            serde_json::from_value(json_value).expect("Failed to deserialize BlockChanges");
+        let block_changes: BlockAggregatedChanges =
+            serde_json::from_value(json_value).expect("Failed to deserialize BlockAggregatedChanges");
 
         assert_eq!(block_changes.partial_block_index, expected);
     }
@@ -2645,7 +2646,7 @@ mod test {
     #[test]
     fn test_serialize_deserialize_block_changes() {
         // Test that models::BlockAggregatedChanges serialized as json can be deserialized as
-        // dto::BlockChanges.
+        // dto::BlockAggregatedChanges.
 
         // Create a models::BlockAggregatedChanges instance
         let block_entity_changes = create_models_block_changes();
@@ -2653,8 +2654,8 @@ mod test {
         // Serialize the struct into JSON
         let json_data = serde_json::to_string(&block_entity_changes).expect("Failed to serialize");
 
-        // Deserialize the JSON back into a dto::BlockChanges struct
-        serde_json::from_str::<BlockChanges>(&json_data).expect("parsing failed");
+        // Deserialize the JSON back into a dto::BlockAggregatedChanges struct
+        serde_json::from_str::<BlockAggregatedChanges>(&json_data).expect("parsing failed");
     }
 
     #[test]
@@ -2766,7 +2767,7 @@ mod test {
         }
         "#;
 
-        serde_json::from_str::<BlockChanges>(json_data).expect("parsing failed");
+        serde_json::from_str::<BlockAggregatedChanges>(json_data).expect("parsing failed");
     }
 
     #[test]
@@ -2775,7 +2776,7 @@ mod test {
         {
             "subscription_id": "5d23bfbe-89ad-4ea3-8672-dc9e973ac9dc",
             "deltas": {
-                "type": "BlockChanges",
+                "type": "BlockAggregatedChanges",
                 "extractor": "uniswap_v2",
                 "chain": "ethereum",
                 "block": {
@@ -3020,21 +3021,21 @@ mod test {
         .into_iter()
         .collect();
         // Create initial and new BlockAccountChanges instances
-        let block_account_changes_initial = BlockChanges {
+        let block_account_changes_initial = BlockAggregatedChanges {
             extractor: "extractor1".to_string(),
             revert: false,
             account_updates: old_account_updates,
             ..Default::default()
         };
 
-        let block_account_changes_new = BlockChanges {
+        let block_account_changes_new = BlockAggregatedChanges {
             extractor: "extractor2".to_string(),
             revert: true,
             account_updates: new_account_updates,
             ..Default::default()
         };
 
-        // Merge the new BlockChanges into the initial one
+        // Merge the new BlockAggregatedChanges into the initial one
         let res = block_account_changes_initial.merge(block_account_changes_new);
 
         // Create the expected result of the merge operation
@@ -3054,7 +3055,7 @@ mod test {
         )]
         .into_iter()
         .collect();
-        let block_account_changes_expected = BlockChanges {
+        let block_account_changes_expected = BlockAggregatedChanges {
             extractor: "extractor1".to_string(),
             revert: true,
             account_updates: expected_account_updates,
@@ -3065,8 +3066,8 @@ mod test {
 
     #[test]
     fn test_block_entity_changes_merge() {
-        // Initialize two BlockChanges instances with different details
-        let block_entity_changes_result1 = BlockChanges {
+        // Initialize two BlockAggregatedChanges instances with different details
+        let block_entity_changes_result1 = BlockAggregatedChanges {
             extractor: String::from("extractor1"),
             revert: false,
             state_updates: hashmap! { "state1".to_string() => ProtocolStateDelta::default() },
@@ -3094,7 +3095,7 @@ mod test {
             component_tvl: hashmap! { "tvl1".to_string() => 1000.0 },
             ..Default::default()
         };
-        let block_entity_changes_result2 = BlockChanges {
+        let block_entity_changes_result2 = BlockAggregatedChanges {
             extractor: String::from("extractor2"),
             revert: true,
             state_updates: hashmap! { "state2".to_string() => ProtocolStateDelta::default() },
@@ -3110,7 +3111,7 @@ mod test {
 
         let res = block_entity_changes_result1.merge(block_entity_changes_result2);
 
-        let expected_block_entity_changes_result = BlockChanges {
+        let expected_block_entity_changes_result = BlockAggregatedChanges {
             extractor: String::from("extractor1"),
             revert: true,
             state_updates: hashmap! {

--- a/crates/tycho-common/src/dto.rs
+++ b/crates/tycho-common/src/dto.rs
@@ -2037,57 +2037,6 @@ pub struct TracedEntryPointRequestResponse {
         HashMap<ComponentId, Vec<(EntryPointWithTracingParams, TracingResult)>>,
     pub pagination: PaginationResponse,
 }
-impl From<TracedEntryPointRequestResponse> for DCIUpdate {
-    fn from(response: TracedEntryPointRequestResponse) -> Self {
-        let mut new_entrypoints = HashMap::new();
-        let mut new_entrypoint_params = HashMap::new();
-        let mut trace_results = HashMap::new();
-
-        for (component, traces) in response.traced_entry_points {
-            let mut entrypoints = HashSet::new();
-
-            for (entrypoint, trace) in traces {
-                let entrypoint_id = entrypoint
-                    .entry_point
-                    .external_id
-                    .clone();
-
-                // Collect entrypoints
-                entrypoints.insert(entrypoint.entry_point.clone());
-
-                // Collect entrypoint params
-                new_entrypoint_params
-                    .entry(entrypoint_id.clone())
-                    .or_insert_with(HashSet::new)
-                    .insert((entrypoint.params, component.clone()));
-
-                // Collect trace results
-                trace_results
-                    .entry(entrypoint_id)
-                    .and_modify(|existing_trace: &mut TracingResult| {
-                        // Merge traces for the same entrypoint
-                        existing_trace
-                            .retriggers
-                            .extend(trace.retriggers.clone());
-                        for (address, slots) in trace.accessed_slots.clone() {
-                            existing_trace
-                                .accessed_slots
-                                .entry(address)
-                                .or_default()
-                                .extend(slots);
-                        }
-                    })
-                    .or_insert(trace);
-            }
-
-            if !entrypoints.is_empty() {
-                new_entrypoints.insert(component, entrypoints);
-            }
-        }
-
-        DCIUpdate { new_entrypoints, new_entrypoint_params, trace_results }
-    }
-}
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, ToSchema, Eq, Clone)]
 pub struct AddEntryPointRequestBody {

--- a/crates/tycho-common/src/dto.rs
+++ b/crates/tycho-common/src/dto.rs
@@ -21,9 +21,8 @@ use uuid::Uuid;
 
 use crate::{
     models::{
-        self,
-        blockchain::BlockAggregatedChanges as ModelBlockAggregatedChanges,
-        Address, Balance, Code, ComponentId, StoreKey, StoreVal,
+        self, blockchain::BlockAggregatedChanges as ModelBlockAggregatedChanges, Address, Balance,
+        Code, ComponentId, StoreKey, StoreVal,
     },
     serde_primitives::{
         hex_bytes, hex_bytes_option, hex_hashmap_key, hex_hashmap_key_value, hex_hashmap_value,
@@ -2265,8 +2264,8 @@ mod test {
             json_value["partial_block_index"] = json!(partial_value);
         }
 
-        let block_changes: BlockAggregatedChanges =
-            serde_json::from_value(json_value).expect("Failed to deserialize BlockAggregatedChanges");
+        let block_changes: BlockAggregatedChanges = serde_json::from_value(json_value)
+            .expect("Failed to deserialize BlockAggregatedChanges");
 
         assert_eq!(block_changes.partial_block_index, expected);
     }

--- a/crates/tycho-common/src/models/blockchain.rs
+++ b/crates/tycho-common/src/models/blockchain.rs
@@ -166,6 +166,81 @@ impl BlockAggregatedChanges {
     pub fn is_partial(&self) -> bool {
         self.partial_block_index.is_some()
     }
+
+    pub fn get_block(&self) -> &Block {
+        &self.block
+    }
+
+    pub fn n_changes(&self) -> usize {
+        self.account_deltas.len() + self.state_deltas.len()
+    }
+
+    pub fn filter_by_component<F: Fn(&str) -> bool>(&mut self, keep: F) {
+        self.state_deltas.retain(|k, _| keep(k));
+        self.component_balances
+            .retain(|k, _| keep(k));
+        self.component_tvl
+            .retain(|k, _| keep(k));
+    }
+
+    pub fn filter_by_contract<F: Fn(&Bytes) -> bool>(&mut self, keep: F) {
+        self.account_deltas
+            .retain(|k, _| keep(k));
+        self.account_balances
+            .retain(|k, _| keep(k));
+    }
+
+    /// Merges this update with another one, consuming both.
+    ///
+    /// `other` is assumed to be a more recent update than `self`.
+    pub fn merge(mut self, other: Self) -> Self {
+        for (k, v) in other.account_deltas {
+            match self.account_deltas.entry(k) {
+                Entry::Occupied(mut e) => {
+                    // best-effort: ignore merge errors (address mismatch is a bug)
+                    let _ = e.get_mut().merge(v);
+                }
+                Entry::Vacant(e) => {
+                    e.insert(v);
+                }
+            }
+        }
+
+        for (k, v) in other.state_deltas {
+            match self.state_deltas.entry(k) {
+                Entry::Occupied(mut e) => {
+                    let _ = e.get_mut().merge(v);
+                }
+                Entry::Vacant(e) => {
+                    e.insert(v);
+                }
+            }
+        }
+
+        for (component_id, balances) in other.component_balances {
+            self.component_balances
+                .entry(component_id)
+                .or_default()
+                .extend(balances);
+        }
+
+        for (account, balances) in other.account_balances {
+            self.account_balances
+                .entry(account)
+                .or_default()
+                .extend(balances);
+        }
+
+        self.component_tvl
+            .extend(other.component_tvl);
+        self.new_protocol_components
+            .extend(other.new_protocol_components);
+        self.deleted_protocol_components
+            .extend(other.deleted_protocol_components);
+        self.revert = other.revert;
+        self.block = other.block;
+        self
+    }
 }
 
 impl std::fmt::Display for BlockAggregatedChanges {
@@ -196,11 +271,197 @@ impl From<dto::Block> for Block {
     }
 }
 
+impl From<dto::AddressStorageLocation> for AddressStorageLocation {
+    fn from(value: dto::AddressStorageLocation) -> Self {
+        Self { key: value.key, offset: value.offset }
+    }
+}
+
+impl From<dto::TracingResult> for TracingResult {
+    fn from(value: dto::TracingResult) -> Self {
+        Self {
+            retriggers: value
+                .retriggers
+                .into_iter()
+                .map(|(addr, loc)| (addr, loc.into()))
+                .collect(),
+            accessed_slots: value.accessed_slots,
+        }
+    }
+}
+
+impl From<dto::DCIUpdate> for DCIUpdate {
+    fn from(value: dto::DCIUpdate) -> Self {
+        Self {
+            new_entrypoints: value
+                .new_entrypoints
+                .into_iter()
+                .map(|(k, v)| {
+                    (
+                        k,
+                        v.into_iter()
+                            .map(EntryPoint::from)
+                            .collect(),
+                    )
+                })
+                .collect(),
+            new_entrypoint_params: value
+                .new_entrypoint_params
+                .into_iter()
+                .map(|(k, v)| {
+                    (
+                        k,
+                        v.into_iter()
+                            .map(|(p, c)| (TracingParams::from(p), c))
+                            .collect(),
+                    )
+                })
+                .collect(),
+            trace_results: value
+                .trace_results
+                .into_iter()
+                .map(|(k, v)| (k, TracingResult::from(v)))
+                .collect(),
+        }
+    }
+}
+
+impl From<dto::BlockChanges> for BlockAggregatedChanges {
+    fn from(value: dto::BlockChanges) -> Self {
+        use crate::models::{
+            contract::{AccountBalance, AccountDelta},
+            protocol::{ComponentBalance, ProtocolComponent, ProtocolComponentStateDelta},
+            token::Token,
+        };
+        Self {
+            extractor: value.extractor,
+            chain: value.chain.into(),
+            block: value.block.into(),
+            finalized_block_height: value.finalized_block_height,
+            db_committed_block_height: None,
+            revert: value.revert,
+            state_deltas: value
+                .state_updates
+                .into_iter()
+                .map(|(k, v)| (k, ProtocolComponentStateDelta::from(v)))
+                .collect(),
+            account_deltas: value
+                .account_updates
+                .into_iter()
+                .map(|(k, v)| (k, AccountDelta::from(v)))
+                .collect(),
+            new_tokens: value
+                .new_tokens
+                .into_iter()
+                .map(|(k, v)| (k, Token::from(v)))
+                .collect(),
+            new_protocol_components: value
+                .new_protocol_components
+                .into_iter()
+                .map(|(k, v)| (k, ProtocolComponent::from(v)))
+                .collect(),
+            deleted_protocol_components: value
+                .deleted_protocol_components
+                .into_iter()
+                .map(|(k, v)| (k, ProtocolComponent::from(v)))
+                .collect(),
+            component_balances: value
+                .component_balances
+                .into_iter()
+                .map(|(component_id, token_balances)| {
+                    (
+                        component_id,
+                        token_balances
+                            .0
+                            .into_iter()
+                            .map(|(k, v)| (k, ComponentBalance::from(v)))
+                            .collect(),
+                    )
+                })
+                .collect(),
+            account_balances: value
+                .account_balances
+                .into_iter()
+                .map(|(account, balances)| {
+                    (
+                        account,
+                        balances
+                            .into_iter()
+                            .map(|(k, v)| (k, AccountBalance::from(v)))
+                            .collect(),
+                    )
+                })
+                .collect(),
+            component_tvl: value.component_tvl,
+            dci_update: DCIUpdate::from(value.dci_update),
+            partial_block_index: value.partial_block_index,
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, DeepSizeOf)]
 pub struct DCIUpdate {
     pub new_entrypoints: HashMap<ComponentId, HashSet<EntryPoint>>,
     pub new_entrypoint_params: HashMap<EntryPointId, HashSet<(TracingParams, ComponentId)>>,
     pub trace_results: HashMap<EntryPointId, TracingResult>,
+}
+
+/// Traced entry points for a set of components, as returned by the Tycho RPC.
+///
+/// Maps each component ID to the list of `(EntryPointWithTracingParams, TracingResult)` pairs
+/// produced by the tracer for that component.
+pub type TracedEntryPoints =
+    HashMap<ComponentId, Vec<(EntryPointWithTracingParams, TracingResult)>>;
+
+impl From<TracedEntryPoints> for DCIUpdate {
+    fn from(traced_entry_points: TracedEntryPoints) -> Self {
+        let mut new_entrypoints: HashMap<ComponentId, HashSet<EntryPoint>> = HashMap::new();
+        let mut new_entrypoint_params: HashMap<
+            EntryPointId,
+            HashSet<(TracingParams, ComponentId)>,
+        > = HashMap::new();
+        let mut trace_results: HashMap<EntryPointId, TracingResult> = HashMap::new();
+
+        for (component_id, traces) in traced_entry_points {
+            let mut entrypoints = HashSet::new();
+
+            for (ep_with_params, trace) in traces {
+                let ep_id = ep_with_params
+                    .entry_point
+                    .external_id
+                    .clone();
+
+                entrypoints.insert(ep_with_params.entry_point.clone());
+
+                new_entrypoint_params
+                    .entry(ep_id.clone())
+                    .or_default()
+                    .insert((ep_with_params.params, component_id.clone()));
+
+                trace_results
+                    .entry(ep_id)
+                    .and_modify(|existing: &mut TracingResult| {
+                        existing
+                            .retriggers
+                            .extend(trace.retriggers.clone());
+                        for (address, slots) in trace.accessed_slots.clone() {
+                            existing
+                                .accessed_slots
+                                .entry(address)
+                                .or_default()
+                                .extend(slots);
+                        }
+                    })
+                    .or_insert(trace);
+            }
+
+            if !entrypoints.is_empty() {
+                new_entrypoints.insert(component_id, entrypoints);
+            }
+        }
+
+        DCIUpdate { new_entrypoints, new_entrypoint_params, trace_results }
+    }
 }
 
 /// Changes grouped by their respective transaction.

--- a/crates/tycho-common/src/models/blockchain.rs
+++ b/crates/tycho-common/src/models/blockchain.rs
@@ -326,8 +326,8 @@ impl From<dto::DCIUpdate> for DCIUpdate {
     }
 }
 
-impl From<dto::BlockChanges> for BlockAggregatedChanges {
-    fn from(value: dto::BlockChanges) -> Self {
+impl From<dto::BlockAggregatedChanges> for BlockAggregatedChanges {
+    fn from(value: dto::BlockAggregatedChanges) -> Self {
         use crate::models::{
             contract::{AccountBalance, AccountDelta},
             protocol::{ComponentBalance, ProtocolComponent, ProtocolComponentStateDelta},

--- a/crates/tycho-common/src/models/contract.rs
+++ b/crates/tycho-common/src/models/contract.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use crate::{
-    keccak256,
+    dto, keccak256,
     models::{
         blockchain::Transaction, Address, Balance, Chain, ChangeType, Code, CodeHash, ContractId,
         ContractStore, ContractStoreDeltas, MergeError, StoreKey, TxHash,
@@ -343,6 +343,72 @@ impl ContractChanges {
 
 /// Multiple binary key-value stores grouped by account address.
 pub type AccountToContractChanges = HashMap<Address, ContractChanges>;
+
+impl From<dto::AccountBalance> for AccountBalance {
+    fn from(value: dto::AccountBalance) -> Self {
+        Self {
+            token: value.token,
+            balance: value.balance,
+            modify_tx: value.modify_tx,
+            account: value.account,
+        }
+    }
+}
+
+impl From<dto::AccountUpdate> for AccountDelta {
+    fn from(value: dto::AccountUpdate) -> Self {
+        // Client receives zero-value writes, not explicit deletions via WS,
+        // so all slot values are treated as Some(v).
+        AccountDelta::new(
+            value.chain.into(),
+            value.address,
+            value
+                .slots
+                .into_iter()
+                .map(|(k, v)| (k, Some(v)))
+                .collect(),
+            value.balance,
+            value.code,
+            value.change.into(),
+        )
+    }
+}
+
+#[allow(deprecated)] // creation_tx field on ResponseAccount is deprecated
+impl From<dto::ResponseAccount> for Account {
+    fn from(value: dto::ResponseAccount) -> Self {
+        // Snapshot responses don't carry per-balance modify_tx; use zero as placeholder.
+        let token_balances = value
+            .token_balances
+            .into_iter()
+            .map(|(token, balance)| {
+                let acct = value.address.clone();
+                (
+                    token.clone(),
+                    AccountBalance {
+                        token,
+                        balance,
+                        modify_tx: crate::Bytes::zero(32),
+                        account: acct,
+                    },
+                )
+            })
+            .collect();
+        Account::new(
+            value.chain.into(),
+            value.address,
+            value.title,
+            value.slots,
+            value.native_balance,
+            token_balances,
+            value.code,
+            value.code_hash,
+            value.balance_modify_tx,
+            value.code_modify_tx,
+            value.creation_tx,
+        )
+    }
+}
 
 #[cfg(test)]
 mod test {

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -114,6 +114,17 @@ impl From<dto::Chain> for Chain {
     }
 }
 
+impl From<dto::ChangeType> for ChangeType {
+    fn from(value: dto::ChangeType) -> Self {
+        match value {
+            dto::ChangeType::Update => ChangeType::Update,
+            dto::ChangeType::Creation => ChangeType::Creation,
+            dto::ChangeType::Deletion => ChangeType::Deletion,
+            dto::ChangeType::Unspecified => ChangeType::Update,
+        }
+    }
+}
+
 fn native_eth(chain: Chain) -> Token {
     Token::new(
         &Bytes::from_str("0x0000000000000000000000000000000000000000").unwrap(),

--- a/crates/tycho-common/src/models/protocol.rs
+++ b/crates/tycho-common/src/models/protocol.rs
@@ -9,6 +9,7 @@ use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    dto,
     models::{
         token::Token, Address, AttrStoreKey, Balance, Chain, ChangeType, ComponentId, MergeError,
         StoreVal, TxHash,
@@ -264,6 +265,55 @@ pub struct GetAmountOutParams {
     pub token_out: Bytes,
     pub sender: Bytes,
     pub receiver: Bytes,
+}
+
+impl From<dto::ProtocolStateDelta> for ProtocolComponentStateDelta {
+    fn from(value: dto::ProtocolStateDelta) -> Self {
+        Self {
+            component_id: value.component_id,
+            updated_attributes: value.updated_attributes,
+            deleted_attributes: value.deleted_attributes,
+        }
+    }
+}
+
+impl From<dto::ComponentBalance> for ComponentBalance {
+    fn from(value: dto::ComponentBalance) -> Self {
+        Self {
+            token: value.token,
+            balance: value.balance,
+            balance_float: value.balance_float,
+            modify_tx: value.modify_tx,
+            component_id: value.component_id,
+        }
+    }
+}
+
+impl From<dto::ProtocolComponent> for ProtocolComponent {
+    fn from(value: dto::ProtocolComponent) -> Self {
+        Self {
+            id: value.id,
+            protocol_system: value.protocol_system,
+            protocol_type_name: value.protocol_type_name,
+            chain: value.chain.into(),
+            tokens: value.tokens,
+            contract_addresses: value.contract_ids,
+            static_attributes: value.static_attributes,
+            change: value.change.into(),
+            creation_tx: value.creation_tx,
+            created_at: value.created_at,
+        }
+    }
+}
+
+impl From<dto::ResponseProtocolState> for ProtocolComponentState {
+    fn from(value: dto::ResponseProtocolState) -> Self {
+        Self {
+            component_id: value.component_id,
+            attributes: value.attributes,
+            balances: value.balances,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/tycho-common/src/models/token.rs
+++ b/crates/tycho-common/src/models/token.rs
@@ -104,19 +104,17 @@ impl From<Arc<Token>> for Address {
     }
 }
 
-impl TryFrom<ResponseToken> for Token {
-    type Error = ();
-
-    fn try_from(value: ResponseToken) -> Result<Self, Self::Error> {
-        Ok(Self {
+impl From<ResponseToken> for Token {
+    fn from(value: ResponseToken) -> Self {
+        Self {
+            chain: value.chain.into(),
             address: value.address,
+            symbol: value.symbol,
             decimals: value.decimals,
-            symbol: value.symbol.to_string(),
-            gas: value.gas,
-            chain: Chain::from(value.chain),
             tax: value.tax,
+            gas: value.gas,
             quality: value.quality,
-        })
+        }
     }
 }
 

--- a/crates/tycho-indexer/src/services/ws.rs
+++ b/crates/tycho-indexer/src/services/ws.rs
@@ -13,7 +13,7 @@ use actix_web_actors::ws;
 use metrics::{counter, gauge};
 use tracing::{debug, error, info, instrument, trace, warn};
 use tycho_common::{
-    dto::{BlockChanges, Command, Response, WebSocketMessage},
+    dto::{BlockAggregatedChanges, Command, Response, WebSocketMessage},
     models::{error::WebsocketError, ExtractorIdentity},
 };
 use uuid::Uuid;
@@ -419,18 +419,18 @@ impl Actor for WsActor {
 }
 
 /// Handle incoming messages from the extractor and forward them to the WS connection
-impl StreamHandler<Result<(Uuid, BlockChanges), ws::ProtocolError>> for WsActor {
+impl StreamHandler<Result<(Uuid, BlockAggregatedChanges), ws::ProtocolError>> for WsActor {
     #[instrument(skip_all, fields(WsActor.id = %self.id))]
     fn handle(
         &mut self,
-        msg: Result<(Uuid, BlockChanges), ws::ProtocolError>,
+        msg: Result<(Uuid, BlockAggregatedChanges), ws::ProtocolError>,
         ctx: &mut Self::Context,
     ) {
         trace!("Message received from extractor");
         match msg {
             Ok((subscription_id, deltas)) => {
                 trace!("Forwarding message to client");
-                let msg = WebSocketMessage::BlockChanges { deltas, subscription_id };
+                let msg = WebSocketMessage::BlockAggregatedChanges { deltas, subscription_id };
                 let json_str = serde_json::to_string(&msg).unwrap();
 
                 // Check if compression is enabled for this subscription
@@ -580,7 +580,7 @@ mod tests {
     };
     use tracing::{debug, info_span, Instrument};
     use tycho_common::{
-        dto::{BlockChanges, Response},
+        dto::{BlockAggregatedChanges, Response},
         models::{
             blockchain::{Block, BlockAggregatedChanges},
             Chain,
@@ -742,7 +742,7 @@ mod tests {
     struct DummyDelta {
         #[allow(dead_code)]
         subscription_id: Uuid,
-        deltas: BlockChanges,
+        deltas: BlockAggregatedChanges,
     }
 
     async fn wait_for_dummy_message(

--- a/crates/tycho-indexer/src/services/ws.rs
+++ b/crates/tycho-indexer/src/services/ws.rs
@@ -580,7 +580,7 @@ mod tests {
     };
     use tracing::{debug, info_span, Instrument};
     use tycho_common::{
-        dto::Response,
+        dto::{BlockAggregatedChanges as DtoBlockAggregatedChanges, Response},
         models::{
             blockchain::{Block, BlockAggregatedChanges},
             Chain,
@@ -742,7 +742,7 @@ mod tests {
     struct DummyDelta {
         #[allow(dead_code)]
         subscription_id: Uuid,
-        deltas: BlockAggregatedChanges,
+        deltas: DtoBlockAggregatedChanges,
     }
 
     async fn wait_for_dummy_message(

--- a/crates/tycho-indexer/src/services/ws.rs
+++ b/crates/tycho-indexer/src/services/ws.rs
@@ -580,7 +580,7 @@ mod tests {
     };
     use tracing::{debug, info_span, Instrument};
     use tycho_common::{
-        dto::{BlockAggregatedChanges, Response},
+        dto::Response,
         models::{
             blockchain::{Block, BlockAggregatedChanges},
             Chain,

--- a/crates/tycho-indexer/src/services/ws.rs
+++ b/crates/tycho-indexer/src/services/ws.rs
@@ -580,7 +580,7 @@ mod tests {
     };
     use tracing::{debug, info_span, Instrument};
     use tycho_common::{
-        dto::{BlockAggregatedChanges as DtoBlockAggregatedChanges, Response},
+        dto::{self, Response},
         models::{
             blockchain::{Block, BlockAggregatedChanges},
             Chain,
@@ -742,7 +742,7 @@ mod tests {
     struct DummyDelta {
         #[allow(dead_code)]
         subscription_id: Uuid,
-        deltas: DtoBlockAggregatedChanges,
+        deltas: dto::BlockAggregatedChanges,
     }
 
     async fn wait_for_dummy_message(

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -1160,13 +1160,13 @@ mod tests {
     fn load_test_msg(name: &str) -> FeedMessage<BlockHeader> {
         use std::{fs, path::Path};
 
-        use tycho_client::feed::dto::FeedMessage as DtoFeedMessage;
+        use tycho_client::feed::dto;
         let project_root = env!("CARGO_MANIFEST_DIR");
         let asset_path = Path::new(project_root).join(format!("tests/assets/decoder/{name}.json"));
         let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
-        let dto: DtoFeedMessage<BlockHeader> =
+        let feed_msg: dto::FeedMessage<BlockHeader> =
             serde_json::from_str(&json_data).expect("Failed to deserialize FeedMsg json!");
-        FeedMessage::from(dto)
+        FeedMessage::from(feed_msg)
     }
 
     #[tokio::test]

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -327,10 +327,7 @@ where
                     .get_vm_storage()
                     .iter()
                 {
-                    let account: ResponseAccount = value
-                        .clone()
-                        .try_into()
-                        .map_err(|e| StreamDecodeError::Fatal(format!("{e}")))?;
+                    let account: ResponseAccount = value.clone().into();
 
                     if state_guard.tokens.contains_key(key) {
                         let original_address = account.address;

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -1160,17 +1160,18 @@ mod tests {
         decoder
     }
 
-    fn load_test_msg(_name: &str) -> FeedMessage<BlockHeader> {
-        // TODO: FeedMessage no longer implements Deserialize because ComponentWithState::state is
-        // now ProtocolComponentState (a model type without serde), breaking JSON deserialization
-        // from test assets. These tests need to be rewritten to construct FeedMessage directly
-        // rather than deserializing from JSON fixtures.
-        unimplemented!("FeedMessage deserialization from JSON is no longer supported")
+    fn load_test_msg(name: &str) -> FeedMessage<BlockHeader> {
+        use std::{fs, path::Path};
+        use tycho_client::feed::dto::FeedMessageDto;
+        let project_root = env!("CARGO_MANIFEST_DIR");
+        let asset_path =
+            Path::new(project_root).join(format!("tests/assets/decoder/{name}.json"));
+        let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
+        let dto: FeedMessageDto<BlockHeader> =
+            serde_json::from_str(&json_data).expect("Failed to deserialize FeedMsg json!");
+        FeedMessage::from(dto)
     }
 
-    // TODO: test needs rewriting to construct FeedMessage directly; JSON deserialization no
-    // longer works because ProtocolComponentState doesn't implement Deserialize.
-    #[ignore]
     #[tokio::test]
     async fn test_decode() {
         let decoder = setup_decoder(true).await;
@@ -1192,9 +1193,6 @@ mod tests {
         assert_eq!(res2.sync_states.len(), 1);
     }
 
-    // TODO: test needs rewriting to construct FeedMessage directly; JSON deserialization no
-    // longer works because ProtocolComponentState doesn't implement Deserialize.
-    #[ignore]
     #[tokio::test]
     async fn test_decode_component_missing_token() {
         let decoder = setup_decoder(false).await;
@@ -1219,9 +1217,6 @@ mod tests {
         assert_eq!(res1.states.len(), 0);
     }
 
-    // TODO: test needs rewriting to construct FeedMessage directly; JSON deserialization no
-    // longer works because ProtocolComponentState doesn't implement Deserialize.
-    #[ignore]
     #[tokio::test]
     async fn test_decode_component_bad_id() {
         let decoder = setup_decoder(true).await;
@@ -1237,12 +1232,9 @@ mod tests {
         }
     }
 
-    // TODO: test needs rewriting to construct FeedMessage directly; JSON deserialization no
-    // longer works because ProtocolComponentState doesn't implement Deserialize.
     #[rstest]
     #[case(true)]
     #[case(false)]
-    #[ignore]
     #[tokio::test]
     async fn test_decode_component_bad_state(#[case] skip_failures: bool) {
         let mut decoder = setup_decoder(true).await;
@@ -1267,9 +1259,6 @@ mod tests {
         }
     }
 
-    // TODO: test needs rewriting to construct FeedMessage directly; JSON deserialization no
-    // longer works because ProtocolComponentState doesn't implement Deserialize.
-    #[ignore]
     #[tokio::test]
     async fn test_decode_updates_state_on_contract_change() {
         let decoder = setup_decoder(true).await;
@@ -1338,9 +1327,6 @@ mod tests {
         assert_eq!(generated_address, address!("00000000000000000000000000001e240badbabe"));
     }
 
-    // TODO: test needs rewriting to construct FeedMessage directly; JSON deserialization no
-    // longer works because ProtocolComponentState doesn't implement Deserialize.
-    #[ignore]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_euler_hook_low_pool_manager_balance() {
         let mut decoder = TychoStreamDecoder::new();

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -1162,10 +1162,10 @@ mod tests {
 
     fn load_test_msg(name: &str) -> FeedMessage<BlockHeader> {
         use std::{fs, path::Path};
+
         use tycho_client::feed::dto::FeedMessage as DtoFeedMessage;
         let project_root = env!("CARGO_MANIFEST_DIR");
-        let asset_path =
-            Path::new(project_root).join(format!("tests/assets/decoder/{name}.json"));
+        let asset_path = Path::new(project_root).join(format!("tests/assets/decoder/{name}.json"));
         let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
         let dto: DtoFeedMessage<BlockHeader> =
             serde_json::from_str(&json_data).expect("Failed to deserialize FeedMsg json!");

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -1162,12 +1162,12 @@ mod tests {
 
     fn load_test_msg(name: &str) -> FeedMessage<BlockHeader> {
         use std::{fs, path::Path};
-        use tycho_client::feed::dto::FeedMessageDto;
+        use tycho_client::feed::dto::FeedMessage as DtoFeedMessage;
         let project_root = env!("CARGO_MANIFEST_DIR");
         let asset_path =
             Path::new(project_root).join(format!("tests/assets/decoder/{name}.json"));
         let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
-        let dto: FeedMessageDto<BlockHeader> =
+        let dto: DtoFeedMessage<BlockHeader> =
             serde_json::from_str(&json_data).expect("Failed to deserialize FeedMsg json!");
         FeedMessage::from(dto)
     }

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -259,16 +259,7 @@ where
                         t.quality >= self.min_token_quality &&
                             !state_guard.tokens.contains_key(*addr)
                     })
-                    .filter_map(|(addr, t)| {
-                        t.clone()
-                            .try_into()
-                            .map(|token| (addr.clone(), token))
-                            .inspect_err(|e| {
-                                warn!("Failed decoding token {e:?} {addr:#044x}");
-                                *e
-                            })
-                            .ok()
-                    })
+                    .map(|(addr, t)| (addr.clone(), t.clone()))
                     .collect::<HashMap<Bytes, Token>>();
 
                 if !new_tokens.is_empty() {
@@ -364,7 +355,7 @@ where
                                 // tracked again.
                                 let proxy_state = AccountUpdate::new(
                                     original_address,
-                                    value.chain.into(),
+                                    value.chain,
                                     account.slots.clone(),
                                     Some(account.native_balance),
                                     None,
@@ -388,7 +379,7 @@ where
                                     original_address,
                                     Some(impl_addr),
                                     &account.slots,
-                                    value.chain.into(),
+                                    value.chain,
                                     Some(account.native_balance),
                                 );
 
@@ -453,10 +444,14 @@ where
                 .get_vm_storage()
                 .iter()
                 .filter_map(|(addr, acc)| {
-                    let balances = acc.token_balances.clone();
-                    if balances.is_empty() {
+                    if acc.token_balances.is_empty() {
                         return None;
                     }
+                    let balances = acc
+                        .token_balances
+                        .iter()
+                        .map(|(token_addr, ab)| (token_addr.clone(), ab.balance.clone()))
+                        .collect::<HashMap<Bytes, Bytes>>();
                     Some((addr.clone(), balances))
                 })
                 .collect::<AccountBalances>();
@@ -515,7 +510,7 @@ where
                                             token_address,
                                             None,
                                             &HashMap::new(),
-                                            snapshot.component.chain.into(),
+                                            snapshot.component.chain,
                                             None,
                                         ),
                                     );
@@ -640,11 +635,8 @@ where
                 let mut account_update_by_address: HashMap<Address, AccountUpdate> = HashMap::new();
                 // New proxy token accounts that must overwrite any existing placeholder.
                 let mut new_proxy_accounts: Vec<AccountUpdate> = Vec::new();
-                for (key, value) in deltas.account_updates.iter() {
-                    let mut update: AccountUpdate = value
-                        .clone()
-                        .try_into()
-                        .map_err(|e| StreamDecodeError::Fatal(format!("{e}")))?;
+                for (key, value) in deltas.account_deltas.iter() {
+                    let mut update: AccountUpdate = value.clone().into();
 
                     // TEMP PATCH (ENG-4993)
                     //
@@ -726,7 +718,7 @@ where
                 drop(state_guard);
 
                 let state_guard = self.state.read().await;
-                info!("Updating engine with {} contract deltas", deltas.account_updates.len());
+                info!("Updating engine with {} contract deltas", deltas.account_deltas.len());
                 update_engine(
                     SHARED_TYCHO_DB.clone(),
                     header.clone().block(),
@@ -746,7 +738,7 @@ where
 
                 // Collect all pools related to the updated accounts
                 let mut pools_to_update = HashSet::new();
-                for (account, _update) in deltas.account_updates {
+                for (account, _update) in deltas.account_deltas {
                     // get new pools related to the account updated
                     pools_to_update.extend(
                         contracts_map
@@ -771,7 +763,7 @@ where
                         .iter()
                         .map(|(pool_id, bals)| {
                             let mut balances = HashMap::new();
-                            for (t, b) in &bals.0 {
+                            for (t, b) in bals {
                                 balances.insert(t.clone(), b.balance.clone());
                             }
                             pools_to_update.insert(pool_id.clone());
@@ -798,10 +790,12 @@ where
                 };
 
                 // update states with protocol state deltas (attribute changes etc.)
-                for (id, update) in deltas.state_updates {
+                for (id, update) in deltas.state_deltas {
                     // TODO: is this needed?
-                    let update_with_block =
-                        Self::add_block_info_to_delta(update, current_block.clone());
+                    let update_with_block = Self::add_block_info_to_delta(
+                        ProtocolStateDelta::from(update),
+                        current_block.clone(),
+                    );
                     match Self::apply_update(
                         &id,
                         update_with_block,
@@ -1133,7 +1127,7 @@ impl ProtocolSim for MockProtocolSim {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, path::Path, str::FromStr};
+    use std::str::FromStr;
 
     use alloy::primitives::address;
     use mockall::predicate::*;
@@ -1166,13 +1160,17 @@ mod tests {
         decoder
     }
 
-    fn load_test_msg(name: &str) -> FeedMessage<BlockHeader> {
-        let project_root = env!("CARGO_MANIFEST_DIR");
-        let asset_path = Path::new(project_root).join(format!("tests/assets/decoder/{name}.json"));
-        let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
-        serde_json::from_str(&json_data).expect("Failed to deserialize FeedMsg json!")
+    fn load_test_msg(_name: &str) -> FeedMessage<BlockHeader> {
+        // TODO: FeedMessage no longer implements Deserialize because ComponentWithState::state is
+        // now ProtocolComponentState (a model type without serde), breaking JSON deserialization
+        // from test assets. These tests need to be rewritten to construct FeedMessage directly
+        // rather than deserializing from JSON fixtures.
+        unimplemented!("FeedMessage deserialization from JSON is no longer supported")
     }
 
+    // TODO: test needs rewriting to construct FeedMessage directly; JSON deserialization no
+    // longer works because ProtocolComponentState doesn't implement Deserialize.
+    #[ignore]
     #[tokio::test]
     async fn test_decode() {
         let decoder = setup_decoder(true).await;
@@ -1194,6 +1192,9 @@ mod tests {
         assert_eq!(res2.sync_states.len(), 1);
     }
 
+    // TODO: test needs rewriting to construct FeedMessage directly; JSON deserialization no
+    // longer works because ProtocolComponentState doesn't implement Deserialize.
+    #[ignore]
     #[tokio::test]
     async fn test_decode_component_missing_token() {
         let decoder = setup_decoder(false).await;
@@ -1218,6 +1219,9 @@ mod tests {
         assert_eq!(res1.states.len(), 0);
     }
 
+    // TODO: test needs rewriting to construct FeedMessage directly; JSON deserialization no
+    // longer works because ProtocolComponentState doesn't implement Deserialize.
+    #[ignore]
     #[tokio::test]
     async fn test_decode_component_bad_id() {
         let decoder = setup_decoder(true).await;
@@ -1233,9 +1237,12 @@ mod tests {
         }
     }
 
+    // TODO: test needs rewriting to construct FeedMessage directly; JSON deserialization no
+    // longer works because ProtocolComponentState doesn't implement Deserialize.
     #[rstest]
     #[case(true)]
     #[case(false)]
+    #[ignore]
     #[tokio::test]
     async fn test_decode_component_bad_state(#[case] skip_failures: bool) {
         let mut decoder = setup_decoder(true).await;
@@ -1260,6 +1267,9 @@ mod tests {
         }
     }
 
+    // TODO: test needs rewriting to construct FeedMessage directly; JSON deserialization no
+    // longer works because ProtocolComponentState doesn't implement Deserialize.
+    #[ignore]
     #[tokio::test]
     async fn test_decode_updates_state_on_contract_change() {
         let decoder = setup_decoder(true).await;
@@ -1328,6 +1338,9 @@ mod tests {
         assert_eq!(generated_address, address!("00000000000000000000000000001e240badbabe"));
     }
 
+    // TODO: test needs rewriting to construct FeedMessage directly; JSON deserialization no
+    // longer works because ProtocolComponentState doesn't implement Deserialize.
+    #[ignore]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_euler_hook_low_pool_manager_balance() {
         let mut decoder = TychoStreamDecoder::new();

--- a/crates/tycho-simulation/src/evm/protocol/aerodrome_v1/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/aerodrome_v1/decoder.rs
@@ -113,12 +113,18 @@ mod tests {
                     ("reserve1".to_string(), Bytes::from(vec![0; 32])),
                 ]),
                 balances: HashMap::new(),
-            },
-            component: tycho_common::dto::ProtocolComponent {
-                tokens: vec![token0, token1],
-                static_attributes: HashMap::from([("is_stable".to_string(), Bytes::from(vec![0]))]),
-                ..Default::default()
-            },
+            }
+            .into(),
+            component: tycho_common::models::protocol::ProtocolComponent::from(
+                tycho_common::dto::ProtocolComponent {
+                    tokens: vec![token0, token1],
+                    static_attributes: HashMap::from([(
+                        "is_stable".to_string(),
+                        Bytes::from(vec![0]),
+                    )]),
+                    ..Default::default()
+                },
+            ),
             component_tvl: None,
             entrypoints: Vec::new(),
         };
@@ -167,12 +173,15 @@ mod tests {
                 component_id: "State1".to_owned(),
                 attributes,
                 balances: HashMap::new(),
-            },
-            component: tycho_common::dto::ProtocolComponent {
-                tokens: vec![token0, token1],
-                static_attributes,
-                ..Default::default()
-            },
+            }
+            .into(),
+            component: tycho_common::models::protocol::ProtocolComponent::from(
+                tycho_common::dto::ProtocolComponent {
+                    tokens: vec![token0, token1],
+                    static_attributes,
+                    ..Default::default()
+                },
+            ),
             component_tvl: None,
             entrypoints: Vec::new(),
         };
@@ -205,12 +214,18 @@ mod tests {
                     ("fee".to_string(), Bytes::from(10_001_u32.to_be_bytes().to_vec())),
                 ]),
                 balances: HashMap::new(),
-            },
-            component: tycho_common::dto::ProtocolComponent {
-                tokens: vec![token0, token1],
-                static_attributes: HashMap::from([("is_stable".to_string(), Bytes::from(vec![0]))]),
-                ..Default::default()
-            },
+            }
+            .into(),
+            component: tycho_common::models::protocol::ProtocolComponent::from(
+                tycho_common::dto::ProtocolComponent {
+                    tokens: vec![token0, token1],
+                    static_attributes: HashMap::from([(
+                        "is_stable".to_string(),
+                        Bytes::from(vec![0]),
+                    )]),
+                    ..Default::default()
+                },
+            ),
             component_tvl: None,
             entrypoints: Vec::new(),
         };
@@ -238,12 +253,18 @@ mod tests {
                     ("fee".to_string(), Bytes::from(420_u32.to_be_bytes().to_vec())),
                 ]),
                 balances: HashMap::new(),
-            },
-            component: tycho_common::dto::ProtocolComponent {
-                tokens: vec![token0, token1],
-                static_attributes: HashMap::from([("is_stable".to_string(), Bytes::from(vec![1]))]),
-                ..Default::default()
-            },
+            }
+            .into(),
+            component: tycho_common::models::protocol::ProtocolComponent::from(
+                tycho_common::dto::ProtocolComponent {
+                    tokens: vec![token0, token1],
+                    static_attributes: HashMap::from([(
+                        "is_stable".to_string(),
+                        Bytes::from(vec![1]),
+                    )]),
+                    ..Default::default()
+                },
+            ),
             component_tvl: None,
             entrypoints: Vec::new(),
         };

--- a/crates/tycho-simulation/src/evm/protocol/aerodrome_v1/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/aerodrome_v1/decoder.rs
@@ -78,8 +78,7 @@ mod tests {
     use rstest::rstest;
     use tycho_client::feed::synchronizer::ComponentWithState;
     use tycho_common::{
-        dto::ResponseProtocolState,
-        models::{token::Token, Chain},
+        models::{protocol::ProtocolComponentState, token::Token, Chain},
         simulation::protocol_sim::ProtocolSim,
         Bytes,
     };
@@ -106,25 +105,19 @@ mod tests {
     async fn test_aerodrome_v1_try_from() {
         let (token0, token1) = token_keys();
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 component_id: "State1".to_owned(),
                 attributes: HashMap::from([
                     ("reserve0".to_string(), Bytes::from(vec![0; 32])),
                     ("reserve1".to_string(), Bytes::from(vec![0; 32])),
                 ]),
                 balances: HashMap::new(),
-            }
-            .into(),
-            component: tycho_common::models::protocol::ProtocolComponent::from(
-                tycho_common::dto::ProtocolComponent {
-                    tokens: vec![token0, token1],
-                    static_attributes: HashMap::from([(
-                        "is_stable".to_string(),
-                        Bytes::from(vec![0]),
-                    )]),
-                    ..Default::default()
-                },
-            ),
+            },
+            component: tycho_common::models::protocol::ProtocolComponent {
+                tokens: vec![token0, token1],
+                static_attributes: HashMap::from([("is_stable".to_string(), Bytes::from(vec![0]))]),
+                ..Default::default()
+            },
             component_tvl: None,
             entrypoints: Vec::new(),
         };
@@ -169,19 +162,16 @@ mod tests {
         }
 
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 component_id: "State1".to_owned(),
                 attributes,
                 balances: HashMap::new(),
-            }
-            .into(),
-            component: tycho_common::models::protocol::ProtocolComponent::from(
-                tycho_common::dto::ProtocolComponent {
-                    tokens: vec![token0, token1],
-                    static_attributes,
-                    ..Default::default()
-                },
-            ),
+            },
+            component: tycho_common::models::protocol::ProtocolComponent {
+                tokens: vec![token0, token1],
+                static_attributes,
+                ..Default::default()
+            },
             component_tvl: None,
             entrypoints: Vec::new(),
         };
@@ -206,7 +196,7 @@ mod tests {
     async fn test_aerodrome_v1_try_from_invalid_fee() {
         let (token0, token1) = token_keys();
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 component_id: "State1".to_owned(),
                 attributes: HashMap::from([
                     ("reserve0".to_string(), Bytes::from(vec![0; 32])),
@@ -214,18 +204,12 @@ mod tests {
                     ("fee".to_string(), Bytes::from(10_001_u32.to_be_bytes().to_vec())),
                 ]),
                 balances: HashMap::new(),
-            }
-            .into(),
-            component: tycho_common::models::protocol::ProtocolComponent::from(
-                tycho_common::dto::ProtocolComponent {
-                    tokens: vec![token0, token1],
-                    static_attributes: HashMap::from([(
-                        "is_stable".to_string(),
-                        Bytes::from(vec![0]),
-                    )]),
-                    ..Default::default()
-                },
-            ),
+            },
+            component: tycho_common::models::protocol::ProtocolComponent {
+                tokens: vec![token0, token1],
+                static_attributes: HashMap::from([("is_stable".to_string(), Bytes::from(vec![0]))]),
+                ..Default::default()
+            },
             component_tvl: None,
             entrypoints: Vec::new(),
         };
@@ -245,7 +229,7 @@ mod tests {
     async fn test_aerodrome_v1_try_from_zero_fee_indicator() {
         let (token0, token1) = token_keys();
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 component_id: "State1".to_owned(),
                 attributes: HashMap::from([
                     ("reserve0".to_string(), Bytes::from(vec![0; 32])),
@@ -253,18 +237,12 @@ mod tests {
                     ("fee".to_string(), Bytes::from(420_u32.to_be_bytes().to_vec())),
                 ]),
                 balances: HashMap::new(),
-            }
-            .into(),
-            component: tycho_common::models::protocol::ProtocolComponent::from(
-                tycho_common::dto::ProtocolComponent {
-                    tokens: vec![token0, token1],
-                    static_attributes: HashMap::from([(
-                        "is_stable".to_string(),
-                        Bytes::from(vec![1]),
-                    )]),
-                    ..Default::default()
-                },
-            ),
+            },
+            component: tycho_common::models::protocol::ProtocolComponent {
+                tokens: vec![token0, token1],
+                static_attributes: HashMap::from([("is_stable".to_string(), Bytes::from(vec![1]))]),
+                ..Default::default()
+            },
             component_tvl: None,
             entrypoints: Vec::new(),
         };

--- a/crates/tycho-simulation/src/evm/protocol/cowamm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/cowamm/decoder.rs
@@ -2,7 +2,10 @@ use std::collections::HashMap;
 
 use alloy::primitives::U256;
 use tycho_client::feed::{synchronizer::ComponentWithState, BlockHeader};
-use tycho_common::{dto::ProtocolComponent, models::token::Token, Bytes};
+use tycho_common::{
+    models::{protocol::ProtocolComponent, token::Token},
+    Bytes,
+};
 
 use crate::{
     evm::protocol::cowamm::state::CowAMMState,
@@ -166,7 +169,7 @@ mod tests {
     #[tokio::test]
     async fn test_cowamm_try_from_with_block() {
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState { attributes: attributes(), ..Default::default() },
+            state: ResponseProtocolState { attributes: attributes(), ..Default::default() }.into(),
             component: component(),
             component_tvl: None,
             entrypoints: Vec::new(),
@@ -210,7 +213,8 @@ mod tests {
                 component_id: "State1".to_owned(),
                 attributes,
                 balances: HashMap::new(),
-            },
+            }
+            .into(),
             component,
             component_tvl: None,
             entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/cowamm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/cowamm/decoder.rs
@@ -161,7 +161,7 @@ pub fn state() -> CowAMMState {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
-    use tycho_common::dto::ResponseProtocolState;
+    use tycho_common::models::protocol::ProtocolComponentState;
 
     use super::*;
     use crate::evm::protocol::test_utils::try_decode_snapshot_with_defaults;
@@ -169,7 +169,11 @@ mod tests {
     #[tokio::test]
     async fn test_cowamm_try_from_with_block() {
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState { attributes: attributes(), ..Default::default() }.into(),
+            state: ProtocolComponentState {
+                component_id: String::new(),
+                attributes: attributes(),
+                balances: HashMap::new(),
+            },
             component: component(),
             component_tvl: None,
             entrypoints: Vec::new(),
@@ -209,12 +213,11 @@ mod tests {
         };
 
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 component_id: "State1".to_owned(),
                 attributes,
                 balances: HashMap::new(),
-            }
-            .into(),
+            },
             component,
             component_tvl: None,
             entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/ekubo/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ekubo/decoder.rs
@@ -208,8 +208,9 @@ mod tests {
             state: ResponseProtocolState {
                 attributes: case.state_attributes,
                 ..Default::default()
-            },
-            component: case.component,
+            }
+            .into(),
+            component: case.component.into(),
             component_tvl: None,
             entrypoints: Vec::new(),
         };
@@ -225,7 +226,8 @@ mod tests {
     #[tokio::test]
     async fn test_try_from_invalid(case: TestCase) {
         for missing_attribute in case.required_attributes {
-            let mut component = case.component.clone();
+            let mut component: tycho_common::models::protocol::ProtocolComponent =
+                case.component.clone().into();
             let mut attributes = case.state_attributes.clone();
 
             component
@@ -238,7 +240,8 @@ mod tests {
                     attributes,
                     component_id: Default::default(),
                     balances: Default::default(),
-                },
+                }
+                .into(),
                 component,
                 component_tvl: None,
                 entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/ekubo/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ekubo/decoder.rs
@@ -194,7 +194,7 @@ fn attribute<'a>(
 mod tests {
     use rstest::*;
     use rstest_reuse::apply;
-    use tycho_common::dto::ResponseProtocolState;
+    use tycho_common::models::protocol::ProtocolComponentState;
 
     use super::*;
     use crate::evm::protocol::{
@@ -205,12 +205,12 @@ mod tests {
     #[tokio::test]
     async fn test_try_from_with_header(case: TestCase) {
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
+                component_id: String::new(),
                 attributes: case.state_attributes,
-                ..Default::default()
-            }
-            .into(),
-            component: case.component.into(),
+                balances: HashMap::new(),
+            },
+            component: case.component,
             component_tvl: None,
             entrypoints: Vec::new(),
         };
@@ -226,8 +226,7 @@ mod tests {
     #[tokio::test]
     async fn test_try_from_invalid(case: TestCase) {
         for missing_attribute in case.required_attributes {
-            let mut component: tycho_common::models::protocol::ProtocolComponent =
-                case.component.clone().into();
+            let mut component = case.component.clone();
             let mut attributes = case.state_attributes.clone();
 
             component
@@ -236,12 +235,11 @@ mod tests {
             attributes.remove(&missing_attribute);
 
             let snapshot = ComponentWithState {
-                state: ResponseProtocolState {
+                state: ProtocolComponentState {
                     attributes,
-                    component_id: Default::default(),
-                    balances: Default::default(),
-                }
-                .into(),
+                    component_id: String::new(),
+                    balances: HashMap::new(),
+                },
                 component,
                 component_tvl: None,
                 entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/ekubo/test_cases.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ekubo/test_cases.rs
@@ -16,8 +16,7 @@ use num_bigint::BigUint;
 use rstest::*;
 use rstest_reuse::template;
 use tycho_common::{
-    dto::ProtocolComponent,
-    models::{token::Token, Chain},
+    models::{protocol::ProtocolComponent, token::Token, Chain},
     Bytes,
 };
 

--- a/crates/tycho-simulation/src/evm/protocol/ekubo_v3/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ekubo_v3/decoder.rs
@@ -360,7 +360,7 @@ fn has_no_swap_call_points(extension: Address) -> bool {
 mod tests {
     use rstest::*;
     use rstest_reuse::apply;
-    use tycho_common::dto::ResponseProtocolState;
+    use tycho_common::models::protocol::ProtocolComponentState;
 
     use super::*;
     use crate::evm::protocol::{
@@ -371,12 +371,12 @@ mod tests {
     #[tokio::test]
     async fn test_try_from_with_header(case: TestCase) {
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
+                component_id: String::new(),
                 attributes: case.state_attributes,
-                ..Default::default()
-            }
-            .into(),
-            component: case.component.into(),
+                balances: HashMap::new(),
+            },
+            component: case.component,
             component_tvl: None,
             entrypoints: Vec::new(),
         };
@@ -408,8 +408,7 @@ mod tests {
             EkuboV3State::BoostedFees(_) => return,
         };
 
-        let mut component: tycho_common::models::protocol::ProtocolComponent =
-            case.component.into();
+        let mut component = case.component;
         // Add legacy extension_id attribute (keeps real extension address since
         // the SDK validates it)
         component
@@ -435,8 +434,11 @@ mod tests {
             .collect();
 
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState { attributes: state_attributes, ..Default::default() }
-                .into(),
+            state: ProtocolComponentState {
+                component_id: String::new(),
+                attributes: state_attributes,
+                balances: HashMap::new(),
+            },
             component,
             component_tvl: None,
             entrypoints: Vec::new(),
@@ -453,8 +455,7 @@ mod tests {
     #[tokio::test]
     async fn test_try_from_invalid(case: TestCase) {
         for missing_attribute in case.required_attributes {
-            let mut component: tycho_common::models::protocol::ProtocolComponent =
-                case.component.clone().into();
+            let mut component = case.component.clone();
             let mut attributes = case.state_attributes.clone();
 
             component
@@ -463,12 +464,11 @@ mod tests {
             attributes.remove(&missing_attribute);
 
             let snapshot = ComponentWithState {
-                state: ResponseProtocolState {
+                state: ProtocolComponentState {
                     attributes,
-                    component_id: Default::default(),
-                    balances: Default::default(),
-                }
-                .into(),
+                    component_id: String::new(),
+                    balances: HashMap::new(),
+                },
                 component,
                 component_tvl: None,
                 entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/ekubo_v3/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ekubo_v3/decoder.rs
@@ -374,8 +374,9 @@ mod tests {
             state: ResponseProtocolState {
                 attributes: case.state_attributes,
                 ..Default::default()
-            },
-            component: case.component,
+            }
+            .into(),
+            component: case.component.into(),
             component_tvl: None,
             entrypoints: Vec::new(),
         };
@@ -407,7 +408,8 @@ mod tests {
             EkuboV3State::BoostedFees(_) => return,
         };
 
-        let mut component = case.component;
+        let mut component: tycho_common::models::protocol::ProtocolComponent =
+            case.component.into();
         // Add legacy extension_id attribute (keeps real extension address since
         // the SDK validates it)
         component
@@ -433,7 +435,8 @@ mod tests {
             .collect();
 
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState { attributes: state_attributes, ..Default::default() },
+            state: ResponseProtocolState { attributes: state_attributes, ..Default::default() }
+                .into(),
             component,
             component_tvl: None,
             entrypoints: Vec::new(),
@@ -450,7 +453,8 @@ mod tests {
     #[tokio::test]
     async fn test_try_from_invalid(case: TestCase) {
         for missing_attribute in case.required_attributes {
-            let mut component = case.component.clone();
+            let mut component: tycho_common::models::protocol::ProtocolComponent =
+                case.component.clone().into();
             let mut attributes = case.state_attributes.clone();
 
             component
@@ -463,7 +467,8 @@ mod tests {
                     attributes,
                     component_id: Default::default(),
                     balances: Default::default(),
-                },
+                }
+                .into(),
                 component,
                 component_tvl: None,
                 entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/ekubo_v3/test_cases.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ekubo_v3/test_cases.rs
@@ -27,8 +27,7 @@ use revm::primitives::{address, Address};
 use rstest::*;
 use rstest_reuse::template;
 use tycho_common::{
-    dto::ProtocolComponent,
-    models::{token::Token, Chain},
+    models::{protocol::ProtocolComponent, token::Token, Chain},
     Bytes,
 };
 

--- a/crates/tycho-simulation/src/evm/protocol/pancakeswap_v2/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/pancakeswap_v2/decoder.rs
@@ -55,7 +55,8 @@ mod tests {
                     ("reserve1".to_string(), Bytes::from(vec![0; 32])),
                 ]),
                 balances: HashMap::new(),
-            },
+            }
+            .into(),
             component: Default::default(),
             component_tvl: None,
             entrypoints: Vec::new(),
@@ -83,7 +84,8 @@ mod tests {
                 component_id: "State1".to_owned(),
                 attributes,
                 balances: HashMap::new(),
-            },
+            }
+            .into(),
             component: Default::default(),
             component_tvl: None,
             entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/pancakeswap_v2/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/pancakeswap_v2/decoder.rs
@@ -37,7 +37,7 @@ mod tests {
     use alloy::primitives::U256;
     use rstest::rstest;
     use tycho_client::feed::synchronizer::ComponentWithState;
-    use tycho_common::{dto::ResponseProtocolState, Bytes};
+    use tycho_common::{models::protocol::ProtocolComponentState, Bytes};
 
     use super::super::state::PancakeswapV2State;
     use crate::{
@@ -48,15 +48,14 @@ mod tests {
     #[tokio::test]
     async fn test_pancakeswap_v2_try_from() {
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 component_id: "State1".to_owned(),
                 attributes: HashMap::from([
                     ("reserve0".to_string(), Bytes::from(vec![0; 32])),
                     ("reserve1".to_string(), Bytes::from(vec![0; 32])),
                 ]),
                 balances: HashMap::new(),
-            }
-            .into(),
+            },
             component: Default::default(),
             component_tvl: None,
             entrypoints: Vec::new(),
@@ -80,12 +79,11 @@ mod tests {
         attributes.remove(missing_attribute);
 
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 component_id: "State1".to_owned(),
                 attributes,
                 balances: HashMap::new(),
-            }
-            .into(),
+            },
             component: Default::default(),
             component_tvl: None,
             entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/rocketpool/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/rocketpool/decoder.rs
@@ -131,7 +131,8 @@ mod tests {
                     ),
                 ]),
                 balances: HashMap::new(),
-            },
+            }
+            .into(),
             component: Default::default(),
             component_tvl: None,
             entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/rocketpool/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/rocketpool/decoder.rs
@@ -66,7 +66,7 @@ mod tests {
     use alloy::primitives::U256;
     use rstest::rstest;
     use tycho_client::feed::synchronizer::ComponentWithState;
-    use tycho_common::{dto::ResponseProtocolState, Bytes};
+    use tycho_common::{models::protocol::ProtocolComponentState, Bytes};
 
     use super::super::state::RocketpoolState;
     use crate::{
@@ -76,7 +76,7 @@ mod tests {
 
     fn create_test_snapshot() -> ComponentWithState {
         ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 component_id: "Rocketpool".to_owned(),
                 attributes: HashMap::from([
                     (
@@ -131,8 +131,7 @@ mod tests {
                     ),
                 ]),
                 balances: HashMap::new(),
-            }
-            .into(),
+            },
             component: Default::default(),
             component_tvl: None,
             entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v2/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v2/decoder.rs
@@ -35,7 +35,7 @@ mod tests {
     use alloy::primitives::U256;
     use rstest::rstest;
     use tycho_client::feed::synchronizer::ComponentWithState;
-    use tycho_common::{dto::ResponseProtocolState, Bytes};
+    use tycho_common::{models::protocol::ProtocolComponentState, Bytes};
 
     use super::super::state::UniswapV2State;
     use crate::{
@@ -46,15 +46,14 @@ mod tests {
     #[tokio::test]
     async fn test_usv2_try_from() {
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 component_id: "State1".to_owned(),
                 attributes: HashMap::from([
                     ("reserve0".to_string(), Bytes::from(vec![0; 32])),
                     ("reserve1".to_string(), Bytes::from(vec![0; 32])),
                 ]),
                 balances: HashMap::new(),
-            }
-            .into(),
+            },
             component: Default::default(),
             component_tvl: None,
             entrypoints: Vec::new(),
@@ -78,12 +77,11 @@ mod tests {
         attributes.remove(missing_attribute);
 
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 component_id: "State1".to_owned(),
                 attributes,
                 balances: HashMap::new(),
-            }
-            .into(),
+            },
             component: Default::default(),
             component_tvl: None,
             entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v2/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v2/decoder.rs
@@ -53,7 +53,8 @@ mod tests {
                     ("reserve1".to_string(), Bytes::from(vec![0; 32])),
                 ]),
                 balances: HashMap::new(),
-            },
+            }
+            .into(),
             component: Default::default(),
             component_tvl: None,
             entrypoints: Vec::new(),
@@ -81,7 +82,8 @@ mod tests {
                 component_id: "State1".to_owned(),
                 attributes,
                 balances: HashMap::new(),
-            },
+            }
+            .into(),
             component: Default::default(),
             component_tvl: None,
             entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/decoder.rs
@@ -137,9 +137,9 @@ mod tests {
 
     use chrono::DateTime;
     use rstest::rstest;
-    use tycho_common::{
-        dto::{Chain, ChangeType, ResponseProtocolState},
-        models::protocol::ProtocolComponent,
+    use tycho_common::models::{
+        protocol::{ProtocolComponent, ProtocolComponentState},
+        Chain, ChangeType,
     };
 
     use super::*;
@@ -158,11 +158,11 @@ mod tests {
             id: "State1".to_string(),
             protocol_system: "system1".to_string(),
             protocol_type_name: "typename1".to_string(),
-            chain: Chain::Ethereum.into(),
+            chain: Chain::Ethereum,
             tokens: Vec::new(),
             contract_addresses: Vec::new(),
             static_attributes,
-            change: ChangeType::Creation.into(),
+            change: ChangeType::Creation,
             creation_tx: Bytes::from_str("0x0000").unwrap(),
             created_at: creation_time,
         }
@@ -182,12 +182,11 @@ mod tests {
     #[tokio::test]
     async fn test_usv3_try_from() {
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 component_id: "State1".to_owned(),
                 attributes: usv3_attributes(),
                 balances: HashMap::new(),
-            }
-            .into(),
+            },
             component: usv3_component(),
             component_tvl: None,
             entrypoints: Vec::new(),
@@ -235,12 +234,11 @@ mod tests {
         }
 
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 component_id: "State1".to_owned(),
                 attributes,
                 balances: HashMap::new(),
-            }
-            .into(),
+            },
             component,
             component_tvl: None,
             entrypoints: Vec::new(),
@@ -264,12 +262,11 @@ mod tests {
             .insert("fee".to_string(), Bytes::from(4000_i32.to_be_bytes().to_vec()));
 
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 component_id: "State1".to_owned(),
                 attributes: usv3_attributes(),
                 balances: HashMap::new(),
-            }
-            .into(),
+            },
             component,
             component_tvl: None,
             entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/decoder.rs
@@ -137,7 +137,10 @@ mod tests {
 
     use chrono::DateTime;
     use rstest::rstest;
-    use tycho_common::dto::{Chain, ChangeType, ProtocolComponent, ResponseProtocolState};
+    use tycho_common::{
+        dto::{Chain, ChangeType, ResponseProtocolState},
+        models::protocol::ProtocolComponent,
+    };
 
     use super::*;
     use crate::evm::protocol::test_utils::try_decode_snapshot_with_defaults;
@@ -155,11 +158,11 @@ mod tests {
             id: "State1".to_string(),
             protocol_system: "system1".to_string(),
             protocol_type_name: "typename1".to_string(),
-            chain: Chain::Ethereum,
+            chain: Chain::Ethereum.into(),
             tokens: Vec::new(),
-            contract_ids: Vec::new(),
+            contract_addresses: Vec::new(),
             static_attributes,
-            change: ChangeType::Creation,
+            change: ChangeType::Creation.into(),
             creation_tx: Bytes::from_str("0x0000").unwrap(),
             created_at: creation_time,
         }
@@ -183,7 +186,8 @@ mod tests {
                 component_id: "State1".to_owned(),
                 attributes: usv3_attributes(),
                 balances: HashMap::new(),
-            },
+            }
+            .into(),
             component: usv3_component(),
             component_tvl: None,
             entrypoints: Vec::new(),
@@ -235,7 +239,8 @@ mod tests {
                 component_id: "State1".to_owned(),
                 attributes,
                 balances: HashMap::new(),
-            },
+            }
+            .into(),
             component,
             component_tvl: None,
             entrypoints: Vec::new(),
@@ -263,7 +268,8 @@ mod tests {
                 component_id: "State1".to_owned(),
                 attributes: usv3_attributes(),
                 balances: HashMap::new(),
-            },
+            }
+            .into(),
             component,
             component_tvl: None,
             entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
@@ -875,10 +875,9 @@ mod tests {
             Path::new(project_root).join("tests/assets/decoder/uniswap_v3_snapshot.json");
         let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
         let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
-        let state: ComponentWithState =
-            serde_json::from_value::<DtoComponentWithState>(data)
-                .expect("Expected json to match ComponentWithState structure")
-                .into();
+        let state: ComponentWithState = serde_json::from_value::<DtoComponentWithState>(data)
+            .expect("Expected json to match ComponentWithState structure")
+            .into();
 
         let usv3_state = UniswapV3State::try_from_with_header(
             state,
@@ -1443,6 +1442,7 @@ mod tests_forks {
     #[tokio::test]
     async fn test_pancakeswap_get_amount_out() {
         use std::{fs, path::Path};
+
         use serde_json::Value;
         use tycho_client::feed::dto::ComponentWithState as DtoComponentWithState;
         let project_root = env!("CARGO_MANIFEST_DIR");
@@ -1450,10 +1450,9 @@ mod tests_forks {
             Path::new(project_root).join("tests/assets/decoder/pancakeswap_v3_snapshot.json");
         let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
         let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
-        let state: ComponentWithState =
-            serde_json::from_value::<DtoComponentWithState>(data)
-                .expect("Expected json to match ComponentWithState structure")
-                .into();
+        let state: ComponentWithState = serde_json::from_value::<DtoComponentWithState>(data)
+            .expect("Expected json to match ComponentWithState structure")
+            .into();
 
         let pool_state = UniswapV3State::try_from_with_header(
             state,

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
@@ -869,14 +869,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_limits() {
-        use tycho_client::feed::dto::ComponentWithStateDto;
+        use tycho_client::feed::dto::ComponentWithState as DtoComponentWithState;
         let project_root = env!("CARGO_MANIFEST_DIR");
         let asset_path =
             Path::new(project_root).join("tests/assets/decoder/uniswap_v3_snapshot.json");
         let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
         let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
         let state: ComponentWithState =
-            serde_json::from_value::<ComponentWithStateDto>(data)
+            serde_json::from_value::<DtoComponentWithState>(data)
                 .expect("Expected json to match ComponentWithState structure")
                 .into();
 
@@ -1444,14 +1444,14 @@ mod tests_forks {
     async fn test_pancakeswap_get_amount_out() {
         use std::{fs, path::Path};
         use serde_json::Value;
-        use tycho_client::feed::dto::ComponentWithStateDto;
+        use tycho_client::feed::dto::ComponentWithState as DtoComponentWithState;
         let project_root = env!("CARGO_MANIFEST_DIR");
         let asset_path =
             Path::new(project_root).join("tests/assets/decoder/pancakeswap_v3_snapshot.json");
         let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
         let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
         let state: ComponentWithState =
-            serde_json::from_value::<ComponentWithStateDto>(data)
+            serde_json::from_value::<DtoComponentWithState>(data)
                 .expect("Expected json to match ComponentWithState structure")
                 .into();
 

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
@@ -869,13 +869,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_limits() {
-        use tycho_client::feed::dto::ComponentWithState as DtoComponentWithState;
+        use tycho_client::feed::dto;
         let project_root = env!("CARGO_MANIFEST_DIR");
         let asset_path =
             Path::new(project_root).join("tests/assets/decoder/uniswap_v3_snapshot.json");
         let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
         let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
-        let state: ComponentWithState = serde_json::from_value::<DtoComponentWithState>(data)
+        let state: ComponentWithState = serde_json::from_value::<dto::ComponentWithState>(data)
             .expect("Expected json to match ComponentWithState structure")
             .into();
 
@@ -1444,13 +1444,13 @@ mod tests_forks {
         use std::{fs, path::Path};
 
         use serde_json::Value;
-        use tycho_client::feed::dto::ComponentWithState as DtoComponentWithState;
+        use tycho_client::feed::dto;
         let project_root = env!("CARGO_MANIFEST_DIR");
         let asset_path =
             Path::new(project_root).join("tests/assets/decoder/pancakeswap_v3_snapshot.json");
         let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
         let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
-        let state: ComponentWithState = serde_json::from_value::<DtoComponentWithState>(data)
+        let state: ComponentWithState = serde_json::from_value::<dto::ComponentWithState>(data)
             .expect("Expected json to match ComponentWithState structure")
             .into();
 

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
@@ -573,14 +573,22 @@ impl ProtocolSim for UniswapV3State {
 mod tests {
     use std::{
         collections::{HashMap, HashSet},
+        fs,
+        path::Path,
         str::FromStr,
     };
 
     use num_bigint::ToBigUint;
+    use num_traits::FromPrimitive;
+    use serde_json::Value;
+    use tycho_client::feed::synchronizer::ComponentWithState;
     use tycho_common::{hex_bytes::Bytes, models::Chain, simulation::protocol_sim::Price};
 
     use super::*;
-    use crate::evm::protocol::utils::uniswap::sqrt_price_math::get_sqrt_price_q96;
+    use crate::{
+        evm::protocol::utils::uniswap::sqrt_price_math::get_sqrt_price_q96,
+        protocol::models::{DecoderContext, TryFromWithBlock},
+    };
 
     #[test]
     fn test_get_amount_out_full_range_liquidity() {
@@ -859,12 +867,59 @@ mod tests {
         );
     }
 
-    // TODO: test needs rewriting to construct ComponentWithState directly; JSON deserialization
-    // no longer works because ProtocolComponentState doesn't implement Deserialize.
-    #[ignore]
     #[tokio::test]
     async fn test_get_limits() {
-        unimplemented!("needs rewrite: ComponentWithState is no longer Deserialize");
+        use tycho_client::feed::dto::ComponentWithStateDto;
+        let project_root = env!("CARGO_MANIFEST_DIR");
+        let asset_path =
+            Path::new(project_root).join("tests/assets/decoder/uniswap_v3_snapshot.json");
+        let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
+        let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
+        let state: ComponentWithState =
+            serde_json::from_value::<ComponentWithStateDto>(data)
+                .expect("Expected json to match ComponentWithState structure")
+                .into();
+
+        let usv3_state = UniswapV3State::try_from_with_header(
+            state,
+            Default::default(),
+            &Default::default(),
+            &Default::default(),
+            &DecoderContext::new(),
+        )
+        .await
+        .unwrap();
+
+        let t0 = Token::new(
+            &Bytes::from_str("0x2260fac5e5542a773aa44fbcfedf7c193bc2c599").unwrap(),
+            "WBTC",
+            8,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        );
+        let t1 = Token::new(
+            &Bytes::from_str("0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf").unwrap(),
+            "cbBTC",
+            8,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        );
+
+        let res = usv3_state
+            .get_limits(t0.address.clone(), t1.address.clone())
+            .unwrap();
+
+        assert_eq!(&res.0, &BigUint::from_u128(155144999154).unwrap());
+
+        let out = usv3_state
+            .get_amount_out(res.0, &t0, &t1)
+            .expect("swap for limit in didn't work");
+
+        assert_eq!(&res.1, &out.amount);
     }
 
     // Helper to create a basic test pool
@@ -1379,16 +1434,61 @@ mod tests {
 mod tests_forks {
     use std::str::FromStr;
 
+    use tycho_client::feed::synchronizer::ComponentWithState;
     use tycho_common::{hex_bytes::Bytes, models::Chain};
 
     use super::*;
+    use crate::protocol::models::{DecoderContext, TryFromWithBlock};
 
-    // TODO: test needs rewriting to construct ComponentWithState directly; JSON deserialization
-    // no longer works because ProtocolComponentState doesn't implement Deserialize.
-    #[ignore]
     #[tokio::test]
     async fn test_pancakeswap_get_amount_out() {
-        unimplemented!("needs rewrite: ComponentWithState is no longer Deserialize");
+        use std::{fs, path::Path};
+        use serde_json::Value;
+        use tycho_client::feed::dto::ComponentWithStateDto;
+        let project_root = env!("CARGO_MANIFEST_DIR");
+        let asset_path =
+            Path::new(project_root).join("tests/assets/decoder/pancakeswap_v3_snapshot.json");
+        let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
+        let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
+        let state: ComponentWithState =
+            serde_json::from_value::<ComponentWithStateDto>(data)
+                .expect("Expected json to match ComponentWithState structure")
+                .into();
+
+        let pool_state = UniswapV3State::try_from_with_header(
+            state,
+            Default::default(),
+            &Default::default(),
+            &Default::default(),
+            &DecoderContext::new(),
+        )
+        .await
+        .unwrap();
+
+        let usdc = Token::new(
+            &Bytes::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap(),
+            "USDC",
+            6,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        );
+        let usdt = Token::new(
+            &Bytes::from_str("0xdac17f958d2ee523a2206206994597c13d831ec7").unwrap(),
+            "USDT",
+            6,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        );
+
+        let res = pool_state
+            .get_amount_out(BigUint::from_str("5976361609").unwrap(), &usdt, &usdc)
+            .unwrap();
+
+        assert_eq!(res.amount, BigUint::from_str("5975901673").unwrap());
     }
 
     #[test]

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
@@ -573,22 +573,14 @@ impl ProtocolSim for UniswapV3State {
 mod tests {
     use std::{
         collections::{HashMap, HashSet},
-        fs,
-        path::Path,
         str::FromStr,
     };
 
     use num_bigint::ToBigUint;
-    use num_traits::FromPrimitive;
-    use serde_json::Value;
-    use tycho_client::feed::synchronizer::ComponentWithState;
     use tycho_common::{hex_bytes::Bytes, models::Chain, simulation::protocol_sim::Price};
 
     use super::*;
-    use crate::{
-        evm::protocol::utils::uniswap::sqrt_price_math::get_sqrt_price_q96,
-        protocol::models::{DecoderContext, TryFromWithBlock},
-    };
+    use crate::evm::protocol::utils::uniswap::sqrt_price_math::get_sqrt_price_q96;
 
     #[test]
     fn test_get_amount_out_full_range_liquidity() {
@@ -867,57 +859,12 @@ mod tests {
         );
     }
 
+    // TODO: test needs rewriting to construct ComponentWithState directly; JSON deserialization
+    // no longer works because ProtocolComponentState doesn't implement Deserialize.
+    #[ignore]
     #[tokio::test]
     async fn test_get_limits() {
-        let project_root = env!("CARGO_MANIFEST_DIR");
-        let asset_path =
-            Path::new(project_root).join("tests/assets/decoder/uniswap_v3_snapshot.json");
-        let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
-        let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
-
-        let state: ComponentWithState = serde_json::from_value(data)
-            .expect("Expected json to match ComponentWithState structure");
-
-        let usv3_state = UniswapV3State::try_from_with_header(
-            state,
-            Default::default(),
-            &Default::default(),
-            &Default::default(),
-            &DecoderContext::new(),
-        )
-        .await
-        .unwrap();
-
-        let t0 = Token::new(
-            &Bytes::from_str("0x2260fac5e5542a773aa44fbcfedf7c193bc2c599").unwrap(),
-            "WBTC",
-            8,
-            0,
-            &[Some(10_000)],
-            Chain::Ethereum,
-            100,
-        );
-        let t1 = Token::new(
-            &Bytes::from_str("0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf").unwrap(),
-            "cbBTC",
-            8,
-            0,
-            &[Some(10_000)],
-            Chain::Ethereum,
-            100,
-        );
-
-        let res = usv3_state
-            .get_limits(t0.address.clone(), t1.address.clone())
-            .unwrap();
-
-        assert_eq!(&res.0, &BigUint::from_u128(155144999154).unwrap()); // Crazy amount because of this tick: "ticks/-887272/net-liquidity": "0x10d73d"
-
-        let out = usv3_state
-            .get_amount_out(res.0, &t0, &t1)
-            .expect("swap for limit in didn't work");
-
-        assert_eq!(&res.1, &out.amount);
+        unimplemented!("needs rewrite: ComponentWithState is no longer Deserialize");
     }
 
     // Helper to create a basic test pool
@@ -1430,61 +1377,18 @@ mod tests {
 
 #[cfg(test)]
 mod tests_forks {
-    use std::{fs, path::Path, str::FromStr};
+    use std::str::FromStr;
 
-    use serde_json::Value;
-    use tycho_client::feed::synchronizer::ComponentWithState;
-    use tycho_common::models::Chain;
+    use tycho_common::{hex_bytes::Bytes, models::Chain};
 
     use super::*;
-    use crate::protocol::models::{DecoderContext, TryFromWithBlock};
 
+    // TODO: test needs rewriting to construct ComponentWithState directly; JSON deserialization
+    // no longer works because ProtocolComponentState doesn't implement Deserialize.
+    #[ignore]
     #[tokio::test]
     async fn test_pancakeswap_get_amount_out() {
-        let project_root = env!("CARGO_MANIFEST_DIR");
-        let asset_path =
-            Path::new(project_root).join("tests/assets/decoder/pancakeswap_v3_snapshot.json");
-        let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
-        let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
-
-        let state: ComponentWithState = serde_json::from_value(data)
-            .expect("Expected json to match ComponentWithState structure");
-
-        let pool_state = UniswapV3State::try_from_with_header(
-            state,
-            Default::default(),
-            &Default::default(),
-            &Default::default(),
-            &DecoderContext::new(),
-        )
-        .await
-        .unwrap();
-
-        let usdc = Token::new(
-            &Bytes::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap(),
-            "USDC",
-            6,
-            0,
-            &[Some(10_000)],
-            Chain::Ethereum,
-            100,
-        );
-        let usdt = Token::new(
-            &Bytes::from_str("0xdac17f958d2ee523a2206206994597c13d831ec7").unwrap(),
-            "USDT",
-            6,
-            0,
-            &[Some(10_000)],
-            Chain::Ethereum,
-            100,
-        );
-
-        // Swap from https://etherscan.io/tx/0x641b1e98990ae49fd00157a29e1530ff6403706b2864aa52b1c30849ce020b2c#eventlog
-        let res = pool_state
-            .get_amount_out(BigUint::from_str("5976361609").unwrap(), &usdt, &usdc)
-            .unwrap();
-
-        assert_eq!(res.amount, BigUint::from_str("5975901673").unwrap());
+        unimplemented!("needs rewrite: ComponentWithState is no longer Deserialize");
     }
 
     #[test]

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/decoder.rs
@@ -206,7 +206,10 @@ mod tests {
 
     use chrono::DateTime;
     use rstest::rstest;
-    use tycho_common::dto::{Chain, ChangeType, ProtocolComponent, ResponseProtocolState};
+    use tycho_common::{
+        dto::{Chain, ChangeType, ResponseProtocolState},
+        models::protocol::ProtocolComponent,
+    };
 
     use super::*;
     use crate::evm::protocol::test_utils::try_decode_snapshot_with_defaults;
@@ -225,11 +228,11 @@ mod tests {
             id: "State1".to_string(),
             protocol_system: "system1".to_string(),
             protocol_type_name: "typename1".to_string(),
-            chain: Chain::Ethereum,
+            chain: Chain::Ethereum.into(),
             tokens: Vec::new(),
-            contract_ids: Vec::new(),
+            contract_addresses: Vec::new(),
             static_attributes,
-            change: ChangeType::Creation,
+            change: ChangeType::Creation.into(),
             creation_tx: Bytes::from_str("0x0000").unwrap(),
             created_at: creation_time,
         }
@@ -260,7 +263,8 @@ mod tests {
                 component_id: "State1".to_owned(),
                 attributes: usv4_attributes(),
                 balances: HashMap::new(),
-            },
+            }
+            .into(),
             component: usv4_component(),
             component_tvl: None,
             entrypoints: Vec::new(),
@@ -317,7 +321,8 @@ mod tests {
                 component_id: "State1".to_owned(),
                 attributes,
                 balances: HashMap::new(),
-            },
+            }
+            .into(),
             component,
             component_tvl: None,
             entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/decoder.rs
@@ -206,9 +206,9 @@ mod tests {
 
     use chrono::DateTime;
     use rstest::rstest;
-    use tycho_common::{
-        dto::{Chain, ChangeType, ResponseProtocolState},
-        models::protocol::ProtocolComponent,
+    use tycho_common::models::{
+        protocol::{ProtocolComponent, ProtocolComponentState},
+        Chain, ChangeType,
     };
 
     use super::*;
@@ -228,11 +228,11 @@ mod tests {
             id: "State1".to_string(),
             protocol_system: "system1".to_string(),
             protocol_type_name: "typename1".to_string(),
-            chain: Chain::Ethereum.into(),
+            chain: Chain::Ethereum,
             tokens: Vec::new(),
             contract_addresses: Vec::new(),
             static_attributes,
-            change: ChangeType::Creation.into(),
+            change: ChangeType::Creation,
             creation_tx: Bytes::from_str("0x0000").unwrap(),
             created_at: creation_time,
         }
@@ -259,12 +259,11 @@ mod tests {
     #[tokio::test]
     async fn test_usv4_try_from() {
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 component_id: "State1".to_owned(),
                 attributes: usv4_attributes(),
                 balances: HashMap::new(),
-            }
-            .into(),
+            },
             component: usv4_component(),
             component_tvl: None,
             entrypoints: Vec::new(),
@@ -317,12 +316,11 @@ mod tests {
         }
 
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 component_id: "State1".to_owned(),
                 attributes,
                 balances: HashMap::new(),
-            }
-            .into(),
+            },
             component,
             component_tvl: None,
             entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
@@ -974,32 +974,28 @@ impl ProtocolSim for UniswapV4State {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashSet, fs, path::Path, str::FromStr};
+    use std::{collections::HashSet, str::FromStr};
 
     use alloy::primitives::aliases::U24;
     use num_traits::FromPrimitive;
     use rstest::rstest;
-    use serde_json::Value;
-    use tycho_client::feed::{synchronizer::ComponentWithState, BlockHeader};
-    use tycho_common::{models::Chain, simulation::protocol_sim::Price};
+    use tycho_client::feed::BlockHeader;
+    use tycho_common::simulation::protocol_sim::Price;
 
     use super::*;
-    use crate::{
-        evm::{
-            engine_db::{
-                create_engine,
-                simulation_db::SimulationDB,
-                utils::{get_client, get_runtime},
-            },
-            protocol::{
-                uniswap_v4::hooks::{
-                    angstrom::hook_handler::{AngstromFees, AngstromHookHandler},
-                    generic_vm_hook_handler::GenericVMHookHandler,
-                },
-                utils::uniswap::{lp_fee, sqrt_price_math::get_sqrt_price_q96},
-            },
+    use crate::evm::{
+        engine_db::{
+            create_engine,
+            simulation_db::SimulationDB,
+            utils::{get_client, get_runtime},
         },
-        protocol::models::{DecoderContext, TryFromWithBlock},
+        protocol::{
+            uniswap_v4::hooks::{
+                angstrom::hook_handler::{AngstromFees, AngstromHookHandler},
+                generic_vm_hook_handler::GenericVMHookHandler,
+            },
+            utils::uniswap::{lp_fee, sqrt_price_math::get_sqrt_price_q96},
+        },
     };
 
     // Helper methods to create commonly used tokens
@@ -1121,161 +1117,22 @@ mod tests {
         );
     }
 
+    // TODO: test needs rewriting to construct ComponentWithState directly; JSON deserialization
+    // no longer works because ProtocolComponentState doesn't implement Deserialize.
+    #[ignore]
     #[tokio::test]
     /// Compares a quote that we got from the UniswapV4 Quoter contract on Sepolia with a simulation
     /// using Tycho-simulation and a state extracted with Tycho-indexer
     async fn test_swap_sim() {
-        let project_root = env!("CARGO_MANIFEST_DIR");
-
-        let asset_path = Path::new(project_root)
-            .join("tests/assets/decoder/uniswap_v4_snapshot_sepolia_block_7239119.json");
-        let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
-        let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
-
-        let state: ComponentWithState = serde_json::from_value(data)
-            .expect("Expected json to match ComponentWithState structure");
-
-        let block = BlockHeader {
-            number: 7239119,
-            hash: Bytes::from_str(
-                "0x28d41d40f2ac275a4f5f621a636b9016b527d11d37d610a45ac3a821346ebf8c",
-            )
-            .expect("Invalid block hash"),
-            parent_hash: Bytes::from(vec![0; 32]),
-            ..Default::default()
-        };
-
-        let t0 = Token::new(
-            &Bytes::from_str("0x647e32181a64f4ffd4f0b0b4b052ec05b277729c").unwrap(),
-            "T0",
-            18,
-            0,
-            &[Some(10_000)],
-            Chain::Ethereum,
-            100,
-        );
-        let t1 = Token::new(
-            &Bytes::from_str("0xe390a1c311b26f14ed0d55d3b0261c2320d15ca5").unwrap(),
-            "T0",
-            18,
-            0,
-            &[Some(10_000)],
-            Chain::Ethereum,
-            100,
-        );
-
-        let all_tokens = [t0.clone(), t1.clone()]
-            .iter()
-            .map(|t| (t.address.clone(), t.clone()))
-            .collect();
-
-        let usv4_state = UniswapV4State::try_from_with_header(
-            state,
-            block,
-            &Default::default(),
-            &all_tokens,
-            &DecoderContext::new(),
-        )
-        .await
-        .unwrap();
-
-        let res = usv4_state
-            .get_amount_out(BigUint::from_u64(1000000000000000000).unwrap(), &t0, &t1)
-            .unwrap();
-
-        // This amount comes from a call to the `quoteExactInputSingle` on the quoter contract on a
-        // sepolia node with these arguments
-        // ```
-        // {"poolKey":{"currency0":"0x647e32181a64f4ffd4f0b0b4b052ec05b277729c","currency1":"0xe390a1c311b26f14ed0d55d3b0261c2320d15ca5","fee":"3000","tickSpacing":"60","hooks":"0x0000000000000000000000000000000000000000"},"zeroForOne":true,"exactAmount":"1000000000000000000","hookData":"0x"}
-        // ```
-        // Here is the curl for it:
-        //
-        // ```
-        // curl -X POST https://eth-sepolia.api.onfinality.io/public \
-        // -H "Content-Type: application/json" \
-        // -d '{
-        //   "jsonrpc": "2.0",
-        //   "method": "eth_call",
-        //   "params": [
-        //     {
-        //       "to": "0xCd8716395D55aD17496448a4b2C42557001e9743",
-        //       "data": "0xaa9d21cb0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000647e32181a64f4ffd4f0b0b4b052ec05b277729c000000000000000000000000e390a1c311b26f14ed0d55d3b0261c2320d15ca50000000000000000000000000000000000000000000000000000000000000bb8000000000000000000000000000000000000000000000000000000000000003c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000"
-        //     },
-        //     "0x6e75cf"
-        //   ],
-        //   "id": 1
-        //   }'
-        // ```
-        let expected_amount = BigUint::from(9999909699895_u64);
-        assert_eq!(res.amount, expected_amount);
+        unimplemented!("needs rewrite: ComponentWithState is no longer Deserialize");
     }
 
+    // TODO: test needs rewriting to construct ComponentWithState directly; JSON deserialization
+    // no longer works because ProtocolComponentState doesn't implement Deserialize.
+    #[ignore]
     #[tokio::test]
     async fn test_get_limits() {
-        let block = BlockHeader {
-            number: 22689129,
-            hash: Bytes::from_str(
-                "0x7763ea30d11aef68da729b65250c09a88ad00458c041064aad8c9a9dbf17adde",
-            )
-            .expect("Invalid block hash"),
-            parent_hash: Bytes::from(vec![0; 32]),
-            ..Default::default()
-        };
-
-        let project_root = env!("CARGO_MANIFEST_DIR");
-        let asset_path =
-            Path::new(project_root).join("tests/assets/decoder/uniswap_v4_snapshot.json");
-        let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
-        let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
-
-        let state: ComponentWithState = serde_json::from_value(data)
-            .expect("Expected json to match ComponentWithState structure");
-
-        let t0 = Token::new(
-            &Bytes::from_str("0x2260fac5e5542a773aa44fbcfedf7c193bc2c599").unwrap(),
-            "WBTC",
-            8,
-            0,
-            &[Some(10_000)],
-            Chain::Ethereum,
-            100,
-        );
-        let t1 = Token::new(
-            &Bytes::from_str("0xdac17f958d2ee523a2206206994597c13d831ec7").unwrap(),
-            "USDT",
-            6,
-            0,
-            &[Some(10_000)],
-            Chain::Ethereum,
-            100,
-        );
-
-        let all_tokens = [t0.clone(), t1.clone()]
-            .iter()
-            .map(|t| (t.address.clone(), t.clone()))
-            .collect();
-
-        let usv4_state = UniswapV4State::try_from_with_header(
-            state,
-            block,
-            &Default::default(),
-            &all_tokens,
-            &DecoderContext::new(),
-        )
-        .await
-        .unwrap();
-
-        let res = usv4_state
-            .get_limits(t0.address.clone(), t1.address.clone())
-            .unwrap();
-
-        assert_eq!(&res.0, &BigUint::from_u128(71698353688830259750744466706).unwrap()); // Crazy amount because of this tick: "ticks/-887220/net-liquidity": "0x00e8481d98"
-
-        let out = usv4_state
-            .get_amount_out(res.0, &t0, &t1)
-            .expect("swap for limit in didn't work");
-
-        assert_eq!(&res.1, &out.amount);
+        unimplemented!("needs rewrite: ComponentWithState is no longer Deserialize");
     }
     #[test]
     fn test_get_amount_out_no_hook() {

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
@@ -974,28 +974,32 @@ impl ProtocolSim for UniswapV4State {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashSet, str::FromStr};
+    use std::{collections::HashSet, fs, path::Path, str::FromStr};
 
     use alloy::primitives::aliases::U24;
     use num_traits::FromPrimitive;
     use rstest::rstest;
-    use tycho_client::feed::BlockHeader;
-    use tycho_common::simulation::protocol_sim::Price;
+    use serde_json::Value;
+    use tycho_client::feed::{synchronizer::ComponentWithState, BlockHeader};
+    use tycho_common::{models::Chain, simulation::protocol_sim::Price};
 
     use super::*;
-    use crate::evm::{
-        engine_db::{
-            create_engine,
-            simulation_db::SimulationDB,
-            utils::{get_client, get_runtime},
-        },
-        protocol::{
-            uniswap_v4::hooks::{
-                angstrom::hook_handler::{AngstromFees, AngstromHookHandler},
-                generic_vm_hook_handler::GenericVMHookHandler,
+    use crate::{
+        evm::{
+            engine_db::{
+                create_engine,
+                simulation_db::SimulationDB,
+                utils::{get_client, get_runtime},
             },
-            utils::uniswap::{lp_fee, sqrt_price_math::get_sqrt_price_q96},
+            protocol::{
+                uniswap_v4::hooks::{
+                    angstrom::hook_handler::{AngstromFees, AngstromHookHandler},
+                    generic_vm_hook_handler::GenericVMHookHandler,
+                },
+                utils::uniswap::{lp_fee, sqrt_price_math::get_sqrt_price_q96},
+            },
         },
+        protocol::models::{DecoderContext, TryFromWithBlock},
     };
 
     // Helper methods to create commonly used tokens
@@ -1117,22 +1121,140 @@ mod tests {
         );
     }
 
-    // TODO: test needs rewriting to construct ComponentWithState directly; JSON deserialization
-    // no longer works because ProtocolComponentState doesn't implement Deserialize.
-    #[ignore]
     #[tokio::test]
-    /// Compares a quote that we got from the UniswapV4 Quoter contract on Sepolia with a simulation
-    /// using Tycho-simulation and a state extracted with Tycho-indexer
+    /// Compares a quote from the UniswapV4 Quoter contract on Sepolia with a simulation.
     async fn test_swap_sim() {
-        unimplemented!("needs rewrite: ComponentWithState is no longer Deserialize");
+        use tycho_client::feed::dto::ComponentWithStateDto;
+        let project_root = env!("CARGO_MANIFEST_DIR");
+        let asset_path = Path::new(project_root)
+            .join("tests/assets/decoder/uniswap_v4_snapshot_sepolia_block_7239119.json");
+        let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
+        let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
+        let state: ComponentWithState =
+            serde_json::from_value::<ComponentWithStateDto>(data)
+                .expect("Expected json to match ComponentWithState structure")
+                .into();
+
+        let block = BlockHeader {
+            number: 7239119,
+            hash: Bytes::from_str(
+                "0x28d41d40f2ac275a4f5f621a636b9016b527d11d37d610a45ac3a821346ebf8c",
+            )
+            .expect("Invalid block hash"),
+            parent_hash: Bytes::from(vec![0; 32]),
+            ..Default::default()
+        };
+
+        let t0 = Token::new(
+            &Bytes::from_str("0x647e32181a64f4ffd4f0b0b4b052ec05b277729c").unwrap(),
+            "T0",
+            18,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        );
+        let t1 = Token::new(
+            &Bytes::from_str("0xe390a1c311b26f14ed0d55d3b0261c2320d15ca5").unwrap(),
+            "T1",
+            18,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        );
+
+        let all_tokens = [t0.clone(), t1.clone()]
+            .iter()
+            .map(|t| (t.address.clone(), t.clone()))
+            .collect();
+
+        let usv4_state = UniswapV4State::try_from_with_header(
+            state,
+            block,
+            &Default::default(),
+            &all_tokens,
+            &DecoderContext::new(),
+        )
+        .await
+        .unwrap();
+
+        let res = usv4_state
+            .get_amount_out(BigUint::from_u64(1000000000000000000).unwrap(), &t0, &t1)
+            .unwrap();
+
+        let expected_amount = BigUint::from(9999909699895_u64);
+        assert_eq!(res.amount, expected_amount);
     }
 
-    // TODO: test needs rewriting to construct ComponentWithState directly; JSON deserialization
-    // no longer works because ProtocolComponentState doesn't implement Deserialize.
-    #[ignore]
     #[tokio::test]
     async fn test_get_limits() {
-        unimplemented!("needs rewrite: ComponentWithState is no longer Deserialize");
+        use tycho_client::feed::dto::ComponentWithStateDto;
+        let block = BlockHeader {
+            number: 22689129,
+            hash: Bytes::from_str(
+                "0x7763ea30d11aef68da729b65250c09a88ad00458c041064aad8c9a9dbf17adde",
+            )
+            .expect("Invalid block hash"),
+            parent_hash: Bytes::from(vec![0; 32]),
+            ..Default::default()
+        };
+
+        let project_root = env!("CARGO_MANIFEST_DIR");
+        let asset_path =
+            Path::new(project_root).join("tests/assets/decoder/uniswap_v4_snapshot.json");
+        let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
+        let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
+        let state: ComponentWithState =
+            serde_json::from_value::<ComponentWithStateDto>(data)
+                .expect("Expected json to match ComponentWithState structure")
+                .into();
+
+        let t0 = Token::new(
+            &Bytes::from_str("0x2260fac5e5542a773aa44fbcfedf7c193bc2c599").unwrap(),
+            "WBTC",
+            8,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        );
+        let t1 = Token::new(
+            &Bytes::from_str("0xdac17f958d2ee523a2206206994597c13d831ec7").unwrap(),
+            "USDT",
+            6,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        );
+
+        let all_tokens = [t0.clone(), t1.clone()]
+            .iter()
+            .map(|t| (t.address.clone(), t.clone()))
+            .collect();
+
+        let usv4_state = UniswapV4State::try_from_with_header(
+            state,
+            block,
+            &Default::default(),
+            &all_tokens,
+            &DecoderContext::new(),
+        )
+        .await
+        .unwrap();
+
+        let res = usv4_state
+            .get_limits(t0.address.clone(), t1.address.clone())
+            .unwrap();
+
+        assert_eq!(&res.0, &BigUint::from_u128(71698353688830259750744466706).unwrap());
+
+        let out = usv4_state
+            .get_amount_out(res.0, &t0, &t1)
+            .expect("swap for limit in didn't work");
+
+        assert_eq!(&res.1, &out.amount);
     }
     #[test]
     fn test_get_amount_out_no_hook() {

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
@@ -1124,13 +1124,13 @@ mod tests {
     #[tokio::test]
     /// Compares a quote from the UniswapV4 Quoter contract on Sepolia with a simulation.
     async fn test_swap_sim() {
-        use tycho_client::feed::dto::ComponentWithState as DtoComponentWithState;
+        use tycho_client::feed::dto;
         let project_root = env!("CARGO_MANIFEST_DIR");
         let asset_path = Path::new(project_root)
             .join("tests/assets/decoder/uniswap_v4_snapshot_sepolia_block_7239119.json");
         let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
         let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
-        let state: ComponentWithState = serde_json::from_value::<DtoComponentWithState>(data)
+        let state: ComponentWithState = serde_json::from_value::<dto::ComponentWithState>(data)
             .expect("Expected json to match ComponentWithState structure")
             .into();
 
@@ -1188,7 +1188,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_limits() {
-        use tycho_client::feed::dto::ComponentWithState as DtoComponentWithState;
+        use tycho_client::feed::dto;
         let block = BlockHeader {
             number: 22689129,
             hash: Bytes::from_str(
@@ -1204,7 +1204,7 @@ mod tests {
             Path::new(project_root).join("tests/assets/decoder/uniswap_v4_snapshot.json");
         let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
         let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
-        let state: ComponentWithState = serde_json::from_value::<DtoComponentWithState>(data)
+        let state: ComponentWithState = serde_json::from_value::<dto::ComponentWithState>(data)
             .expect("Expected json to match ComponentWithState structure")
             .into();
 

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
@@ -1130,10 +1130,9 @@ mod tests {
             .join("tests/assets/decoder/uniswap_v4_snapshot_sepolia_block_7239119.json");
         let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
         let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
-        let state: ComponentWithState =
-            serde_json::from_value::<DtoComponentWithState>(data)
-                .expect("Expected json to match ComponentWithState structure")
-                .into();
+        let state: ComponentWithState = serde_json::from_value::<DtoComponentWithState>(data)
+            .expect("Expected json to match ComponentWithState structure")
+            .into();
 
         let block = BlockHeader {
             number: 7239119,
@@ -1205,10 +1204,9 @@ mod tests {
             Path::new(project_root).join("tests/assets/decoder/uniswap_v4_snapshot.json");
         let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
         let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
-        let state: ComponentWithState =
-            serde_json::from_value::<DtoComponentWithState>(data)
-                .expect("Expected json to match ComponentWithState structure")
-                .into();
+        let state: ComponentWithState = serde_json::from_value::<DtoComponentWithState>(data)
+            .expect("Expected json to match ComponentWithState structure")
+            .into();
 
         let t0 = Token::new(
             &Bytes::from_str("0x2260fac5e5542a773aa44fbcfedf7c193bc2c599").unwrap(),

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
@@ -1124,14 +1124,14 @@ mod tests {
     #[tokio::test]
     /// Compares a quote from the UniswapV4 Quoter contract on Sepolia with a simulation.
     async fn test_swap_sim() {
-        use tycho_client::feed::dto::ComponentWithStateDto;
+        use tycho_client::feed::dto::ComponentWithState as DtoComponentWithState;
         let project_root = env!("CARGO_MANIFEST_DIR");
         let asset_path = Path::new(project_root)
             .join("tests/assets/decoder/uniswap_v4_snapshot_sepolia_block_7239119.json");
         let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
         let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
         let state: ComponentWithState =
-            serde_json::from_value::<ComponentWithStateDto>(data)
+            serde_json::from_value::<DtoComponentWithState>(data)
                 .expect("Expected json to match ComponentWithState structure")
                 .into();
 
@@ -1189,7 +1189,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_limits() {
-        use tycho_client::feed::dto::ComponentWithStateDto;
+        use tycho_client::feed::dto::ComponentWithState as DtoComponentWithState;
         let block = BlockHeader {
             number: 22689129,
             hash: Bytes::from_str(
@@ -1206,7 +1206,7 @@ mod tests {
         let json_data = fs::read_to_string(asset_path).expect("Failed to read test asset");
         let data: Value = serde_json::from_str(&json_data).expect("Failed to parse JSON");
         let state: ComponentWithState =
-            serde_json::from_value::<ComponentWithStateDto>(data)
+            serde_json::from_value::<DtoComponentWithState>(data)
                 .expect("Expected json to match ComponentWithState structure")
                 .into();
 

--- a/crates/tycho-simulation/src/evm/protocol/vm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/vm/decoder.rs
@@ -78,7 +78,7 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for EVMPoolState<PreCache
         }
         let involved_contracts = snapshot
             .component
-            .contract_ids
+            .contract_addresses
             .iter()
             .map(|bytes: &Bytes| Address::from_slice(bytes.as_ref()))
             .collect::<HashSet<Address>>();
@@ -196,7 +196,10 @@ mod tests {
     use chrono::DateTime;
     use revm::{primitives::KECCAK_EMPTY, state::AccountInfo};
     use serde_json::Value;
-    use tycho_common::dto::{Chain, ChangeType, ProtocolComponent, ResponseProtocolState};
+    use tycho_common::{
+        dto::{Chain, ChangeType, ResponseProtocolState},
+        models::protocol::ProtocolComponent,
+    };
 
     use super::*;
     use crate::evm::{
@@ -227,13 +230,13 @@ mod tests {
             id: "0x4626d81b3a1711beb79f4cecff2413886d461677000200000000000000000011".to_string(),
             protocol_system: "vm:balancer_v2".to_string(),
             protocol_type_name: "balancer_v2_pool".to_string(),
-            chain: Chain::Ethereum,
+            chain: Chain::Ethereum.into(),
             tokens,
-            contract_ids: vec![
+            contract_addresses: vec![
                 Bytes::from_str("0xBA12222222228d8Ba445958a75a0704d566BF2C8").unwrap()
             ],
             static_attributes,
-            change: ChangeType::Creation,
+            change: ChangeType::Creation.into(),
             creation_tx: Bytes::from_str("0x0000").unwrap(),
             created_at: creation_time,
         }
@@ -292,7 +295,8 @@ mod tests {
                     .to_owned(),
                 attributes,
                 balances: HashMap::new(),
-            },
+            }
+            .into(),
             component: vm_component(),
             component_tvl: None,
             entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/vm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/vm/decoder.rs
@@ -196,9 +196,9 @@ mod tests {
     use chrono::DateTime;
     use revm::{primitives::KECCAK_EMPTY, state::AccountInfo};
     use serde_json::Value;
-    use tycho_common::{
-        dto::{Chain, ChangeType, ResponseProtocolState},
-        models::protocol::ProtocolComponent,
+    use tycho_common::models::{
+        protocol::{ProtocolComponent, ProtocolComponentState},
+        Chain, ChangeType,
     };
 
     use super::*;
@@ -230,13 +230,13 @@ mod tests {
             id: "0x4626d81b3a1711beb79f4cecff2413886d461677000200000000000000000011".to_string(),
             protocol_system: "vm:balancer_v2".to_string(),
             protocol_type_name: "balancer_v2_pool".to_string(),
-            chain: Chain::Ethereum.into(),
+            chain: Chain::Ethereum,
             tokens,
             contract_addresses: vec![
                 Bytes::from_str("0xBA12222222228d8Ba445958a75a0704d566BF2C8").unwrap()
             ],
             static_attributes,
-            change: ChangeType::Creation.into(),
+            change: ChangeType::Creation,
             creation_tx: Bytes::from_str("0x0000").unwrap(),
             created_at: creation_time,
         }
@@ -254,7 +254,6 @@ mod tests {
         accounts
     }
 
-    #[allow(deprecated)]
     #[tokio::test]
     async fn test_try_from_with_header() {
         let attributes: HashMap<String, Bytes> = vec![
@@ -290,13 +289,12 @@ mod tests {
         .map(|t| (t.address.clone(), t))
         .collect::<HashMap<_, _>>();
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 component_id: "0x4626d81b3a1711beb79f4cecff2413886d461677000200000000000000000011"
                     .to_owned(),
                 attributes,
                 balances: HashMap::new(),
-            }
-            .into(),
+            },
             component: vm_component(),
             component_tvl: None,
             entrypoints: Vec::new(),

--- a/crates/tycho-simulation/src/evm/protocol/vm/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/vm/state.rs
@@ -545,7 +545,6 @@ where
     }
 
     #[cfg(test)]
-    #[deprecated]
     pub fn get_balance_owner(&self) -> Option<Address> {
         self.balance_owner
     }

--- a/crates/tycho-simulation/src/evm/stream.rs
+++ b/crates/tycho-simulation/src/evm/stream.rs
@@ -181,7 +181,7 @@ impl ProtocolStreamBuilder {
     pub fn new(tycho_url: &str, chain: Chain) -> Self {
         Self {
             decoder: TychoStreamDecoder::new(),
-            stream_builder: TychoStreamBuilder::new(tycho_url, chain.into()),
+            stream_builder: TychoStreamBuilder::new(tycho_url, chain),
             stream_end_policy: StreamEndPolicy::default(),
         }
     }

--- a/crates/tycho-simulation/src/evm/tycho_models.rs
+++ b/crates/tycho-simulation/src/evm/tycho_models.rs
@@ -118,49 +118,6 @@ impl TryFrom<tycho_common::dto::ResponseAccount> for ResponseAccount {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use tycho_common::Bytes;
-
-    use super::*;
-
-    fn make_dto_response_account(address: Bytes) -> tycho_common::dto::ResponseAccount {
-        #[allow(deprecated)]
-        tycho_common::dto::ResponseAccount::new(
-            tycho_common::dto::Chain::Ethereum,
-            address,
-            "test".to_string(),
-            HashMap::new(),
-            Bytes::zero(32),
-            HashMap::new(),
-            Bytes::from(vec![0xDE, 0xAD]),
-            Bytes::from("0x00"),
-            Bytes::from("0x00"),
-            Bytes::from("0x00"),
-            None,
-        )
-    }
-
-    #[test]
-    fn test_response_account_conversion_succeeds() {
-        let dto = make_dto_response_account(Bytes::zero(20));
-
-        let result = ResponseAccount::try_from(dto).unwrap();
-
-        assert_eq!(result.address, Address::ZERO);
-        assert_eq!(result.code, vec![0xDE, 0xAD]);
-    }
-
-    #[test]
-    fn test_response_account_conversion_short_address_fails() {
-        let dto = make_dto_response_account(Bytes::from(vec![0x01]));
-
-        let result = ResponseAccount::try_from(dto);
-
-        assert!(result.is_err());
-    }
-}
-
 impl From<tycho_common::models::contract::Account> for ResponseAccount {
     fn from(value: tycho_common::models::contract::Account) -> Self {
         Self {
@@ -204,5 +161,48 @@ impl From<tycho_common::models::contract::AccountDelta> for AccountUpdate {
             code,
             change,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tycho_common::Bytes;
+
+    use super::*;
+
+    fn make_dto_response_account(address: Bytes) -> tycho_common::dto::ResponseAccount {
+        #[allow(deprecated)]
+        tycho_common::dto::ResponseAccount::new(
+            tycho_common::dto::Chain::Ethereum,
+            address,
+            "test".to_string(),
+            HashMap::new(),
+            Bytes::zero(32),
+            HashMap::new(),
+            Bytes::from(vec![0xDE, 0xAD]),
+            Bytes::from("0x00"),
+            Bytes::from("0x00"),
+            Bytes::from("0x00"),
+            None,
+        )
+    }
+
+    #[test]
+    fn test_response_account_conversion_succeeds() {
+        let dto = make_dto_response_account(Bytes::zero(20));
+
+        let result = ResponseAccount::try_from(dto).unwrap();
+
+        assert_eq!(result.address, Address::ZERO);
+        assert_eq!(result.code, vec![0xDE, 0xAD]);
+    }
+
+    #[test]
+    fn test_response_account_conversion_short_address_fails() {
+        let dto = make_dto_response_account(Bytes::from(vec![0x01]));
+
+        let result = ResponseAccount::try_from(dto);
+
+        assert!(result.is_err());
     }
 }

--- a/crates/tycho-simulation/src/evm/tycho_models.rs
+++ b/crates/tycho-simulation/src/evm/tycho_models.rs
@@ -160,3 +160,49 @@ mod tests {
         assert!(result.is_err());
     }
 }
+
+impl From<tycho_common::models::contract::Account> for ResponseAccount {
+    fn from(value: tycho_common::models::contract::Account) -> Self {
+        Self {
+            chain: value.chain,
+            address: Address::from_slice(&value.address[..20]),
+            title: value.title,
+            slots: u256_num::map_slots_to_u256(value.slots),
+            native_balance: u256_num::bytes_to_u256(value.native_balance.into()),
+            token_balances: value
+                .token_balances
+                .into_iter()
+                .map(|(addr, ab)| {
+                    (Address::from_slice(&addr[..20]), u256_num::bytes_to_u256(ab.balance.into()))
+                })
+                .collect(),
+            code: value.code.to_vec(),
+        }
+    }
+}
+
+impl From<tycho_common::models::contract::AccountDelta> for AccountUpdate {
+    fn from(value: tycho_common::models::contract::AccountDelta) -> Self {
+        let code = value.code().clone().map(|c| c.to_vec());
+        let change = value.change_type().into();
+        Self {
+            chain: value.chain,
+            address: Address::from_slice(&value.address[..20]),
+            slots: value
+                .slots
+                .into_iter()
+                .map(|(k, v)| {
+                    (
+                        u256_num::bytes_to_u256(k.into()),
+                        u256_num::bytes_to_u256(v.unwrap_or_default().into()),
+                    )
+                })
+                .collect(),
+            balance: value
+                .balance
+                .map(|b| u256_num::bytes_to_u256(b.into())),
+            code,
+            change,
+        }
+    }
+}

--- a/crates/tycho-simulation/src/protocol/models.rs
+++ b/crates/tycho-simulation/src/protocol/models.rs
@@ -116,7 +116,7 @@ impl ProtocolComponent {
     }
 
     pub fn from_with_tokens(
-        core_model: tycho_common::dto::ProtocolComponent,
+        core_model: tycho_common::models::protocol::ProtocolComponent,
         tokens: Vec<Token>,
     ) -> Self {
         let id = Bytes::from(core_model.id.as_str());
@@ -124,9 +124,9 @@ impl ProtocolComponent {
             id.clone(),
             core_model.protocol_system,
             core_model.protocol_type_name,
-            core_model.chain.into(),
+            core_model.chain,
             tokens,
-            core_model.contract_ids,
+            core_model.contract_addresses,
             core_model.static_attributes,
             core_model.creation_tx,
             core_model.created_at,

--- a/crates/tycho-simulation/src/rfq/protocols/bebop/client.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/bebop/client.rs
@@ -34,7 +34,7 @@ use crate::{
         },
     },
     tycho_client::feed::synchronizer::{ComponentWithState, Snapshot, StateSyncMessage},
-    tycho_common::dto::{ProtocolComponent, ResponseProtocolState},
+    tycho_common::models::protocol::{ProtocolComponent, ProtocolComponentState},
 };
 
 fn bytes_to_address(address: &Bytes) -> Result<Address, RFQError> {
@@ -113,9 +113,9 @@ impl BebopClient {
             id: component_id.clone(),
             protocol_system: Self::PROTOCOL_SYSTEM.to_string(),
             protocol_type_name: "bebop_pool".to_string(),
-            chain: self.chain.into(),
+            chain: self.chain,
             tokens,
-            contract_ids: vec![], // empty for RFQ
+            contract_addresses: vec![], // empty for RFQ
             static_attributes: Default::default(),
             change: Default::default(),
             creation_tx: Default::default(),
@@ -147,11 +147,7 @@ impl BebopClient {
         }
 
         ComponentWithState {
-            state: ResponseProtocolState {
-                component_id: component_id.clone(),
-                attributes,
-                balances: HashMap::new(),
-            },
+            state: ProtocolComponentState::new(&component_id, attributes, HashMap::new()),
             component: protocol_component,
             component_tvl: Some(tvl),
             entrypoints: vec![],
@@ -626,10 +622,7 @@ mod tests {
                                     .protocol_type_name,
                                 "bebop_pool"
                             );
-                            assert_eq!(
-                                component_with_state.component.chain,
-                                Chain::Ethereum.into()
-                            );
+                            assert_eq!(component_with_state.component.chain, Chain::Ethereum);
 
                             let attributes = &component_with_state.state.attributes;
 

--- a/crates/tycho-simulation/src/rfq/protocols/bebop/decoder.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/bebop/decoder.rs
@@ -100,9 +100,9 @@ impl TryFromWithBlock<ComponentWithState, TimestampHeader> for BebopState {
 mod tests {
     use std::env;
 
-    use tycho_common::{
-        dto::{Chain, ChangeType, ResponseProtocolState},
-        models::{protocol::ProtocolComponent, Chain as ModelChain},
+    use tycho_common::models::{
+        protocol::{ProtocolComponent, ProtocolComponentState},
+        Chain as ModelChain, ChangeType,
     };
 
     use super::*;
@@ -160,21 +160,20 @@ mod tests {
         );
 
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 attributes: state_attributes,
                 component_id: "bebop_wbtc_usdc".to_string(),
                 balances: HashMap::new(),
-            }
-            .into(),
+            },
             component: ProtocolComponent {
                 id: "bebop_wbtc_usdc".to_string(),
                 protocol_system: "bebop".to_string(),
                 protocol_type_name: "bebop".to_string(),
-                chain: Chain::Ethereum.into(),
+                chain: ModelChain::Ethereum,
                 tokens: vec![wbtc_token.address.clone(), usdc_token.address.clone()],
                 contract_addresses: Vec::new(),
                 static_attributes: HashMap::new(),
-                change: ChangeType::Creation.into(),
+                change: ChangeType::Creation,
                 creation_tx: Bytes::default(),
                 created_at: chrono::NaiveDateTime::default(),
             },

--- a/crates/tycho-simulation/src/rfq/protocols/bebop/decoder.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/bebop/decoder.rs
@@ -102,7 +102,7 @@ mod tests {
 
     use tycho_common::models::{
         protocol::{ProtocolComponent, ProtocolComponentState},
-        Chain as ModelChain, ChangeType,
+        Chain, ChangeType,
     };
 
     use super::*;
@@ -116,7 +116,7 @@ mod tests {
             8,
             0,
             &[Some(10_000)],
-            ModelChain::Ethereum,
+            Chain::Ethereum,
             100,
         )
     }
@@ -130,7 +130,7 @@ mod tests {
             6,
             0,
             &[Some(10_000)],
-            ModelChain::Ethereum,
+            Chain::Ethereum,
             100,
         )
     }
@@ -169,7 +169,7 @@ mod tests {
                 id: "bebop_wbtc_usdc".to_string(),
                 protocol_system: "bebop".to_string(),
                 protocol_type_name: "bebop".to_string(),
-                chain: ModelChain::Ethereum,
+                chain: Chain::Ethereum,
                 tokens: vec![wbtc_token.address.clone(), usdc_token.address.clone()],
                 contract_addresses: Vec::new(),
                 static_attributes: HashMap::new(),

--- a/crates/tycho-simulation/src/rfq/protocols/bebop/decoder.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/bebop/decoder.rs
@@ -86,7 +86,7 @@ impl TryFromWithBlock<ComponentWithState, TimestampHeader> for BebopState {
             InvalidSnapshotError::ValueError(format!("Failed to get Bebop authentication: {e}"))
         })?;
 
-        let client = BebopClientBuilder::new(snapshot.component.chain.into(), auth.user, auth.key)
+        let client = BebopClientBuilder::new(snapshot.component.chain, auth.user, auth.key)
             .build()
             .map_err(|e| {
                 InvalidSnapshotError::MissingAttribute(format!("Couldn't create BebopClient: {e}"))
@@ -101,8 +101,8 @@ mod tests {
     use std::env;
 
     use tycho_common::{
-        dto::{Chain, ChangeType, ProtocolComponent, ResponseProtocolState},
-        models::Chain as ModelChain,
+        dto::{Chain, ChangeType, ResponseProtocolState},
+        models::{protocol::ProtocolComponent, Chain as ModelChain},
     };
 
     use super::*;
@@ -164,16 +164,17 @@ mod tests {
                 attributes: state_attributes,
                 component_id: "bebop_wbtc_usdc".to_string(),
                 balances: HashMap::new(),
-            },
+            }
+            .into(),
             component: ProtocolComponent {
                 id: "bebop_wbtc_usdc".to_string(),
                 protocol_system: "bebop".to_string(),
                 protocol_type_name: "bebop".to_string(),
-                chain: Chain::Ethereum,
+                chain: Chain::Ethereum.into(),
                 tokens: vec![wbtc_token.address.clone(), usdc_token.address.clone()],
-                contract_ids: Vec::new(),
+                contract_addresses: Vec::new(),
                 static_attributes: HashMap::new(),
-                change: ChangeType::Creation,
+                change: ChangeType::Creation.into(),
                 creation_tx: Bytes::default(),
                 created_at: chrono::NaiveDateTime::default(),
             },

--- a/crates/tycho-simulation/src/rfq/protocols/hashflow/client.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/hashflow/client.rs
@@ -30,7 +30,7 @@ use crate::{
         },
     },
     tycho_client::feed::synchronizer::{ComponentWithState, Snapshot, StateSyncMessage},
-    tycho_common::dto::{ProtocolComponent, ResponseProtocolState},
+    tycho_common::models::protocol::{ProtocolComponent, ProtocolComponentState},
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -128,9 +128,9 @@ impl HashflowClient {
             id: component_id.clone(),
             protocol_system: Self::PROTOCOL_SYSTEM.to_string(),
             protocol_type_name: "hashflow_pool".to_string(),
-            chain: self.chain.into(),
+            chain: self.chain,
             tokens,
-            contract_ids: vec![], // empty for RFQ
+            contract_addresses: vec![], // empty for RFQ
             ..Default::default()
         };
 
@@ -144,11 +144,7 @@ impl HashflowClient {
         attributes.insert("mm".to_string(), mm_name.as_bytes().to_vec().into());
 
         ComponentWithState {
-            state: ResponseProtocolState {
-                component_id: component_id.clone(),
-                attributes,
-                balances: HashMap::new(),
-            },
+            state: ProtocolComponentState::new(&component_id, attributes, HashMap::new()),
             component: protocol_component,
             component_tvl: Some(tvl),
             entrypoints: vec![],

--- a/crates/tycho-simulation/src/rfq/protocols/hashflow/decoder.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/hashflow/decoder.rs
@@ -107,9 +107,9 @@ impl TryFromWithBlock<ComponentWithState, TimestampHeader> for HashflowState {
 mod tests {
     use std::env;
 
-    use tycho_common::{
-        dto::{Chain, ChangeType, ResponseProtocolState},
-        models::{protocol::ProtocolComponent, Chain as ModelChain},
+    use tycho_common::models::{
+        protocol::{ProtocolComponent, ProtocolComponentState},
+        Chain as ModelChain, ChangeType,
     };
 
     use super::*;
@@ -184,21 +184,20 @@ mod tests {
         );
 
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 attributes: state_attributes,
                 component_id: "hashflow_wbtc_usdc".to_string(),
                 balances: HashMap::new(),
-            }
-            .into(),
+            },
             component: ProtocolComponent {
                 id: "hashflow_wbtc_usdc".to_string(),
                 protocol_system: "hashflow".to_string(),
                 protocol_type_name: "hashflow".to_string(),
-                chain: Chain::Ethereum.into(),
+                chain: ModelChain::Ethereum,
                 tokens: vec![wbtc_token.address.clone(), usdc_token.address.clone()],
                 contract_addresses: Vec::new(),
                 static_attributes: HashMap::new(),
-                change: ChangeType::Creation.into(),
+                change: ChangeType::Creation,
                 creation_tx: Bytes::default(),
                 created_at: chrono::NaiveDateTime::default(),
             },

--- a/crates/tycho-simulation/src/rfq/protocols/hashflow/decoder.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/hashflow/decoder.rs
@@ -90,15 +90,14 @@ impl TryFromWithBlock<ComponentWithState, TimestampHeader> for HashflowState {
             InvalidSnapshotError::ValueError(format!("Failed to get Hashflow authentication: {e}"))
         })?;
 
-        let client =
-            HashflowClientBuilder::new(snapshot.component.chain.into(), auth.user, auth.key)
-                .tokens(HashSet::from([base_token_address.clone(), quote_token_address.clone()]))
-                .build()
-                .map_err(|e| {
-                    InvalidSnapshotError::MissingAttribute(format!(
-                        "Couldn't create HashflowClient: {e}"
-                    ))
-                })?;
+        let client = HashflowClientBuilder::new(snapshot.component.chain, auth.user, auth.key)
+            .tokens(HashSet::from([base_token_address.clone(), quote_token_address.clone()]))
+            .build()
+            .map_err(|e| {
+                InvalidSnapshotError::MissingAttribute(format!(
+                    "Couldn't create HashflowClient: {e}"
+                ))
+            })?;
 
         Ok(HashflowState::new(base_token, quote_token, levels, market_maker, client))
     }
@@ -109,8 +108,8 @@ mod tests {
     use std::env;
 
     use tycho_common::{
-        dto::{Chain, ChangeType, ProtocolComponent, ResponseProtocolState},
-        models::Chain as ModelChain,
+        dto::{Chain, ChangeType, ResponseProtocolState},
+        models::{protocol::ProtocolComponent, Chain as ModelChain},
     };
 
     use super::*;
@@ -189,16 +188,17 @@ mod tests {
                 attributes: state_attributes,
                 component_id: "hashflow_wbtc_usdc".to_string(),
                 balances: HashMap::new(),
-            },
+            }
+            .into(),
             component: ProtocolComponent {
                 id: "hashflow_wbtc_usdc".to_string(),
                 protocol_system: "hashflow".to_string(),
                 protocol_type_name: "hashflow".to_string(),
-                chain: Chain::Ethereum,
+                chain: Chain::Ethereum.into(),
                 tokens: vec![wbtc_token.address.clone(), usdc_token.address.clone()],
-                contract_ids: Vec::new(),
+                contract_addresses: Vec::new(),
                 static_attributes: HashMap::new(),
-                change: ChangeType::Creation,
+                change: ChangeType::Creation.into(),
                 creation_tx: Bytes::default(),
                 created_at: chrono::NaiveDateTime::default(),
             },

--- a/crates/tycho-simulation/src/rfq/protocols/hashflow/decoder.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/hashflow/decoder.rs
@@ -109,7 +109,7 @@ mod tests {
 
     use tycho_common::models::{
         protocol::{ProtocolComponent, ProtocolComponentState},
-        Chain as ModelChain, ChangeType,
+        Chain, ChangeType,
     };
 
     use super::*;
@@ -123,7 +123,7 @@ mod tests {
             8,
             0,
             &[Some(10_000)],
-            ModelChain::Ethereum,
+            Chain::Ethereum,
             100,
         )
     }
@@ -137,7 +137,7 @@ mod tests {
             6,
             0,
             &[Some(10_000)],
-            ModelChain::Ethereum,
+            Chain::Ethereum,
             100,
         )
     }
@@ -193,7 +193,7 @@ mod tests {
                 id: "hashflow_wbtc_usdc".to_string(),
                 protocol_system: "hashflow".to_string(),
                 protocol_type_name: "hashflow".to_string(),
-                chain: ModelChain::Ethereum,
+                chain: Chain::Ethereum,
                 tokens: vec![wbtc_token.address.clone(), usdc_token.address.clone()],
                 contract_addresses: Vec::new(),
                 static_attributes: HashMap::new(),
@@ -302,7 +302,7 @@ mod tests {
             18,
             0,
             &[Some(10_000)],
-            ModelChain::Ethereum,
+            Chain::Ethereum,
             100,
         );
 

--- a/crates/tycho-simulation/src/rfq/protocols/liquorice/client.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/liquorice/client.rs
@@ -29,7 +29,7 @@ use crate::{
         },
     },
     tycho_client::feed::synchronizer::{ComponentWithState, Snapshot, StateSyncMessage},
-    tycho_common::dto::{ProtocolComponent, ResponseProtocolState},
+    tycho_common::models::protocol::{ProtocolComponent, ProtocolComponentState},
 };
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -121,9 +121,9 @@ impl LiquoriceClient {
             id: component_id.clone(),
             protocol_system: Self::PROTOCOL_SYSTEM.to_string(),
             protocol_type_name: "liquorice_pool".to_string(),
-            chain: self.chain.into(),
+            chain: self.chain,
             tokens,
-            contract_ids: vec![],
+            contract_addresses: vec![],
             ..Default::default()
         };
 
@@ -133,11 +133,7 @@ impl LiquoriceClient {
         attributes.insert("prices".to_string(), prices_json.as_bytes().to_vec().into());
 
         ComponentWithState {
-            state: ResponseProtocolState {
-                component_id: component_id.clone(),
-                attributes,
-                balances: HashMap::new(),
-            },
+            state: ProtocolComponentState::new(&component_id, attributes, HashMap::new()),
             component: protocol_component,
             component_tvl: Some(tvl),
             entrypoints: vec![],

--- a/crates/tycho-simulation/src/rfq/protocols/liquorice/decoder.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/liquorice/decoder.rs
@@ -67,15 +67,14 @@ impl TryFromWithBlock<ComponentWithState, TimestampHeader> for LiquoriceState {
             InvalidSnapshotError::ValueError(format!("Failed to get Liquorice authentication: {e}"))
         })?;
 
-        let client =
-            LiquoriceClientBuilder::new(snapshot.component.chain.into(), auth.solver, auth.key)
-                .tokens(HashSet::from([base_token_address.clone(), quote_token_address.clone()]))
-                .build()
-                .map_err(|e| {
-                    InvalidSnapshotError::MissingAttribute(format!(
-                        "Couldn't create LiquoriceClient: {e}"
-                    ))
-                })?;
+        let client = LiquoriceClientBuilder::new(snapshot.component.chain, auth.solver, auth.key)
+            .tokens(HashSet::from([base_token_address.clone(), quote_token_address.clone()]))
+            .build()
+            .map_err(|e| {
+                InvalidSnapshotError::MissingAttribute(format!(
+                    "Couldn't create LiquoriceClient: {e}"
+                ))
+            })?;
 
         Ok(LiquoriceState::new(base_token, quote_token, prices_by_mm, client))
     }
@@ -86,8 +85,8 @@ mod tests {
     use std::env;
 
     use tycho_common::{
-        dto::{Chain, ChangeType, ProtocolComponent, ResponseProtocolState},
-        models::Chain as ModelChain,
+        dto::{Chain, ChangeType, ResponseProtocolState},
+        models::{protocol::ProtocolComponent, Chain as ModelChain},
     };
 
     use super::*;
@@ -154,16 +153,17 @@ mod tests {
                 attributes: state_attributes,
                 component_id: "liquorice_wbtc_usdc".to_string(),
                 balances: HashMap::new(),
-            },
+            }
+            .into(),
             component: ProtocolComponent {
                 id: "liquorice_wbtc_usdc".to_string(),
                 protocol_system: "liquorice".to_string(),
                 protocol_type_name: "liquorice".to_string(),
-                chain: Chain::Ethereum,
+                chain: Chain::Ethereum.into(),
                 tokens: vec![wbtc_token.address.clone(), usdc_token.address.clone()],
-                contract_ids: Vec::new(),
+                contract_addresses: Vec::new(),
                 static_attributes: HashMap::new(),
-                change: ChangeType::Creation,
+                change: ChangeType::Creation.into(),
                 creation_tx: Bytes::default(),
                 created_at: chrono::NaiveDateTime::default(),
             },

--- a/crates/tycho-simulation/src/rfq/protocols/liquorice/decoder.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/liquorice/decoder.rs
@@ -86,7 +86,7 @@ mod tests {
 
     use tycho_common::models::{
         protocol::{ProtocolComponent, ProtocolComponentState},
-        Chain as ModelChain, ChangeType,
+        Chain, ChangeType,
     };
 
     use super::*;
@@ -100,7 +100,7 @@ mod tests {
             8,
             0,
             &[Some(10_000)],
-            ModelChain::Ethereum,
+            Chain::Ethereum,
             100,
         )
     }
@@ -114,7 +114,7 @@ mod tests {
             6,
             0,
             &[Some(10_000)],
-            ModelChain::Ethereum,
+            Chain::Ethereum,
             100,
         )
     }
@@ -158,7 +158,7 @@ mod tests {
                 id: "liquorice_wbtc_usdc".to_string(),
                 protocol_system: "liquorice".to_string(),
                 protocol_type_name: "liquorice".to_string(),
-                chain: ModelChain::Ethereum,
+                chain: Chain::Ethereum,
                 tokens: vec![wbtc_token.address.clone(), usdc_token.address.clone()],
                 contract_addresses: Vec::new(),
                 static_attributes: HashMap::new(),
@@ -267,7 +267,7 @@ mod tests {
             18,
             0,
             &[Some(10_000)],
-            ModelChain::Ethereum,
+            Chain::Ethereum,
             100,
         );
 

--- a/crates/tycho-simulation/src/rfq/protocols/liquorice/decoder.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/liquorice/decoder.rs
@@ -84,9 +84,9 @@ impl TryFromWithBlock<ComponentWithState, TimestampHeader> for LiquoriceState {
 mod tests {
     use std::env;
 
-    use tycho_common::{
-        dto::{Chain, ChangeType, ResponseProtocolState},
-        models::{protocol::ProtocolComponent, Chain as ModelChain},
+    use tycho_common::models::{
+        protocol::{ProtocolComponent, ProtocolComponentState},
+        Chain as ModelChain, ChangeType,
     };
 
     use super::*;
@@ -149,21 +149,20 @@ mod tests {
         state_attributes.insert("prices".to_string(), prices_json.into());
 
         let snapshot = ComponentWithState {
-            state: ResponseProtocolState {
+            state: ProtocolComponentState {
                 attributes: state_attributes,
                 component_id: "liquorice_wbtc_usdc".to_string(),
                 balances: HashMap::new(),
-            }
-            .into(),
+            },
             component: ProtocolComponent {
                 id: "liquorice_wbtc_usdc".to_string(),
                 protocol_system: "liquorice".to_string(),
                 protocol_type_name: "liquorice".to_string(),
-                chain: Chain::Ethereum.into(),
+                chain: ModelChain::Ethereum,
                 tokens: vec![wbtc_token.address.clone(), usdc_token.address.clone()],
                 contract_addresses: Vec::new(),
                 static_attributes: HashMap::new(),
-                change: ChangeType::Creation.into(),
+                change: ChangeType::Creation,
                 creation_tx: Bytes::default(),
                 created_at: chrono::NaiveDateTime::default(),
             },

--- a/crates/tycho-simulation/src/rfq/stream.rs
+++ b/crates/tycho-simulation/src/rfq/stream.rs
@@ -117,8 +117,11 @@ mod tests {
     use tokio_stream::wrappers::IntervalStream;
     use tycho_client::feed::synchronizer::{Snapshot, StateSyncMessage};
     use tycho_common::{
-        dto::{ProtocolComponent, ProtocolStateDelta, ResponseProtocolState},
-        models::{protocol::GetAmountOutParams, token::Token},
+        dto::{ProtocolStateDelta, ResponseProtocolState},
+        models::{
+            protocol::{GetAmountOutParams, ProtocolComponent},
+            token::Token,
+        },
         simulation::{
             errors::{SimulationError, TransitionError},
             indicatively_priced::SignedQuote,
@@ -240,7 +243,8 @@ mod tests {
                                     component_id: name.clone(),
                                     attributes: HashMap::new(),
                                     balances: HashMap::new(),
-                                },
+                                }
+                                .into(),
                                 component: protocol_component,
                                 component_tvl: None,
                                 entrypoints: vec![],

--- a/crates/tycho-simulation/src/rfq/stream.rs
+++ b/crates/tycho-simulation/src/rfq/stream.rs
@@ -117,9 +117,9 @@ mod tests {
     use tokio_stream::wrappers::IntervalStream;
     use tycho_client::feed::synchronizer::{Snapshot, StateSyncMessage};
     use tycho_common::{
-        dto::{ProtocolStateDelta, ResponseProtocolState},
+        dto::ProtocolStateDelta,
         models::{
-            protocol::{GetAmountOutParams, ProtocolComponent},
+            protocol::{GetAmountOutParams, ProtocolComponent, ProtocolComponentState},
             token::Token,
         },
         simulation::{
@@ -239,12 +239,11 @@ mod tests {
                         states: HashMap::from([(
                             name.clone(),
                             ComponentWithState {
-                                state: ResponseProtocolState {
+                                state: ProtocolComponentState {
                                     component_id: name.clone(),
                                     attributes: HashMap::new(),
                                     balances: HashMap::new(),
-                                }
-                                .into(),
+                                },
                                 component: protocol_component,
                                 component_tvl: None,
                                 entrypoints: vec![],

--- a/crates/tycho-simulation/src/utils.rs
+++ b/crates/tycho-simulation/src/utils.rs
@@ -88,7 +88,7 @@ pub async fn load_all_tokens(
     #[allow(clippy::mutable_key_type)]
     let tokens = rpc_client
         .get_all_tokens(
-            chain.into(),
+            chain,
             min_quality.or(Some(100)),
             max_days_since_last_trade.or(default_min_days
                 .get(&chain)
@@ -103,17 +103,8 @@ pub async fn load_all_tokens(
     tokens
         .into_iter()
         .map(|token| {
-            let token_clone = token.clone();
-            Token::try_from(token)
-                .map(|converted| (converted.address.clone(), converted))
-                .map_err(|_| {
-                    SimulationError::FatalError(format!(
-                        "Unable to convert token `{symbol}` at {address} on chain {chain} into ERC20 token",
-                        symbol = token_clone.symbol,
-                        address = token_clone.address,
-                        chain = token_clone.chain,
-                    ))
-                })
+            let converted = token;
+            Ok((converted.address.clone(), converted))
         })
         .collect()
 }

--- a/crates/tycho-simulation/src/utils.rs
+++ b/crates/tycho-simulation/src/utils.rs
@@ -87,8 +87,10 @@ pub async fn load_all_tokens(
 
     #[allow(clippy::mutable_key_type)]
     let min_q = min_quality.or(Some(100));
-    let traded = max_days_since_last_trade
-        .or(default_min_days.get(&chain).or(Some(&42)).copied());
+    let traded = max_days_since_last_trade.or(default_min_days
+        .get(&chain)
+        .or(Some(&42))
+        .copied());
     let mut token_params = AllTokensParams::new(chain, RPC_CLIENT_CONCURRENCY);
     if let Some(q) = min_q {
         token_params = token_params.with_min_quality(q);

--- a/crates/tycho-simulation/src/utils.rs
+++ b/crates/tycho-simulation/src/utils.rs
@@ -105,10 +105,7 @@ pub async fn load_all_tokens(
 
     tokens
         .into_iter()
-        .map(|token| {
-            let converted = token;
-            Ok((converted.address.clone(), converted))
-        })
+        .map(|token| Ok((token.address.clone(), token)))
         .collect()
 }
 

--- a/crates/tycho-simulation/src/utils.rs
+++ b/crates/tycho-simulation/src/utils.rs
@@ -6,7 +6,7 @@ use std::{
 
 use tracing::info;
 use tycho_client::{
-    rpc::{HttpRPCClientOptions, RPCClient, RPC_CLIENT_CONCURRENCY},
+    rpc::{AllTokensParams, HttpRPCClientOptions, RPCClient, RPC_CLIENT_CONCURRENCY},
     HttpRPCClient, RPCError,
 };
 use tycho_common::{
@@ -86,17 +86,18 @@ pub async fn load_all_tokens(
     let default_min_days = HashMap::from([(Chain::Base, 1_u64), (Chain::Unichain, 14_u64)]);
 
     #[allow(clippy::mutable_key_type)]
+    let min_q = min_quality.or(Some(100));
+    let traded = max_days_since_last_trade
+        .or(default_min_days.get(&chain).or(Some(&42)).copied());
+    let mut token_params = AllTokensParams::new(chain, RPC_CLIENT_CONCURRENCY);
+    if let Some(q) = min_q {
+        token_params = token_params.with_min_quality(q);
+    }
+    if let Some(d) = traded {
+        token_params = token_params.with_traded_n_days_ago(d);
+    }
     let tokens = rpc_client
-        .get_all_tokens(
-            chain,
-            min_quality.or(Some(100)),
-            max_days_since_last_trade.or(default_min_days
-                .get(&chain)
-                .or(Some(&42))
-                .copied()),
-            None,
-            RPC_CLIENT_CONCURRENCY,
-        )
+        .get_all_tokens(token_params)
         .await
         .map_err(|err| map_rpc_error(err, "Unable to load tokens"))?;
 

--- a/protocols/testing/src/config.rs
+++ b/protocols/testing/src/config.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use similar::{ChangeTag, TextDiff};
-use tycho_simulation::tycho_common::{dto::ProtocolComponent, Bytes};
+use tycho_simulation::tycho_common::{models::protocol::ProtocolComponent, Bytes};
 
 /// Represents a ProtocolComponent with its main attributes
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/protocols/testing/src/main.rs
+++ b/protocols/testing/src/main.rs
@@ -14,7 +14,7 @@ use clap::{Args, Parser, Subcommand};
 use dotenv::dotenv;
 use miette::{miette, IntoDiagnostic, WrapErr};
 use tracing_subscriber::EnvFilter;
-use tycho_simulation::tycho_common::dto::Chain;
+use tycho_simulation::tycho_common::models::Chain;
 
 use crate::test_runner::{TestRunner, TestType, TestTypeFull, TestTypeRange};
 

--- a/protocols/testing/src/test_runner.rs
+++ b/protocols/testing/src/test_runner.rs
@@ -40,8 +40,11 @@ use tycho_simulation::{
         BlockHeader, FeedMessage,
     },
     tycho_common::{
-        dto::{Chain, ProtocolComponent, ResponseProtocolState},
-        models::{token::Token, Chain as ChainModel},
+        models::{
+            protocol::{ProtocolComponent, ProtocolComponentState},
+            token::Token,
+            Chain,
+        },
         Bytes,
     },
 };
@@ -275,7 +278,7 @@ impl TestRunner {
     async fn run_live_testing(&self, config: &IntegrationTestsConfig) -> miette::Result<()> {
         info!("Starting live testing for protocol {}", &config.protocol_system);
 
-        let chain = ChainModel::from(self.chain);
+        let chain = self.chain;
         // Load tokens for the stream
         let all_tokens = tycho_simulation::utils::load_all_tokens(
             "localhost:4242",
@@ -559,7 +562,7 @@ impl TestRunner {
         let (protocol_components, snapshot, all_tokens) =
             self.fetch_from_tycho_rpc(&config.protocol_system, expected_ids, stop_block)?;
 
-        let response_protocol_states_by_id: HashMap<String, ResponseProtocolState> = snapshot
+        let response_protocol_states_by_id: HashMap<String, ProtocolComponentState> = snapshot
             .states
             .clone()
             .into_iter()
@@ -752,7 +755,7 @@ impl TestRunner {
     /// # Returns
     /// A tuple containing:
     /// - `Update` - Decoded protocol state update for simulation
-    /// - `HashMap<String, ResponseProtocolState>` - Protocol states by component ID
+    /// - `HashMap<String, ProtocolComponentState>` - Protocol states by component ID
     /// - `Block` - The block header for the specified block
     #[allow(clippy::type_complexity, clippy::too_many_arguments)]
     fn fetch_from_tycho_rpc(
@@ -811,7 +814,7 @@ impl TestRunner {
         let contract_ids: Vec<Bytes> = protocol_components
             .clone()
             .into_iter()
-            .flat_map(|component| component.contract_ids)
+            .flat_map(|component| component.contract_addresses)
             .chain(
                 traced_entry_points
                     .values()
@@ -861,7 +864,7 @@ impl TestRunner {
         let _ = tycho_simulation::evm::engine_db::SHARED_TYCHO_DB.clear();
 
         let protocol_stream_builder =
-            ProtocolStreamBuilder::new("", self.chain.into()).skip_state_decode_failures(true);
+            ProtocolStreamBuilder::new("", self.chain).skip_state_decode_failures(true);
 
         let mut decoder_context = DecoderContext::new().vm_traces(vm_simulation_traces);
         if let Some(vm_adapter_path) = adapter_contract_path.as_ref() {
@@ -1117,7 +1120,7 @@ impl TestRunner {
                             (protocol_system): EXECUTOR_ADDRESS
                         }
                     });
-                    let chain_model = ChainModel::from(self.chain);
+                    let chain_model = self.chain;
                     let (solution, calldata) = encode_swap(
                         component,
                         None,
@@ -1207,7 +1210,7 @@ impl TestRunner {
             return Ok(());
         }
 
-        let chain_model = ChainModel::from(self.chain);
+        let chain_model = self.chain;
         let rpc_tools = RPCTools::new(self.rpc_provider.url.as_ref(), &chain_model).await?;
 
         // Prepare router overwrites data
@@ -1327,7 +1330,7 @@ impl TestRunner {
     fn validate_token_balances(
         &self,
         component_tokens: &HashMap<String, Vec<Token>>,
-        protocol_states_by_id: &HashMap<String, ResponseProtocolState>,
+        protocol_states_by_id: &HashMap<String, ProtocolComponentState>,
         stop_block: u64,
     ) -> miette::Result<()> {
         for (id, component) in protocol_states_by_id.iter() {
@@ -1413,7 +1416,7 @@ mod tests {
 
     use dotenv::dotenv;
     use glob::glob;
-    use tycho_simulation::tycho_common::{dto::ResponseProtocolState, Bytes};
+    use tycho_simulation::tycho_common::{models::protocol::ProtocolComponentState, Bytes};
 
     use super::*;
 
@@ -1486,7 +1489,7 @@ mod tests {
         let block_number = 21998530;
         let token_bytes = Bytes::from_str("0x0000000000000000000000000000000000000000").unwrap();
         let component_id = "0x787B8840100d9BaAdD7463f4a73b5BA73B00C6cA".to_string();
-        let token = Token::new(&token_bytes, "FAKE", 18, 0, &[], Chain::Ethereum.into(), 100);
+        let token = Token::new(&token_bytes, "FAKE", 18, 0, &[], Chain::Ethereum, 100);
 
         let mut balances = HashMap::new();
         let balance_bytes = Bytes::from(
@@ -1495,16 +1498,12 @@ mod tests {
                 .to_be_bytes::<32>(),
         );
         balances.insert(token_bytes.clone(), balance_bytes.clone());
-        let protocol_state = ResponseProtocolState {
-            component_id: component_id.clone(),
-            balances,
-            ..Default::default()
-        };
+        let protocol_state = ProtocolComponentState::new(&component_id, HashMap::new(), balances);
 
         let mut component_tokens = HashMap::new();
         component_tokens.insert(component_id.clone(), vec![token]);
         let mut protocol_states_by_id = HashMap::new();
-        protocol_states_by_id.insert(component_id.clone(), protocol_state.clone());
+        protocol_states_by_id.insert(component_id.clone(), protocol_state);
 
         let result =
             runner.validate_token_balances(&component_tokens, &protocol_states_by_id, block_number);
@@ -1519,22 +1518,18 @@ mod tests {
         let block_number = 21998530;
         let token_bytes = Bytes::from_str("0x0000000000000000000000000000000000000000").unwrap();
         let component_id = "0x787B8840100d9BaAdD7463f4a73b5BA73B00C6cA".to_string();
-        let token = Token::new(&token_bytes, "FAKE", 18, 0, &[], Chain::Ethereum.into(), 100);
+        let token = Token::new(&token_bytes, "FAKE", 18, 0, &[], Chain::Ethereum, 100);
 
         // Set expected balance to zero
         let mut balances = HashMap::new();
         let balance_bytes = Bytes::from(U256::from(0).to_be_bytes::<32>());
         balances.insert(token_bytes.clone(), balance_bytes.clone());
-        let protocol_state = ResponseProtocolState {
-            component_id: component_id.clone(),
-            balances,
-            ..Default::default()
-        };
+        let protocol_state = ProtocolComponentState::new(&component_id, HashMap::new(), balances);
 
         let mut component_tokens = HashMap::new();
         component_tokens.insert(component_id.clone(), vec![token]);
         let mut protocol_states_by_id = HashMap::new();
-        protocol_states_by_id.insert(component_id.clone(), protocol_state.clone());
+        protocol_states_by_id.insert(component_id.clone(), protocol_state);
 
         dotenv().ok();
         let result =

--- a/protocols/testing/src/test_runner.rs
+++ b/protocols/testing/src/test_runner.rs
@@ -875,7 +875,7 @@ impl TestRunner {
         let protocol_stream_builder = register_protocol(
             protocol_stream_builder,
             protocol_system,
-            self.chain.into(),
+            self.chain,
             decoder_context,
         )?;
 

--- a/protocols/testing/src/tycho_rpc.rs
+++ b/protocols/testing/src/tycho_rpc.rs
@@ -5,7 +5,10 @@ use tracing::{debug, info, warn};
 use tycho_simulation::{
     tycho_client::{
         feed::synchronizer::Snapshot,
-        rpc::{HttpRPCClientOptions, RPCClient, TracedEntryPointsParams},
+        rpc::{
+            AllTokensParams, HttpRPCClientOptions, ProtocolComponentsPaginatedParams, RPCClient,
+            TracedEntryPointsParams,
+        },
         HttpRPCClient, SnapshotParameters,
     },
     tycho_common::{
@@ -71,12 +74,8 @@ impl TychoClient {
 
         self.http_client
             .get_protocol_components_paginated(
-                chain,
-                protocol_system.to_string(),
-                None,
-                None,
-                Some(chunk_size),
-                concurrency,
+                ProtocolComponentsPaginatedParams::new(chain, protocol_system, concurrency)
+                    .with_chunk_size(chunk_size),
             )
             .await
             .map_err(RpcError::from)
@@ -93,9 +92,16 @@ impl TychoClient {
         let concurrency = 1;
 
         #[allow(clippy::mutable_key_type)]
+        let mut params = AllTokensParams::new(chain, concurrency).with_chunk_size(3_000);
+        if let Some(q) = min_quality {
+            params = params.with_min_quality(q);
+        }
+        if let Some(d) = max_days_since_last_trade {
+            params = params.with_traded_n_days_ago(d);
+        }
         let res = self
             .http_client
-            .get_all_tokens(chain, min_quality, max_days_since_last_trade, Some(3_000), concurrency)
+            .get_all_tokens(params)
             .await?
             .into_iter()
             .map(|mut token| {
@@ -124,6 +130,7 @@ impl TychoClient {
                     .with_component_ids(component_ids),
             )
             .await
+            .map(|page| page.into_data())
             .map_err(RpcError::from)
     }
 

--- a/protocols/testing/src/tycho_rpc.rs
+++ b/protocols/testing/src/tycho_rpc.rs
@@ -5,16 +5,16 @@ use tracing::{debug, info, warn};
 use tycho_simulation::{
     tycho_client::{
         feed::synchronizer::Snapshot,
-        rpc::{HttpRPCClientOptions, RPCClient},
+        rpc::{HttpRPCClientOptions, RPCClient, TracedEntryPointsParams},
         HttpRPCClient, SnapshotParameters,
     },
     tycho_common::{
-        dto::{
-            Chain, EntryPointWithTracingParams, PaginationParams, ProtocolComponent,
-            ProtocolComponentsRequestBody, ResponseToken, TracedEntryPointRequestBody,
-            TracingResult,
+        models::{
+            blockchain::{EntryPointWithTracingParams, TracingResult},
+            protocol::ProtocolComponent,
+            token::Token,
+            Chain, ComponentId,
         },
-        models::{token::Token, ComponentId},
         Bytes,
     },
 };
@@ -66,17 +66,20 @@ impl TychoClient {
         protocol_system: &str,
         chain: Chain,
     ) -> Result<Vec<ProtocolComponent>, RpcError> {
-        let request = ProtocolComponentsRequestBody::system_filtered(protocol_system, None, chain);
-
         let chunk_size = 100;
         let concurrency = 1;
 
-        let response = self
-            .http_client
-            .get_protocol_components_paginated(&request, Some(chunk_size), concurrency)
-            .await?;
-
-        Ok(response.protocol_components)
+        self.http_client
+            .get_protocol_components_paginated(
+                chain,
+                protocol_system.to_string(),
+                None,
+                None,
+                Some(chunk_size),
+                concurrency,
+            )
+            .await
+            .map_err(RpcError::from)
     }
 
     pub async fn get_tokens(
@@ -95,19 +98,13 @@ impl TychoClient {
             .get_all_tokens(chain, min_quality, max_days_since_last_trade, Some(3_000), concurrency)
             .await?
             .into_iter()
-            .map(|token| {
-                let mut token_clone: ResponseToken = token.clone();
+            .map(|mut token| {
                 // Set default gas if empty
                 // TODO: Check if this interferes with simulation logic
-                if token_clone.gas.is_empty() {
-                    token_clone.gas = vec![Some(44000_u64)];
+                if token.gas.is_empty() {
+                    token.gas = vec![Some(44000_u64)];
                 }
-                (
-                    token_clone.address.clone(),
-                    token_clone
-                        .try_into()
-                        .expect("Failed to convert token"),
-                )
+                (token.address.clone(), token)
             })
             .collect::<HashMap<_, Token>>();
 
@@ -121,19 +118,13 @@ impl TychoClient {
         component_ids: Vec<String>,
         chain: Chain,
     ) -> Result<HashMap<String, Vec<(EntryPointWithTracingParams, TracingResult)>>, RpcError> {
-        let request_body = TracedEntryPointRequestBody {
-            protocol_system: protocol_system.to_string(),
-            chain,
-            pagination: PaginationParams { page: 0, page_size: 100 },
-            component_ids: Some(component_ids),
-        };
-
-        let traced_entry_points = self
-            .http_client
-            .get_traced_entry_points(&request_body)
-            .await?;
-
-        Ok(traced_entry_points.traced_entry_points)
+        self.http_client
+            .get_traced_entry_points(
+                TracedEntryPointsParams::new(chain, protocol_system)
+                    .with_component_ids(component_ids),
+            )
+            .await
+            .map_err(RpcError::from)
     }
 
     pub async fn get_snapshots(
@@ -152,12 +143,10 @@ impl TychoClient {
         let chunk_size = 100;
         let concurrency = 1;
 
-        let response = self
-            .http_client
+        self.http_client
             .get_snapshots(&params, Some(chunk_size), concurrency)
-            .await?;
-
-        Ok(response)
+            .await
+            .map_err(RpcError::from)
     }
 
     /// Waits for the protocol to be synced and have components available

--- a/protocols/testing/src/tycho_runner.rs
+++ b/protocols/testing/src/tycho_runner.rs
@@ -9,7 +9,7 @@ use std::{
 use miette::{IntoDiagnostic, WrapErr};
 use tempfile::NamedTempFile;
 use tracing::{debug, info};
-use tycho_simulation::tycho_common::dto::Chain;
+use tycho_simulation::tycho_common::models::Chain;
 pub struct TychoRunner {
     chain: Chain,
     db_url: String,


### PR DESCRIPTION
## Summary

- Moves the dto deserialization boundary to the wire edges of `tycho-client` (`rpc.rs`, `deltas.rs`) — dto types no longer appear in public trait signatures, public error types, or internal data structures
- Introduces builder-style parameter structs for all 7 `RPCClient` required methods, making future parameter additions backwards-compatible
- Migrates `DeltasClient::subscribe` to accept `models::ExtractorIdentity`
- Migrates `Chain` in `protocols/testing` from dto to models throughout
- Adds `TracedEntryPoints` type alias and `From<TracedEntryPoints> for DCIUpdate` in `tycho-common::models::blockchain`, replacing the removed `From<TracedEntryPointRequestResponse> for dto::DCIUpdate`

## Key changes

**`tycho-common`**
- `models/blockchain.rs`: new `TracedEntryPoints` type alias + `From<TracedEntryPoints> for DCIUpdate`
- `dto.rs`: removed `From<TracedEntryPointRequestResponse> for DCIUpdate` (superseded by the model-layer impl)

**`tycho-client`**
- `rpc.rs`: 7 builder-style params structs (`ContractStateParams`, `ProtocolComponentsParams`, `ProtocolStatesParams`, `TokensParams`, `ProtocolSystemsParams`, `ComponentTvlParams`, `TracedEntryPointsParams`) — private fields, minimal `new()`, `with_*()` setters, internal-only `with_pagination()`; `RPCClient` trait methods updated to take these structs; dto construction moved fully inside `HttpRPCClient` method bodies
- `deltas.rs`: `DeltasClient::subscribe` takes `models::ExtractorIdentity`; `DeltasError::ServerError` no longer exposes `dto::WebsocketError` in its variant
- `feed/synchronizer.rs`, `feed/component_tracker.rs`, `stream.rs`: updated to new signatures
- `cli.rs`: `Chain` switched from dto to models

**`protocols/testing`**
- `TychoRunner`, `CommonArgs`, `main.rs`: `Chain` switched from dto to models
- `tycho_rpc.rs`: updated to new `RPCClient` method signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)