### PR TITLE
feat(tycho-executor): extend interface for convenience

### DIFF
--- a/crates/tycho-execution/CLAUDE.md
+++ b/crates/tycho-execution/CLAUDE.md
@@ -220,9 +220,10 @@ from `config/executor_addresses.json`. Protocol name prefixes: `vm:` (simulation
 e.g. `vm:balancer_v2`, `vm:curve`), `rfq:` (request-for-quote, e.g. `rfq:bebop`), bare (on-chain,
 e.g. `uniswap_v2`, `fluid_v1`).
 
-There is no `ClientFeeParams` struct on the Rust side. The Solidity struct is encoded as a raw ABI
-tuple `(uint16,address,uint256,uint256,bytes)` embedded in the function signature strings within each strategy encoder.
-The caller provides the pre-signed bytes; the Rust encoder just passes them through.
+`ClientFeeParams` is a Rust struct in `tycho-execution::encoding::models` that mirrors the Solidity struct. Call
+`.into_abi_params()` to convert it to the ABI-encodable tuple for use in calldata construction. The encoder does not
+use it internally — callers are responsible for constructing and signing it. The default value (all zeros) represents
+no fee.
 
 ### Gas estimation
 

--- a/crates/tycho-execution/CLAUDE.md
+++ b/crates/tycho-execution/CLAUDE.md
@@ -220,11 +220,6 @@ from `config/executor_addresses.json`. Protocol name prefixes: `vm:` (simulation
 e.g. `vm:balancer_v2`, `vm:curve`), `rfq:` (request-for-quote, e.g. `rfq:bebop`), bare (on-chain,
 e.g. `uniswap_v2`, `fluid_v1`).
 
-`ClientFeeParams` is a Rust struct in `tycho-execution::encoding::models` that mirrors the Solidity struct. Call
-`.into_abi_params()` to convert it to the ABI-encodable tuple for use in calldata construction. The encoder does not
-use it internally — callers are responsible for constructing and signing it. The default value (all zeros) represents
-no fee.
-
 ### Gas estimation
 
 `Swap::new(component, token_in: Token, token_out: Token, estimated_gas: BigUint)` carries a per-swap simulation gas

--- a/crates/tycho-execution/examples/uniswapx-encoding-example/main.rs
+++ b/crates/tycho-execution/examples/uniswapx-encoding-example/main.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, str::FromStr};
 
 use alloy::{
     hex::encode,
-    primitives::{Address, Keccak256, U256},
+    primitives::{Address, Keccak256},
     sol_types::SolValue,
 };
 use num_bigint::{BigInt, BigUint};
@@ -17,7 +17,7 @@ use tycho_execution::encoding::{
         swap_encoder::swap_encoder_registry::SwapEncoderRegistry,
         utils::{biguint_to_u256, bytes_to_address},
     },
-    models::{Solution, Swap},
+    models::{ClientFeeParams, Solution, Swap},
 };
 
 /// Encodes the input data for a function call to the given function selector.
@@ -133,10 +133,7 @@ fn main() {
     let checked_token = bytes_to_address(solution.token_out()).unwrap();
     let receiver = bytes_to_address(solution.receiver()).unwrap();
 
-    // Empty ClientFeeParams: (clientFeeBps, clientFeeReceiver, maxClientContribution, deadline,
-    // sig)
-    let client_fee_params: (u16, Address, U256, U256, Vec<u8>) =
-        (0u16, Address::ZERO, U256::ZERO, U256::ZERO, vec![]);
+    let client_fee_params = ClientFeeParams::default().into_abi_params();
 
     let method_calldata = (
         given_amount,

--- a/crates/tycho-execution/src/encoding/evm/swap_encoder/swap_encoder_registry.rs
+++ b/crates/tycho-execution/src/encoding/evm/swap_encoder/swap_encoder_registry.rs
@@ -34,6 +34,11 @@ impl SwapEncoderRegistry {
         Self { chain, encoders: HashMap::new() }
     }
 
+    /// Creates a new registry pre-populated with all default encoders for the given chain.
+    pub fn new_with_defaults(chain: Chain) -> Result<Self, EncodingError> {
+        Self::new(chain).add_default_encoders(None)
+    }
+
     /// Populates the registry with the default `SwapEncoders` for the given blockchain by
     /// parsing the executors' addresses in the file at the given path.
     pub fn add_default_encoders(

--- a/crates/tycho-execution/src/encoding/models.rs
+++ b/crates/tycho-execution/src/encoding/models.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+#[cfg(feature = "evm")]
+use alloy::primitives::{Address, U256};
 use clap::ValueEnum;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
@@ -32,6 +34,50 @@ pub enum UserTransferType {
     #[default]
     TransferFrom,
     UseVaultsFunds,
+}
+
+/// Client fee parameters passed to the router, matching the Solidity `ClientFeeParams` struct.
+///
+/// The default value (all zeros) represents no fee. Clients are responsible for constructing
+/// and signing this struct; `tycho-execution` does not use it internally.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct ClientFeeParams {
+    /// Fee in basis points charged by the client (0–10000).
+    pub client_fee_bps: u16,
+    /// Address to receive the client fee.
+    pub client_fee_receiver: Bytes,
+    /// Maximum amount the client will contribute from their vault if slippage reduces the output
+    /// below `min_amount_out`.
+    #[serde(with = "biguint_string")]
+    pub max_client_contribution: BigUint,
+    /// Deadline for the fee signature as a unix timestamp.
+    #[serde(with = "biguint_string")]
+    pub deadline: BigUint,
+    /// EIP-712 signature over the fee parameters and swap intent.
+    pub client_signature: Bytes,
+}
+
+#[cfg(feature = "evm")]
+impl ClientFeeParams {
+    /// Converts into the ABI-encodable tuple matching the Solidity `ClientFeeParams` struct.
+    pub fn into_abi_params(self) -> (u16, Address, U256, U256, Vec<u8>) {
+        let receiver = if self.client_fee_receiver.is_empty() {
+            Address::ZERO
+        } else {
+            Address::from_slice(&self.client_fee_receiver)
+        };
+        (
+            self.client_fee_bps,
+            receiver,
+            U256::from_be_slice(
+                &self
+                    .max_client_contribution
+                    .to_bytes_be(),
+            ),
+            U256::from_be_slice(&self.deadline.to_bytes_be()),
+            self.client_signature.to_vec(),
+        )
+    }
 }
 
 /// Represents a solution containing details describing an order, and instructions for filling

--- a/crates/tycho-execution/src/encoding/models.rs
+++ b/crates/tycho-execution/src/encoding/models.rs
@@ -43,18 +43,56 @@ pub enum UserTransferType {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ClientFeeParams {
     /// Fee in basis points charged by the client (0–10000).
-    pub client_fee_bps: u16,
-    /// Address to receive the client fee.
-    pub client_fee_receiver: Bytes,
+    client_fee_bps: u16,
+    /// Address that identifies the client and receives any client fee.
+    client_fee_receiver: Bytes,
     /// Maximum amount the client will contribute from their vault if slippage reduces the output
     /// below `min_amount_out`.
     #[serde(with = "biguint_string")]
-    pub max_client_contribution: BigUint,
+    max_client_contribution: BigUint,
     /// Deadline for the fee signature as a unix timestamp.
     #[serde(with = "biguint_string")]
-    pub deadline: BigUint,
+    deadline: BigUint,
     /// EIP-712 signature over the fee parameters and swap intent.
-    pub client_signature: Bytes,
+    client_signature: Bytes,
+}
+
+impl ClientFeeParams {
+    /// Creates params that identify the client and charge a fee in basis points.
+    pub fn new(
+        client_fee_receiver: Bytes,
+        client_signature: Bytes,
+        deadline: BigUint,
+        client_fee_bps: u16,
+    ) -> Self {
+        Self {
+            client_fee_bps,
+            client_fee_receiver,
+            max_client_contribution: BigUint::ZERO,
+            deadline,
+            client_signature,
+        }
+    }
+
+    /// Creates params that identify the client for router fee discounts without charging a fee.
+    pub fn new_without_fee(
+        client_fee_receiver: Bytes,
+        client_signature: Bytes,
+        deadline: BigUint,
+    ) -> Self {
+        Self {
+            client_fee_bps: 0,
+            client_fee_receiver,
+            max_client_contribution: BigUint::ZERO,
+            deadline,
+            client_signature,
+        }
+    }
+
+    pub fn with_max_client_contribution(mut self, max_client_contribution: BigUint) -> Self {
+        self.max_client_contribution = max_client_contribution;
+        self
+    }
 }
 
 #[cfg(feature = "evm")]

--- a/crates/tycho-test/src/execution/encoding.rs
+++ b/crates/tycho-test/src/execution/encoding.rs
@@ -21,7 +21,7 @@ use tycho_execution::encoding::{
         encoder_builders::TychoRouterEncoderBuilder,
         swap_encoder::swap_encoder_registry::SwapEncoderRegistry,
     },
-    models::{EncodedSolution, Solution, Swap},
+    models::{ClientFeeParams, EncodedSolution, Solution, Swap},
 };
 use tycho_simulation::{
     evm::protocol::u256_num::biguint_to_u256, protocol::models::ProtocolComponent,
@@ -133,8 +133,7 @@ fn encoded_transaction(
     let token_in = Address::from_slice(solution.token_in());
     let token_out = Address::from_slice(solution.token_out());
     let receiver = Address::from_slice(solution.receiver());
-    let client_fee_params: (u16, Address, U256, U256, Vec<u8>) =
-        (0, Address::ZERO, U256::ZERO, U256::ZERO, vec![]);
+    let client_fee_params = ClientFeeParams::default().into_abi_params();
 
     let method_calldata = (
         amount_in,

--- a/docs/README.md
+++ b/docs/README.md
@@ -206,8 +206,7 @@ let solution = Solution::new(
 #### b. Encode solution
 
 ```rust
-let swap_encoder_registry = SwapEncoderRegistry::new(Chain::Ethereum)
-    .add_default_encoders(None)
+let swap_encoder_registry = SwapEncoderRegistry::new_with_defaults(Chain::Ethereum)
     .expect("Failed to get default SwapEncoderRegistry");
     
 let encoder = TychoRouterEncoderBuilder::new()

--- a/docs/for-solvers/execution/encoding/README.md
+++ b/docs/for-solvers/execution/encoding/README.md
@@ -127,16 +127,15 @@ split swaps.
 
 Builder options:
 
-* `swap_encoder_registry` — Registry of protocol-specific `SwapEncoder` s used during encoding.
-  Use `add_default_encoders` for built-in support, or add custom encoders for protocols you've implemented locally.
+* `swap_encoder_registry` — Registry of protocol-specific `SwapEncoder`s used during encoding.
+  Use `new_with_defaults` for built-in support, or add custom encoders for protocols you've implemented locally.
 * `router_address` — Router address for execution. Defaults to the deployed address for the given chain (
   see [Tycho addresses](../contract-addresses.md)).
 
 #### **Builder Example Usage**
 
 ```rust
-let swap_encoder_registry = SwapEncoderRegistry::new(Chain::Ethereum)
-.add_default_encoders(None)
+let swap_encoder_registry = SwapEncoderRegistry::new_with_defaults(Chain::Ethereum)
 .expect("Failed to get default SwapEncoderRegistry");
 
 let encoder = TychoRouterEncoderBuilder::new()
@@ -150,9 +149,7 @@ let encoder = TychoRouterEncoderBuilder::new()
 
 Each protocol needs its own `SwapEncoder` to define how the protocol encodes swaps into calldata.
 
-The `SwapEncoderRegistry` manages these encoders. Call `add_default_encoders()` to use the built-in implementations.
-This method accepts an optional `executors_addresses` JSON string with executor addresses for encoding. Pass `None` to
-default to `config/executor_addresses.json`.
+The `SwapEncoderRegistry` manages these encoders. Use `SwapEncoderRegistry::new_with_defaults(chain)` to get a registry pre-populated with all built-in encoders. If you need to supply custom executor addresses, use `SwapEncoderRegistry::new(chain).add_default_encoders(Some(addresses_json))` instead.
 
 If you need to add custom protocol support, register your own encoder implementation:
 

--- a/docs/for-solvers/execution/encoding/README.md
+++ b/docs/for-solvers/execution/encoding/README.md
@@ -22,7 +22,7 @@ The `Solution` struct defines your order and how it should be filled. This is th
 {% tab title="UserTransferType" %}
 Specifies how user funds (the input token) enter the router:
 
-<table><thead><tr><th width="210.01953125" align="center">Variant</th><th>Description</th></tr></thead><tbody><tr><td align="center"><strong>TransferFrom</strong> <em>(default)</em></td><td>Use standard ERC-20 approve + transferFrom. You must approve the TychoRouter to spend your tokens.</td></tr><tr><td align="center"><strong>TransferFromPermit2</strong></td><td>Use Permit2 for token transfer. You must approve the Permit2 contract and sign the permit externally.</td></tr><tr><td align="center"><strong>UseVaultsFunds</strong></td><td>No transfer is performed. Uses tokens already deposited in the TychoRouter vault.</td></tr></tbody></table>
+<table><thead><tr><th width="210.01953125" align="center">Variant</th><th>Description</th></tr></thead><tbody><tr><td align="center"><strong>TransferFromPermit2</strong></td><td>Use Permit2 for token transfer. You must approve the Permit2 contract and sign the permit externally.</td></tr><tr><td align="center"><strong>TransferFrom</strong> <em>(default)</em></td><td>Use standard ERC-20 approve + transferFrom. You must approve the TychoRouter to spend your tokens.</td></tr><tr><td align="center"><strong>UseVaultsFunds</strong></td><td>No transfer is performed. Uses tokens already deposited in the TychoRouter vault.</td></tr></tbody></table>
 {% endtab %}
 
 {% tab title="Swap" %}
@@ -168,13 +168,22 @@ Convert solutions into calldata:
 let encoded_solutions = encoder.encode_solutions(solutions);
 ```
 
+<<<<<<< HEAD
 This returns a `Vec<EncodedSolution>` containing only the encoded swaps. It does **not** build the full calldata. You must encode the full method call yourself. If you use Permit2, you must handle permit
+=======
+This returns a `Vec<`[`EncodedSolution`](./#encoded-solution-struct)`>` containing only the encoded swaps. It does **not** build the full calldata. You must encode the full method call yourself. If you use Permit2, you must handle permit
+>>>>>>> 2f3ae5544 (docs: improve encoding page tables and copy)
 creation and signing yourself using the public `Permit2` utility (see [Token transfers](../#permit2)).
 
 The full method call includes the following parameters, which act as **execution guardrails:**
 
+<<<<<<< HEAD
 * `amountIn` and `tokenIn` — the amount and token to be transferred into the TychoRouter from you. For native ETH, use `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` — the router reverts on `address(0)`.
 * `minAmountOut` and `tokenOut` — the minimum amount you want to receive. Same ETH address rule applies. For maximum security, determine this from a **third-party source**.
+=======
+* `amountIn` and `tokenIn` — the amount and token to be transferred into the TychoRouter from you.
+* `minAmountOut` and `tokenOut` — the minimum amount you want to receive. For maximum security, determine this from a **third-party source**.
+>>>>>>> 2f3ae5544 (docs: improve encoding page tables and copy)
 * `receiver` — who receives the final output. Set this to the TychoRouter address to credit output tokens to the vault.
 * `nTokens` — _(split swaps only)_ the number of distinct tokens in the split routing graph.
 * `clientFeeParams` — controls fee-taking and client contribution (see [Client Fee Signature](#client-fee-signature)). Pass all-zero values if you don't need fees.
@@ -189,10 +198,13 @@ security.
 Refer to the [quickstart](../../../) for an example of converting an `EncodedSolution` into full calldata. Tailor the
 example to your use case. See the `TychoRouter` contract functions for reference.
 
+<<<<<<< HEAD
 #### Native Tokens <a href="#native-tokens" id="native-tokens"></a>
 
 The encoder automatically bridges ETH↔WETH gaps anywhere in the swap path — at the start, end, or between swaps — using a dedicated WETH executor. Set `token_in` and `token_out` to the tokens the user actually holds and expects to receive, and the encoder inserts wrap/unwrap steps as needed. This works with protocols like Uniswap V4 that accept native ETH directly, with no extra configuration required.
 
+=======
+>>>>>>> 2f3ae5544 (docs: improve encoding page tables and copy)
 #### Client Fee Signature
 
 If you don't want fees, pass all-zero
@@ -293,8 +305,12 @@ The returned 65-byte signature is passed as the `clientSignature` field in `Clie
 The encoding crate ships a `tycho-encode` CLI that lets you encode swaps without writing Rust. Install it with:
 
 ```bash
+<<<<<<< HEAD
 cargo install --path crates/tycho-execution
 tycho-encode --version  # verify the install succeeded
+=======
+cargo install --path .
+>>>>>>> 2f3ae5544 (docs: improve encoding page tables and copy)
 ```
 
 Pass a JSON-serialised `Solution` via stdin and specify the encoder as a subcommand:

--- a/docs/for-solvers/execution/encoding/README.md
+++ b/docs/for-solvers/execution/encoding/README.md
@@ -165,29 +165,34 @@ Convert solutions into calldata:
 let encoded_solutions = encoder.encode_solutions(solutions);
 ```
 
-<<<<<<< HEAD
 This returns a `Vec<EncodedSolution>` containing only the encoded swaps. It does **not** build the full calldata. You must encode the full method call yourself. If you use Permit2, you must handle permit
-=======
-This returns a `Vec<`[`EncodedSolution`](./#encoded-solution-struct)`>` containing only the encoded swaps. It does **not** build the full calldata. You must encode the full method call yourself. If you use Permit2, you must handle permit
->>>>>>> 2f3ae5544 (docs: improve encoding page tables and copy)
 creation and signing yourself using the public `Permit2` utility (see [Token transfers](../#permit2)).
 
 The full method call includes the following parameters, which act as **execution guardrails:**
 
-<<<<<<< HEAD
 * `amountIn` and `tokenIn` — the amount and token to be transferred into the TychoRouter from you. For native ETH, use `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` — the router reverts on `address(0)`.
 * `minAmountOut` and `tokenOut` — the minimum amount you want to receive. Same ETH address rule applies. For maximum security, determine this from a **third-party source**.
-=======
-* `amountIn` and `tokenIn` — the amount and token to be transferred into the TychoRouter from you.
-* `minAmountOut` and `tokenOut` — the minimum amount you want to receive. For maximum security, determine this from a **third-party source**.
->>>>>>> 2f3ae5544 (docs: improve encoding page tables and copy)
 * `receiver` — who receives the final output. Set this to the TychoRouter address to credit output tokens to the vault.
 * `nTokens` — _(split swaps only)_ the number of distinct tokens in the split routing graph.
 * `clientFeeParams` — controls fee-taking and client contribution (see [Client Fee Signature](#client-fee-signature)). Pass all-zero values if you don't need fees.
 
 The `ClientFeeParams` struct is defined as:
 
-<table><thead><tr><th width="210">Field</th><th width="490">Description</th></tr></thead><tbody><tr><td><code>clientFeeBps</code></td><td>Fee percentage in basis points. <code>100</code> = 1%. Set to <code>0</code> to disable</td></tr><tr><td><code>clientFeeReceiver</code></td><td>Address that receives the client's portion of the fee (credited to their vault balance)</td></tr><tr><td><code>maxClientContribution</code></td><td>Maximum amount the client is willing to pay out of pocket if slippage causes the output to fall below <code>minAmountOut</code>. If the shortfall exceeds this value, the transaction reverts. Set to <code>0</code> if the client should not subsidize</td></tr><tr><td><code>deadline</code></td><td>Unix timestamp after which the signature is no longer valid</td></tr><tr><td><code>clientSignature</code></td><td>EIP-712 signature over all other fields, signed by <code>clientFeeReceiver</code></td></tr></tbody></table>
+<table><thead><tr><th width="210">Field</th><th width="490">Description</th></tr></thead><tbody><tr><td><code>clientFeeBps</code></td><td>Fee percentage in basis points. <code>100</code> = 1%. Set to <code>0</code> to take no fee</td></tr><tr><td><code>clientFeeReceiver</code></td><td>Address that receives the client fee (credited to their vault balance)</td></tr><tr><td><code>maxClientContribution</code></td><td>Maximum amount the client is willing to pay out of pocket if slippage causes the output to fall below <code>minAmountOut</code>. If the shortfall exceeds this value, the transaction reverts. Set to <code>0</code> if the client should not subsidize</td></tr><tr><td><code>deadline</code></td><td>Unix timestamp after which the signature is no longer valid</td></tr><tr><td><code>clientSignature</code></td><td>EIP-712 signature over all other fields, signed by <code>clientFeeReceiver</code></td></tr></tbody></table>
+
+The `tycho-execution` crate provides a `ClientFeeParams` Rust struct that mirrors this. Callers are responsible for
+constructing and signing it — the encoder does not use it internally. Call `.into_abi_params()` to convert it to the
+ABI-encodable tuple for calldata construction.
+
+```rust
+// No fee
+let params = ClientFeeParams::default().into_abi_params();
+
+// With a fee
+let params = ClientFeeParams::new(receiver, signature, deadline, fee_bps)
+    .with_max_client_contribution(max_contribution)
+    .into_abi_params();
+```
 
 These **execution guardrails** protect against MEV exploits. Setting them correctly gives you full control over swap
 security.
@@ -195,21 +200,14 @@ security.
 Refer to the [quickstart](../../../) for an example of converting an `EncodedSolution` into full calldata. Tailor the
 example to your use case. See the `TychoRouter` contract functions for reference.
 
-<<<<<<< HEAD
 #### Native Tokens <a href="#native-tokens" id="native-tokens"></a>
 
 The encoder automatically bridges ETH↔WETH gaps anywhere in the swap path — at the start, end, or between swaps — using a dedicated WETH executor. Set `token_in` and `token_out` to the tokens the user actually holds and expects to receive, and the encoder inserts wrap/unwrap steps as needed. This works with protocols like Uniswap V4 that accept native ETH directly, with no extra configuration required.
 
-=======
->>>>>>> 2f3ae5544 (docs: improve encoding page tables and copy)
 #### Client Fee Signature
 
-If you don't want fees, pass all-zero
-values: `clientFeeBps: 0`, `clientFeeReceiver: address(0)`, `maxClientContribution: 0`, `deadline: 0`, and an
-empty `clientSignature`.
-
-If you do want fees, the `clientFeeReceiver` must sign the fee parameters using EIP-712. This prevents third parties
-from spoofing fee configurations. The signature covers the following typed struct:
+Only required when charging a fee. The `clientFeeReceiver` must sign the fee parameters using EIP-712 — this prevents
+third parties from spoofing fee configurations. The signature covers the following typed struct:
 
 ```solidity
 ClientFee(uint16 clientFeeBps, address clientFeeReceiver, uint256 maxClientContribution, uint256 deadline)
@@ -302,12 +300,8 @@ The returned 65-byte signature is passed as the `clientSignature` field in `Clie
 The encoding crate ships a `tycho-encode` CLI that lets you encode swaps without writing Rust. Install it with:
 
 ```bash
-<<<<<<< HEAD
 cargo install --path crates/tycho-execution
 tycho-encode --version  # verify the install succeeded
-=======
-cargo install --path .
->>>>>>> 2f3ae5544 (docs: improve encoding page tables and copy)
 ```
 
 Pass a JSON-serialised `Solution` via stdin and specify the encoder as a subcommand:

--- a/docs/for-solvers/execution/executing.md
+++ b/docs/for-solvers/execution/executing.md
@@ -16,7 +16,7 @@ For an example of how to execute trades using the Tycho Router, refer to the [Qu
 
 The TychoRouter V3 supports a dual fee system:
 
-* **Client fees**: Set `client_fee_bps` and `client_fee_receiver` in the `Solution` to charge a percentage of the output amount. Fees are credited to the receiver's vault balance.
+* **Client fees**: Construct a `ClientFeeParams` with your `client_fee_bps`, `client_fee_receiver`, and signature, and pass it when calling the router. Fees are credited to the receiver's vault balance.
 * **Router fees**: Configured on-chain by Propeller Heads. These are mandatory and cannot be bypassed through encoding. The router can charge a fee on the output amount and/or a percentage of the client fee. Currently set to 10 bps (0.1%) on the swap output and 20% share of the client fee (the integrator keeps 80%).
 
 ### Client Contribution (Slippage Subsidy)

--- a/docs/for-solvers/execution/execution-venues.md
+++ b/docs/for-solvers/execution/execution-venues.md
@@ -11,8 +11,7 @@ To solve orders on <a href="https://docs.cow.fi/cow-protocol/tutorials/solvers" 
 First, initialize the encoder:
 
 ```rust
-let swap_encoder_registry = SwapEncoderRegistry::new(Chain::Ethereum)
-    .add_default_encoders(None)
+let swap_encoder_registry = SwapEncoderRegistry::new_with_defaults(Chain::Ethereum)
     .expect("Failed to get default SwapEncoderRegistry");
 
 let encoder = TychoRouterEncoderBuilder::new()

--- a/docs/for-solvers/execution/migration-guide-v2-to-v3.md
+++ b/docs/for-solvers/execution/migration-guide-v2-to-v3.md
@@ -22,7 +22,7 @@ Router V3.
 
 **New fields:**
 
-<table><thead><tr><th width="210">Field</th><th width="210">Type</th><th width="280">Description</th></tr></thead><tbody><tr><td><code>user_transfer_type</code></td><td><code>UserTransferType</code></td><td>How user funds enter the router. Moved here from the encoder builder.</td></tr><tr><td><code>client_fee_bps</code></td><td><code>u16</code></td><td>Fee in basis points charged by the client (0–10000).</td></tr><tr><td><code>client_fee_receiver</code></td><td><code>Bytes</code></td><td>Address to receive the client fee.</td></tr><tr><td><code>max_client_contribution</code></td><td><code>BigUint</code></td><td>Maximum amount the client will subsidize from their vault if slippage reduces the output below <code>min_amount_out</code>.</td></tr></tbody></table>
+<table><thead><tr><th width="210">Field</th><th width="210">Type</th><th width="280">Description</th></tr></thead><tbody><tr><td><code>user_transfer_type</code></td><td><code>UserTransferType</code></td><td>How user funds enter the router. Moved here from the encoder builder.</td></tr></tbody></table>
 
 **Private fields with getters/setters:**
 
@@ -52,10 +52,7 @@ amount,      // amount_in
 min_out,     // min_amount_out
 vec![swap],  // swaps
 )
-.with_user_transfer_type(UserTransferType::TransferFrom)
-.with_client_fee_bps(50)
-.with_client_fee_receiver(fee_addr)
-.with_max_client_contribution(BigUint::from(0u64));
+.with_user_transfer_type(UserTransferType::TransferFrom);
 ```
 
 #### UserTransferType Moved to Solution
@@ -244,6 +241,22 @@ struct ClientFeeParams {
 
 When constructing calldata yourself (recommended), encode this struct as part of the function arguments. Even if you are
 not charging fees, you must pass this parameter with zero values.
+
+A `ClientFeeParams` Rust struct matching this Solidity struct is available in `tycho-execution`. Clients are
+responsible for constructing and signing it — the encoder does not use it internally. Call `.into_abi_params()` to
+convert it to the ABI-encodable tuple:
+
+```rust
+// No fee (zero values)
+let client_fee_params = ClientFeeParams::default().into_abi_params();
+
+// With a fee
+let client_fee_params = ClientFeeParams {
+    client_fee_bps: 50,
+    client_fee_receiver: fee_receiver_bytes,
+    ..ClientFeeParams::default()
+}.into_abi_params();
+```
 
 #### Vault Integration
 

--- a/docs/for-solvers/execution/migration-guide-v2-to-v3.md
+++ b/docs/for-solvers/execution/migration-guide-v2-to-v3.md
@@ -223,8 +223,7 @@ let registry = SwapEncoderRegistry::new()
 .add_default_encoders(executors_addresses)?;
 
 // V3
-let registry = SwapEncoderRegistry::new(Chain::Ethereum)
-.add_default_encoders(executors_addresses)?;
+let registry = SwapEncoderRegistry::new_with_defaults(Chain::Ethereum)?;
 ```
 
 ### Execution Changes

--- a/docs/for-solvers/request-for-quote-protocols.md
+++ b/docs/for-solvers/request-for-quote-protocols.md
@@ -170,8 +170,7 @@ After encoding, quotes are valid for only 1–3 seconds. Execution must follow i
 #### Encode solution
 
 ```rust
-let swap_encoder_registry = SwapEncoderRegistry::new(Chain::Ethereum)
-    .add_default_encoders(None)
+let swap_encoder_registry = SwapEncoderRegistry::new_with_defaults(Chain::Ethereum)
     .expect("Failed to get default SwapEncoderRegistry");
     
 let encoder = TychoRouterEncoderBuilder::new()


### PR DESCRIPTION
- Add a `new_with_defaults` constructor for `SwapEncoderRegistry`. This replaces the lessor intuitive `SwapEncoderRegistry::new(Chain::Ethereum).add_default_encoders(None)`. NOTE: ideally we should change `add_default_encoders`'s param to not be optional anymore, but this is a breaking change and isn't of any major consequence so I decided to leave it.
-  Add a `ClientFeeParams` helper struct