### PR TITLE
fix: update CI workflow and Dockerfile for improved profiling

### DIFF
--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -50,6 +50,7 @@ jobs:
       image_name: tycho-indexer
       dockerfile: docker/tycho-indexer.Dockerfile
       build_args: CARGO_PROFILE=profiling # Use profiling profile for heap profiling with jeprof/pprof. The cost is a bigger binary, no performance penalty.
+      kaniko_verbosity: debug
     secrets:
       app_id: ${{ secrets.APP_ID }}
       app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/docker/tycho-indexer.Dockerfile
+++ b/docker/tycho-indexer.Dockerfile
@@ -19,13 +19,14 @@ ARG CARGO_PROFILE=release
 ARG EXTRA_CARGO_FLAGS=""
 COPY --from=planner /build/recipe.json recipe.json
 # Pre-build deps only (cached layer)
-RUN cargo chef cook --package tycho-indexer --release --recipe-path recipe.json
+RUN cargo chef cook --package tycho-indexer --profile ${CARGO_PROFILE} --recipe-path recipe.json
 # Full build
 COPY . .
 RUN RUSTFLAGS="--cfg tokio_unstable" cargo build --package tycho-indexer --profile ${CARGO_PROFILE} ${EXTRA_CARGO_FLAGS}
 
 # ── Stage 4: minimal runtime ─────────────────────────────────────────────────
 FROM debian:bookworm-slim
+ARG CARGO_PROFILE=release
 WORKDIR /opt/tycho-indexer
 COPY --from=builder /build/target/${CARGO_PROFILE}/tycho-indexer ./tycho-indexer
 COPY crates/tycho-indexer/extractors.yaml ./extractors.yaml


### PR DESCRIPTION
- Set kaniko verbosity to debug in the main workflow for better logging.
- Modify Dockerfile to use the CARGO_PROFILE argument for cargo chef cook, enhancing build flexibility.

This commit is marked as "fix" to trigger the main release workflow.