### PR TITLE
fix(router v3): Vault deposits for fee tokens

### DIFF
--- a/crates/tycho-execution/contracts/src/Vault.sol
+++ b/crates/tycho-execution/contracts/src/Vault.sol
@@ -137,9 +137,13 @@ abstract contract Vault is ERC6909, ReentrancyGuard, Pausable {
             require(msg.value == amount, "Value mismatch");
             _mint(msg.sender, id, amount);
         } else {
-            // ERC20 deposit - transfer to this contract (router)
-            _mint(msg.sender, id, amount);
+            // ERC20 deposit - transfer to this contract and measure actual received
+            // amount to handle  fee-on-transfer and rebasing tokens
+            uint256 balanceBefore = IERC20(token).balanceOf(address(this));
             IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+            uint256 received =
+                IERC20(token).balanceOf(address(this)) - balanceBefore;
+            _mint(msg.sender, id, received);
         }
     }
 

--- a/crates/tycho-execution/contracts/test/Vault.t.sol
+++ b/crates/tycho-execution/contracts/test/Vault.t.sol
@@ -394,4 +394,25 @@ contract VaultTest is Constants, TestUtils {
         assertEq(balanceStart - balanceEnd, inputAmount);
         assertEq(balanceEnd, 1_000_000);
     }
+
+    function testDepositFeeOnTransferToken() public {
+        // TWIF charges 6% on every transfer
+        address TWIF = 0x2Dd636C514Bb4705c756D161585Ff9ec665f18A2;
+
+        uint256 amount = 1_000_000;
+        uint256 expectedReceived = amount - (amount * 6) / 100;
+
+        deal(TWIF, ALICE, amount);
+        vm.startPrank(ALICE);
+        IERC20(TWIF).approve(address(vault), amount);
+        vault.deposit(TWIF, amount);
+        vm.stopPrank();
+
+        // Vault credits only the actual received amount
+        assertEq(
+            vault.balanceOf(ALICE, uint256(uint160(TWIF))), expectedReceived
+        );
+        // Router holds exactly the credited amount
+        assertEq(IERC20(TWIF).balanceOf(address(vault)), expectedReceived);
+    }
 }


### PR DESCRIPTION
This was not accounting for the actual amount received after fees are taken.