### PR TITLE
fix(router v3): Account for final transfer in slippage check

### DIFF
--- a/crates/tycho-execution/contracts/src/TychoRouter.sol
+++ b/crates/tycho-execution/contracts/src/TychoRouter.sol
@@ -731,6 +731,11 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
 
         amountOut =
             _settleOutput(amountOut, amountIn, tokenIn, tokenOut, receiver);
+
+        // Check final amount to account for fee tokens or rebasing tokens
+        if (amountOut < minAmountOut) {
+            revert TychoRouter__NegativeSlippage(amountOut, minAmountOut);
+        }
     }
 
     /**
@@ -803,6 +808,11 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
 
         amountOut =
             _settleOutput(amountOut, amountIn, tokenIn, tokenOut, receiver);
+
+        // Check final amount to account for fee tokens or rebasing tokens
+        if (amountOut < minAmountOut) {
+            revert TychoRouter__NegativeSlippage(amountOut, minAmountOut);
+        }
     }
 
     /**
@@ -874,6 +884,11 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
 
         amountOut =
             _settleOutput(amountOut, amountIn, tokenIn, tokenOut, receiver);
+
+        // Check final amount to account for fee tokens or rebasing tokens
+        if (amountOut < minAmountOut) {
+            revert TychoRouter__NegativeSlippage(amountOut, minAmountOut);
+        }
     }
 
     /**
@@ -1244,7 +1259,7 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
             int256 outputDelta = _getDelta(tokenOut);
             if (outputDelta > 0) {
                 // Output tokens are still in the Router. This could be because no
-                // output swap has been performed, or the user has specified the
+                // output transfer has been performed yet, or the user has specified the
                 // receiver to be the router in order to rebalance their vault.
                 _updateDeltaAccounting(tokenOut, int256(requiredContribution));
             } else if (outputDelta == 0) {
@@ -1253,8 +1268,14 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
                 } else if (tokenOut == ETH_ADDRESS) {
                     Address.sendValue(payable(receiver), requiredContribution);
                 } else {
+                    // Measure user balance before and after required contribution to
+                    // account for fee tokens
+                    uint256 balanceBefore = IERC20(tokenOut).balanceOf(receiver);
                     IERC20(tokenOut)
                         .safeTransfer(receiver, requiredContribution);
+                    uint256 actualContribution =
+                        IERC20(tokenOut).balanceOf(receiver) - balanceBefore;
+                    return amountOut + actualContribution;
                 }
             } else {
                 // Negative output delta indicates unprofitable arbitrage.

--- a/crates/tycho-execution/contracts/src/TychoRouter.sol
+++ b/crates/tycho-execution/contracts/src/TychoRouter.sol
@@ -729,13 +729,9 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
             clientFeeParams.clientFeeReceiver
         );
 
-        amountOut =
-            _settleOutput(amountOut, amountIn, tokenIn, tokenOut, receiver);
-
-        // Check final amount to account for fee tokens or rebasing tokens
-        if (amountOut < minAmountOut) {
-            revert TychoRouter__NegativeSlippage(amountOut, minAmountOut);
-        }
+        amountOut = _settleOutput(
+            amountOut, minAmountOut, amountIn, tokenIn, tokenOut, receiver
+        );
     }
 
     /**
@@ -806,13 +802,9 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
             client
         );
 
-        amountOut =
-            _settleOutput(amountOut, amountIn, tokenIn, tokenOut, receiver);
-
-        // Check final amount to account for fee tokens or rebasing tokens
-        if (amountOut < minAmountOut) {
-            revert TychoRouter__NegativeSlippage(amountOut, minAmountOut);
-        }
+        amountOut = _settleOutput(
+            amountOut, minAmountOut, amountIn, tokenIn, tokenOut, receiver
+        );
     }
 
     /**
@@ -882,21 +874,18 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
             client
         );
 
-        amountOut =
-            _settleOutput(amountOut, amountIn, tokenIn, tokenOut, receiver);
-
-        // Check final amount to account for fee tokens or rebasing tokens
-        if (amountOut < minAmountOut) {
-            revert TychoRouter__NegativeSlippage(amountOut, minAmountOut);
-        }
+        amountOut = _settleOutput(
+            amountOut, minAmountOut, amountIn, tokenIn, tokenOut, receiver
+        );
     }
 
     /**
      * @dev Transfers output tokens to receiver (or credits vault),
-     *      and finalizes transient deltas.
+     *      finalizes transient deltas, and checks slippage.
      */
     function _settleOutput(
         uint256 amountOut,
+        uint256 minAmountOut,
         uint256 amountIn,
         address tokenIn,
         address tokenOut,
@@ -916,6 +905,11 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
         }
 
         _finalizeBalances(msg.sender, tokenIn, amountIn);
+
+        // Check final amount to account for fee tokens or rebasing tokens
+        if (amountOut < minAmountOut) {
+            revert TychoRouter__NegativeSlippage(amountOut, minAmountOut);
+        }
 
         return amountOut;
     }

--- a/crates/tycho-execution/contracts/test/TychoRouterSingleSwap.t.sol
+++ b/crates/tycho-execution/contracts/test/TychoRouterSingleSwap.t.sol
@@ -4,6 +4,8 @@ import {TychoRouter, ClientFeeParams} from "@src/TychoRouter.sol";
 import {Dispatcher__UnsupportedSingleHopCycle} from "@src/Dispatcher.sol";
 import "./TychoRouterTestSetup.sol";
 import {Vault__InsufficientBalance} from "@src/Vault.sol";
+import {UniswapV4Executor} from "@src/executors/UniswapV4Executor.sol";
+import {UniswapV4Utils} from "./protocols/UniswapV4Utils.sol";
 
 contract LyingSwapOutputPool {
     // Fake UniswapV2 pool that reports reserves that would result in ~1000 USDC output
@@ -617,6 +619,77 @@ contract TychoRouterSingleSwapTest is TychoRouterTestSetup {
         );
         tychoRouter.singleSwap(
             amountIn, WETH_ADDR, WETH_ADDR, 1, ALICE, noClientFee(), swap
+        );
+        vm.stopPrank();
+    }
+}
+
+contract TychoRouterSingleSwapFeeTokenTest is TychoRouterTestSetup {
+    // TWIF/USDC V4 pool exists at this block
+    function getForkBlock() public view override returns (uint256) {
+        return 22689128;
+    }
+
+    function testFinalFeeBelowMinAmount() public {
+        // Swap USDC → TWIF (6% fee-on-transfer) via UniswapV4.
+        // A small client fee forces the output through the router instead of going
+        // directly to ALICE, causing an extra TWIF transfer (and an extra 6% tax).
+        // The minAmountOut check ensures the user is protected.
+        address TWIF = 0x2Dd636C514Bb4705c756D161585Ff9ec665f18A2;
+        uint256 amountIn = 100_000000; // 100 USDC
+
+        deal(USDC_ADDR, ALICE, amountIn);
+        vm.startPrank(ALICE);
+        IERC20(USDC_ADDR).approve(tychoRouterAddr, amountIn);
+
+        UniswapV4Executor.UniswapV4Pool[] memory pools =
+            new UniswapV4Executor.UniswapV4Pool[](1);
+        pools[0] = UniswapV4Executor.UniswapV4Pool({
+            intermediaryToken: TWIF,
+            fee: 10000,
+            tickSpacing: int24(200),
+            hook: address(0),
+            hookData: new bytes(0)
+        });
+        bytes memory protocolData =
+            UniswapV4Utils.encodeExactInput(USDC_ADDR, TWIF, false, pools);
+        bytes memory swap =
+            encodeSingleSwap(address(usv4Executor), protocolData);
+
+        ClientFeeParams memory feeParams = makeClientFeeParams(
+            1, // 1 bps (0.01%)
+            0,
+            amountIn,
+            USDC_ADDR,
+            TWIF,
+            106000000000000000000000000000, // min amount
+            ALICE,
+            swap,
+            tychoRouterAddr,
+            CLIENT_FEE_RECEIVER_PK
+        );
+
+        // Output after the UniswapV4 swap is 107508473722887877019425641400
+        // The user has correctly calculated this and set their min amount to be
+        // 106000000000000000000000000000, which is even enough to account for the
+        // client fee. They however forgot to account for the final transfer fee, so
+        // they only end up with 101057965299514598220586024960 in their wallet.
+        // TychoRouter reverts.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TychoRouter__NegativeSlippage.selector,
+                101047859502984652937820276907,
+                106000000000000000000000000000
+            )
+        );
+        uint256 amountOut = tychoRouter.singleSwap(
+            amountIn,
+            USDC_ADDR,
+            TWIF,
+            106000000000000000000000000000,
+            ALICE,
+            feeParams,
+            swap
         );
         vm.stopPrank();
     }

--- a/crates/tycho-execution/contracts/test/TychoRouterSingleSwap.t.sol
+++ b/crates/tycho-execution/contracts/test/TychoRouterSingleSwap.t.sol
@@ -693,4 +693,78 @@ contract TychoRouterSingleSwapFeeTokenTest is TychoRouterTestSetup {
         );
         vm.stopPrank();
     }
+
+    function testFinalFeeClientContributionBelowMinAmount() public {
+        // Swap USDC → TWIF (6% fee-on-transfer) via UniswapV4.
+        // There is no client fee so the final swap is optimized and sent straight
+        // to the user. However, the final amount is not enough, so a client
+        // contribution is sent. Unfortunately, the fee on the client contribution
+        // means this client contribution is not enough in the end - swap should still
+        // revert.
+        address TWIF = 0x2Dd636C514Bb4705c756D161585Ff9ec665f18A2;
+        uint256 amountIn = 100_000000; // 100 USDC
+
+        address CLIENT = vm.addr(CLIENT_FEE_RECEIVER_PK);
+
+        uint256 clientBalance = 200000000000000000000000000000;
+        deal(TWIF, CLIENT, clientBalance);
+        vm.startPrank(CLIENT);
+        IERC20(TWIF).approve(tychoRouterAddr, clientBalance);
+        tychoRouter.deposit(TWIF, clientBalance);
+        vm.stopPrank();
+
+        deal(USDC_ADDR, ALICE, amountIn);
+        vm.startPrank(ALICE);
+        IERC20(USDC_ADDR).approve(tychoRouterAddr, amountIn);
+
+        UniswapV4Executor.UniswapV4Pool[] memory pools =
+            new UniswapV4Executor.UniswapV4Pool[](1);
+        pools[0] = UniswapV4Executor.UniswapV4Pool({
+            intermediaryToken: TWIF,
+            fee: 10000,
+            tickSpacing: int24(200),
+            hook: address(0),
+            hookData: new bytes(0)
+        });
+        bytes memory protocolData =
+            UniswapV4Utils.encodeExactInput(USDC_ADDR, TWIF, false, pools);
+        bytes memory swap =
+            encodeSingleSwap(address(usv4Executor), protocolData);
+
+        ClientFeeParams memory feeParams = makeClientFeeParams(
+            0, // no client fee
+            500000000000000000000000000, // max client contribution
+            amountIn,
+            USDC_ADDR,
+            TWIF,
+            108000000000000000000000000000, // min amount
+            ALICE,
+            swap,
+            tychoRouterAddr,
+            CLIENT_FEE_RECEIVER_PK
+        );
+
+        // Output after the UniswapV4 swap is 107508473722887877019425641400
+        // The user wants 108000000000000000000000000000. Client attempts to contribute,
+        // but since fees are taken on the contribution amount, this is not enough.
+        // Swap should revert.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TychoRouter__NegativeSlippage.selector,
+                // 107508473722887877019425641400 + 0.94 * expected client contribution
+                107970508423373272621165538484,
+                108000000000000000000000000000
+            )
+        );
+        uint256 amountOut = tychoRouter.singleSwap(
+            amountIn,
+            USDC_ADDR,
+            TWIF,
+            108000000000000000000000000000,
+            ALICE,
+            feeParams,
+            swap
+        );
+        vm.stopPrank();
+    }
 }


### PR DESCRIPTION
Problem:
- In some cases, we were checking the amount in the router to perform the final slippage check. This did not account for the final transfer to the user, so users could end up receiving less than the min amount.

Important Notes:
- Our client contribution may not work if the token is already in the user's wallet (for example for an optimized final swap with no fees). We send an additional amount to the user to make the contribution, but after fees are taken on this contribution transfer, the contribution might still not be enough.
- We might totally miss making a contribution altogether: we might think all is fine and no contribution is necessary, and the swap will revert at the final output transfer due to the contribution. This is hard to fix without a bigger refactor (dangerous at this point). 
- In general: fee taking with client contribution is a very difficult thing to achieve nicely (unless we want to either find ourselves in a loop of check balance -> contribute -> check balance -> contribute, or perform some token fee estimation math). I think it would be sufficient to just mention that these specific cases can cause reverts in our docs.

TL;DR

What this PR does: ensures the min amount check works (even with a client contribution)
What this PR doesn’t do (and shouldn’t do): ensure the user receives enough client contribution to prevent a revert