### PR TITLE
fix(integration-test): improve integration test stability and protocol state metrics

### DIFF
--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -690,6 +690,9 @@ async fn process_update(
                     metrics::record_block_processing_duration(latency_seconds, block_type);
                 }
                 metrics::record_protocol_update_skipped();
+                for protocol in update.update.sync_states.keys() {
+                    metrics::record_protocol_sync_state_skipped(protocol);
+                }
                 return Ok(());
             }
             BlockPollResult::Timeout => {

--- a/crates/tycho-integration-test/src/metrics.rs
+++ b/crates/tycho-integration-test/src/metrics.rs
@@ -50,7 +50,8 @@ pub fn initialize_metrics() {
     );
     describe_gauge!(
         "tycho_integration_protocol_sync_state",
-        "Current synchronization state per protocol (1=Started, 2=Ready, 3=Delayed, 4=Stale, 5=Advanced, 6=Ended)"
+        "Current synchronization state per protocol (1=Started, 2=Ready, 3=Delayed, 4=Stale, \
+         5=Advanced, 6=Ended, 7=Skipped — Tycho reported Ready but RPC block was ahead)"
     );
     describe_counter!(
         "tycho_integration_protocol_updates_skipped_total",
@@ -184,6 +185,18 @@ pub fn record_protocol_sync_state(protocol: &str, sync_state: &SynchronizerState
         "protocol" => protocol.to_string()
     )
     .set(state_value);
+}
+
+/// Record that an update was skipped because the RPC block was ahead of the update block.
+///
+/// The protocol's `SynchronizerState` may report Ready in this case — the lag is only
+/// observable by comparing the update block against the RPC's latest block.
+pub fn record_protocol_sync_state_skipped(protocol: &str) {
+    gauge!(
+        "tycho_integration_protocol_sync_state",
+        "protocol" => protocol.to_string()
+    )
+    .set(7.0);
 }
 
 /// Explicitly mark a protocol as stale when no update has been received within the expected window.

--- a/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
+++ b/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
@@ -4,7 +4,7 @@ use futures::{Stream, StreamExt};
 use miette::{miette, IntoDiagnostic, WrapErr};
 use tokio::{sync::mpsc::Sender, task::JoinHandle};
 use tracing::{info, warn};
-use tycho_client::feed::component_tracker::ComponentFilter;
+use tycho_client::{feed::component_tracker::ComponentFilter, stream::RetryConfiguration};
 use tycho_common::{
     models::{token::Token, Chain},
     Bytes,
@@ -150,10 +150,12 @@ impl ProtocolStreamProcessor {
         if self.partial_blocks {
             protocol_stream = protocol_stream.enable_partial_blocks();
         }
+        let infinite_retries = RetryConfiguration::constant(u64::MAX, Duration::from_secs(10));
         protocol_stream
             .auth_key(Some(self.tycho_api_key.clone()))
             .skip_state_decode_failures(true)
             .startup_timeout(Duration::from_secs(500))
+            .websocket_retry_config(&infinite_retries)
             .set_tokens(all_tokens.clone())
             .await
             .build()


### PR DESCRIPTION
- set to infinite reconnect attempts for tycho stream
- emit 'skipped' state for protocols whose data arrived too late for us to simulate on and we skipped it