### PR TITLE
feat(simulation): add partial blocks flag to Update

### DIFF
--- a/crates/tycho-integration-test/CLAUDE.md
+++ b/crates/tycho-integration-test/CLAUDE.md
@@ -21,8 +21,9 @@ cargo run -p tycho-integration-test -- \
   --tvl-threshold 100
 ```
 
-Key optional flags: `--disable-onchain`, `--disable-rfq`, `--protocols uniswap_v2,curve`,
-`--max-blocks 100`, `--parallel-simulations 5`, `--always-test-components <id,...>`.
+Key optional flags: `--disable-onchain`, `--disable-rfq`, `--disable-execution`,
+`--protocols uniswap_v2,curve`, `--max-blocks 100`, `--parallel-simulations 5`,
+`--always-test-components <id,...>`.
 
 ## Module Structure
 
@@ -30,7 +31,7 @@ Key optional flags: `--disable-onchain`, `--disable-rfq`, `--protocols uniswap_v
   dispatches blocks to stream processors, calls `poll_rpc_for_block` for on-chain comparison
 - **`stream_processor/`**:
   - `protocol_stream_processor.rs`: Handles on-chain protocol updates — applies deltas to
-    `ProtocolSim` instances, runs `get_amount_out` simulations, validates via Tenderly execution
+    `ProtocolSim` instances, runs `get_amount_out` simulations, validates via RPC execution
   - `rfq_stream_processor.rs`: Handles RFQ protocol updates — fetches live quotes, compares
     against simulation
 - **`statistics.rs`**: `TestStatistics` + `ProtocolStatistics` — per-protocol counters for
@@ -42,5 +43,5 @@ Key optional flags: `--disable-onchain`, `--disable-rfq`, `--protocols uniswap_v
 For each block update, for a random sample of components (up to `--max-simulations`):
 1. `ProtocolSim::get_amount_out` — checks the simulation returns a non-zero output
 2. `ProtocolSim::get_limits` — checks token limits are non-zero
-3. Encodes a swap via `tycho-execution` and simulates it via Tenderly — checks it doesn't revert
-   and that on-chain output is within slippage tolerance of simulated output
+3. Encodes a swap via `tycho-execution` and simulates it via RPC (`eth_call`) — checks it doesn't
+   revert and that on-chain output is within slippage tolerance of simulated output

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -35,7 +35,7 @@ use tycho_simulation::{
         hashflow::{client::HashflowClient, state::HashflowState},
         liquorice::{client::LiquoriceClient, state::LiquoriceState},
     },
-    tycho_common::models::Chain,
+    tycho_common::models::{Chain, TvlThresholdTier},
     utils::load_all_tokens,
 };
 use tycho_test::{
@@ -57,9 +57,10 @@ use crate::{
 
 #[derive(Parser, Clone)]
 struct Cli {
-    /// The tvl threshold in ETH/native token units to filter the graph by
-    #[arg(long, default_value_t = 100.0)]
-    tvl_threshold: f64,
+    /// The TVL threshold in native token units to filter the graph by.
+    /// Defaults to a chain-appropriate value targeting ~$200K USD equivalent (Medium tier).
+    #[arg(long)]
+    tvl_threshold: Option<f64>,
 
     #[arg(long, default_value = "ethereum")]
     chain: Chain,
@@ -259,8 +260,11 @@ async fn main() -> miette::Result<()> {
 async fn run(cli: Cli) -> miette::Result<()> {
     info!("Starting integration test");
 
-    let cli = Arc::new(cli);
     let chain = cli.chain;
+    let tvl_threshold = cli
+        .tvl_threshold
+        .unwrap_or_else(|| chain.default_tvl_threshold(TvlThresholdTier::Medium));
+    let cli = Arc::new(cli);
 
     let rpc_tools = tycho_test::RPCTools::new(&cli.rpc_url, &chain).await?;
 
@@ -292,7 +296,7 @@ async fn run(cli: Cli) -> miette::Result<()> {
             chain,
             cli.tycho_url.clone(),
             cli.tycho_api_key.clone(),
-            cli.tvl_threshold,
+            tvl_threshold,
             cli.tvl_buffer_ratio,
             cli.protocols.clone(),
             cli.partial_blocks,
@@ -307,7 +311,7 @@ async fn run(cli: Cli) -> miette::Result<()> {
     if !cli.disable_rfq {
         if let Ok(rfq_stream_processor) = RFQStreamProcessor::new(
             chain,
-            cli.tvl_threshold,
+            tvl_threshold,
             cli.max_simulations as usize,
             Duration::from_secs(cli.skip_messages_duration),
         ) {

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -166,6 +166,11 @@ struct Cli {
     /// Router fee on output in bps (defaults to 10 bps)
     #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u16).range(1..))]
     router_fee: u16,
+
+    /// Disable on-chain swap execution via Tenderly (simulation only, no execution validation).
+    /// Useful for diagnosing stream latency without Tenderly congestion.
+    #[arg(long, default_value_t = false)]
+    disable_execution: bool,
 }
 
 impl Debug for Cli {
@@ -868,6 +873,10 @@ async fn process_update(
 
     if block_execution_info.is_empty() {
         warn!("No simulations were gathered for block {}", block.number());
+        return Ok(());
+    }
+
+    if cli.disable_execution {
         return Ok(());
     }
 

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -677,8 +677,11 @@ async fn process_update(
 
         // Flashblocks-capable endpoints expose sequencer pre-confirmed state under `pending`;
         // standard endpoints use `latest` (confirmed blocks only).
-        let block_tag =
-            if cli.partial_blocks { BlockNumberOrTag::Pending } else { BlockNumberOrTag::Latest };
+        let block_tag = if cli.partial_blocks && update.update.is_partial {
+            BlockNumberOrTag::Pending
+        } else {
+            BlockNumberOrTag::Latest
+        };
         let poll_interval = Duration::from_millis(cli.rpc_poll_interval_ms);
 
         let poll_result = poll_rpc_for_block(
@@ -777,7 +780,7 @@ async fn process_update(
             .map(|(validator, id, _protocol)| (*validator, id.clone()))
             .collect();
 
-        let validation_block_id = if cli.partial_blocks {
+        let validation_block_id = if update.update.is_partial {
             BlockId::pending()
         } else {
             BlockId::from(block.header.number)

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -167,8 +167,8 @@ struct Cli {
     #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u16).range(1..))]
     router_fee: u16,
 
-    /// Disable on-chain swap execution via Tenderly (simulation only, no execution validation).
-    /// Useful for diagnosing stream latency without Tenderly congestion.
+    /// Disable on-chain swap execution validation (RPC simulation only, no swap encoding or
+    /// execution). Useful for diagnosing stream latency without execution overhead.
     #[arg(long, default_value_t = false)]
     disable_execution: bool,
 }

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -246,6 +246,10 @@ where
             .clone()
             .block_number_or_timestamp();
         let current_block = header.clone().block();
+        let is_partial = current_block
+            .as_ref()
+            .map(|h| h.partial_block_index.is_some())
+            .unwrap_or(false);
 
         for (protocol, protocol_msg) in msg.state_msgs.iter() {
             // Add any new tokens
@@ -919,6 +923,7 @@ where
 
         // Send the tick with all updated states
         Ok(Update::new(block_number_or_timestamp, updated_states, new_pairs)
+            .set_is_partial(is_partial)
             .set_removed_pairs(removed_pairs)
             .set_sync_states(msg.sync_states.clone()))
     }

--- a/crates/tycho-simulation/src/protocol/models.rs
+++ b/crates/tycho-simulation/src/protocol/models.rs
@@ -175,6 +175,9 @@ where
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Update {
     pub block_number_or_timestamp: u64,
+    /// True when this update is for a partial (pre-confirmation) block, false for full blocks.
+    #[serde(default)]
+    pub is_partial: bool,
     /// Synchronization state per protocol
     pub sync_states: HashMap<String, SynchronizerState>,
     /// The new and updated states of this block.
@@ -196,11 +199,17 @@ impl Update {
     ) -> Self {
         Update {
             block_number_or_timestamp: block_number,
+            is_partial: false,
             sync_states: HashMap::new(),
             states,
             new_pairs,
             removed_pairs: HashMap::new(),
         }
+    }
+
+    pub fn set_is_partial(mut self, is_partial: bool) -> Self {
+        self.is_partial = is_partial;
+        self
     }
 
     pub fn set_removed_pairs(mut self, pairs: HashMap<String, ProtocolComponent>) -> Self {


### PR DESCRIPTION
- add partial block flag to `Update` struct to differentiate between a partial and full update. 
- [tycho-integration-test] add flag to run with execution disabled (useful for testing on new chains)
- [tycho-integration-test] use chain-specific TVL defaults to better mimic what our users will recieve