### PR TITLE
fix: preserve UnknownExtractor through paginated fetch + ws retry cooldown

### DIFF
--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -102,8 +102,12 @@ impl HeaderLike for BlockHeader {
 
 #[derive(Error, Debug)]
 pub enum BlockSynchronizerError {
-    #[error("Failed to initialize synchronizer: {0}")]
-    InitializationError(#[from] SynchronizerError),
+    #[error("Failed to initialize extractor '{extractor}': {source}")]
+    InitializationError {
+        extractor: ExtractorIdentity,
+        #[source]
+        source: SynchronizerError,
+    },
 
     #[error("Failed to process new block: {0}")]
     BlockHistoryError(#[from] BlockHistoryError),
@@ -685,7 +689,12 @@ where
                     warn!(%extractor_id, %reason, "Extractor not recognised by server, skipping");
                     to_skip.push(extractor_id);
                 }
-                Err(e) => return Err(BlockSynchronizerError::InitializationError(e)),
+                Err(e) => {
+                    return Err(BlockSynchronizerError::InitializationError {
+                        extractor: extractor_id,
+                        source: e,
+                    })
+                }
             }
         }
         for id in &to_skip {

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -893,8 +893,7 @@ pub trait RPCClient: Send + Sync {
 
                 let first_page = self
                     .get_protocol_components(base_params)
-                    .await
-                    .map_err(|err| RPCError::Fatal(err.to_string()))?;
+                    .await?;
 
                 let total_items = first_page.total();
                 let total_pages = (total_items as f64 / chunk_size as f64).ceil() as i64;

--- a/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
+++ b/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
@@ -150,7 +150,9 @@ impl ProtocolStreamProcessor {
         if self.partial_blocks {
             protocol_stream = protocol_stream.enable_partial_blocks();
         }
-        let infinite_retries = RetryConfiguration::constant(u64::MAX, Duration::from_secs(10));
+        // 1 s cooldown: must stay below the state-sync cooldown (≥ 2 s on every chain)
+        // so synchronizers don't exhaust their retries while the WS is reconnecting.
+        let infinite_retries = RetryConfiguration::constant(u64::MAX, Duration::from_secs(1));
         protocol_stream
             .auth_key(Some(self.tycho_api_key.clone()))
             .skip_state_decode_failures(true)


### PR DESCRIPTION
## Summary

Three fixes for Ethereum integration test failures.

**`rpc.rs`**: `get_protocol_components_paginated` wrapped the first-page fetch in `.map_err(|err| RPCError::Fatal(...))`, converting any `RPCError` — including the typed `UnknownExtractor` — into `Fatal` before it reached `BlockSynchronizer`. `BlockSynchronizer` only skips gracefully on `UnknownExtractor`; everything else propagates as a fatal `InitializationError`, crashing the stream build when an extractor is not yet deployed on the server. Since `get_protocol_components` already returns `RPCError`, the `map_err` was unnecessary — replaced with `?`.

**`feed/mod.rs`**: `BlockSynchronizerError::InitializationError` dropped the extractor identity, producing an opaque `"Failed to initialize synchronizer: ..."` message with no indication of what failed. Changed to a struct variant carrying the `ExtractorIdentity`, so the error now reads `"Failed to initialize extractor 'ethereum:vm:liquidityparty': ..."`.

**`protocol_stream_processor.rs`**: the websocket infinite-retry config used a 10 s cooldown, which exceeds the state-sync cooldown (3 s on Ethereum, 2 s on every other chain). This produced `"Websocket cooldown should be < than state synchronizer cooldown"` on every startup. Changed to 1 s, which is always below the minimum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)