### PR TITLE
fix(integration-test): add infinite retries for state synchronizer

### DIFF
--- a/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
+++ b/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
@@ -157,7 +157,7 @@ impl ProtocolStreamProcessor {
         protocol_stream
             .auth_key(Some(self.tycho_api_key.clone()))
             .skip_state_decode_failures(true)
-            .startup_timeout(Duration::from_secs(500))
+            .startup_timeout(Duration::from_secs(1000))
             .websocket_retry_config(&infinite_ws_retries)
             .state_synchronizer_retry_config(&infinite_sync_retries)
             .set_tokens(all_tokens.clone())

--- a/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
+++ b/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
@@ -152,12 +152,14 @@ impl ProtocolStreamProcessor {
         }
         // 1 s cooldown: must stay below the state-sync cooldown (≥ 2 s on every chain)
         // so synchronizers don't exhaust their retries while the WS is reconnecting.
-        let infinite_retries = RetryConfiguration::constant(u64::MAX, Duration::from_secs(1));
+        let infinite_ws_retries = RetryConfiguration::constant(u64::MAX, Duration::from_secs(1));
+        let infinite_sync_retries = RetryConfiguration::constant(u64::MAX, Duration::from_secs(3));
         protocol_stream
             .auth_key(Some(self.tycho_api_key.clone()))
             .skip_state_decode_failures(true)
             .startup_timeout(Duration::from_secs(500))
-            .websocket_retry_config(&infinite_retries)
+            .websocket_retry_config(&infinite_ws_retries)
+            .state_synchronizer_retry_config(&infinite_sync_retries)
             .set_tokens(all_tokens.clone())
             .await
             .build()


### PR DESCRIPTION
### Context:
  - **WS client** — manages the raw WebSocket connection to the Tycho server. One shared connection for all protocols. When it drops, it reconnects. This is what has infinite retries already.       
  - **ProtocolStateSynchronizer** — one per protocol. Its job is to build a consistent view of a protocol's state. On startup it: subscribes via WS, waits for the first delta, fetches a full HTTP snapshot at that block height, merges them, then continuously forwards new deltas. When anything goes wrong (subscription closed, snapshot fetch fails, timeout), it restarts this whole process. **This is what had only 32 retries.**                                                                                                                                                                                        
  - **BlockSynchronizer** — sits above all the state synchronizers, aligns them by block number, and emits one unified FeedMessage per block to the consumer. This is where the Ended state lives and where there's no recovery. 
  
### Issue:
VM protocols (balancer_v2, curve, maverick_v2) showed persistent "Ended" state in the cluster integration test because:

- The WS client had infinite retries, but the state synchronizer used the default of 32 attempts (~96s on Ethereum)
- VM extractors are heavier and might not be ready within that window
- Cluster logs confirmed "Max retries exceeded" for VM protocols
- Once a synchronizer enters Ended state, there is no recovery path — the protocol is dead for the lifetime of the client
- Each client restart hit the same race, making it persistent

Fix: set infinite retries on the state synchronizer (3s cooldown) to match the WS client's infinite retry policy.