### PR TITLE
feat: add PendingBlockProcessor and TxDeltaIndexer infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,10 +2702,8 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link 0.1.3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,12 +45,7 @@ serde = { version = "1.0.204", features = ["rc", "derive"] }
 serde_json = "1.0.120"
 toml = "0.8"
 typetag = "0.2.21"
-uuid = { version = "1.4.1", features = [
-    "serde",
-    "v4",
-    "fast-rng",
-    "macro-diagnostics",
-] }
+uuid = { version = "1.4.1", features = ["serde", "macro-diagnostics"] }
 
 # --- Async & concurrency ---
 tokio = { version = "1.47.1", features = ["full"] }
@@ -77,7 +72,7 @@ alloy = { version = "1.1.0", default-features = false }
 ethabi = "18.0.0"
 
 # --- Utility ---
-chrono = { version = "0.4.26", features = ["serde"] }
+chrono = { version = "0.4.26", default-features = false, features = ["serde", "clock", "std"] }
 hex = "0.4.3"
 hex-literal = "0.4.1"
 rand = "0.8.5"

--- a/crates/tycho-common/Cargo.toml
+++ b/crates/tycho-common/Cargo.toml
@@ -24,7 +24,6 @@ chrono.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
-uuid.workspace = true
 utoipa.workspace = true
 async-trait.workspace = true
 anyhow.workspace = true
@@ -35,8 +34,9 @@ tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 bytes = "1.5.0"
 mockall = { workspace = true, optional = true }
 num-bigint = "0.4"
-deepsize.workspace = true# perf: make optional, as used only by the indexer for memory profiling
+deepsize.workspace = true # perf: make optional, as used only by the indexer for memory profiling
 itertools = "0.10.5"
+uuid.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
@@ -45,6 +45,7 @@ diesel-async.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true
 maplit = "1.0.2"
+uuid = { workspace = true, features = ["v4", "fast-rng"] }
 
 [features]
 diesel = ["dep:diesel"]

--- a/crates/tycho-common/src/models/blockchain.rs
+++ b/crates/tycho-common/src/models/blockchain.rs
@@ -64,6 +64,92 @@ impl Transaction {
     }
 }
 
+/// Raw EVM log emitted by a contract during transaction execution.
+///
+/// Used as the primary input to [`TxDeltaIndexer`] implementations.
+///
+/// [`TxDeltaIndexer`]: crate::traits::TxDeltaIndexer
+#[derive(Debug, Clone)]
+pub struct LogInput {
+    address: Bytes,
+    topics: Vec<Bytes>,
+    data: Bytes,
+    log_index: u32,
+}
+
+impl LogInput {
+    pub fn new(address: Bytes, topics: Vec<Bytes>, data: Bytes, log_index: u32) -> Self {
+        Self { address, topics, data, log_index }
+    }
+
+    pub fn address(&self) -> &Bytes {
+        &self.address
+    }
+
+    pub fn topics(&self) -> &[Bytes] {
+        &self.topics
+    }
+
+    pub fn data(&self) -> &Bytes {
+        &self.data
+    }
+
+    pub fn log_index(&self) -> u32 {
+        self.log_index
+    }
+}
+
+/// Raw EVM transaction with its associated logs.
+///
+/// The `succeeded` flag allows callers to pass all transactions in a block and
+/// have the processor skip reverted ones, avoiding a separate pre-filter.
+#[derive(Debug, Clone)]
+pub struct TxInput {
+    hash: Bytes,
+    from: Bytes,
+    to: Bytes,
+    index: u64,
+    logs: Vec<LogInput>,
+    succeeded: bool,
+}
+
+impl TxInput {
+    pub fn new(
+        hash: Bytes,
+        from: Bytes,
+        to: Bytes,
+        index: u64,
+        logs: Vec<LogInput>,
+        succeeded: bool,
+    ) -> Self {
+        Self { hash, from, to, index, logs, succeeded }
+    }
+
+    pub fn hash(&self) -> &Bytes {
+        &self.hash
+    }
+
+    pub fn from(&self) -> &Bytes {
+        &self.from
+    }
+
+    pub fn to(&self) -> &Bytes {
+        &self.to
+    }
+
+    pub fn index(&self) -> u64 {
+        self.index
+    }
+
+    pub fn logs(&self) -> &[LogInput] {
+        &self.logs
+    }
+
+    pub fn succeeded(&self) -> bool {
+        self.succeeded
+    }
+}
+
 pub struct BlockTransactionDeltas<T> {
     pub extractor: String,
     pub chain: Chain,

--- a/crates/tycho-common/src/traits.rs
+++ b/crates/tycho-common/src/traits.rs
@@ -50,7 +50,7 @@ pub trait TxDeltaIndexer: Send {
     /// * `block` — a finalised [`BlockAggregatedChanges`] as received from the Tycho client. On the
     ///   first call this carries the full component and state snapshot; on later calls it carries
     ///   only the changed attributes and balances.
-    fn apply_block(&mut self, block: &BlockAggregatedChanges);
+    fn apply_block(&mut self, block: &BlockAggregatedChanges) -> anyhow::Result<()>;
 
     /// Applies a batch of in-flight transactions against the current state and
     /// returns the protocol state deltas they would produce.

--- a/crates/tycho-common/src/traits.rs
+++ b/crates/tycho-common/src/traits.rs
@@ -5,13 +5,74 @@ use async_trait::async_trait;
 
 use crate::{
     models::{
-        blockchain::{Block, BlockTag, EntryPointWithTracingParams, TracedEntryPoint},
+        blockchain::{
+            Block, BlockAggregatedChanges, BlockTag, EntryPointWithTracingParams, TracedEntryPoint,
+            TxInput,
+        },
         contract::AccountDelta,
         token::{Token, TokenQuality, TransferCost, TransferTax},
         Address, Balance, BlockHash, StoreKey,
     },
     Bytes,
 };
+
+/// Indexes protocol state deltas from raw EVM transactions.
+///
+/// A `TxDeltaIndexer` is a native-code substitute for a Substreams package.
+/// It consumes a stream of finalised [`BlockAggregatedChanges`] to keep its internal
+/// protocol state current, then — on demand — applies a batch of in-flight
+/// [`TxInput`]s and returns the resulting [`BlockAggregatedChanges`]. The primary
+/// consumer is an Ethereum block builder that needs to know how a candidate
+/// transaction bundle alters DEX state before deciding whether to include it.
+///
+/// # Lifecycle
+///
+/// 1. **Hydrate** — call [`apply_block`][TxDeltaIndexer::apply_block] for each finalised block
+///    received from the Tycho client. The first call serves as initialisation: `state_deltas` and
+///    `component_balances` will contain the full snapshot at that height rather than a sparse
+///    delta. Subsequent calls apply incremental deltas.
+///
+/// 2. **Query** — call [`generate_deltas`][TxDeltaIndexer::generate_deltas] with a batch of
+///    in-flight transactions at any point. The indexer applies them against its current internal
+///    state and returns a [`BlockAggregatedChanges`] describing what would change. Internal state
+///    is **not** mutated by this call; it always operates on the state left by the most recent
+///    `apply_block`.
+pub trait TxDeltaIndexer: Send {
+    /// Advances internal protocol state by applying a finalised block.
+    ///
+    /// Must be called in block-height order. The first call initialises the
+    /// indexer from a full snapshot; subsequent calls apply incremental state
+    /// deltas. After this call returns, [`generate_deltas`][TxDeltaIndexer::generate_deltas]
+    /// will produce deltas relative to the new state.
+    ///
+    /// # Parameters
+    ///
+    /// * `block` — a finalised [`BlockAggregatedChanges`] as received from the Tycho client. On the
+    ///   first call this carries the full component and state snapshot; on later calls it carries
+    ///   only the changed attributes and balances.
+    fn apply_block(&mut self, block: &BlockAggregatedChanges);
+
+    /// Applies a batch of in-flight transactions against the current state and
+    /// returns the protocol state deltas they would produce.
+    ///
+    /// The returned [`BlockAggregatedChanges`] contains the aggregated deltas across
+    /// all transactions in the batch: `state_deltas`, `component_balances`,
+    /// `new_protocol_components`, and `deleted_protocol_components`. Block
+    /// metadata (`block`, `chain`, `extractor`, `finalized_block_height`) is
+    /// populated from the state stored by the most recent
+    /// [`apply_block`][TxDeltaIndexer::apply_block] call.
+    ///
+    /// Internal state is **not** modified. Calling `generate_deltas` twice with
+    /// the same transactions returns identical results.
+    ///
+    /// Transactions where `succeeded == false` are silently skipped.
+    ///
+    /// # Parameters
+    ///
+    /// * `txs` — ordered slice of in-flight transactions, typically a builder's candidate bundle or
+    ///   the full mempool selection for one block.
+    fn generate_deltas(&mut self, txs: &[TxInput]) -> BlockAggregatedChanges;
+}
 
 /// A struct representing a request to get an account state.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/tycho-indexer/Cargo.toml
+++ b/crates/tycho-indexer/Cargo.toml
@@ -52,7 +52,7 @@ tracing-subscriber = { version = "0.3.17", default-features = false, features = 
 tycho-common.workspace = true
 tycho-ethereum.workspace = true
 tycho-storage.workspace = true
-uuid.workspace = true
+uuid = { workspace = true, features = ["v4", "fast-rng"] }
 # Pinned: actix-web 4.12+ uses actix-http methods not present in 3.11.x; keep at last working set
 actix-web = { version = "=4.11.0", default-features = false, features = [
     "macros",

--- a/crates/tycho-simulation/Cargo.toml
+++ b/crates/tycho-simulation/Cargo.toml
@@ -23,7 +23,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 typetag = { workspace = true }
-uuid = { workspace = true }
+uuid = { workspace = true, features = ["v4", "fast-rng"] }
 
 # Error handling
 thiserror = { workspace = true }

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -939,8 +939,9 @@ where
     /// supplied `pending_deltas`, and returns the result — **without writing back** to
     /// `DecoderState`. Calling this method twice with the same input produces identical results.
     ///
-    /// Only native protocols are supported: VM protocols that require `update_engine()` are
-    /// silently skipped (their pools will not appear in the returned `Update`).
+    /// Only native protocols are supported. VM protocols (extractor prefix `"vm:"`) are rejected
+    /// at registration time in
+    /// [`with_pending_indexer`](crate::evm::stream::ProtocolStreamBuilder::with_pending_indexer).
     ///
     /// # Parameters
     /// * `pending_deltas` — map from extractor name to the `BlockAggregatedChanges` produced by the

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -12,7 +12,7 @@ use tracing::{debug, error, info, warn};
 use tycho_client::feed::{synchronizer::ComponentWithState, BlockHeader, FeedMessage, HeaderLike};
 use tycho_common::{
     dto::{ChangeType, ProtocolStateDelta},
-    models::{token::Token, Chain},
+    models::{blockchain::BlockAggregatedChanges, token::Token, Chain},
     simulation::protocol_sim::{Balances, ProtocolSim},
     Bytes,
 };
@@ -61,6 +61,8 @@ struct DecoderState {
     // again TODO: handle more gracefully inside tycho-client. We could fetch the snapshot and
     // try to decode it again.
     failed_components: HashSet<String>,
+    // The block number of the last confirmed block decoded via `decode()`.
+    current_block_number: u64,
 }
 
 type DecodeFut =
@@ -901,6 +903,8 @@ where
             .states
             .extend(updated_states.clone());
 
+        state_guard.current_block_number = block_number_or_timestamp;
+
         // Add new components to persistent state
         for (id, component) in new_pairs.iter() {
             state_guard
@@ -926,6 +930,72 @@ where
             .set_is_partial(is_partial)
             .set_removed_pairs(removed_pairs)
             .set_sync_states(msg.sync_states.clone()))
+    }
+
+    /// Applies pending deltas from one or more `TxDeltaIndexer`s against the current confirmed
+    /// state and returns an ephemeral `Update`.
+    ///
+    /// This is the read-only counterpart of `decode()`. It clones pool states, applies the
+    /// supplied `pending_deltas`, and returns the result — **without writing back** to
+    /// `DecoderState`. Calling this method twice with the same input produces identical results.
+    ///
+    /// Only native protocols are supported: VM protocols that require `update_engine()` are
+    /// silently skipped (their pools will not appear in the returned `Update`).
+    ///
+    /// # Parameters
+    /// * `pending_deltas` — map from extractor name to the `BlockAggregatedChanges` produced by the
+    ///   corresponding `TxDeltaIndexer::generate_deltas()` call.
+    /// * `header` — the target block header. Its `block_number_or_timestamp()` is stamped on the
+    ///   returned [`Update`]; its `block_number` and `block_timestamp` are injected into each state
+    ///   delta so that protocols relying on block context (e.g. aerodrome slipstreams, etherfi)
+    ///   receive correct values.
+    pub async fn apply_deltas_ephemeral(
+        &self,
+        pending_deltas: &HashMap<String, BlockAggregatedChanges>,
+        header: H,
+    ) -> Result<Update, StreamDecodeError> {
+        let block_number_or_timestamp = header
+            .clone()
+            .block_number_or_timestamp();
+        let current_block = header.block();
+        let state_guard = self.state.read().await;
+
+        let mut updated_states: HashMap<String, Box<dyn ProtocolSim>> = HashMap::new();
+
+        for deltas in pending_deltas.values() {
+            let all_balances = Balances {
+                component_balances: deltas
+                    .component_balances
+                    .iter()
+                    .map(|(pool_id, bals)| {
+                        let balances = bals
+                            .iter()
+                            .map(|(t, b)| (t.clone(), b.balance.clone()))
+                            .collect();
+                        (pool_id.clone(), balances)
+                    })
+                    .collect(),
+                account_balances: HashMap::new(),
+            };
+
+            for (id, state_delta) in &deltas.state_deltas {
+                let dto_delta = Self::add_block_info_to_delta(
+                    ProtocolStateDelta::from(state_delta.clone()),
+                    current_block.clone(),
+                );
+                if let Err(e) = Self::apply_update(
+                    id,
+                    dto_delta,
+                    &mut updated_states,
+                    &state_guard,
+                    &all_balances,
+                ) {
+                    warn!(pool = id, error = %e, "EphemeralDeltaTransitionError");
+                }
+            }
+        }
+
+        Ok(Update::new(block_number_or_timestamp, updated_states, HashMap::new()))
     }
 
     /// Add block information (number and timestamp) to a ProtocolStateDelta

--- a/crates/tycho-simulation/src/evm/mod.rs
+++ b/crates/tycho-simulation/src/evm/mod.rs
@@ -4,6 +4,7 @@ use tycho_common::keccak256;
 pub mod account_storage;
 pub mod decoder;
 pub mod engine_db;
+pub mod pending;
 pub mod protocol;
 pub mod query_pool_swap;
 pub mod simulation;

--- a/crates/tycho-simulation/src/evm/pending.rs
+++ b/crates/tycho-simulation/src/evm/pending.rs
@@ -41,6 +41,8 @@ pub enum PendingError {
     ParentNotYetConfirmed { needed: u64, current: u64 },
     #[error("decoder error: {0}")]
     Decoder(#[from] StreamDecodeError),
+    #[error("indexer error for extractor '{extractor}': {message}")]
+    Indexer { extractor: String, message: String },
 }
 
 /// Wires one or more [`TxDeltaIndexer`]s to an existing [`TychoStreamDecoder`], enabling
@@ -120,8 +122,8 @@ impl PendingBlockProcessor {
     /// Only needed when using the processor standalone (without
     /// [`ProtocolStreamBuilder::build_with_pending`](crate::evm::stream::ProtocolStreamBuilder::build_with_pending)).
     /// When using `build_with_pending`, confirmed blocks are forwarded automatically.
-    pub fn advance(&mut self, msg: &FeedMessage<BlockHeader>) {
-        self.advance_inner(msg);
+    pub fn advance(&mut self, msg: &FeedMessage<BlockHeader>) -> Result<(), PendingError> {
+        self.advance_inner(msg)
     }
 
     /// Simulates `txs` against the confirmed parent state of `target_block` and returns an
@@ -151,7 +153,7 @@ impl PendingBlockProcessor {
     ) -> Result<PendingUpdate, PendingError> {
         // Drain any confirmed blocks that have arrived since our last call.
         while let Ok(msg) = self.block_rx.try_recv() {
-            self.advance_inner(&msg);
+            self.advance_inner(&msg)?;
         }
 
         let parent = target_header.number.saturating_sub(1);
@@ -175,7 +177,7 @@ impl PendingBlockProcessor {
         Ok(PendingUpdate { label, update })
     }
 
-    fn advance_inner(&mut self, msg: &FeedMessage<BlockHeader>) {
+    fn advance_inner(&mut self, msg: &FeedMessage<BlockHeader>) -> Result<(), PendingError> {
         let msg_block = msg
             .state_msgs
             .values()
@@ -195,11 +197,21 @@ impl PendingBlockProcessor {
                     &state_msg.header,
                     self.chain,
                 );
-                indexer.apply_block(&block_changes);
+                indexer
+                    .apply_block(&block_changes)
+                    .map_err(|e| PendingError::Indexer {
+                        extractor: extractor.clone(),
+                        message: format!("{e:#}"),
+                    })?;
             }
 
             if let Some(deltas) = &state_msg.deltas {
-                indexer.apply_block(deltas);
+                indexer
+                    .apply_block(deltas)
+                    .map_err(|e| PendingError::Indexer {
+                        extractor: extractor.clone(),
+                        message: format!("{e:#}"),
+                    })?;
             }
         }
 
@@ -208,6 +220,7 @@ impl PendingBlockProcessor {
             // Receivers that have been dropped are silently ignored.
             let _ = self.confirmed_block_tx.send(msg_block);
         }
+        Ok(())
     }
 }
 

--- a/crates/tycho-simulation/src/evm/pending.rs
+++ b/crates/tycho-simulation/src/evm/pending.rs
@@ -1,0 +1,279 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use thiserror::Error;
+use tokio::sync::{mpsc::UnboundedReceiver, watch};
+use tycho_client::feed::{synchronizer::Snapshot, BlockHeader, FeedMessage};
+use tycho_common::{
+    models::{
+        blockchain::{Block, BlockAggregatedChanges, TxInput},
+        protocol::{ComponentBalance, ProtocolComponent, ProtocolComponentStateDelta},
+        Chain,
+    },
+    traits::TxDeltaIndexer,
+    Bytes,
+};
+
+use crate::{
+    evm::decoder::{StreamDecodeError, TychoStreamDecoder},
+    protocol::models::Update,
+};
+
+/// An ephemeral [`Update`] tagged with a caller-supplied label.
+///
+/// The label is an opaque string chosen by the caller to distinguish parallel bundle evaluations
+/// (e.g. bundle ID, strategy name). It is separate from `update.block_number_or_timestamp`,
+/// which carries the target block the bundle was evaluated against.
+pub struct PendingUpdate {
+    pub label: String,
+    pub update: Update,
+}
+
+#[derive(Debug, Error)]
+pub enum PendingError {
+    /// Returned when `generate_pending_update` is called before the parent block of
+    /// `target_block` has been confirmed. Use
+    /// [`subscribe_confirmed_block`](PendingBlockProcessor::subscribe_confirmed_block) to wait
+    /// for the right block before calling.
+    #[error("parent block {needed} not yet confirmed (current: {current})")]
+    ParentNotYetConfirmed { needed: u64, current: u64 },
+    #[error("decoder error: {0}")]
+    Decoder(#[from] StreamDecodeError),
+}
+
+/// Wires one or more [`TxDeltaIndexer`]s to an existing [`TychoStreamDecoder`], enabling
+/// ephemeral simulation of candidate transaction bundles against the correct parent state
+/// for a specific target block.
+///
+/// # Block targeting
+///
+/// Call [`subscribe_confirmed_block`](Self::subscribe_confirmed_block) to obtain a
+/// [`watch::Receiver<u64>`] that fires on every confirmed block. Use it to wait for the
+/// right parent before submitting a bundle:
+///
+/// ```no_run
+/// # async fn example(
+/// #     mut pending: tycho_simulation::evm::pending::PendingBlockProcessor,
+/// #     txs: &[tycho_common::models::blockchain::TxInput],
+/// #     target_header: tycho_client::feed::BlockHeader,
+/// # ) {
+/// pending
+///     .subscribe_confirmed_block()
+///     .wait_for(|&n| n >= target_header.number - 1)
+///     .await
+///     .expect("stream closed");
+/// let update = pending
+///     .generate_pending_update(txs, target_header, "bundle-1".to_string())
+///     .await
+///     .expect("pending update failed");
+/// # }
+/// ```
+///
+/// # Concurrency
+///
+/// `PendingBlockProcessor` is intentionally **not** wrapped in a `Mutex` at construction
+/// time. The confirmed stream forwards blocks via an unbounded channel — it never blocks
+/// waiting for the consumer. Multiple callers can each hold a watch receiver and
+/// independently decide when to acquire whatever external lock they use around
+/// `generate_pending_update`.
+pub struct PendingBlockProcessor {
+    indexers: HashMap<String, Box<dyn TxDeltaIndexer>>,
+    decoder: Arc<TychoStreamDecoder<BlockHeader>>,
+    chain: Chain,
+    /// Block number of the most recently confirmed block applied to `indexers`.
+    current_confirmed_block: u64,
+    /// Notified on every `advance_inner` call; drives `subscribe_confirmed_block`.
+    confirmed_block_tx: watch::Sender<u64>,
+    /// Confirmed blocks forwarded by the stream pipeline.
+    block_rx: UnboundedReceiver<FeedMessage<BlockHeader>>,
+}
+
+impl PendingBlockProcessor {
+    pub(crate) fn new(
+        indexers: HashMap<String, Box<dyn TxDeltaIndexer>>,
+        decoder: Arc<TychoStreamDecoder<BlockHeader>>,
+        chain: Chain,
+        block_rx: UnboundedReceiver<FeedMessage<BlockHeader>>,
+    ) -> Self {
+        let (confirmed_block_tx, _) = watch::channel(0u64);
+        Self { indexers, decoder, chain, current_confirmed_block: 0, confirmed_block_tx, block_rx }
+    }
+
+    /// Returns a receiver that is notified with the latest confirmed block number every time
+    /// a new block is applied.
+    ///
+    /// Typical usage: `.wait_for(|&n| n >= target_block - 1).await` before calling
+    /// [`generate_pending_update`](Self::generate_pending_update).
+    pub fn subscribe_confirmed_block(&self) -> watch::Receiver<u64> {
+        self.confirmed_block_tx.subscribe()
+    }
+
+    /// Returns the block number of the last confirmed block applied to the indexers.
+    pub fn current_confirmed_block(&self) -> u64 {
+        self.current_confirmed_block
+    }
+
+    /// Advances each registered indexer by applying one confirmed block.
+    ///
+    /// Only needed when using the processor standalone (without
+    /// [`ProtocolStreamBuilder::build_with_pending`](crate::evm::stream::ProtocolStreamBuilder::build_with_pending)).
+    /// When using `build_with_pending`, confirmed blocks are forwarded automatically.
+    pub fn advance(&mut self, msg: &FeedMessage<BlockHeader>) {
+        self.advance_inner(msg);
+    }
+
+    /// Simulates `txs` against the confirmed parent state of `target_block` and returns an
+    /// ephemeral [`Update`].
+    ///
+    /// Drains any confirmed blocks that have arrived since the last call, then immediately
+    /// checks whether the parent block (`target_block - 1`) is available. If not, returns
+    /// [`PendingError::ParentNotYetConfirmed`] — **no blocking**. Use
+    /// [`subscribe_confirmed_block`](Self::subscribe_confirmed_block) to wait for the right
+    /// block before calling.
+    ///
+    /// Neither the indexers' internal state nor the decoder's confirmed pool states are
+    /// mutated. Calling this twice with the same arguments returns identical results.
+    ///
+    /// # Parameters
+    /// * `txs` — candidate bundle in execution order; failed transactions are skipped.
+    /// * `target_header` — header of the block being built. Its `number` is used for the
+    ///   parent-block guard; the full header is forwarded to `apply_deltas_ephemeral` so that block
+    ///   number and timestamp are injected into each state delta.
+    /// * `label` — opaque caller-supplied tag stamped onto the returned [`PendingUpdate`]. Use it
+    ///   to associate the result with a specific bundle or evaluation context.
+    pub async fn generate_pending_update(
+        &mut self,
+        txs: &[TxInput],
+        target_header: BlockHeader,
+        label: String,
+    ) -> Result<PendingUpdate, PendingError> {
+        // Drain any confirmed blocks that have arrived since our last call.
+        while let Ok(msg) = self.block_rx.try_recv() {
+            self.advance_inner(&msg);
+        }
+
+        let parent = target_header.number.saturating_sub(1);
+        if self.current_confirmed_block < parent {
+            return Err(PendingError::ParentNotYetConfirmed {
+                needed: parent,
+                current: self.current_confirmed_block,
+            });
+        }
+
+        let mut pending_deltas: HashMap<String, BlockAggregatedChanges> = HashMap::new();
+        for (extractor, indexer) in &mut self.indexers {
+            let changes = indexer.generate_deltas(txs);
+            pending_deltas.insert(extractor.clone(), changes);
+        }
+
+        let update = self
+            .decoder
+            .apply_deltas_ephemeral(&pending_deltas, target_header)
+            .await?;
+        Ok(PendingUpdate { label, update })
+    }
+
+    fn advance_inner(&mut self, msg: &FeedMessage<BlockHeader>) {
+        let msg_block = msg
+            .state_msgs
+            .values()
+            .map(|s| s.header.number)
+            .max()
+            .unwrap_or(0);
+
+        for (extractor, state_msg) in &msg.state_msgs {
+            let Some(indexer) = self.indexers.get_mut(extractor) else {
+                continue;
+            };
+
+            if !state_msg.snapshots.states.is_empty() {
+                let block_changes = snapshot_to_block_changes(
+                    extractor,
+                    &state_msg.snapshots,
+                    &state_msg.header,
+                    self.chain,
+                );
+                indexer.apply_block(&block_changes);
+            }
+
+            if let Some(deltas) = &state_msg.deltas {
+                indexer.apply_block(deltas);
+            }
+        }
+
+        if msg_block > self.current_confirmed_block {
+            self.current_confirmed_block = msg_block;
+            // Receivers that have been dropped are silently ignored.
+            let _ = self.confirmed_block_tx.send(msg_block);
+        }
+    }
+}
+
+/// Converts a startup snapshot into a `BlockAggregatedChanges` suitable for
+/// [`TxDeltaIndexer::apply_block`].
+fn snapshot_to_block_changes(
+    extractor: &str,
+    snapshot: &Snapshot,
+    header: &BlockHeader,
+    chain: Chain,
+) -> BlockAggregatedChanges {
+    let ts = chrono::DateTime::from_timestamp(header.timestamp as i64, 0)
+        .unwrap_or_default()
+        .naive_utc();
+    let block = Block {
+        number: header.number,
+        chain,
+        hash: header.hash.clone(),
+        parent_hash: header.parent_hash.clone(),
+        ts,
+    };
+
+    let mut new_protocol_components: HashMap<String, ProtocolComponent> = HashMap::new();
+    let mut state_deltas: HashMap<String, ProtocolComponentStateDelta> = HashMap::new();
+    let mut component_balances: HashMap<String, HashMap<Bytes, ComponentBalance>> = HashMap::new();
+
+    for (id, comp_with_state) in &snapshot.states {
+        new_protocol_components.insert(id.clone(), comp_with_state.component.clone());
+
+        state_deltas.insert(
+            id.clone(),
+            ProtocolComponentStateDelta {
+                component_id: id.clone(),
+                updated_attributes: comp_with_state.state.attributes.clone(),
+                deleted_attributes: HashSet::new(),
+            },
+        );
+
+        let token_balances: HashMap<Bytes, ComponentBalance> = comp_with_state
+            .state
+            .balances
+            .iter()
+            .map(|(token, balance)| {
+                (
+                    token.clone(),
+                    ComponentBalance {
+                        token: token.clone(),
+                        balance: balance.clone(),
+                        balance_float: 0.0,
+                        modify_tx: Bytes::default(),
+                        component_id: id.clone(),
+                    },
+                )
+            })
+            .collect();
+        component_balances.insert(id.clone(), token_balances);
+    }
+
+    BlockAggregatedChanges {
+        extractor: extractor.to_string(),
+        chain,
+        block,
+        finalized_block_height: header.number,
+        new_protocol_components,
+        state_deltas,
+        component_balances,
+        ..Default::default()
+    }
+}

--- a/crates/tycho-simulation/src/evm/stream.rs
+++ b/crates/tycho-simulation/src/evm/stream.rs
@@ -454,14 +454,22 @@ impl ProtocolStreamBuilder {
     /// The indexer is associated with `extractor` (the protocol synchronizer name, e.g.
     /// `"uniswap_v3"`). Use [`build_with_pending`](Self::build_with_pending) to obtain both
     /// the confirmed stream and the pending processor.
+    ///
+    /// Returns an error if `extractor` names a VM protocol (prefix `"vm:"`), which requires
+    /// `update_engine()` and cannot be simulated natively.
     pub fn with_pending_indexer(
         mut self,
         extractor: &str,
         indexer: Box<dyn TxDeltaIndexer>,
-    ) -> Self {
+    ) -> Result<Self, StreamError> {
+        if extractor.starts_with("vm:") {
+            return Err(StreamError::SetUpError(format!(
+                "extractor '{extractor}' is a VM protocol; TxDeltaIndexer only supports native protocols"
+            )));
+        }
         self.pending_indexers
             .insert(extractor.to_string(), indexer);
-        self
+        Ok(self)
     }
 
     /// Builds the confirmed protocol stream and a [`PendingBlockProcessor`] that stays

--- a/crates/tycho-simulation/src/evm/stream.rs
+++ b/crates/tycho-simulation/src/evm/stream.rs
@@ -114,19 +114,21 @@ use tracing::{debug, error, warn};
 use tycho_client::{
     feed::{
         component_tracker::ComponentFilter, synchronizer::ComponentWithState, BlockHeader,
-        SynchronizerState,
+        FeedMessage, SynchronizerState,
     },
     stream::{RetryConfiguration, StreamError, TychoStreamBuilder},
 };
 use tycho_common::{
     models::{token::Token, Chain},
     simulation::protocol_sim::ProtocolSim,
+    traits::TxDeltaIndexer,
     Bytes,
 };
 
 use crate::{
     evm::{
         decoder::{StreamDecodeError, TychoStreamDecoder},
+        pending::PendingBlockProcessor,
         protocol::uniswap_v4::hooks::hook_handler_creator::initialize_hook_handlers,
     },
     protocol::{
@@ -172,6 +174,8 @@ pub struct ProtocolStreamBuilder {
     decoder: TychoStreamDecoder<BlockHeader>,
     stream_builder: TychoStreamBuilder,
     stream_end_policy: StreamEndPolicy,
+    chain: Chain,
+    pending_indexers: HashMap<String, Box<dyn TxDeltaIndexer>>,
 }
 
 impl ProtocolStreamBuilder {
@@ -183,6 +187,8 @@ impl ProtocolStreamBuilder {
             decoder: TychoStreamDecoder::new(),
             stream_builder: TychoStreamBuilder::new(tycho_url, chain),
             stream_end_policy: StreamEndPolicy::default(),
+            chain,
+            pending_indexers: HashMap::new(),
         }
     }
 
@@ -441,6 +447,94 @@ impl ProtocolStreamBuilder {
 
     pub fn get_decoder(&self) -> &TychoStreamDecoder<BlockHeader> {
         &self.decoder
+    }
+
+    /// Registers a [`TxDeltaIndexer`] for ephemeral pending-block simulation.
+    ///
+    /// The indexer is associated with `extractor` (the protocol synchronizer name, e.g.
+    /// `"uniswap_v3"`). Use [`build_with_pending`](Self::build_with_pending) to obtain both
+    /// the confirmed stream and the pending processor.
+    pub fn with_pending_indexer(
+        mut self,
+        extractor: &str,
+        indexer: Box<dyn TxDeltaIndexer>,
+    ) -> Self {
+        self.pending_indexers
+            .insert(extractor.to_string(), indexer);
+        self
+    }
+
+    /// Builds the confirmed protocol stream and a [`PendingBlockProcessor`] that stays
+    /// in sync with it automatically.
+    ///
+    /// The stream pipeline forwards every confirmed [`FeedMessage`] to the processor via an
+    /// internal unbounded channel — it never blocks waiting for the consumer. The consumer
+    /// owns the returned `PendingBlockProcessor` exclusively and may wrap it in whatever
+    /// synchronisation primitive suits their use case (e.g. `Mutex` for shared access,
+    /// nothing for single-threaded use).
+    ///
+    /// Call [`generate_pending_update`](PendingBlockProcessor::generate_pending_update) to
+    /// simulate a candidate bundle; it drains the channel automatically before computing.
+    pub async fn build_with_pending(
+        self,
+    ) -> Result<
+        (impl Stream<Item = Result<Update, StreamDecodeError>>, PendingBlockProcessor),
+        StreamError,
+    > {
+        initialize_hook_handlers().map_err(|e| {
+            StreamError::SetUpError(format!("Error initializing hook handlers: {e:?}"))
+        })?;
+        let (_, rx) = self.stream_builder.build().await?;
+        let decoder = Arc::new(self.decoder);
+
+        let (advance_tx, advance_rx) =
+            tokio::sync::mpsc::unbounded_channel::<FeedMessage<BlockHeader>>();
+        let pending = PendingBlockProcessor::new(
+            self.pending_indexers,
+            decoder.clone(),
+            self.chain,
+            advance_rx,
+        );
+
+        let stream_end_policy = self.stream_end_policy;
+        let stream = Box::pin(
+            ReceiverStream::new(rx)
+                .take_while(move |msg| match msg {
+                    Ok(msg) => {
+                        let states = msg.sync_states.values();
+                        if stream_end_policy.should_end(states) {
+                            error!(
+                                "Block stream ended due to {:?}: {:?}",
+                                stream_end_policy, msg.sync_states
+                            );
+                            futures::future::ready(false)
+                        } else {
+                            futures::future::ready(true)
+                        }
+                    }
+                    Err(e) => {
+                        error!("Block stream ended with terminal error: {e}");
+                        futures::future::ready(false)
+                    }
+                })
+                .then({
+                    let decoder = decoder.clone();
+                    move |msg| {
+                        let decoder = decoder.clone();
+                        let advance_tx = advance_tx.clone();
+                        async move {
+                            let msg = msg.expect("Safe since stream ends if we receive an error");
+                            // Non-blocking: if the receiver is gone we just skip the send.
+                            let _ = advance_tx.send(msg.clone());
+                            decoder.decode(&msg).await.map_err(|e| {
+                                debug!(msg=?msg, "Decode error: {}", e);
+                                e
+                            })
+                        }
+                    }
+                }),
+        );
+        Ok((stream, pending))
     }
 
     /// Builds and returns the configured protocol stream.


### PR DESCRIPTION
## Summary

- Adds `TxDeltaIndexer` trait and `TxInput`/`LogInput` structs to `tycho-common` as a native-code substitute for Substreams packages
- Adds `PendingBlockProcessor` to `tycho-simulation` — accepts a slice of `TxInput`, runs registered indexers, applies deltas ephemerally (without touching confirmed state), and returns a labelled `PendingUpdate`
- Adds `apply_deltas_ephemeral` to `TychoStreamDecoder`: read-only counterpart of `decode()` that clones pool states, applies pending deltas, injects block context, and returns an `Update`
- Adds `build_with_pending` to `ProtocolStreamBuilder` to wire a `PendingBlockProcessor` alongside the live feed via an unbounded channel

## Design notes

- `PendingBlockProcessor::generate_pending_update` drains confirmed blocks from the feed channel with `try_recv` before running, so its view of pool state is always up to date
- Returns `PendingError::ParentNotYetConfirmed` immediately if the target block's parent hasn't been confirmed yet
- `PendingUpdate` wraps `Update` with a caller-defined `label` string — avoids modifying the shared `Update` type

## Test plan

- [ ] CI passes (unit tests, clippy, format)
- [ ] Integration tests with UniswapV3 processor (covered in follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)