### PR TITLE
fix: handle codeless Creation deltas and missing contract_code in snapshots

### DIFF
--- a/crates/tycho-indexer/src/extractor/protobuf_deserialisation.rs
+++ b/crates/tycho-indexer/src/extractor/protobuf_deserialisation.rs
@@ -35,6 +35,12 @@ impl TryFromMessage for AccountDelta {
     fn try_from_message(args: Self::Args<'_>) -> Result<Self, ExtractionError> {
         let (msg, chain) = args;
         let change = ChangeType::try_from_message(msg.change())?;
+        // For Creation deltas, code must always be Some — even for EOAs where code is empty
+        // bytes. None means "code unchanged" for Updates, but is incorrect for Creations.
+        let code = match change {
+            ChangeType::Creation => Some(msg.code.into()),
+            _ => if !msg.code.is_empty() { Some(msg.code.into()) } else { None },
+        };
         let update = AccountDelta::new(
             chain,
             msg.address.into(),
@@ -43,7 +49,7 @@ impl TryFromMessage for AccountDelta {
                 .map(|cs| (cs.slot.into(), Some(cs.value.into())))
                 .collect(),
             if !msg.balance.is_empty() { Some(msg.balance.into()) } else { None },
-            if !msg.code.is_empty() { Some(msg.code.into()) } else { None },
+            code,
             change,
         );
         Ok(update)

--- a/crates/tycho-indexer/src/extractor/protobuf_deserialisation.rs
+++ b/crates/tycho-indexer/src/extractor/protobuf_deserialisation.rs
@@ -39,7 +39,13 @@ impl TryFromMessage for AccountDelta {
         // bytes. None means "code unchanged" for Updates, but is incorrect for Creations.
         let code = match change {
             ChangeType::Creation => Some(msg.code.into()),
-            _ => if !msg.code.is_empty() { Some(msg.code.into()) } else { None },
+            _ => {
+                if !msg.code.is_empty() {
+                    Some(msg.code.into())
+                } else {
+                    None
+                }
+            }
         };
         let update = AccountDelta::new(
             chain,

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -641,15 +641,15 @@ where
 
                     // TEMP PATCH (ENG-4993)
                     //
-                    // The indexer emits deltas without code marked as creations, which crashes
-                    // TychoDB. Until fixed, treat them as updates (since EVM code cannot be
-                    // deleted).
+                    // The indexer may emit Creation deltas with no code for EOA addresses.
+                    // Treat them as EOAs (empty code) rather than downgrading to Update, which
+                    // would skip init_account and cause "uninitialized account" warnings.
                     if update.code.is_none() && matches!(update.change, ChangeType::Creation) {
                         error!(
                             update = ?update,
                             "FaultyCreationDelta"
                         );
-                        update.change = ChangeType::Update;
+                        update.code = Some(vec![]);
                     }
 
                     if state_guard.tokens.contains_key(key) {

--- a/crates/tycho-storage/src/postgres/contract.rs
+++ b/crates/tycho-storage/src/postgres/contract.rs
@@ -10,7 +10,7 @@ use diesel::{
 };
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use itertools::Itertools;
-use tracing::{debug, debug_span, error, instrument, Instrument, Level};
+use tracing::{debug, debug_span, error, instrument, warn, Instrument, Level};
 use tycho_common::{
     keccak256,
     models::{
@@ -897,21 +897,25 @@ impl PostgresGateway {
             .map(|code| (code.entity.account_id, code))
             .collect();
 
-        // Since we already filtered accounts to only include those with code in the initial query,
-        // we can use accounts directly. For specific IDs, we still need to verify all accounts have
-        // code.
-        let filtered_accounts = if ids.is_some() {
-            // If specific IDs were requested, all accounts must have code
-            if accounts.len() != code_map.len() {
-                return Err(StorageError::Unexpected(format!(
-                    "Some accounts were missing code. Got {} accounts and {} code entries.",
-                    accounts.len(),
-                    code_map.len(),
-                )));
-            }
+        // Accounts are pre-filtered to have code in the all-IDs path. For the specific-IDs
+        // path we filter here and warn about any gaps, which indicate a DB inconsistency
+        // (e.g. an account inserted via the token path that never received a contract_code row).
+        let filtered_accounts = if ids.is_some() && accounts.len() != code_map.len() {
+            let missing: Vec<String> = accounts
+                .iter()
+                .filter(|a| !code_map.contains_key(&a.id))
+                .map(|a| hex::encode(&a.address))
+                .collect();
+            warn!(
+                missing_count = accounts.len() - code_map.len(),
+                ?missing,
+                "Accounts missing contract_code at this version; skipping them"
+            );
             accounts
+                .into_iter()
+                .filter(|a| code_map.contains_key(&a.id))
+                .collect()
         } else {
-            // If no specific IDs were requested, accounts are already filtered to have code
             accounts
         };
 


### PR DESCRIPTION
  - **Protobuf deserialisation**: Ensure account creations at least have empty bytecode. 
    
  - **Simulation decoder**: The ENG-4993 patch was downgrading `Creation→Update` when `code=None`, skipping `init_account` and causing "uninitialized account" warnings. Now fills `code=Some([])` and keeps `change=Creation`.
    
  - **Snapshot query**: Tokens are inserted into `account` with no `contract_code`. When DCI later traces such an address, the bytecode write may not yet be committed when a snapshot request arrives, causing `get_contracts` to error. The query now skips and warns on those accounts; the RPC layer is expected to recover them from `PendingDeltasBuffer`.