### PR TITLE
fix(gas-estimations): Tweak gas estimations for slipstreams and univ3

### DIFF
--- a/crates/tycho-simulation/src/evm/protocol/aerodrome_slipstreams/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/aerodrome_slipstreams/state.rs
@@ -53,11 +53,13 @@ const TICK_CROSSING_GAS_COST: i32 = 70_000;
 // buffer (~77k–91k gas) instead of a simple slot read (~18k–27k gas). This extra cost is
 // added once per swap on top of the base.
 const TWAP_FEE_OVERHEAD: i32 = 65_000;
-
+// Pre/post loop overhead: fee(), slot0 reads, end-of-swap writes.
+const SWAP_BASE_GAS: i32 = 125_000;
 // Conservative max gas for a single swap. Used to cap get_limits iteration.
 const MAX_SWAP_GAS: u64 = 16_700_000;
 // Maximum initialized ticks that can be crossed within MAX_SWAP_GAS.
-const MAX_TICKS_CROSSED: u64 = (MAX_SWAP_GAS - 125_000) / TICK_CROSSING_GAS_COST as u64;
+const MAX_TICKS_CROSSED: u64 =
+    (MAX_SWAP_GAS - SWAP_BASE_GAS as u64) / TICK_CROSSING_GAS_COST as u64;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AerodromeSlipstreamsState {
@@ -173,7 +175,7 @@ impl AerodromeSlipstreamsState {
             liquidity: self.liquidity,
         };
         let twap_overhead = if self.dfc.scaling_factor() != 0 { TWAP_FEE_OVERHEAD } else { 0 };
-        let mut gas_used = U256::from((125_000 + twap_overhead) as u64);
+        let mut gas_used = U256::from((SWAP_BASE_GAS + twap_overhead) as u64);
         let mut n_loops = 0;
 
         let fee = self.get_fee()?;

--- a/crates/tycho-simulation/src/evm/protocol/aerodrome_slipstreams/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/aerodrome_slipstreams/state.rs
@@ -38,10 +38,26 @@ use crate::evm::protocol::{
     },
 };
 
-// The names of the constants reflect the exact method from the tenderly log.
-const TICK_CROSSING_GAS_COST: i32 = 25_000;
-// nextInitializedTickWithinOneWord +  computeSwapStep + calculateFees
-const LOOP_GAS_COST: i32 = 10_000;
+// Cold-storage warmup on the first loop iteration:
+// nextInitializedTickWithinOneWord first call (~3,000) vs warm (~1,060)
+// calculateFees first call via cold getUnstakedFee STATICCALL (~19,050) vs warm (~6,055)
+const FIRST_LOOP_OVERHEAD: i32 = 15_000;
+// Steady-state per-loop: nextInitializedTickWithinOneWord (warm) + getSqrtRatioAtTick
+// + computeSwapStep + calculateFees (warm) + toInt256x2 + EVM opcode overhead
+const LOOP_GAS_COST: i32 = 12_500;
+// cross(): updates tick fee growth and staked reward growth slots.
+// Warm ticks (previously crossed, non-zero SSTORE slots) cost ~22k; cold ticks ~76k.
+// We bias toward the cold end to prefer overestimation: 70k.
+const TICK_CROSSING_GAS_COST: i32 = 70_000;
+// When dfc.scaling_factor != 0, fee() does a TWAP binary search on the observation ring
+// buffer (~77k–91k gas) instead of a simple slot read (~18k–27k gas). This extra cost is
+// added once per swap on top of the base.
+const TWAP_FEE_OVERHEAD: i32 = 65_000;
+
+// Conservative max gas for a single swap. Used to cap get_limits iteration.
+const MAX_SWAP_GAS: u64 = 16_700_000;
+// Maximum initialized ticks that can be crossed within MAX_SWAP_GAS.
+const MAX_TICKS_CROSSED: u64 = (MAX_SWAP_GAS - 125_000) / TICK_CROSSING_GAS_COST as u64;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AerodromeSlipstreamsState {
@@ -156,7 +172,9 @@ impl AerodromeSlipstreamsState {
             tick: self.tick,
             liquidity: self.liquidity,
         };
-        let mut gas_used = U256::from(130_000);
+        let twap_overhead = if self.dfc.scaling_factor() != 0 { TWAP_FEE_OVERHEAD } else { 0 };
+        let mut gas_used = U256::from((125_000 + twap_overhead) as u64);
+        let mut n_loops = 0;
 
         let fee = self.get_fee()?;
         while state.amount_remaining != I256::from_raw(U256::from(0u64)) &&
@@ -246,6 +264,10 @@ impl AerodromeSlipstreamsState {
                 state.tick = get_tick_at_sqrt_ratio(state.sqrt_price)?;
             }
             gas_used = safe_add_u256(gas_used, U256::from(LOOP_GAS_COST))?;
+            if n_loops == 0 {
+                gas_used = safe_add_u256(gas_used, U256::from(FIRST_LOOP_OVERHEAD))?;
+            }
+            n_loops += 1;
         }
         Ok(SwapResults {
             amount_calculated: state.amount_calculated,
@@ -357,10 +379,15 @@ impl ProtocolSim for AerodromeSlipstreamsState {
 
         // Iterate through all ticks in the direction of the swap
         // Continues until there is no more liquidity in the pool or no more ticks to process
+        let mut ticks_crossed: u64 = 0;
         while let Ok((tick, initialized)) = self
             .ticks
             .next_initialized_tick_within_one_word(current_tick, zero_for_one)
         {
+            if ticks_crossed >= MAX_TICKS_CROSSED {
+                break;
+            }
+            ticks_crossed += 1;
             // Clamp the tick value to ensure it's within valid range
             let next_tick = tick.clamp(MIN_TICK, MAX_TICK);
 

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
@@ -39,16 +39,16 @@ use crate::evm::protocol::{
     },
 };
 
-// Gas limit constants for capping get_limits calculations
-// These prevent simulations from exceeding Ethereum's block gas limit
-// The names of the constants reflect the exact method from the tenderly log.
-const SWAP_BASE_GAS: u64 = 130_000;
-// Bitmap word scan
+// Pre/post loop overhead: cold SLOADs (slot0, liquidity, feeGrowthGlobal) +
+// cold SSTOREs (slot0 write, liquidity write) at end of swap.
+const SWAP_BASE_GAS: u64 = 70_000;
+// Bitmap word scan (cold SLOAD of tickBitmap word)
 const GAS_PER_BITMAP_WORD: u64 = 2_100;
-// swap math step: getSqrtRatioAtTick + computeSwapStep + amount accounting
-const GAS_PER_SWAP_MATH_STEP: u64 = 4_000;
-// Initialized tick crossing
-const GAS_PER_INITIALIZED_TICK_CROSS: u64 = 17_540;
+// swap math step: getSqrtRatioAtTick + computeSwapStep + amount accounting + getTickAtSqrtRatio
+const GAS_PER_SWAP_MATH_STEP: u64 = 5_400;
+// Initialized tick crossing: cross() updates feeGrowthOutside0/1 (2 SSTOREs).
+// Warm ≈ 10-17k, cold ≈ 40-52k. 24k biases toward cold for overestimation.
+const GAS_PER_INITIALIZED_TICK_CROSS: u64 = 24_000;
 // Output transfer + balanceBefore + callback + balanceAfter.
 const V3_CALLBACK_SETTLEMENT_GAS: u64 = 70_000;
 // Conservative max gas budget for a single swap (Ethereum transaction gas limit)
@@ -134,7 +134,7 @@ impl UniswapV3State {
             tick: self.tick,
             liquidity: self.liquidity,
         };
-        let mut gas_used = U256::from(0);
+        let mut gas_used = U256::from(SWAP_BASE_GAS);
 
         while state.amount_remaining != I256::from_raw(U256::from(0u64)) &&
             state.sqrt_price != price_limit
@@ -912,13 +912,20 @@ mod tests {
             .get_limits(t0.address.clone(), t1.address.clone())
             .unwrap();
 
-        assert_eq!(&res.0, &BigUint::from_u128(155144999154).unwrap());
+        assert_eq!(&res.0, &BigUint::from_u128(29160572556).unwrap());
 
         let out = usv3_state
             .get_amount_out(res.0, &t0, &t1)
             .expect("swap for limit in didn't work");
 
-        assert_eq!(&res.1, &out.amount);
+        // Allow 1-unit rounding difference: get_limits uses ceiling/floor delta math
+        // while get_amount_out uses the full swap path.
+        let diff = if res.1 > out.amount {
+            res.1.clone() - out.amount.clone()
+        } else {
+            out.amount.clone() - res.1.clone()
+        };
+        assert!(diff <= BigUint::from(1u64), "limit_out and amount_out differ by {diff}");
     }
 
     // Helper to create a basic test pool

--- a/crates/tycho-simulation/src/evm/protocol/utils/slipstreams/dynamic_fee_module.rs
+++ b/crates/tycho-simulation/src/evm/protocol/utils/slipstreams/dynamic_fee_module.rs
@@ -30,6 +30,10 @@ impl DynamicFeeConfig {
     pub fn update_base_fee(&mut self, base_fee: u32) {
         self.base_fee = base_fee;
     }
+
+    pub fn scaling_factor(&self) -> u64 {
+        self.scaling_factor
+    }
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
Increase gas estimations for both Slipstreams and Uniswap V3:
- The values for the tick crossing depend on the storage being warmed or cold. Preferred to overestimate here
- For Slipstreams:
  - In the first loop there is some overhead that was not accounted for
  - There might be extra gas spent on calculating the fee
- For Uniswap v3:
  - 🐞 The SWAP_BASE_GAS was actually never user 🐞  
  - Increase the values slightly

Some simulations if you want to look through the values yourself:
- Slipstreams:
  - https://www.tdly.co/shared/simulation/7e6afeb5-4f40-4d4a-af76-1428a555da01
  - https://www.tdly.co/shared/simulation/55551da3-d88c-4c28-bf18-bce924601d5c
  - https://www.tdly.co/shared/simulation/73d3cab1-0a53-417f-b4f1-10bcc1b88fb0
  - https://www.tdly.co/shared/simulation/86811eb4-431e-42d0-9021-836f69e246ac
- Uniswap v3:
  - https://www.tdly.co/shared/simulation/b4b73e88-bc1f-493c-88b5-b893aadf854b
  - https://www.tdly.co/shared/simulation/e421f7c4-c4a7-4232-97a3-3c6dbb348dda
  - https://www.tdly.co/shared/simulation/ed9dacb4-a250-4b30-a745-74e601b03be0

Also:
- In Slipstreams cap limits calculation with `MAX_SWAP_GAS` like we do for univ3.