### PR TITLE
ci: disable tycho-indexer and tycho crate push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -132,16 +132,17 @@ jobs:
         run: sleep 30
 
       # Wave 4: indexer (depends on storage, common, client, ethereum)
-      - name: Publish tycho-indexer
-        run: >
-          cargo publish -p tycho-indexer --locked
-          --token ${{ secrets.CRATESIO_REGISTRY_TOKEN }}
+      # TODO: Re-enable this when we can release tycho-storage to crates.io
+      # - name: Publish tycho-indexer
+      #   run: >
+      #     cargo publish -p tycho-indexer --locked
+      #     --token ${{ secrets.CRATESIO_REGISTRY_TOKEN }}
 
-      - name: Wait for crates.io to index wave 4
-        run: sleep 30
+      # - name: Wait for crates.io to index wave 4
+      #   run: sleep 30
 
-      # Wave 5: metacrate
-      - name: Publish tycho (metacrate)
-        run: >
-          cargo publish -p tycho --locked --dry-run
-          --token ${{ secrets.CRATESIO_REGISTRY_TOKEN }}
+      # # Wave 5: metacrate
+      # - name: Publish tycho (metacrate)
+      #   run: >
+      #     cargo publish -p tycho --locked
+      #     --token ${{ secrets.CRATESIO_REGISTRY_TOKEN }}


### PR DESCRIPTION
It requires tycho-storage to be pushed and this is blocked due to crate name conflicts.