### PR TITLE
fix(tycho-ethereum): retry next slot candidate on transport errors in slot detection

### DIFF
--- a/crates/tycho-ethereum/src/services/entrypoint_tracer/balance_slot_detector.rs
+++ b/crates/tycho-ethereum/src/services/entrypoint_tracer/balance_slot_detector.rs
@@ -89,8 +89,8 @@ mod tests {
 
     use super::{BalanceStrategy, SlotDetectionStrategy, *};
     use crate::test_fixtures::{
-        TestFixture, ARB_USDC_HOLDER_ADDR, ARB_USDC_STR, ARB_WETH_STR, STETH_STR,
-        USDC_HOLDER_ADDR, USDC_STR, USDT_STR, WETH_STR,
+        TestFixture, ARB_USDC_HOLDER_ADDR, ARB_USDC_STR, ARB_WETH_STR, STETH_STR, USDC_HOLDER_ADDR,
+        USDC_STR, USDT_STR, WETH_STR,
     };
 
     const BLOCK_HASH: &str = "0x658814e4cb074359f10dd71237cc57b1ae6791fc9de59fde570e724bd884cbb0";

--- a/crates/tycho-ethereum/src/services/entrypoint_tracer/balance_slot_detector.rs
+++ b/crates/tycho-ethereum/src/services/entrypoint_tracer/balance_slot_detector.rs
@@ -89,7 +89,8 @@ mod tests {
 
     use super::{BalanceStrategy, SlotDetectionStrategy, *};
     use crate::test_fixtures::{
-        TestFixture, STETH_STR, USDC_HOLDER_ADDR, USDC_STR, USDT_STR, WETH_STR,
+        TestFixture, ARB_USDC_HOLDER_ADDR, ARB_USDC_STR, ARB_WETH_STR, STETH_STR,
+        USDC_HOLDER_ADDR, USDC_STR, USDT_STR, WETH_STR,
     };
 
     const BLOCK_HASH: &str = "0x658814e4cb074359f10dd71237cc57b1ae6791fc9de59fde570e724bd884cbb0";
@@ -97,6 +98,14 @@ mod tests {
     impl TestFixture {
         fn create_balance_detector() -> EVMBalanceSlotDetector {
             let fixture = TestFixture::new();
+
+            let rpc = fixture.create_rpc_client(true);
+
+            EVMBalanceSlotDetector::new(&rpc).with_max_token_batch_size(5)
+        }
+
+        fn create_arb_balance_detector() -> EVMBalanceSlotDetector {
+            let fixture = TestFixture::new_arbitrum();
 
             let rpc = fixture.create_rpc_client(true);
 
@@ -286,6 +295,101 @@ mod tests {
             }
         } else {
             panic!("No result for stETH token");
+        }
+    }
+
+    /// Tests balance slot detection for Arbitrum USDC (FiatToken proxy) with a zero-balance
+    /// user address. This reproduces the production failure where Arbitrum precompile storage
+    /// slots appear in the trace and cause detection to fail.
+    ///
+    /// The prestateTracer returns slots from Arbitrum precompile addresses (0xa4b05fff...)
+    /// alongside the actual USDC contract slots. When the user has zero balance, both the
+    /// precompile zero-value slot and the actual balance slot have value 0. If the precompile
+    /// slot is tested first, the eth_call override fails with "overriding address ... not
+    /// allowed", and the current code treats this as a terminal error instead of trying the
+    /// next candidate.
+    #[rstest]
+    #[case("0xf847a638E44186F3287ee9F8cAF73FF4d4B80784", "ZeroBalanceUser")]
+    #[case(ARB_USDC_HOLDER_ADDR, "NonZeroBalanceUser")]
+    #[tokio::test]
+    #[ignore = "require ARB_RPC_URL"]
+    async fn test_detect_arb_usdc_balance_slots(
+        #[case] holder_address_hex: &str,
+        #[case] holder_name: &str,
+    ) {
+        let arb_usdc = Address::from_str(ARB_USDC_STR).expect("Invalid ARB USDC address");
+        let arb_weth = Address::from_str(ARB_WETH_STR).expect("Invalid ARB WETH address");
+
+        let holder_address = Address::from_str(holder_address_hex).expect("Invalid holder address");
+
+        let tokens = vec![arb_usdc.clone(), arb_weth.clone()];
+
+        // Use latest block — Arbitrum fixture uses block 0 / default hash
+        let rpc_url = std::env::var("ARB_RPC_URL").expect("ARB_RPC_URL must be set");
+        let client = reqwest::Client::new();
+        let response: serde_json::Value = client
+            .post(&rpc_url)
+            .header("Content-Type", "application/json")
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "method": "eth_getBlockByNumber",
+                "params": ["latest", false],
+                "id": 1
+            }))
+            .send()
+            .await
+            .expect("Failed to fetch block")
+            .json()
+            .await
+            .expect("Failed to parse response");
+
+        let block_hash_str = response["result"]["hash"]
+            .as_str()
+            .expect("Missing block hash");
+        let block_hash = BlockHash::from_str(block_hash_str).expect("Invalid block hash");
+        println!("Arbitrum block hash: {block_hash}");
+
+        let detector = TestFixture::create_arb_balance_detector();
+        let results = detector
+            .detect_balance_slots(&tokens, holder_address, block_hash)
+            .await;
+
+        assert!(!results.is_empty(), "Expected results for at least one token, but got none");
+
+        // Check USDC result
+        if let Some(usdc_result) = results.get(&arb_usdc) {
+            match usdc_result {
+                Ok((storage_addr, slot)) => {
+                    println!(
+                        "ARB USDC slot detected for {holder_name} - Storage: {storage_addr}, Slot: {slot}"
+                    );
+                    assert_eq!(
+                        storage_addr, &arb_usdc,
+                        "Storage address should be the USDC proxy, not an Arbitrum precompile"
+                    );
+                }
+                Err(e) => panic!(
+                    "Failed to detect ARB USDC balance slot for {holder_name}: {e}. \
+                     This is the production bug: slot detection fails for USDC on Arbitrum \
+                     because Arbitrum precompile slots interfere with candidate selection."
+                ),
+            }
+        } else {
+            panic!("No result for ARB USDC token for {holder_name}");
+        }
+
+        // Check WETH result (should always work as it's not a proxy)
+        if let Some(weth_result) = results.get(&arb_weth) {
+            match weth_result {
+                Ok((storage_addr, slot)) => {
+                    println!(
+                        "ARB WETH slot detected for {holder_name} - Storage: {storage_addr}, Slot: {slot}"
+                    );
+                }
+                Err(e) => panic!("Failed to detect ARB WETH balance slot for {holder_name}: {e}"),
+            }
+        } else {
+            panic!("No result for ARB WETH token for {holder_name}");
         }
     }
 

--- a/crates/tycho-ethereum/src/services/entrypoint_tracer/slot_detector.rs
+++ b/crates/tycho-ethereum/src/services/entrypoint_tracer/slot_detector.rs
@@ -445,6 +445,13 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
         for (token, result) in token_slots {
             match result {
                 Ok((mut all_slots, original_value)) => {
+                    // Only keep slots stored at the token's own address.
+                    // ERC-20 balances/allowances are always at the token address
+                    // (even for proxy contracts using delegatecall). This filters
+                    // out noise from chain-specific precompiles (e.g. Arbitrum
+                    // ArbOS at 0xa4b05fff...) and other contracts in the trace.
+                    all_slots.retain(|((storage_addr, _), _)| *storage_addr == token);
+
                     if all_slots.is_empty() {
                         detected_results.insert(token, Err(SlotDetectorError::TokenNotInTrace));
                     } else {
@@ -1040,16 +1047,18 @@ mod tests {
         let detector = TestFixture::create_slot_detector_without_rpc();
 
         let token = Address::from([0x11u8; 20]);
-        let precompile_addr = Address::from([0xAAu8; 20]);
         let slot_a = Bytes::from(vec![0x01u8; 32]);
         let slot_b = Bytes::from(vec![0x02u8; 32]);
 
+        // Both slots are at the token address (the upfront filter in
+        // detect_correct_slots guarantees this). A transport error on
+        // slot_a (e.g. network failure) should retry with slot_b.
         let slots_to_test = vec![SlotMetadata {
             token: token.clone(),
             original_value: U256::ZERO,
             test_value: U256::from(1_000_000_000_000_000_000u64),
             all_slots: vec![
-                ((precompile_addr.clone(), slot_a.clone()), U256::ZERO),
+                ((token.clone(), slot_a.clone()), U256::ZERO),
                 ((token.clone(), slot_b.clone()), U256::ZERO),
             ],
         }];
@@ -1057,7 +1066,7 @@ mod tests {
         let responses: Vec<TransportResult<Value>> = vec![Err(
             alloy::transports::RpcError::LocalUsageError(Box::new(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                "overriding address not allowed",
+                "transport error",
             ))),
         )];
 

--- a/crates/tycho-ethereum/src/services/entrypoint_tracer/slot_detector.rs
+++ b/crates/tycho-ethereum/src/services/entrypoint_tracer/slot_detector.rs
@@ -1063,12 +1063,11 @@ mod tests {
             ],
         }];
 
-        let responses: Vec<TransportResult<Value>> = vec![Err(
-            alloy::transports::RpcError::LocalUsageError(Box::new(std::io::Error::new(
+        let responses: Vec<TransportResult<Value>> =
+            vec![Err(alloy::transports::RpcError::LocalUsageError(Box::new(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 "transport error",
-            ))),
-        )];
+            ))))];
 
         let mut results = HashMap::new();
         let retry_data =
@@ -1094,12 +1093,11 @@ mod tests {
             all_slots: vec![((token.clone(), slot_a.clone()), U256::ZERO)],
         }];
 
-        let responses: Vec<TransportResult<Value>> = vec![Err(
-            alloy::transports::RpcError::LocalUsageError(Box::new(std::io::Error::new(
+        let responses: Vec<TransportResult<Value>> =
+            vec![Err(alloy::transports::RpcError::LocalUsageError(Box::new(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 "overriding address not allowed",
-            ))),
-        )];
+            ))))];
 
         let mut results = HashMap::new();
         let retry_data =

--- a/crates/tycho-ethereum/src/services/entrypoint_tracer/slot_detector.rs
+++ b/crates/tycho-ethereum/src/services/entrypoint_tracer/slot_detector.rs
@@ -1064,10 +1064,9 @@ mod tests {
         }];
 
         let responses: Vec<TransportResult<Value>> =
-            vec![Err(alloy::transports::RpcError::LocalUsageError(Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "transport error",
-            ))))];
+            vec![Err(alloy::transports::RpcError::LocalUsageError(Box::new(
+                std::io::Error::other("transport error"),
+            )))];
 
         let mut results = HashMap::new();
         let retry_data =
@@ -1094,10 +1093,9 @@ mod tests {
         }];
 
         let responses: Vec<TransportResult<Value>> =
-            vec![Err(alloy::transports::RpcError::LocalUsageError(Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "overriding address not allowed",
-            ))))];
+            vec![Err(alloy::transports::RpcError::LocalUsageError(Box::new(
+                std::io::Error::other("overriding address not allowed"),
+            )))];
 
         let mut results = HashMap::new();
         let retry_data =

--- a/crates/tycho-ethereum/src/services/entrypoint_tracer/slot_detector.rs
+++ b/crates/tycho-ethereum/src/services/entrypoint_tracer/slot_detector.rs
@@ -525,26 +525,39 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
 
             match responses.get(response_id) {
                 Some(response) => {
-                    // Check for errors
-                    let response_value = match response {
-                        Err(error) => {
-                            results.insert(
-                                metadata.token,
-                                Err(SlotDetectorError::RequestError(format!(
-                                    "Slot test call failed: {error}",
-                                ))),
-                            );
-                            continue;
-                        }
-                        Ok(response_value) => response_value,
-                    };
-
                     let (storage_addr, slot) = &metadata
                         .all_slots
                         .first()
                         .expect("all_slots should not be empty")
                         .0
                         .clone();
+
+                    // On transport errors (e.g. Arbitrum disallows overriding
+                    // precompile addresses), drop this candidate and retry.
+                    let response_value = match response {
+                        Err(error) => {
+                            metadata
+                                .all_slots
+                                .retain(|s| s.0 != (storage_addr.clone(), slot.clone()));
+                            if !metadata.all_slots.is_empty() {
+                                warn!(
+                                    token = %metadata.token,
+                                    error = %error,
+                                    "Slot test call failed - trying next slot"
+                                );
+                                retry_data.push(metadata);
+                            } else {
+                                results.insert(
+                                    metadata.token,
+                                    Err(SlotDetectorError::RequestError(format!(
+                                        "Slot test call failed: {error}",
+                                    ))),
+                                );
+                            }
+                            continue;
+                        }
+                        Ok(response_value) => response_value,
+                    };
 
                     match self.extract_u256_from_call_response(response_value) {
                         Ok(returned_value) => {
@@ -635,8 +648,11 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
 mod tests {
     use std::collections::HashMap;
 
-    use alloy::primitives::{Address as AlloyAddress, U256};
-    use serde_json::json;
+    use alloy::{
+        primitives::{Address as AlloyAddress, U256},
+        transports::TransportResult,
+    };
+    use serde_json::{json, Value};
     use tycho_common::{
         models::{Address, BlockHash},
         Bytes,
@@ -1017,6 +1033,72 @@ mod tests {
         assert_eq!(retry_data[0].all_slots[0].0 .1, slot_b);
         // No final result yet — token is still being retried
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_transport_error_schedules_retry_with_remaining() {
+        let detector = TestFixture::create_slot_detector_without_rpc();
+
+        let token = Address::from([0x11u8; 20]);
+        let precompile_addr = Address::from([0xAAu8; 20]);
+        let slot_a = Bytes::from(vec![0x01u8; 32]);
+        let slot_b = Bytes::from(vec![0x02u8; 32]);
+
+        let slots_to_test = vec![SlotMetadata {
+            token: token.clone(),
+            original_value: U256::ZERO,
+            test_value: U256::from(1_000_000_000_000_000_000u64),
+            all_slots: vec![
+                ((precompile_addr.clone(), slot_a.clone()), U256::ZERO),
+                ((token.clone(), slot_b.clone()), U256::ZERO),
+            ],
+        }];
+
+        let responses: Vec<TransportResult<Value>> = vec![Err(
+            alloy::transports::RpcError::LocalUsageError(Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "overriding address not allowed",
+            ))),
+        )];
+
+        let mut results = HashMap::new();
+        let retry_data =
+            detector.process_slot_test_responses(responses, slots_to_test, &mut results);
+
+        assert_eq!(retry_data.len(), 1, "Should schedule retry with remaining slot");
+        assert_eq!(retry_data[0].all_slots.len(), 1);
+        assert_eq!(retry_data[0].all_slots[0].0 .1, slot_b);
+        assert!(results.is_empty(), "No final result yet — token is still being retried");
+    }
+
+    #[test]
+    fn test_transport_error_with_no_remaining_slots_is_terminal() {
+        let detector = TestFixture::create_slot_detector_without_rpc();
+
+        let token = Address::from([0x11u8; 20]);
+        let slot_a = Bytes::from(vec![0x01u8; 32]);
+
+        let slots_to_test = vec![SlotMetadata {
+            token: token.clone(),
+            original_value: U256::ZERO,
+            test_value: U256::from(1_000_000_000_000_000_000u64),
+            all_slots: vec![((token.clone(), slot_a.clone()), U256::ZERO)],
+        }];
+
+        let responses: Vec<TransportResult<Value>> = vec![Err(
+            alloy::transports::RpcError::LocalUsageError(Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "overriding address not allowed",
+            ))),
+        )];
+
+        let mut results = HashMap::new();
+        let retry_data =
+            detector.process_slot_test_responses(responses, slots_to_test, &mut results);
+
+        assert!(retry_data.is_empty(), "No more slots to retry");
+        assert!(results.contains_key(&token));
+        assert!(matches!(results[&token], Err(SlotDetectorError::RequestError(_))));
     }
 
     #[test]

--- a/crates/tycho-ethereum/src/services/entrypoint_tracer/slot_detector.rs
+++ b/crates/tycho-ethereum/src/services/entrypoint_tracer/slot_detector.rs
@@ -349,17 +349,14 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
 
     /// Sort slots by priority for testing.
     ///
-    /// Primary sort: Distance to expected balance (closest first)
-    /// Secondary sort: Reverse index (last accessed first, used as tiebreaker)
-    ///
-    /// This sorting is done once when we first get the slot candidates.
-    fn sort_slots_by_priority(slots: &mut SlotValues, original_value: U256) {
-        slots.sort_by_key(|(_, new_value)| {
-            // Primary: distance to original balance (closer is better)
-            // Note: We can't use reverse index here as a secondary key in a simple way,
-            // but the initial order from the trace is already in access order,
-            // so slots with the same distance will maintain their relative order (stable sort)
-            new_value.abs_diff(original_value)
+    /// Primary: slots at the token's own address first (most common case).
+    /// Secondary: distance to original value (closer first).
+    fn sort_slots_by_priority(slots: &mut SlotValues, token: &Address, original_value: U256) {
+        slots.sort_by_key(|((storage_addr, _), new_value)| {
+            // Primary: token-address slots first (precompiles / external storage last)
+            // Secondary: distance to original balance (closer is better)
+            let is_foreign = storage_addr != token;
+            (is_foreign, new_value.abs_diff(original_value))
         });
     }
 
@@ -429,10 +426,9 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
 
     /// Detects the correct storage slot by testing candidates with storage overrides.
     ///
-    /// Testing order:
-    /// 1. Start with the slot whose value is closest to the original allowance
-    /// 2. Fall back to the last accessed slot
-    /// 3. Try remaining slots in reverse order (most recently accessed first)
+    /// Candidates are sorted by priority (token-address first, then value distance) and tested in
+    /// order. If a candidate fails with a transport error (e.g. chain disallows overriding a
+    /// precompile address), it is dropped and the next candidate is retried.
     async fn detect_correct_slots(
         &self,
         token_slots: DetectedSlotsResults,
@@ -445,17 +441,10 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
         for (token, result) in token_slots {
             match result {
                 Ok((mut all_slots, original_value)) => {
-                    // Only keep slots stored at the token's own address.
-                    // ERC-20 balances/allowances are always at the token address
-                    // (even for proxy contracts using delegatecall). This filters
-                    // out noise from chain-specific precompiles (e.g. Arbitrum
-                    // ArbOS at 0xa4b05fff...) and other contracts in the trace.
-                    all_slots.retain(|((storage_addr, _), _)| *storage_addr == token);
-
                     if all_slots.is_empty() {
                         detected_results.insert(token, Err(SlotDetectorError::TokenNotInTrace));
                     } else {
-                        Self::sort_slots_by_priority(&mut all_slots, original_value);
+                        Self::sort_slots_by_priority(&mut all_slots, &token, original_value);
                         all_slots.truncate(MAX_SLOT_CANDIDATES);
 
                         slots_to_test.push(SlotMetadata {
@@ -532,12 +521,11 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
 
             match responses.get(response_id) {
                 Some(response) => {
-                    let (storage_addr, slot) = &metadata
-                        .all_slots
-                        .first()
-                        .expect("all_slots should not be empty")
-                        .0
-                        .clone();
+                    let Some(((storage_addr, slot), _)) = metadata.all_slots.first() else {
+                        results.insert(metadata.token, Err(SlotDetectorError::TokenNotInTrace));
+                        continue;
+                    };
+                    let (storage_addr, slot) = (storage_addr.clone(), slot.clone());
 
                     // On transport errors (e.g. Arbitrum disallows overriding
                     // precompile addresses), drop this candidate and retry.
@@ -1000,9 +988,44 @@ mod tests {
             ((addr.clone(), slot_c.clone()), U256::from(1500u64)),
         ];
 
-        SlotDetector::<TestFixtureStrategy>::sort_slots_by_priority(&mut slots, original_value);
+        SlotDetector::<TestFixtureStrategy>::sort_slots_by_priority(
+            &mut slots,
+            &addr,
+            original_value,
+        );
 
         // Expected order: slot_b (dist 1), slot_c (dist 500), slot_a (dist 4000)
+        assert_eq!(slots[0].0 .1, slot_b);
+        assert_eq!(slots[1].0 .1, slot_c);
+        assert_eq!(slots[2].0 .1, slot_a);
+    }
+
+    #[test]
+    fn test_sort_slots_by_priority_foreign_address_last() {
+        let token = Address::from([0x11u8; 20]);
+        let foreign = Address::from([0xaau8; 20]);
+        let slot_a = Bytes::from(vec![0x01u8; 32]);
+        let slot_b = Bytes::from(vec![0x02u8; 32]);
+        let slot_c = Bytes::from(vec![0x03u8; 32]);
+
+        let original_value = U256::from(1000u64);
+
+        // slot_a is at a foreign address (e.g. Arbitrum precompile) with closest value,
+        // slot_b and slot_c are at the token address with farther values.
+        // Token-address slots must come before foreign-address slots regardless of distance.
+        let mut slots: SlotValues = vec![
+            ((foreign.clone(), slot_a.clone()), U256::from(999u64)), // distance 1, but foreign
+            ((token.clone(), slot_b.clone()), U256::from(1500u64)),  // distance 500, token
+            ((token.clone(), slot_c.clone()), U256::from(5000u64)),  // distance 4000, token
+        ];
+
+        SlotDetector::<TestFixtureStrategy>::sort_slots_by_priority(
+            &mut slots,
+            &token,
+            original_value,
+        );
+
+        // Token slots first (ordered by distance), foreign slot last
         assert_eq!(slots[0].0 .1, slot_b);
         assert_eq!(slots[1].0 .1, slot_c);
         assert_eq!(slots[2].0 .1, slot_a);
@@ -1050,9 +1073,8 @@ mod tests {
         let slot_a = Bytes::from(vec![0x01u8; 32]);
         let slot_b = Bytes::from(vec![0x02u8; 32]);
 
-        // Both slots are at the token address (the upfront filter in
-        // detect_correct_slots guarantees this). A transport error on
-        // slot_a (e.g. network failure) should retry with slot_b.
+        // A transport error on slot_a (e.g. Arbitrum precompile override rejected)
+        // should drop that candidate and retry with slot_b.
         let slots_to_test = vec![SlotMetadata {
             token: token.clone(),
             original_value: U256::ZERO,
@@ -1120,7 +1142,11 @@ mod tests {
             ((addr.clone(), slot_b.clone()), U256::from(1100u64)),
         ];
 
-        SlotDetector::<TestFixtureStrategy>::sort_slots_by_priority(&mut slots, original_value);
+        SlotDetector::<TestFixtureStrategy>::sort_slots_by_priority(
+            &mut slots,
+            &addr,
+            original_value,
+        );
 
         // Stable sort preserves original order for equal keys
         assert_eq!(slots[0].0 .1, slot_a);


### PR DESCRIPTION
## Summary

On Arbitrum, `debug_traceCall` with `prestateTracer` includes storage slots from precompile addresses (e.g. `0xa4b05fff...`) alongside the actual token contract slots. When the user has zero balance, a precompile zero-value slot ties with the real balance slot in priority and gets tested first. The `eth_call` state override on a precompile fails with `"overriding address ... not allowed"`, which was treated as a terminal error — never trying the remaining candidates.

- **Retry on transport error**: when an `eth_call` slot test fails with a transport error (e.g. the RPC rejects a state override on a precompile), drop that candidate and retry with the next one. Previously this was a terminal error.
- **Prioritise token-address slots**: sort candidates so slots stored at the token's own address come first, with value-distance as a tiebreaker. Slots from foreign addresses (precompiles, external storage contracts) are pushed to the end and still tested if all token-address candidates fail. This avoids wasting RPC calls on precompile slots in the common case while remaining correct for tokens that store balances in a separate contract.
- **Remove unsafe `.expect()`**: replace `all_slots.first().expect(...)` with a `let…else` that records `TokenNotInTrace` and continues, avoiding a panic if the invariant is ever violated.

## Test plan
- [x] New Arbitrum integration test (`test_detect_arb_usdc_balance_slots`) confirms detection succeeds for both zero-balance and non-zero-balance holders on Arbitrum USDC (requires `ARB_RPC_URL`)
- [x] New unit test (`test_sort_slots_by_priority_foreign_address_last`) verifies foreign-address slots are sorted after token-address slots regardless of value distance
- [x] New unit tests (`test_transport_error_schedules_retry_with_remaining`, `test_transport_error_with_no_remaining_slots_is_terminal`) cover the retry-on-error behavior without RPC
- [x] All existing slot detector tests pass