### PR TITLE
fix(tycho-execution): add quickswap_v2 to swap encoder registry

### DIFF
--- a/crates/tycho-execution/src/encoding/evm/swap_encoder/swap_encoder_registry.rs
+++ b/crates/tycho-execution/src/encoding/evm/swap_encoder/swap_encoder_registry.rs
@@ -100,13 +100,7 @@ impl SwapEncoderRegistry {
         config: Option<HashMap<String, String>>,
     ) -> Result<Box<dyn SwapEncoder>, EncodingError> {
         match protocol_system {
-            "uniswap_v2" => {
-                Ok(Box::new(UniswapV2SwapEncoder::new(executor_address, self.chain, config)?))
-            }
-            "sushiswap_v2" => {
-                Ok(Box::new(UniswapV2SwapEncoder::new(executor_address, self.chain, config)?))
-            }
-            "pancakeswap_v2" => {
+            "uniswap_v2" | "sushiswap_v2" | "pancakeswap_v2" | "quickswap_v2" => {
                 Ok(Box::new(UniswapV2SwapEncoder::new(executor_address, self.chain, config)?))
             }
             "aerodrome_v1" => {
@@ -115,10 +109,7 @@ impl SwapEncoderRegistry {
             "vm:balancer_v2" => {
                 Ok(Box::new(BalancerV2SwapEncoder::new(executor_address, self.chain, config)?))
             }
-            "uniswap_v3" => {
-                Ok(Box::new(UniswapV3SwapEncoder::new(executor_address, self.chain, config)?))
-            }
-            "pancakeswap_v3" => {
+            "uniswap_v3" | "pancakeswap_v3" => {
                 Ok(Box::new(UniswapV3SwapEncoder::new(executor_address, self.chain, config)?))
             }
             "uniswap_v4" => {


### PR DESCRIPTION
## Summary
- Adds `quickswap_v2` to the protocol system match in `SwapEncoderRegistry`. QuickSwap V2 on Polygon is a Uniswap V2 fork and uses the same swap encoding. Without this mapping, the integration test fatally errors with `"Unknown protocol system: quickswap_v2"` when encountering QuickSwap pools on Polygon.

## Test plan
- [x] `cargo check -p tycho-execution` passes
- [x] Existing encoder tests unaffected (QuickSwap uses the same `UniswapV2SwapEncoder`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)