### PR TITLE
fix(gas-estimations): Tweak gas estimations for univ4 and univ2

### DIFF
--- a/crates/tycho-execution/src/encoding/evm/gas_estimator.rs
+++ b/crates/tycho-execution/src/encoding/evm/gas_estimator.rs
@@ -29,7 +29,8 @@ pub const PROTOCOLS_CALLBACK: &[&str] = &[
 /// Protocols where the router-to-pool input transfer is skipped (funds are sent directly without
 /// an intermediate router hop). The input transfer cost is therefore not double-counted — it is
 /// only charged once, on the first hop or when the optimized path applies.
-pub const PROTOCOLS_OPTIMIZABLE_TRANSFER_IN: &[&str] = &["erc4626", "maverick_v2", "uniswap_v2"];
+pub const PROTOCOLS_OPTIMIZABLE_TRANSFER_IN: &[&str] =
+    &["erc4626", "maverick_v2", "uniswap_v2", "sushiswap_v2", "pancakeswap_v2", "quickswap_v2"];
 
 /// ProtocolWillDebit: the router must `approve(protocol)` before swapping.
 /// The protocol's `transferFrom` is inside `swap()` and already in the gas computation of

--- a/crates/tycho-simulation/src/evm/protocol/pancakeswap_v2/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/pancakeswap_v2/state.rs
@@ -27,6 +27,7 @@ use crate::evm::protocol::{
     utils::add_fee_markup,
 };
 
+const SWAP_BASE_GAS: u64 = 90_000;
 const PANCAKESWAP_V2_FEE: u32 = 25; // 0.25% fee
 const FEE_PRECISION: U256 = U256::from_limbs([10000, 0, 0, 0]);
 const FEE_NUMERATOR: U256 = U256::from_limbs([9975, 0, 0, 0]);
@@ -83,7 +84,7 @@ impl ProtocolSim for PancakeswapV2State {
         };
         Ok(GetAmountOutResult::new(
             u256_to_biguint(amount_out),
-            BigUint::from(70_000u32),
+            BigUint::from(SWAP_BASE_GAS),
             Box::new(new_state),
         ))
     }

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v2/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v2/state.rs
@@ -27,6 +27,7 @@ use crate::evm::protocol::{
     utils::add_fee_markup,
 };
 
+const SWAP_BASE_GAS: u64 = 90_000;
 const UNISWAP_V2_FEE_BPS: u32 = 30; // 0.3% fee
 const FEE_PRECISION: U256 = U256::from_limbs([10000, 0, 0, 0]);
 const FEE_NUMERATOR: U256 = U256::from_limbs([9970, 0, 0, 0]);
@@ -83,7 +84,7 @@ impl ProtocolSim for UniswapV2State {
         };
         Ok(GetAmountOutResult::new(
             u256_to_biguint(amount_out),
-            BigUint::from(70_000u32),
+            BigUint::from(SWAP_BASE_GAS),
             Box::new(new_state),
         ))
     }

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
@@ -51,14 +51,16 @@ use crate::{
     impl_non_serializable_protocol,
 };
 
-// Gas limit constants for capping get_limits calculations
-// These prevent simulations from exceeding Ethereum's block gas limit
-// The names of the constants reflect the exact method from the tenderly log.
-const SWAP_BASE_GAS: u64 = 130_000;
+// Fixed overhead per swap: covers router overhead, executor preamble (decode, sync,
+// unlock/callback pattern), and token transfer-in.
+const SWAP_BASE_GAS: u64 = 185_000;
+// Per loop: PoolManager.swap bitmap lookup + sqrt math + computeSwapStep.
+// V4's singleton PoolManager hits warmer storage than V3 standalone pools: ~3,500/loop.
+const GAS_PER_BITMAP_LOOKUP: u64 = 3_500;
+// Initialized tick crossing: _updateTick() updates feeGrowthOutside0/1 (2 SSTOREs).
+// Warm ≈ 10–17k, cold ≈ 40–52k. 17,540 reflects warm scenario.
 const GAS_PER_TICK: u64 = 17_540;
-const GAS_PER_BITMAP_LOOKUP: u64 = 4_000;
-// Cost of taking the output amount from the Uniswap V4 PoolManager, corresponds to
-// PoolManager.take()
+// Settlement overhead within swapExactInputSingle: _settle() + _getFullCredit() + misc.
 const V4_CALLBACK_SETTLEMENT_GAS: u64 = 30_000;
 // Conservative max gas budget for a single swap (Ethereum transaction gas limit)
 const MAX_SWAP_GAS: u64 = 16_700_000;
@@ -213,7 +215,7 @@ impl UniswapV4State {
             tick: self.tick,
             liquidity: self.liquidity,
         };
-        let mut gas_used = U256::from(0);
+        let mut gas_used = U256::from(SWAP_BASE_GAS);
 
         while state.amount_remaining != I256::ZERO && state.sqrt_price != price_limit {
             let (mut next_tick, initialized) = match self

--- a/crates/tycho-test/src/execution/encoding.rs
+++ b/crates/tycho-test/src/execution/encoding.rs
@@ -19,7 +19,7 @@ use tycho_common::{
 use tycho_execution::encoding::{
     evm::{
         encoder_builders::TychoRouterEncoderBuilder,
-        swap_encoder::swap_encoder_registry::SwapEncoderRegistry,
+        swap_encoder::swap_encoder_registry::SwapEncoderRegistry, ROUTER_ETH_ADDRESS,
     },
     models::{ClientFeeParams, EncodedSolution, Solution, Swap},
 };
@@ -130,8 +130,17 @@ fn encoded_transaction(
 ) -> miette::Result<Transaction> {
     let amount_in = biguint_to_u256(solution.amount_in());
     let min_amount_out = biguint_to_u256(solution.min_amount_out());
-    let token_in = Address::from_slice(solution.token_in());
-    let token_out = Address::from_slice(solution.token_out());
+    let router_eth = Address::from_slice(ROUTER_ETH_ADDRESS.as_ref());
+    let to_router_address = |raw: Address| {
+        if raw.as_slice() == native_address.as_ref() {
+            router_eth
+        } else {
+            raw
+        }
+    };
+
+    let token_in = to_router_address(Address::from_slice(solution.token_in()));
+    let token_out = to_router_address(Address::from_slice(solution.token_out()));
     let receiver = Address::from_slice(solution.receiver());
     let client_fee_params = ClientFeeParams::default().into_abi_params();
 


### PR DESCRIPTION
Increase gas estimations for both Uni v4 and v2:

### For UniV4:
- 🐞 The SWAP_BASE_GAS was actually never user 🐞
- Increase the values slightly

Some simulations if you want to look through the values yourself:
- https://www.tdly.co/shared/simulation/f9fddfd1-ef82-45a0-b6de-6708748727ef
- https://www.tdly.co/shared/simulation/72473e60-bf95-46a6-b816-56211658460c
- https://www.tdly.co/shared/simulation/a4dfa3da-b437-4947-9dd1-b1a446a25467


### For UniV2:
- Increase SWAP_BASE_GAS slightly - this value is highly dependent on the transfer of the token out though. 90k should overestimate slightly for most cases

Some simulations if you want to look through the values yourself:
- https://www.tdly.co/shared/simulation/db89b8a1-78ee-4c15-83c3-4fc8c348d273
- https://www.tdly.co/shared/simulation/064be642-4d6d-4999-940e-3f5c325d1e88
- https://www.tdly.co/shared/simulation/dca574ea-36f3-43e7-9c3f-a2131ea106c7

### Misc fixes:
- in tycho-test: Use proper eth marker when encoding router call (found some errors because of this when running for Univ4)
- gas-estimations: Add univ2 clones to PROTOCOLS_OPTIMIZABLE_TRANSFER_IN

