### PR TITLE
fix: add factory static attribute to Slipstreams

### DIFF
--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base-aerodrome-slipstreams"
-version = "0.3.1"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/protocols/substreams/base-aerodrome-slipstreams/Cargo.toml
+++ b/protocols/substreams/base-aerodrome-slipstreams/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base-aerodrome-slipstreams"
-version = "0.3.1"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/base-aerodrome-slipstreams/base-aerodrome-slipstreams.yaml
+++ b/protocols/substreams/base-aerodrome-slipstreams/base-aerodrome-slipstreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "base_aerodrome_slipstreams"
-  version: v0.1.0
+  version: v0.1.1
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/base-aerodrome-slipstreams"
 
 protobuf:

--- a/protocols/substreams/base-aerodrome-slipstreams/src/modules/3_map_pool_created.rs
+++ b/protocols/substreams/base-aerodrome-slipstreams/src/modules/3_map_pool_created.rs
@@ -35,7 +35,7 @@ fn get_new_pools(
     tick_spacing_to_fee_store: StoreGetInt64,
 ) {
     // Extract new pools from PoolCreated events
-    let mut on_pool_created = |event: PoolCreated, _tx: &eth::TransactionTrace, _log: &eth::Log| {
+    let mut on_pool_created = |event: PoolCreated, _tx: &eth::TransactionTrace, log: &eth::Log| {
         let tycho_tx: Transaction = _tx.into();
         // Get default fee for tick spacing
         let default_fee = tick_spacing_to_fee_store
@@ -107,6 +107,11 @@ fn get_new_pools(
                     Attribute {
                         name: "pool_address".to_string(),
                         value: event.pool,
+                        change: ChangeType::Creation.into(),
+                    },
+                    Attribute {
+                        name: "factory".to_string(),
+                        value: log.address.to_hex().into_bytes(),
                         change: ChangeType::Creation.into(),
                     },
                 ],

--- a/protocols/substreams/base-aerodrome-slipstreams/src/modules/5_map_balance_changes.rs
+++ b/protocols/substreams/base-aerodrome-slipstreams/src/modules/5_map_balance_changes.rs
@@ -26,8 +26,7 @@ pub fn map_balance_changes(
             .flat_map(|call| &call.logs)
         {
             // Skip if the log is not from a known slipstreams pool.
-            if let Some(pool) =
-                pools_store.get_last(format!("{}:{}", "Pool", &log.address.to_hex()))
+            if let Some(pool) = pools_store.get_last(format!("{}:{}", "Pool", log.address.to_hex()))
             {
                 tx_deltas.extend(get_log_changed_balances(&tx, log, &pool))
             } else {

--- a/protocols/substreams/base-aerodrome-slipstreams/src/modules/7_map_protocol_changes.rs
+++ b/protocols/substreams/base-aerodrome-slipstreams/src/modules/7_map_protocol_changes.rs
@@ -84,8 +84,7 @@ pub fn map_protocol_changes(
             .or_insert_with(|| TransactionChangesBuilder::new(&tx));
 
         for (log, call_view) in trx.logs_with_calls() {
-            if let Some(pool) =
-                pools_store.get_last(format!("{}:{}", "Pool", &log.address.to_hex()))
+            if let Some(pool) = pools_store.get_last(format!("{}:{}", "Pool", log.address.to_hex()))
             {
                 let changed_attributes = get_log_changed_attributes(
                     log,


### PR DESCRIPTION
## Summary

- Add a `factory` static attribute to Aerodrome Slipstreams pool components.
- Bump `base-aerodrome-slipstreams` to `v0.1.1`.

The previous Cargo package version was incorrectly left at `0.3.1`, copied over from the Uniswap V3 substream setup. This PR aligns the Cargo package, lockfile, and Substreams manifest versions.
