### PR TITLE
fix(router): guard Vault ERC20 deposit and FeeCalculator setters

### DIFF
--- a/crates/tycho-execution/contracts/src/FeeCalculator.sol
+++ b/crates/tycho-execution/contracts/src/FeeCalculator.sol
@@ -165,6 +165,7 @@ contract FeeCalculator is AccessControl, IFeeCalculator {
         external
         onlyRole(ROUTER_FEE_SETTER_ROLE)
     {
+        if (feeBps > _MAX_FEE_BPS) revert FeeCalculator__FeeTooHigh();
         uint16 oldFeeBps = _routerFeeOnOutputBps;
         _routerFeeOnOutputBps = feeBps;
         emit RouterFeeOnOutputUpdated(oldFeeBps, feeBps);
@@ -187,6 +188,7 @@ contract FeeCalculator is AccessControl, IFeeCalculator {
         external
         onlyRole(ROUTER_FEE_SETTER_ROLE)
     {
+        if (feeBps > _MAX_FEE_BPS) revert FeeCalculator__FeeTooHigh();
         CustomFees memory customFees = _customRouterFees[client];
         uint16 oldFeeBps = customFees.hasCustomFeeOnOutput
             ? customFees.feeBpsOnOutput
@@ -239,6 +241,7 @@ contract FeeCalculator is AccessControl, IFeeCalculator {
         external
         onlyRole(ROUTER_FEE_SETTER_ROLE)
     {
+        if (feeBps > _MAX_FEE_BPS) revert FeeCalculator__FeeTooHigh();
         uint16 oldFeeBps = _routerFeeOnClientFeeBps;
         _routerFeeOnClientFeeBps = feeBps;
         emit RouterFeeOnClientFeeUpdated(oldFeeBps, feeBps);
@@ -261,6 +264,7 @@ contract FeeCalculator is AccessControl, IFeeCalculator {
         external
         onlyRole(ROUTER_FEE_SETTER_ROLE)
     {
+        if (feeBps > _MAX_FEE_BPS) revert FeeCalculator__FeeTooHigh();
         CustomFees memory customFees = _customRouterFees[client];
         uint16 oldFeeBps = customFees.hasCustomFeeOnClientFee
             ? customFees.feeBpsOnClientFee

--- a/crates/tycho-execution/contracts/src/Vault.sol
+++ b/crates/tycho-execution/contracts/src/Vault.sol
@@ -137,6 +137,7 @@ abstract contract Vault is ERC6909, ReentrancyGuard, Pausable {
             require(msg.value == amount, "Value mismatch");
             _mint(msg.sender, id, amount);
         } else {
+            require(msg.value == 0, "ETH not accepted for ERC20 deposit");
             // ERC20 deposit - transfer to this contract and measure actual received
             // amount to handle  fee-on-transfer and rebasing tokens
             uint256 balanceBefore = IERC20(token).balanceOf(address(this));

--- a/crates/tycho-execution/contracts/test/FeeCalculator.t.sol
+++ b/crates/tycho-execution/contracts/test/FeeCalculator.t.sol
@@ -166,16 +166,12 @@ contract FeeCalculatorTest is Constants {
     }
 
     function testCalculateRouterFeeOnClientFeeTooHigh() public {
-        // Set router fee on client fee > 100%
+        // Setting router fee on client fee > 100% reverts at the setter
         vm.prank(FEE_SETTER);
-        feeCalculator.setRouterFeeOnClientFee(10001); // 100.01%
-
-        uint256 amountIn = 1 ether;
-
         vm.expectRevert(
             abi.encodeWithSelector(FeeCalculator__FeeTooHigh.selector)
         );
-        feeCalculator.calculateFee(amountIn, ALICE, 100);
+        feeCalculator.setRouterFeeOnClientFee(10001); // 100.01%
     }
 
     function testCalculateWithCustomRouterFeeReceiver() public {
@@ -563,12 +559,27 @@ contract FeeCalculatorConfigTest is Constants {
         uint16 maxFee = type(uint16).max;
 
         vm.startPrank(FEE_SETTER);
+        vm.expectRevert(
+            abi.encodeWithSelector(FeeCalculator__FeeTooHigh.selector)
+        );
         feeCalculator.setRouterFeeOnOutput(maxFee);
+        vm.expectRevert(
+            abi.encodeWithSelector(FeeCalculator__FeeTooHigh.selector)
+        );
         feeCalculator.setRouterFeeOnClientFee(maxFee);
         vm.stopPrank();
+    }
 
-        assertEq(feeCalculator.getRouterFeeOnOutput(), maxFee);
-        assertEq(feeCalculator.getRouterFeeOnClientFee(), maxFee);
+    function testMaximumValidFee() public {
+        uint16 maxValidFee = 10000;
+
+        vm.startPrank(FEE_SETTER);
+        feeCalculator.setRouterFeeOnOutput(maxValidFee);
+        feeCalculator.setRouterFeeOnClientFee(maxValidFee);
+        vm.stopPrank();
+
+        assertEq(feeCalculator.getRouterFeeOnOutput(), maxValidFee);
+        assertEq(feeCalculator.getRouterFeeOnClientFee(), maxValidFee);
     }
 
     function testRoleHolderCanTransferOwnRole() public {


### PR DESCRIPTION
Fixes: 
1. Reject msg.value > 0 for ERC20 Vault.deposit().
2. Add _MAX_FEE_BPS bounds check to all four FeeCalculator fee setter functions.