### PR TITLE
fix: add block-not-found retry in integration-test

### DIFF
--- a/crates/tycho-test/src/execution/execution_simulator.rs
+++ b/crates/tycho-test/src/execution/execution_simulator.rs
@@ -306,11 +306,15 @@ impl ExecutionSimulator {
                     }
                 }
                 Err(err) => {
+                    let reason = format!("Transaction failed: {}", err);
+                    if crate::is_block_not_found(&reason) {
+                        // All calls share the same block_id in a single batch request to one node,
+                        // so if one fails with block-not-found the rest will too. Early-return so
+                        // the caller can retry the whole batch.
+                        return Err(reason.into());
+                    }
                     error!("Error tracing transaction {}: {:?}", simulation_id, err);
-                    results.insert(
-                        simulation_id.clone(),
-                        SimulationResult::Revert { reason: format!("Transaction failed: {}", err) },
-                    );
+                    results.insert(simulation_id.clone(), SimulationResult::Revert { reason });
                 }
             }
         }

--- a/crates/tycho-test/src/lib.rs
+++ b/crates/tycho-test/src/lib.rs
@@ -2,3 +2,7 @@ pub mod execution;
 pub mod rpc_tools;
 pub mod validation;
 pub use rpc_tools::RPCTools;
+
+pub(crate) fn is_block_not_found(msg: &str) -> bool {
+    msg.contains("header not found") || (msg.contains("block #") && msg.contains("not found"))
+}


### PR DESCRIPTION
For some chains like Arbitrum we're often receiving Tycho message before nodes. In that case we were emitting a revert metric. This changes this to return an `Err`, triggering the retry logic.