### PR TITLE
docs: add Arbitrum and Polygon hosted endpoints

### DIFF
--- a/docs/for-solvers/hosted-endpoints.md
+++ b/docs/for-solvers/hosted-endpoints.md
@@ -12,7 +12,7 @@ description: Tycho Indexer's hosted endpoints
 
 Tycho Fynd endpoints are dedicated instances for Fynd users. They enforce stricter data filtering restrictions to support higher load.
 
-<table><thead><tr><th width="244">Chain</th><th>URL</th></tr></thead><tbody><tr><td>Ethereum (Mainnet)</td><td>tycho-fynd-ethereum.propellerheads.xyz</td></tr><tr><td>Base Mainnet</td><td>tycho-fynd-base.propellerheads.xyz</td></tr><tr><td>Unichain Mainnet</td><td>tycho-fynd-unichain.propellerheads.xyz</td></tr></tbody></table>
+<table><thead><tr><th width="244">Chain</th><th>URL</th></tr></thead><tbody><tr><td>Ethereum (Mainnet)</td><td>tycho-fynd-ethereum.propellerheads.xyz</td></tr><tr><td>Base Mainnet</td><td>tycho-fynd-base.propellerheads.xyz</td></tr><tr><td>Unichain Mainnet</td><td>tycho-fynd-unichain.propellerheads.xyz</td></tr><tr><td>Arbitrum Mainnet</td><td>tycho-fynd-arbitrum.propellerheads.xyz</td></tr><tr><td>Polygon Mainnet</td><td>tycho-fynd-polygon.propellerheads.xyz</td></tr></tbody></table>
 
 {% hint style="info" %}
 For API Documentation, Tycho Indexer includes Swagger docs, available at /docs/ path.
@@ -54,7 +54,7 @@ All Fynd endpoints share the same filtering restrictions:
 
 The available protocol systems vary by chain:
 
-<table><thead><tr><th width="244">Chain</th><th>Protocol Systems</th></tr></thead><tbody><tr><td>Ethereum (Mainnet)</td><td><code>uniswap_v2</code>, <code>uniswap_v3</code>, <code>uniswap_v4</code>, <code>sushiswap_v2</code>, <code>pancakeswap_v2</code>, <code>pancakeswap_v3</code>, <code>ekubo_v2</code>, <code>ekubo_v3</code>, <code>fluid_v1</code></td></tr><tr><td>Base Mainnet</td><td><code>uniswap_v2</code>, <code>uniswap_v3</code>, <code>uniswap_v4</code>, <code>pancakeswap_v3</code>, <code>aerodrome_slipstreams</code></td></tr><tr><td>Unichain Mainnet</td><td><code>uniswap_v2</code>, <code>uniswap_v3</code>, <code>uniswap_v4</code>, <code>velodrome_slipstreams</code>, <code>uniswap_v4_hooks</code></td></tr></tbody></table>
+<table><thead><tr><th width="244">Chain</th><th>Protocol Systems</th></tr></thead><tbody><tr><td>Ethereum (Mainnet)</td><td><code>uniswap_v2</code>, <code>uniswap_v3</code>, <code>uniswap_v4</code>, <code>sushiswap_v2</code>, <code>pancakeswap_v2</code>, <code>pancakeswap_v3</code>, <code>ekubo_v2</code>, <code>ekubo_v3</code>, <code>fluid_v1</code></td></tr><tr><td>Base Mainnet</td><td><code>uniswap_v2</code>, <code>uniswap_v3</code>, <code>uniswap_v4</code>, <code>pancakeswap_v3</code>, <code>aerodrome_slipstreams</code></td></tr><tr><td>Unichain Mainnet</td><td><code>uniswap_v2</code>, <code>uniswap_v3</code>, <code>uniswap_v4</code>, <code>velodrome_slipstreams</code>, <code>uniswap_v4_hooks</code></td></tr><tr><td>Arbitrum Mainnet</td><td><code>uniswap_v2</code>, <code>uniswap_v3</code>, <code>uniswap_v4</code>, <code>pancakeswap_v3</code></td></tr><tr><td>Polygon Mainnet</td><td><code>uniswap_v2</code>, <code>uniswap_v3</code>, <code>uniswap_v4</code>, <code>quickswap_v2</code></td></tr></tbody></table>
 
 ## Metrics
 

--- a/docs/for-solvers/hosted-endpoints.md
+++ b/docs/for-solvers/hosted-endpoints.md
@@ -6,7 +6,7 @@ description: Tycho Indexer's hosted endpoints
 
 ## Tycho Indexer
 
-<table><thead><tr><th width="244">Chain</th><th>URL</th></tr></thead><tbody><tr><td>Ethereum (Mainnet)</td><td>tycho-beta.propellerheads.xyz</td></tr><tr><td>Base Mainnet</td><td>tycho-base-beta.propellerheads.xyz</td></tr><tr><td>Unichain Mainnet</td><td>tycho-unichain-beta.propellerheads.xyz</td></tr></tbody></table>
+<table><thead><tr><th width="244">Chain</th><th>URL</th></tr></thead><tbody><tr><td>Ethereum (Mainnet)</td><td>tycho-beta.propellerheads.xyz</td></tr><tr><td>Base Mainnet</td><td>tycho-base-beta.propellerheads.xyz</td></tr><tr><td>Unichain Mainnet</td><td>tycho-unichain-beta.propellerheads.xyz</td></tr><tr><td>Arbitrum Mainnet</td><td>tycho-arbitrum-beta.propellerheads.xyz</td></tr><tr><td>Polygon Mainnet</td><td>tycho-polygon-beta.propellerheads.xyz</td></tr></tbody></table>
 
 ### Tycho Fynd
 
@@ -18,6 +18,10 @@ Tycho Fynd endpoints are dedicated instances for Fynd users. They enforce strict
 For API Documentation, Tycho Indexer includes Swagger docs, available at /docs/ path.
 
 Example, for Mainnet: <a href="https://tycho-beta.propellerheads.xyz/docs/" target="_blank" rel="noopener noreferrer">https://tycho-beta.propellerheads.xyz/docs/</a>
+{% endhint %}
+
+{% hint style="info" %}
+We're constantly adding new protocols. To see the current protocol systems for a specific endpoint, use the [Retrieve protocol systems](indexer/tycho-rpc.md#v1-protocol_systems) endpoint.
 {% endhint %}
 
 ## Plans
@@ -50,11 +54,7 @@ All Fynd endpoints share the same filtering restrictions:
 
 The available protocol systems vary by chain:
 
-<table><thead><tr><th width="244">Chain</th><th>Protocol Systems</th></tr></thead><tbody><tr><td>Ethereum (Mainnet)</td><td><code>uniswap_v2</code>, <code>uniswap_v3</code>, <code>uniswap_v4</code>, <code>sushiswap_v2</code>, <code>pancakeswap_v2</code>, <code>pancakeswap_v3</code>, <code>ekubo_v2</code>, <code>ekubo_v3</code>, <code>fluid_v1</code></td></tr><tr><td>Base Mainnet</td><td><code>uniswap_v2</code>, <code>uniswap_v3</code>, <code>uniswap_v4</code>, <code>pancakeswap_v3</code>, <code>aerodrome_slipstreams</code></td></tr><tr><td>Unichain Mainnet</td><td><code>uniswap_v2</code>, <code>uniswap_v3</code>, <code>uniswap_v4</code>, <code>velodrome_slipstreams</code></td></tr></tbody></table>
-
-{% hint style="info" %}
-We're constantly adding new protocols. To see the current protocol systems for a specific endpoint, use the [Retrieve protocol systems](indexer/tycho-rpc.md#v1-protocol_systems) endpoint.
-{% endhint %}
+<table><thead><tr><th width="244">Chain</th><th>Protocol Systems</th></tr></thead><tbody><tr><td>Ethereum (Mainnet)</td><td><code>uniswap_v2</code>, <code>uniswap_v3</code>, <code>uniswap_v4</code>, <code>sushiswap_v2</code>, <code>pancakeswap_v2</code>, <code>pancakeswap_v3</code>, <code>ekubo_v2</code>, <code>ekubo_v3</code>, <code>fluid_v1</code></td></tr><tr><td>Base Mainnet</td><td><code>uniswap_v2</code>, <code>uniswap_v3</code>, <code>uniswap_v4</code>, <code>pancakeswap_v3</code>, <code>aerodrome_slipstreams</code></td></tr><tr><td>Unichain Mainnet</td><td><code>uniswap_v2</code>, <code>uniswap_v3</code>, <code>uniswap_v4</code>, <code>velodrome_slipstreams</code>, <code>uniswap_v4_hooks</code></td></tr></tbody></table>
 
 ## Metrics
 


### PR DESCRIPTION
Tycho is now live on Arbitrum and Polygon. This updates the Hosted Endpoints page to reflect that.

## Changes

- Add **Arbitrum** and **Polygon** to the Tycho Indexer URL table.
- Add **Arbitrum** and **Polygon** to the Tycho Fynd URL table and protocol-systems table.
- Move the "constantly adding new protocols" hint to right after the API Documentation box, before Plans.
- Add `uniswap_v4_hooks` to the Fynd Unichain protocol-systems row.

## Endpoints

| Chain | Indexer | Fynd |
|-------|---------|------|
| Arbitrum | `tycho-arbitrum-beta.propellerheads.xyz` | `tycho-fynd-arbitrum.propellerheads.xyz` |
| Polygon | `tycho-polygon-beta.propellerheads.xyz` | `tycho-fynd-polygon.propellerheads.xyz` |

## Verification

Protocol systems verified live against every endpoint via `/v1/protocol_systems`:

| Chain | Protocol systems |
|-------|------------------|
| Arbitrum (Indexer + Fynd) | `uniswap_v2`, `uniswap_v3`, `uniswap_v4`, `pancakeswap_v3` |
| Polygon (Indexer + Fynd) | `uniswap_v2`, `uniswap_v3`, `uniswap_v4`, `quickswap_v2` |

Fynd Arbitrum and Polygon match their respective Indexer endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)