### PR TITLE
feat: add Custom variant to Chain enum to support user-defined chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,9 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -9789,6 +9792,7 @@ name = "tycho-common"
 version = "0.317.0"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "async-trait",
  "bytes",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9880,6 +9880,7 @@ dependencies = [
  "actix-web-opentelemetry",
  "alloy",
  "anyhow",
+ "arrayvec",
  "async-stream",
  "async-trait",
  "aws-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9880,7 +9880,6 @@ dependencies = [
  "actix-web-opentelemetry",
  "alloy",
  "anyhow",
- "arrayvec",
  "async-stream",
  "async-trait",
  "aws-config",

--- a/crates/tycho-client-py/python/tests/test_decode.py
+++ b/crates/tycho-client-py/python/tests/test_decode.py
@@ -4,11 +4,15 @@ from hexbytes import HexBytes
 
 from tycho_indexer_client.dto import (
     Chain,
+    ChainTokenConfig,
     ContractId,
     ContractStateParams,
+    CustomChainConfig,
+    ExtractorIdentity,
     FeedMessage,
     SynchronizerState,
     SynchronizerStateEnum,
+    TvlThresholds,
     Header,
 )
 
@@ -45,6 +49,59 @@ def test_decode_deltas(asset_dir):
             revert=False,
         ),
     )
+
+
+# JSON shaped exactly as Tycho serialises `Chain::Custom(..)` (serde, externally tagged, lowercase
+# variant name), mirroring the Rust `test_config()` in tycho-common/src/models/mod.rs. The TVL
+# thresholds are deliberately fractional: Rust serialises them as f64, so this guards that the
+# Python client preserves the fractional part instead of truncating to int. If the Rust wire
+# format changes, this fixture must change with it.
+CUSTOM_CHAIN_JSON = {
+    "custom": {
+        "name": "testchain",
+        "chain_id": 9999,
+        "block_time_secs": 5,
+        "native": {
+            "address": "0x" + "aa" * 20,
+            "symbol": "TST",
+            "decimals": 18,
+        },
+        "wrapped_native": {
+            "address": "0x" + "bb" * 20,
+            "symbol": "WTST",
+            "decimals": 18,
+        },
+        "default_tvl_thresholds": {"low": 50.5, "medium": 500.25},
+    }
+}
+
+
+def test_decode_extractor_identity_known_chain():
+    # Known chains serialise as a bare lowercase string.
+    ident = ExtractorIdentity(chain="ethereum", name="uniswap_v2")
+
+    assert ident.chain == Chain.ethereum
+
+
+def test_decode_extractor_identity_custom_chain():
+    ident = ExtractorIdentity(chain=CUSTOM_CHAIN_JSON, name="my_extractor")
+
+    assert isinstance(ident.chain, CustomChainConfig)
+    assert ident.chain == CustomChainConfig(
+        name="testchain",
+        chain_id=9999,
+        block_time_secs=5,
+        native=ChainTokenConfig(
+            address="0x" + "aa" * 20, symbol="TST", decimals=18
+        ),
+        wrapped_native=ChainTokenConfig(
+            address="0x" + "bb" * 20, symbol="WTST", decimals=18
+        ),
+        default_tvl_thresholds=TvlThresholds(low=50.5, medium=500.25),
+    )
+    # Guard against silent int truncation of the f64 thresholds.
+    assert ident.chain.default_tvl_thresholds.low == 50.5
+    assert ident.chain.default_tvl_thresholds.medium == 500.25
 
 
 def test_decode_contract_state_params_backward_compatibility():

--- a/crates/tycho-client-py/python/tycho_indexer_client/__init__.py
+++ b/crates/tycho-client-py/python/tycho_indexer_client/__init__.py
@@ -11,6 +11,9 @@ from .rpc_client import (
 )
 from .dto import (
     Chain,
+    CustomChainConfig,
+    ChainTokenConfig,
+    TvlThresholds,
     ProtocolComponent,
     ResponseProtocolState,
     ResponseAccount,

--- a/crates/tycho-client-py/python/tycho_indexer_client/dto.py
+++ b/crates/tycho-client-py/python/tycho_indexer_client/dto.py
@@ -48,6 +48,38 @@ class Chain(str, Enum):
     polygon = "polygon"
 
 
+class ChainTokenConfig(BaseModel):
+    address: str
+    symbol: str
+    decimals: int
+
+
+class TvlThresholds(BaseModel):
+    low: int
+    medium: int
+
+
+class CustomChainConfig(BaseModel):
+    name: str
+    chain_id: int
+    block_time_secs: int
+    native: ChainTokenConfig
+    wrapped_native: ChainTokenConfig
+    default_tvl_thresholds: TvlThresholds
+
+    def __str__(self) -> str:
+        return self.name
+
+    @root_validator(pre=True)
+    def _unwrap_serde_tag(cls, values):
+        # Rust serialises Custom(cfg) as {"custom": {...}} — unwrap the tag.
+        if "custom" in values and len(values) == 1:
+            return values["custom"]
+        return values
+
+
+
+
 class ChangeType(str, Enum):
     update = "Update"
     deletion = "Deletion"
@@ -56,7 +88,7 @@ class ChangeType(str, Enum):
 
 
 class ExtractorIdentity(BaseModel):
-    chain: Chain
+    chain: Union[Chain, CustomChainConfig]
     name: str
 
 
@@ -93,13 +125,13 @@ class Block(BaseModel):
     number: int
     hash: HexBytes
     parent_hash: HexBytes
-    chain: Chain
+    chain: Union[Chain, CustomChainConfig]
     ts: datetime
 
 
 class BlockParam(BaseModel):
     hash: Optional[HexBytes] = None
-    chain: Optional[Chain] = None
+    chain: Optional[Union[Chain, CustomChainConfig]] = None
     number: Optional[int] = None
 
 
@@ -120,7 +152,7 @@ class TokenBalances(BaseModel):
 
 class AccountUpdate(BaseModel):
     address: HexBytes
-    chain: Chain
+    chain: Union[Chain, CustomChainConfig]
     slots: Dict[HexBytes, HexBytes]
     balance: Optional[HexBytes] = None
     code: Optional[HexBytes] = None
@@ -137,7 +169,7 @@ class ProtocolComponent(BaseModel):
     id: str
     protocol_system: str
     protocol_type_name: str
-    chain: Chain
+    chain: Union[Chain, CustomChainConfig]
     tokens: List[HexBytes]
     contract_ids: List[HexBytes]
     static_attributes: Dict[str, HexBytes]
@@ -147,7 +179,7 @@ class ProtocolComponent(BaseModel):
 
 
 class ResponseToken(BaseModel):
-    chain: Chain
+    chain: Union[Chain, CustomChainConfig]
     address: HexBytes = Field(..., example="0xc9f2e6ea1637E499406986ac50ddC92401ce1f58")
     symbol: str = Field(..., example="WETH")
     decimals: int
@@ -158,7 +190,7 @@ class ResponseToken(BaseModel):
 
 class BlockChanges(BaseModel):
     extractor: str
-    chain: Chain
+    chain: Union[Chain, CustomChainConfig]
     block: Block
     finalized_block_height: int
     revert: bool
@@ -186,7 +218,7 @@ class ComponentWithState(BaseModel):
 
 
 class ResponseAccount(BaseModel):
-    chain: Chain
+    chain: Union[Chain, CustomChainConfig]
     address: HexBytes
     title: str
     slots: Dict[HexBytes, HexBytes]
@@ -257,13 +289,13 @@ class PaginationParams(BaseModel):
 
 
 class ProtocolId(BaseModel):
-    chain: Chain
+    chain: Union[Chain, CustomChainConfig]
     id: str
 
 
 class ContractId(BaseModel):
     address: HexBytes
-    chain: Chain
+    chain: Union[Chain, CustomChainConfig]
 
 
 class VersionParams(BaseModel):
@@ -324,7 +356,7 @@ class TokensParams(BaseModel):
 
 
 class ProtocolSystemsParams(BaseModel):
-    chain: Optional[Chain] = None
+    chain: Optional[Union[Chain, CustomChainConfig]] = None
     pagination: Optional[PaginationParams] = None
 
     class Config:
@@ -332,7 +364,7 @@ class ProtocolSystemsParams(BaseModel):
 
 
 class ComponentTvlParams(BaseModel):
-    chain: Optional[Chain] = None
+    chain: Optional[Union[Chain, CustomChainConfig]] = None
     protocol_system: Optional[str] = Field(default=None, alias="protocolSystem")
     component_ids: Optional[List[str]] = Field(default=None)
     pagination: Optional[PaginationParams] = None
@@ -342,7 +374,7 @@ class ComponentTvlParams(BaseModel):
 
 
 class TracedEntryPointParams(BaseModel):
-    chain: Optional[Chain] = None
+    chain: Optional[Union[Chain, CustomChainConfig]] = None
     protocol_system: str
     component_ids: Optional[List[str]] = Field(default=None)
     pagination: Optional[PaginationParams] = None

--- a/crates/tycho-client-py/python/tycho_indexer_client/dto.py
+++ b/crates/tycho-client-py/python/tycho_indexer_client/dto.py
@@ -55,8 +55,8 @@ class ChainTokenConfig(BaseModel):
 
 
 class TvlThresholds(BaseModel):
-    low: int
-    medium: int
+    low: float
+    medium: float
 
 
 class CustomChainConfig(BaseModel):

--- a/crates/tycho-client-py/python/tycho_indexer_client/rpc_client.py
+++ b/crates/tycho-client-py/python/tycho_indexer_client/rpc_client.py
@@ -1,10 +1,11 @@
 import json
-from typing import Optional
+from typing import Optional, Union
 
 import requests
 
 from .dto import (
     Chain,
+    CustomChainConfig,
     ProtocolComponentsParams,
     ProtocolStateParams,
     ContractStateParams,
@@ -57,7 +58,7 @@ class TychoRPCClient:
         self,
         rpc_url: str = "http://0.0.0.0:4242",
         auth_token: str = None,
-        chain: Chain = Chain.ethereum,
+        chain: Union[Chain, CustomChainConfig] = Chain.ethereum,
     ):
         """
         Initialize the Tycho RPC client.

--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use std::{
     collections::{HashMap, HashSet},
     fmt::{Display, Formatter},
@@ -245,6 +243,7 @@ impl SynchronizerStream {
             rx,
         }
     }
+    #[allow(clippy::result_large_err)]
     async fn try_advance(
         &mut self,
         block_history: &BlockHistory,
@@ -420,6 +419,7 @@ impl SynchronizerStream {
     }
 
     /// Helper method to check if synchronizer should transition to stale based on time elapsed
+    #[allow(clippy::result_large_err)]
     fn check_and_transition_to_stale_if_needed(
         &mut self,
         stale_threshold: std::time::Duration,
@@ -458,6 +458,7 @@ impl SynchronizerStream {
     /// - Next expected block -> Ready state
     /// - Latest/Delayed block -> Either Delayed or Stale (if >60s since last update)
     /// - Advanced block -> Advanced state (block ahead of expected position)
+    #[allow(clippy::result_large_err)]
     fn transition(
         &mut self,
         latest_retrieved: BlockHeader,
@@ -943,6 +944,7 @@ where
     /// ## Note
     /// This method assumes that at least one synchronizer is in Advanced, Ready or
     /// Delayed state, it will return an error in case this is not the case.
+    #[allow(clippy::result_large_err)]
     fn reinit_block_history(
         sync_streams: &mut [SynchronizerStream],
         block_history: &mut BlockHistory,
@@ -986,6 +988,7 @@ where
     ///
     /// Used once before entering the main loop, where all-Stale is a fatal configuration
     /// problem (nothing to sync from), not a temporary disconnect.
+    #[allow(clippy::result_large_err)]
     fn require_active_stream(sync_streams: &[SynchronizerStream]) -> BlockSyncResult<()> {
         if sync_streams
             .iter()
@@ -1009,6 +1012,7 @@ where
     ///
     /// Returns `Err` if at least one synchronizer has permanently ended while all
     /// remaining ones are stale — no recovery path exists.
+    #[allow(clippy::result_large_err)]
     fn check_streams(sync_streams: &[SynchronizerStream]) -> BlockSyncResult<()> {
         let mut has_any_ended = false;
         let mut latest_ended_stream: Option<&SynchronizerStream> = None;

--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::result_large_err)]
+
 use std::{
     collections::{HashMap, HashSet},
     fmt::{Display, Formatter},
@@ -100,6 +102,7 @@ impl HeaderLike for BlockHeader {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Error, Debug)]
 pub enum BlockSynchronizerError {
     #[error("Failed to initialize extractor '{extractor}': {source}")]

--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -307,6 +307,7 @@ impl SynchronizerStream {
     ///
     /// ## Note
     /// This method assumes that the current state is `Ready`.
+    #[allow(clippy::result_large_err)]
     async fn try_recv_next_expected(
         &mut self,
         max_wait: std::time::Duration,
@@ -352,6 +353,7 @@ impl SynchronizerStream {
     /// If a synchronizer is delayed, this method will try to catch up to the next expected block
     /// by consuming all waiting messages in its queue and waiting for any new block messages
     /// within a timeout. Finally, all update messages are merged into one and returned.
+    #[allow(clippy::result_large_err)]
     async fn try_catch_up(
         &mut self,
         block_history: &BlockHistory,
@@ -666,6 +668,7 @@ where
     ///
     /// Will error directly if the startup fails. Once the startup is complete, it will
     /// communicate any fatal errors through the stream before closing it.
+    #[allow(clippy::result_large_err)]
     pub async fn run(
         mut self,
     ) -> BlockSyncResult<(JoinHandle<()>, Receiver<BlockSyncResult<FeedMessage<BlockHeader>>>)>
@@ -867,6 +870,7 @@ where
     ///
     /// The result is written into `ready_sync_messages`. Errors only if there is a
     /// non-recoverable error or all synchronizers have ended.
+    #[allow(clippy::result_large_err)]
     async fn handle_next_message(
         &self,
         sync_streams: &mut [SynchronizerStream],

--- a/crates/tycho-client/src/stream.rs
+++ b/crates/tycho-client/src/stream.rs
@@ -117,6 +117,7 @@ impl TychoStreamBuilder {
             Chain::Bsc => (1, 12, 50),
             Chain::Unichain => (1, 10, 100),
             Chain::Polygon => (2, 12, 50), // ~2s block time
+            Chain::Custom(cfg) => (cfg.block_time_secs, cfg.block_time_secs * 3, 50),
         }
     }
 

--- a/crates/tycho-common/Cargo.toml
+++ b/crates/tycho-common/Cargo.toml
@@ -35,6 +35,7 @@ bytes = "1.5.0"
 mockall = { workspace = true, optional = true }
 num-bigint = "0.4"
 deepsize.workspace = true # perf: make optional, as used only by the indexer for memory profiling
+arrayvec = { version = "0.7", features = ["serde"] }
 itertools = "0.10.5"
 uuid.workspace = true
 

--- a/crates/tycho-common/src/dto.rs
+++ b/crates/tycho-common/src/dto.rs
@@ -65,7 +65,7 @@ impl FromStr for Chain {
     type Err = strum::ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        models::Chain::from_str(s).map(Chain::from)
+        models::Chain::from_str(s).map(Self::from)
     }
 }
 

--- a/crates/tycho-common/src/dto.rs
+++ b/crates/tycho-common/src/dto.rs
@@ -9,6 +9,7 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt,
     hash::{Hash, Hasher},
+    str::FromStr,
 };
 
 use chrono::{NaiveDateTime, Utc};
@@ -20,7 +21,7 @@ use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
 use crate::{
-    models::{self, Address, Balance, Code, ComponentId, StoreKey, StoreVal},
+    models::{self, Address, Balance, Code, ComponentId, CustomChainConfig, StoreKey, StoreVal},
     serde_primitives::{
         hex_bytes, hex_bytes_option, hex_hashmap_key, hex_hashmap_key_value, hex_hashmap_value,
     },
@@ -29,22 +30,9 @@ use crate::{
 
 /// Currently supported Blockchains
 #[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    Serialize,
-    Deserialize,
-    EnumString,
-    Display,
-    Default,
-    ToSchema,
-    DeepSizeOf,
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default, ToSchema, DeepSizeOf,
 )]
 #[serde(rename_all = "lowercase")]
-#[strum(serialize_all = "lowercase")]
 pub enum Chain {
     #[default]
     Ethereum,
@@ -55,6 +43,7 @@ pub enum Chain {
     Bsc,
     Unichain,
     Polygon,
+    Custom(CustomChainConfig),
 }
 
 pub use models::TvlThresholdTier;
@@ -63,6 +52,20 @@ impl Chain {
     /// Returns a default TVL threshold in native token units for the given tier.
     pub fn default_tvl_threshold(&self, tier: TvlThresholdTier) -> f64 {
         models::Chain::from(*self).default_tvl_threshold(tier)
+    }
+}
+
+impl fmt::Display for Chain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        models::Chain::from(*self).fmt(f)
+    }
+}
+
+impl FromStr for Chain {
+    type Err = strum::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        models::Chain::from_str(s).map(Chain::from)
     }
 }
 
@@ -99,6 +102,7 @@ impl From<models::Chain> for Chain {
             models::Chain::Bsc => Chain::Bsc,
             models::Chain::Unichain => Chain::Unichain,
             models::Chain::Polygon => Chain::Polygon,
+            models::Chain::Custom(cfg) => Chain::Custom(cfg),
         }
     }
 }

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -6,9 +6,9 @@ pub mod token;
 
 use std::{collections::HashMap, fmt::Display, str::FromStr};
 
+use arrayvec::ArrayString;
 use deepsize::DeepSizeOf;
 use serde::{Deserialize, Serialize};
-use strum_macros::{Display, EnumString};
 use thiserror::Error;
 use token::Token;
 
@@ -58,6 +58,66 @@ pub type ProtocolSystem = String;
 /// Entry point id literal type to uniquely identify an entry point.
 pub type EntryPointId = String;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ChainAddress {
+    bytes: [u8; 32],
+    len: u8,
+}
+
+impl ChainAddress {
+    pub fn new(bytes: &[u8]) -> Result<Self, ChainAddressError> {
+        if bytes.len() > 32 {
+            return Err(ChainAddressError::TooLong(bytes.len()));
+        }
+        let mut arr = [0u8; 32];
+        arr[..bytes.len()].copy_from_slice(bytes);
+        Ok(Self { bytes: arr, len: bytes.len() as u8 })
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes[..self.len as usize]
+    }
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ChainAddressError {
+    #[error("address is {0} bytes, max is 32")]
+    TooLong(usize),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ChainTokenConfig {
+    pub address: ChainAddress,
+    pub symbol: ArrayString<8>,
+    pub decimals: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TvlThresholds {
+    pub low: u64,
+    pub medium: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CustomChainConfig {
+    pub name: ArrayString<32>,
+    pub chain_id: u64,
+    pub block_time_secs: u64,
+    pub native: ChainTokenConfig,
+    pub wrapped_native: ChainTokenConfig,
+    pub default_tvl_thresholds: TvlThresholds,
+}
+
+impl DeepSizeOf for CustomChainConfig {
+    fn deep_size_of(&self) -> usize {
+        0
+    }
+
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
+        0
+    }
+}
+
 /// TVL threshold tiers for chain-aware filtering defaults.
 ///
 /// TVL is denominated in each chain's native token. Since native tokens have different USD values,
@@ -71,22 +131,8 @@ pub enum TvlThresholdTier {
     Medium,
 }
 
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    Serialize,
-    Deserialize,
-    EnumString,
-    Display,
-    Default,
-    DeepSizeOf,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default, DeepSizeOf)]
 #[serde(rename_all = "lowercase")]
-#[strum(serialize_all = "lowercase")]
 pub enum Chain {
     #[default]
     Ethereum,
@@ -97,6 +143,41 @@ pub enum Chain {
     Bsc,
     Unichain,
     Polygon,
+    Custom(CustomChainConfig),
+}
+
+impl FromStr for Chain {
+    type Err = strum::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ethereum" => Ok(Chain::Ethereum),
+            "starknet" => Ok(Chain::Starknet),
+            "zksync" => Ok(Chain::ZkSync),
+            "arbitrum" => Ok(Chain::Arbitrum),
+            "base" => Ok(Chain::Base),
+            "bsc" => Ok(Chain::Bsc),
+            "unichain" => Ok(Chain::Unichain),
+            "polygon" => Ok(Chain::Polygon),
+            _ => Err(strum::ParseError::VariantNotFound),
+        }
+    }
+}
+
+impl Display for Chain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Chain::Ethereum => f.write_str("ethereum"),
+            Chain::Starknet => f.write_str("starknet"),
+            Chain::ZkSync => f.write_str("zksync"),
+            Chain::Arbitrum => f.write_str("arbitrum"),
+            Chain::Base => f.write_str("base"),
+            Chain::Bsc => f.write_str("bsc"),
+            Chain::Unichain => f.write_str("unichain"),
+            Chain::Polygon => f.write_str("polygon"),
+            Chain::Custom(cfg) => f.write_str(cfg.name.as_str()),
+        }
+    }
 }
 
 impl From<dto::Chain> for Chain {
@@ -110,6 +191,7 @@ impl From<dto::Chain> for Chain {
             dto::Chain::Bsc => Chain::Bsc,
             dto::Chain::Unichain => Chain::Unichain,
             dto::Chain::Polygon => Chain::Polygon,
+            dto::Chain::Custom(cfg) => Chain::Custom(cfg),
         }
     }
 }
@@ -165,12 +247,43 @@ fn native_pol(chain: Chain) -> Token {
     )
 }
 
+fn native_custom(cfg: &CustomChainConfig) -> Token {
+    let addr = Bytes::from(cfg.native.address.as_bytes().to_vec());
+    Token::new(
+        &addr,
+        cfg.native.symbol.as_str(),
+        cfg.native.decimals as u32,
+        0,
+        &[Some(2300)],
+        Chain::Custom(*cfg),
+        100,
+    )
+}
+
 fn wrapped_native_bsc(chain: Chain, address: &str) -> Token {
     Token::new(&Bytes::from_str(address).unwrap(), "WBNB", 18, 0, &[Some(2300)], chain, 100)
 }
 
 fn wrapped_native_pol(chain: Chain, address: &str) -> Token {
     Token::new(&Bytes::from_str(address).unwrap(), "WMATIC", 18, 0, &[Some(2300)], chain, 100)
+}
+
+fn wrapped_native_custom(cfg: &CustomChainConfig) -> Token {
+    let addr = Bytes::from(
+        cfg.wrapped_native
+            .address
+            .as_bytes()
+            .to_vec(),
+    );
+    Token::new(
+        &addr,
+        cfg.wrapped_native.symbol.as_str(),
+        cfg.wrapped_native.decimals as u32,
+        0,
+        &[Some(2300)],
+        Chain::Custom(*cfg),
+        100,
+    )
 }
 
 impl Chain {
@@ -184,6 +297,7 @@ impl Chain {
             Chain::Bsc => 56,
             Chain::Unichain => 130,
             Chain::Polygon => 137,
+            Chain::Custom(cfg) => cfg.chain_id,
         }
     }
 
@@ -223,6 +337,11 @@ impl Chain {
             // BSC (BNB ≈ $630): 32 BNB ≈ $20K, 320 BNB ≈ $200K
             (Chain::Bsc, TvlThresholdTier::Low) => 32.0,
             (Chain::Bsc, TvlThresholdTier::Medium) => 320.0,
+
+            (Chain::Custom(cfg), TvlThresholdTier::Low) => cfg.default_tvl_thresholds.low as f64,
+            (Chain::Custom(cfg), TvlThresholdTier::Medium) => {
+                cfg.default_tvl_thresholds.medium as f64
+            }
         }
     }
 
@@ -239,6 +358,7 @@ impl Chain {
             Chain::Bsc => native_bsc(Chain::Bsc),
             Chain::Unichain => native_eth(Chain::Unichain),
             Chain::Polygon => native_pol(Chain::Polygon),
+            Chain::Custom(cfg) => native_custom(cfg),
         }
     }
 
@@ -270,6 +390,7 @@ impl Chain {
             Chain::Polygon => {
                 wrapped_native_pol(Chain::Polygon, "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270")
             }
+            Chain::Custom(cfg) => wrapped_native_custom(cfg),
         }
     }
 }
@@ -431,4 +552,85 @@ pub enum MergeError {
     TransactionOrderError(String, u64, u64),
     #[error("Cannot merge: {0}")]
     InvalidState(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> CustomChainConfig {
+        CustomChainConfig {
+            name: ArrayString::from("testchain").unwrap(),
+            chain_id: 9999,
+            block_time_secs: 5,
+            native: ChainTokenConfig {
+                address: ChainAddress::new(&[0xAA; 20]).unwrap(),
+                symbol: ArrayString::from("TST").unwrap(),
+                decimals: 18,
+            },
+            wrapped_native: ChainTokenConfig {
+                address: ChainAddress::new(&[0xBB; 20]).unwrap(),
+                symbol: ArrayString::from("WTST").unwrap(),
+                decimals: 18,
+            },
+            default_tvl_thresholds: TvlThresholds { low: 50, medium: 500 },
+        }
+    }
+
+    #[test]
+    fn test_custom_chain_display() {
+        assert_eq!(Chain::Custom(test_config()).to_string(), "testchain");
+    }
+
+    #[test]
+    fn test_from_str_custom_returns_err() {
+        assert!("custom".parse::<Chain>().is_err());
+        assert!("unknown".parse::<Chain>().is_err());
+    }
+
+    #[test]
+    fn test_custom_chain_id() {
+        assert_eq!(Chain::Custom(test_config()).id(), 9999);
+    }
+
+    #[test]
+    fn test_custom_chain_tvl_thresholds() {
+        let chain = Chain::Custom(test_config());
+        assert_eq!(chain.default_tvl_threshold(TvlThresholdTier::Low), 50.0);
+        assert_eq!(chain.default_tvl_threshold(TvlThresholdTier::Medium), 500.0);
+    }
+
+    #[test]
+    fn test_custom_chain_native_token() {
+        let chain = Chain::Custom(test_config());
+        let token = chain.native_token();
+        assert_eq!(token.symbol, "TST");
+        assert_eq!(token.decimals, 18);
+        assert_eq!(token.chain, chain);
+        assert_eq!(token.address, Bytes::from(vec![0xAA; 20]));
+    }
+
+    #[test]
+    fn test_custom_chain_wrapped_native_token() {
+        let chain = Chain::Custom(test_config());
+        let token = chain.wrapped_native_token();
+        assert_eq!(token.symbol, "WTST");
+        assert_eq!(token.chain, chain);
+        assert_eq!(token.address, Bytes::from(vec![0xBB; 20]));
+    }
+
+    #[test]
+    fn test_chain_address_new_rejects_oversized_input() {
+        assert_eq!(
+            ChainAddress::new(&[0u8; 33]),
+            Err(ChainAddressError::TooLong(33))
+        );
+    }
+
+    #[test]
+    fn test_chain_address_as_bytes_returns_active_slice() {
+        let addr = ChainAddress::new(&[0xAA; 20]).unwrap();
+        assert_eq!(addr.as_bytes(), &[0xAA; 20]);
+        assert_eq!(addr.as_bytes().len(), 20);
+    }
 }

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -625,10 +625,7 @@ mod tests {
 
     #[test]
     fn test_chain_address_new_rejects_oversized_input() {
-        assert_eq!(
-            ChainAddress::new(&[0u8; 33]),
-            Err(ChainAddressError::TooLong(33))
-        );
+        assert_eq!(ChainAddress::new(&[0u8; 33]), Err(ChainAddressError::TooLong(33)));
     }
 
     #[test]

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -123,15 +123,30 @@ impl ChainTokenConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema)]
 pub struct TvlThresholds {
-    low: u64,
-    medium: u64,
+    low: f64,
+    medium: f64,
 }
 
 impl TvlThresholds {
-    pub fn new(low: u64, medium: u64) -> Self {
+    pub fn new(low: f64, medium: f64) -> Self {
         Self { low, medium }
+    }
+}
+
+impl PartialEq for TvlThresholds {
+    fn eq(&self, other: &Self) -> bool {
+        self.low.to_bits() == other.low.to_bits() && self.medium.to_bits() == other.medium.to_bits()
+    }
+}
+
+impl Eq for TvlThresholds {}
+
+impl std::hash::Hash for TvlThresholds {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.low.to_bits().hash(state);
+        self.medium.to_bits().hash(state);
     }
 }
 
@@ -387,10 +402,8 @@ impl Chain {
             (Chain::Bsc, TvlThresholdTier::Low) => 32.0,
             (Chain::Bsc, TvlThresholdTier::Medium) => 320.0,
 
-            (Chain::Custom(cfg), TvlThresholdTier::Low) => cfg.default_tvl_thresholds.low as f64,
-            (Chain::Custom(cfg), TvlThresholdTier::Medium) => {
-                cfg.default_tvl_thresholds.medium as f64
-            }
+            (Chain::Custom(cfg), TvlThresholdTier::Low) => cfg.default_tvl_thresholds.low,
+            (Chain::Custom(cfg), TvlThresholdTier::Medium) => cfg.default_tvl_thresholds.medium,
         }
     }
 
@@ -622,7 +635,7 @@ mod tests {
                 symbol: ArrayString::from("WTST").unwrap(),
                 decimals: 18,
             },
-            default_tvl_thresholds: TvlThresholds { low: 50, medium: 500 },
+            default_tvl_thresholds: TvlThresholds { low: 50.0, medium: 500.0 },
         }
     }
 

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -86,30 +86,81 @@ pub enum ChainAddressError {
     TooLong(usize),
 }
 
+#[derive(Error, Debug, PartialEq)]
+pub enum ChainConfigError {
+    #[error("invalid hex address '{0}': {1}")]
+    InvalidAddress(String, String),
+    #[error("address '{0}': {1}")]
+    AddressTooLong(String, String),
+    #[error("symbol '{0}' too long (max 8 chars)")]
+    SymbolTooLong(String),
+    #[error("chain name '{0}' too long (max 32 chars)")]
+    NameTooLong(String),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 pub struct ChainTokenConfig {
     #[schema(value_type = String)]
-    pub address: ChainAddress,
+    address: ChainAddress,
     #[schema(value_type = String)]
-    pub symbol: ArrayString<8>,
-    pub decimals: u8,
+    symbol: ArrayString<8>,
+    decimals: u8,
+}
+
+impl ChainTokenConfig {
+    pub fn try_new(
+        address_hex: &str,
+        symbol: &str,
+        decimals: u8,
+    ) -> Result<Self, ChainConfigError> {
+        let raw = hex::decode(address_hex.trim_start_matches("0x"))
+            .map_err(|e| ChainConfigError::InvalidAddress(address_hex.to_owned(), e.to_string()))?;
+        let address = ChainAddress::new(&raw)
+            .map_err(|e| ChainConfigError::AddressTooLong(address_hex.to_owned(), e.to_string()))?;
+        let symbol = ArrayString::from(symbol)
+            .map_err(|_| ChainConfigError::SymbolTooLong(symbol.to_owned()))?;
+        Ok(Self { address, symbol, decimals })
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 pub struct TvlThresholds {
-    pub low: u64,
-    pub medium: u64,
+    low: u64,
+    medium: u64,
+}
+
+impl TvlThresholds {
+    pub fn new(low: u64, medium: u64) -> Self {
+        Self { low, medium }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 pub struct CustomChainConfig {
     #[schema(value_type = String)]
-    pub name: ArrayString<32>,
-    pub chain_id: u64,
+    name: ArrayString<32>,
+    chain_id: u64,
     pub block_time_secs: u64,
-    pub native: ChainTokenConfig,
-    pub wrapped_native: ChainTokenConfig,
-    pub default_tvl_thresholds: TvlThresholds,
+    native: ChainTokenConfig,
+    wrapped_native: ChainTokenConfig,
+    default_tvl_thresholds: TvlThresholds,
+}
+
+impl CustomChainConfig {
+    pub fn try_new(
+        name: &str,
+        chain_id: u64,
+        block_time_secs: u64,
+        native: ChainTokenConfig,
+        wrapped_native: ChainTokenConfig,
+        default_tvl_thresholds: TvlThresholds,
+    ) -> Result<Self, ChainConfigError> {
+        let name =
+            ArrayString::from(name).map_err(|_| ChainConfigError::NameTooLong(name.to_owned()))?;
+        Ok(Self { name, chain_id, block_time_secs, native, wrapped_native, default_tvl_thresholds })
+    }
+
+
 }
 
 impl DeepSizeOf for CustomChainConfig {

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -159,15 +159,9 @@ impl CustomChainConfig {
             ArrayString::from(name).map_err(|_| ChainConfigError::NameTooLong(name.to_owned()))?;
         Ok(Self { name, chain_id, block_time_secs, native, wrapped_native, default_tvl_thresholds })
     }
-
-
 }
 
 impl DeepSizeOf for CustomChainConfig {
-    fn deep_size_of(&self) -> usize {
-        0
-    }
-
     fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
         0
     }

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -11,6 +11,7 @@ use deepsize::DeepSizeOf;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use token::Token;
+use utoipa::ToSchema;
 
 use crate::{dto, Bytes};
 
@@ -85,21 +86,24 @@ pub enum ChainAddressError {
     TooLong(usize),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 pub struct ChainTokenConfig {
+    #[schema(value_type = String)]
     pub address: ChainAddress,
+    #[schema(value_type = String)]
     pub symbol: ArrayString<8>,
     pub decimals: u8,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 pub struct TvlThresholds {
     pub low: u64,
     pub medium: u64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 pub struct CustomChainConfig {
+    #[schema(value_type = String)]
     pub name: ArrayString<32>,
     pub chain_id: u64,
     pub block_time_secs: u64,

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -191,6 +191,10 @@ impl CustomChainConfig {
             ArrayString::from(name).map_err(|_| ChainConfigError::NameTooLong(name.to_owned()))?;
         Ok(Self { name, chain_id, block_time_secs, native, wrapped_native, default_tvl_thresholds })
     }
+
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
 }
 
 impl DeepSizeOf for CustomChainConfig {

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -59,7 +59,7 @@ pub type ProtocolSystem = String;
 /// Entry point id literal type to uniquely identify an entry point.
 pub type EntryPointId = String;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ChainAddress {
     bytes: [u8; 32],
     len: u8,
@@ -77,6 +77,23 @@ impl ChainAddress {
 
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes[..self.len as usize]
+    }
+}
+
+/// Serialized as a `0x`-prefixed hex string so config files and wire payloads use the same
+/// representation a human writes (e.g. `"0x0000...0000"`).
+impl Serialize for ChainAddress {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&format!("0x{}", hex::encode(self.as_bytes())))
+    }
+}
+
+impl<'de> Deserialize<'de> for ChainAddress {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        let raw = hex::decode(s.trim_start_matches("0x"))
+            .map_err(|e| serde::de::Error::custom(format!("invalid hex address '{s}': {e}")))?;
+        ChainAddress::new(&raw).map_err(serde::de::Error::custom)
     }
 }
 

--- a/crates/tycho-indexer/Cargo.toml
+++ b/crates/tycho-indexer/Cargo.toml
@@ -81,6 +81,7 @@ opentelemetry-otlp = { version = "0.15", default-features = false, features = [
     "grpc-tonic",
 ] }
 opentelemetry_sdk = { version = "0.22", features = ["rt-tokio"] }
+arrayvec = { version = "0.7" }
 rand.workspace = true
 serde_yaml = "0.9.32"
 tracing-opentelemetry = { version = "0.23", default-features = false }

--- a/crates/tycho-indexer/Cargo.toml
+++ b/crates/tycho-indexer/Cargo.toml
@@ -81,7 +81,6 @@ opentelemetry-otlp = { version = "0.15", default-features = false, features = [
     "grpc-tonic",
 ] }
 opentelemetry_sdk = { version = "0.22", features = ["rt-tokio"] }
-arrayvec = { version = "0.7" }
 rand.workspace = true
 serde_yaml = "0.9.32"
 tracing-opentelemetry = { version = "0.23", default-features = false }

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -19,6 +19,8 @@ use std::{
     sync::{mpsc, Arc},
 };
 
+use arrayvec::ArrayString;
+
 use actix_web::{dev::ServerHandle, web, App, HttpResponse, HttpServer, Responder};
 use anyhow::anyhow;
 use chrono::{NaiveDateTime, Utc};
@@ -38,7 +40,8 @@ use tycho_common::{
     models::{
         blockchain::{Block, Transaction},
         contract::AccountDelta,
-        Address, Chain, ExtractionState, ImplementationType,
+        Address, Chain, ChainAddress, ChainTokenConfig, CustomChainConfig, ExtractionState,
+        ImplementationType, TvlThresholds,
     },
     storage::{ChainGateway, ContractStateGateway, ExtractionStateGateway},
     traits::{AccountExtractor, StorageSnapshotRequest},
@@ -68,14 +71,35 @@ use tycho_storage::postgres::{builder::GatewayBuilder, cache::CachedGateway};
 
 mod ot;
 
+#[derive(Debug, Deserialize, Clone)]
+struct TokenConfig {
+    address: String,
+    symbol: String,
+    decimals: u8,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct ChainConfig {
+    chain_id: u64,
+    block_time_secs: u64,
+    native_token: TokenConfig,
+    wrapped_native_token: TokenConfig,
+    tvl_thresholds: TvlThresholds,
+}
+
 #[derive(Debug, Deserialize)]
 struct ExtractorConfigs {
     extractors: std::collections::HashMap<String, ExtractorConfig>,
+    #[serde(default)]
+    chains: std::collections::HashMap<String, ChainConfig>,
 }
 
 impl ExtractorConfigs {
-    fn new(extractors: std::collections::HashMap<String, ExtractorConfig>) -> Self {
-        Self { extractors }
+    fn new(
+        extractors: std::collections::HashMap<String, ExtractorConfig>,
+        chains: std::collections::HashMap<String, ChainConfig>,
+    ) -> Self {
+        Self { extractors, chains }
     }
 
     fn from_yaml(path: &str) -> Result<Self, Box<dyn std::error::Error>> {
@@ -84,6 +108,51 @@ impl ExtractorConfigs {
         file.read_to_string(&mut contents)?;
         let config: ExtractorConfigs = serde_yaml::from_str(&contents)?;
         Ok(config)
+    }
+}
+
+fn parse_chain_token(token: &TokenConfig) -> Result<ChainTokenConfig, ExtractionError> {
+    let raw = hex::decode(token.address.trim_start_matches("0x")).map_err(|e| {
+        ExtractionError::Setup(format!("Invalid address '{}': {e}", token.address))
+    })?;
+    let address = ChainAddress::new(&raw).map_err(|e| {
+        ExtractionError::Setup(format!("Invalid address '{}': {e}", token.address))
+    })?;
+    let symbol = ArrayString::from(&token.symbol).map_err(|_| {
+        ExtractionError::Setup(format!(
+            "Symbol '{}' too long (max {} chars)",
+            token.symbol,
+            8
+        ))
+    })?;
+    Ok(ChainTokenConfig { address, symbol, decimals: token.decimals })
+}
+
+fn resolve_chain(
+    name: &str,
+    custom_chains: &HashMap<String, ChainConfig>,
+) -> Result<Chain, ExtractionError> {
+    match Chain::from_str(name) {
+        Ok(chain) => Ok(chain),
+        Err(_) => {
+            let entry = custom_chains.get(name).ok_or_else(|| {
+                ExtractionError::Setup(format!(
+                    "Unknown chain '{name}': add it to the [chains] config section"
+                ))
+            })?;
+            let chain_name = ArrayString::from(name).map_err(|_| {
+                ExtractionError::Setup(format!("Chain name '{name}' too long (max 32 chars)"))
+            })?;
+            let cfg = CustomChainConfig {
+                name: chain_name,
+                chain_id: entry.chain_id,
+                block_time_secs: entry.block_time_secs,
+                native: parse_chain_token(&entry.native_token)?,
+                wrapped_native: parse_chain_token(&entry.wrapped_native_token)?,
+                default_tvl_thresholds: entry.tvl_thresholds,
+            };
+            Ok(Chain::Custom(cfg))
+        }
     }
 }
 
@@ -247,17 +316,16 @@ fn run_indexer(global_args: GlobalArgs, index_args: IndexArgs) -> Result<(), Ext
                 .parse()
                 .expect("Failed to parse retention horizon");
 
+            let chains = index_args
+                .chains
+                .iter()
+                .map(|name| resolve_chain(name, &extractors_config.chains))
+                .collect::<Result<Vec<_>, _>>()?;
+
             let (extraction_tasks, other_tasks) = create_indexing_tasks(
                 &global_args,
                 &index_args.substreams_args,
-                &index_args
-                    .chains
-                    .iter()
-                    .map(|chain_str| {
-                        Chain::from_str(chain_str)
-                            .unwrap_or_else(|_| panic!("Unknown chain {chain_str}"))
-                    })
-                    .collect::<Vec<_>>(),
+                &chains,
                 retention_horizon,
                 extractors_config,
                 Some(extraction_runtime.handle()),
@@ -311,31 +379,34 @@ async fn run_spkg(global_args: GlobalArgs, run_args: RunSpkgArgs) -> Result<(), 
             _ => Err(ExtractionError::Setup(format!("Unknown DCI plugin: {s}"))),
         })?;
 
-    let config = ExtractorConfigs::new(HashMap::from([(
-        run_args.protocol_system.clone(),
-        ExtractorConfig::new(
+    let config = ExtractorConfigs::new(
+        HashMap::from([(
             run_args.protocol_system.clone(),
-            Chain::from_str(&run_args.chain).unwrap(),
-            ImplementationType::Vm,
-            1, /* TODO: if we want to increase this, we need to commit the cache when we reached
-                * `end_block` */
-            run_args.start_block,
-            run_args.stop_block(),
-            run_args
-                .protocol_type_names
-                .into_iter()
-                .map(|name| {
-                    ProtocolTypeConfig::new(name, tycho_common::models::FinancialType::Swap)
-                })
-                .collect::<Vec<_>>(),
-            run_args.spkg,
-            run_args.module,
-            run_args.initialized_accounts,
-            run_args.initialization_block,
-            None,
-            dci_plugin,
-        ),
-    )]));
+            ExtractorConfig::new(
+                run_args.protocol_system.clone(),
+                Chain::from_str(&run_args.chain).unwrap(),
+                ImplementationType::Vm,
+                1, /* TODO: if we want to increase this, we need to commit the cache when we reached
+                    * `end_block` */
+                run_args.start_block,
+                run_args.stop_block(),
+                run_args
+                    .protocol_type_names
+                    .into_iter()
+                    .map(|name| {
+                        ProtocolTypeConfig::new(name, tycho_common::models::FinancialType::Swap)
+                    })
+                    .collect::<Vec<_>>(),
+                run_args.spkg,
+                run_args.module,
+                run_args.initialized_accounts,
+                run_args.initialization_block,
+                None,
+                dci_plugin,
+            ),
+        )]),
+        HashMap::new(),
+    );
 
     let (extraction_tasks, mut other_tasks) = create_indexing_tasks(
         &global_args,

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -822,7 +822,7 @@ chains:
             2,
             expected_native,
             expected_wrapped,
-            TvlThresholds::new(1000, 10000),
+            TvlThresholds::new(1000.0, 10000.0),
         )
         .unwrap();
         assert_eq!(cfg, expected_cfg);

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -764,14 +764,6 @@ async fn run_analyze_tokens(
 mod tests {
     use super::*;
 
-    fn eth_token(symbol: &str) -> TokenConfig {
-        TokenConfig {
-            address: "0x0000000000000000000000000000000000000000".to_string(),
-            symbol: symbol.to_string(),
-            decimals: 18,
-        }
-    }
-
     #[test]
     fn test_resolve_unknown_chain_fails() {
         let err = resolve_chain("notachain", &HashMap::new()).unwrap_err();

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -19,10 +19,9 @@ use std::{
     sync::{mpsc, Arc},
 };
 
-use arrayvec::ArrayString;
-
 use actix_web::{dev::ServerHandle, web, App, HttpResponse, HttpServer, Responder};
 use anyhow::anyhow;
+use arrayvec::ArrayString;
 use chrono::{NaiveDateTime, Utc};
 use clap::Parser;
 use futures03::future::select_all;
@@ -112,18 +111,12 @@ impl ExtractorConfigs {
 }
 
 fn parse_chain_token(token: &TokenConfig) -> Result<ChainTokenConfig, ExtractionError> {
-    let raw = hex::decode(token.address.trim_start_matches("0x")).map_err(|e| {
-        ExtractionError::Setup(format!("Invalid address '{}': {e}", token.address))
-    })?;
-    let address = ChainAddress::new(&raw).map_err(|e| {
-        ExtractionError::Setup(format!("Invalid address '{}': {e}", token.address))
-    })?;
+    let raw = hex::decode(token.address.trim_start_matches("0x"))
+        .map_err(|e| ExtractionError::Setup(format!("Invalid address '{}': {e}", token.address)))?;
+    let address = ChainAddress::new(&raw)
+        .map_err(|e| ExtractionError::Setup(format!("Invalid address '{}': {e}", token.address)))?;
     let symbol = ArrayString::from(&token.symbol).map_err(|_| {
-        ExtractionError::Setup(format!(
-            "Symbol '{}' too long (max {} chars)",
-            token.symbol,
-            8
-        ))
+        ExtractionError::Setup(format!("Symbol '{}' too long (max {} chars)", token.symbol, 8))
     })?;
     Ok(ChainTokenConfig { address, symbol, decimals: token.decimals })
 }
@@ -386,8 +379,8 @@ async fn run_spkg(global_args: GlobalArgs, run_args: RunSpkgArgs) -> Result<(), 
                 run_args.protocol_system.clone(),
                 Chain::from_str(&run_args.chain).unwrap(),
                 ImplementationType::Vm,
-                1, /* TODO: if we want to increase this, we need to commit the cache when we reached
-                    * `end_block` */
+                1, /* TODO: if we want to increase this, we need to commit the cache when we
+                    * reached `end_block` */
                 run_args.start_block,
                 run_args.stop_block(),
                 run_args
@@ -765,6 +758,86 @@ async fn run_analyze_tokens(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn eth_token(symbol: &str) -> TokenConfig {
+        TokenConfig {
+            address: "0x0000000000000000000000000000000000000000".to_string(),
+            symbol: symbol.to_string(),
+            decimals: 18,
+        }
+    }
+
+    #[test]
+    fn test_resolve_unknown_chain_fails() {
+        let err = resolve_chain("notachain", &HashMap::new()).unwrap_err();
+        assert!(matches!(err, ExtractionError::Setup(msg) if msg.contains("notachain")));
+    }
+
+    #[test]
+    fn test_parse_chain_token_invalid_hex() {
+        let token = TokenConfig {
+            address: "0xGGGGGGGG".to_string(),
+            symbol: "ETH".to_string(),
+            decimals: 18,
+        };
+        assert!(parse_chain_token(&token).is_err());
+    }
+
+    #[test]
+    fn test_parse_chain_token_symbol_too_long() {
+        let token = TokenConfig {
+            address: "0x0000000000000000000000000000000000000000".to_string(),
+            symbol: "TOOLONGSYM".to_string(),
+            decimals: 18,
+        };
+        assert!(parse_chain_token(&token).is_err());
+    }
+
+    #[test]
+    fn test_resolve_custom_chain_from_yaml() {
+        let yaml = r#"
+extractors: {}
+chains:
+  mychain:
+    chain_id: 99999
+    block_time_secs: 2
+    native_token:
+      address: "0x0000000000000000000000000000000000000000"
+      symbol: "ETH"
+      decimals: 18
+    wrapped_native_token:
+      address: "0x4200000000000000000000000000000000000006"
+      symbol: "WETH"
+      decimals: 18
+    tvl_thresholds:
+      low: 1000
+      medium: 10000
+"#;
+        let config: ExtractorConfigs = serde_yaml::from_str(yaml).expect("yaml parse failed");
+        let Chain::Custom(cfg) = resolve_chain("mychain", &config.chains).expect("resolve failed")
+        else {
+            panic!("expected Chain::Custom")
+        };
+
+        assert_eq!(cfg.name.as_str(), "mychain");
+        assert_eq!(cfg.chain_id, 99999);
+        assert_eq!(cfg.block_time_secs, 2);
+        assert_eq!(cfg.default_tvl_thresholds, TvlThresholds { low: 1000, medium: 10000 });
+        assert_eq!(cfg.native.symbol.as_str(), "ETH");
+        assert_eq!(cfg.native.decimals, 18);
+        assert_eq!(cfg.native.address.as_bytes(), [0u8; 20].as_slice());
+        assert_eq!(
+            cfg.wrapped_native.address.as_bytes(),
+            hex::decode("4200000000000000000000000000000000000006")
+                .unwrap()
+                .as_slice()
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -21,7 +21,6 @@ use std::{
 
 use actix_web::{dev::ServerHandle, web, App, HttpResponse, HttpServer, Responder};
 use anyhow::anyhow;
-use arrayvec::ArrayString;
 use chrono::{NaiveDateTime, Utc};
 use clap::Parser;
 use futures03::future::select_all;
@@ -39,7 +38,7 @@ use tycho_common::{
     models::{
         blockchain::{Block, Transaction},
         contract::AccountDelta,
-        Address, Chain, ChainAddress, ChainTokenConfig, CustomChainConfig, ExtractionState,
+        Address, Chain, ChainConfigError, ChainTokenConfig, CustomChainConfig, ExtractionState,
         ImplementationType, TvlThresholds,
     },
     storage::{ChainGateway, ContractStateGateway, ExtractionStateGateway},
@@ -110,17 +109,6 @@ impl ExtractorConfigs {
     }
 }
 
-fn parse_chain_token(token: &TokenConfig) -> Result<ChainTokenConfig, ExtractionError> {
-    let raw = hex::decode(token.address.trim_start_matches("0x"))
-        .map_err(|e| ExtractionError::Setup(format!("Invalid address '{}': {e}", token.address)))?;
-    let address = ChainAddress::new(&raw)
-        .map_err(|e| ExtractionError::Setup(format!("Invalid address '{}': {e}", token.address)))?;
-    let symbol = ArrayString::from(&token.symbol).map_err(|_| {
-        ExtractionError::Setup(format!("Symbol '{}' too long (max {} chars)", token.symbol, 8))
-    })?;
-    Ok(ChainTokenConfig { address, symbol, decimals: token.decimals })
-}
-
 fn resolve_chain(
     name: &str,
     custom_chains: &HashMap<String, ChainConfig>,
@@ -133,17 +121,28 @@ fn resolve_chain(
                     "Unknown chain '{name}': add it to the [chains] config section"
                 ))
             })?;
-            let chain_name = ArrayString::from(name).map_err(|_| {
-                ExtractionError::Setup(format!("Chain name '{name}' too long (max 32 chars)"))
-            })?;
-            let cfg = CustomChainConfig {
-                name: chain_name,
-                chain_id: entry.chain_id,
-                block_time_secs: entry.block_time_secs,
-                native: parse_chain_token(&entry.native_token)?,
-                wrapped_native: parse_chain_token(&entry.wrapped_native_token)?,
-                default_tvl_thresholds: entry.tvl_thresholds,
-            };
+            let map_err = |e: ChainConfigError| ExtractionError::Setup(e.to_string());
+            let native = ChainTokenConfig::try_new(
+                &entry.native_token.address,
+                &entry.native_token.symbol,
+                entry.native_token.decimals,
+            )
+            .map_err(map_err)?;
+            let wrapped_native = ChainTokenConfig::try_new(
+                &entry.wrapped_native_token.address,
+                &entry.wrapped_native_token.symbol,
+                entry.wrapped_native_token.decimals,
+            )
+            .map_err(map_err)?;
+            let cfg = CustomChainConfig::try_new(
+                name,
+                entry.chain_id,
+                entry.block_time_secs,
+                native,
+                wrapped_native,
+                entry.tvl_thresholds,
+            )
+            .map_err(map_err)?;
             Ok(Chain::Custom(cfg))
         }
     }
@@ -771,23 +770,18 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_chain_token_invalid_hex() {
-        let token = TokenConfig {
-            address: "0xGGGGGGGG".to_string(),
-            symbol: "ETH".to_string(),
-            decimals: 18,
-        };
-        assert!(parse_chain_token(&token).is_err());
+    fn test_chain_token_invalid_hex() {
+        assert!(ChainTokenConfig::try_new("0xGGGGGGGG", "ETH", 18).is_err());
     }
 
     #[test]
-    fn test_parse_chain_token_symbol_too_long() {
-        let token = TokenConfig {
-            address: "0x0000000000000000000000000000000000000000".to_string(),
-            symbol: "TOOLONGSYM".to_string(),
-            decimals: 18,
-        };
-        assert!(parse_chain_token(&token).is_err());
+    fn test_chain_token_symbol_too_long() {
+        assert!(ChainTokenConfig::try_new(
+            "0x0000000000000000000000000000000000000000",
+            "TOOLONGSYM",
+            18
+        )
+        .is_err());
     }
 
     #[test]
@@ -816,19 +810,22 @@ chains:
             panic!("expected Chain::Custom")
         };
 
-        assert_eq!(cfg.name.as_str(), "mychain");
-        assert_eq!(cfg.chain_id, 99999);
-        assert_eq!(cfg.block_time_secs, 2);
-        assert_eq!(cfg.default_tvl_thresholds, TvlThresholds { low: 1000, medium: 10000 });
-        assert_eq!(cfg.native.symbol.as_str(), "ETH");
-        assert_eq!(cfg.native.decimals, 18);
-        assert_eq!(cfg.native.address.as_bytes(), [0u8; 20].as_slice());
-        assert_eq!(
-            cfg.wrapped_native.address.as_bytes(),
-            hex::decode("4200000000000000000000000000000000000006")
-                .unwrap()
-                .as_slice()
-        );
+        let expected_native =
+            ChainTokenConfig::try_new("0x0000000000000000000000000000000000000000", "ETH", 18)
+                .unwrap();
+        let expected_wrapped =
+            ChainTokenConfig::try_new("0x4200000000000000000000000000000000000006", "WETH", 18)
+                .unwrap();
+        let expected_cfg = CustomChainConfig::try_new(
+            "mychain",
+            99999,
+            2,
+            expected_native,
+            expected_wrapped,
+            TvlThresholds::new(1000, 10000),
+        )
+        .unwrap();
+        assert_eq!(cfg, expected_cfg);
     }
 }
 

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -38,8 +38,7 @@ use tycho_common::{
     models::{
         blockchain::{Block, Transaction},
         contract::AccountDelta,
-        Address, Chain, ChainConfigError, ChainTokenConfig, CustomChainConfig, ExtractionState,
-        ImplementationType, TvlThresholds,
+        Address, Chain, CustomChainConfig, ExtractionState, ImplementationType,
     },
     storage::{ChainGateway, ContractStateGateway, ExtractionStateGateway},
     traits::{AccountExtractor, StorageSnapshotRequest},
@@ -69,26 +68,17 @@ use tycho_storage::postgres::{builder::GatewayBuilder, cache::CachedGateway};
 
 mod ot;
 
-#[derive(Debug, Deserialize, Clone)]
-struct ChainConfig {
-    chain_id: u64,
-    block_time_secs: u64,
-    native_token: ChainTokenConfig,
-    wrapped_native_token: ChainTokenConfig,
-    tvl_thresholds: TvlThresholds,
-}
-
 #[derive(Debug, Deserialize)]
 struct ExtractorConfigs {
     extractors: std::collections::HashMap<String, ExtractorConfig>,
     #[serde(default)]
-    chains: std::collections::HashMap<String, ChainConfig>,
+    chains: Vec<CustomChainConfig>,
 }
 
 impl ExtractorConfigs {
     fn new(
         extractors: std::collections::HashMap<String, ExtractorConfig>,
-        chains: std::collections::HashMap<String, ChainConfig>,
+        chains: Vec<CustomChainConfig>,
     ) -> Self {
         Self { extractors, chains }
     }
@@ -104,27 +94,19 @@ impl ExtractorConfigs {
 
 fn resolve_chain(
     name: &str,
-    custom_chains: &HashMap<String, ChainConfig>,
+    custom_chains: &[CustomChainConfig],
 ) -> Result<Chain, ExtractionError> {
     match Chain::from_str(name) {
         Ok(chain) => Ok(chain),
-        Err(_) => {
-            let entry = custom_chains.get(name).ok_or_else(|| {
+        Err(_) => custom_chains
+            .iter()
+            .find(|cfg| cfg.name() == name)
+            .map(|cfg| Chain::Custom(*cfg))
+            .ok_or_else(|| {
                 ExtractionError::Setup(format!(
                     "Unknown chain '{name}': add it to the [chains] config section"
                 ))
-            })?;
-            let cfg = CustomChainConfig::try_new(
-                name,
-                entry.chain_id,
-                entry.block_time_secs,
-                entry.native_token,
-                entry.wrapped_native_token,
-                entry.tvl_thresholds,
-            )
-            .map_err(|e: ChainConfigError| ExtractionError::Setup(e.to_string()))?;
-            Ok(Chain::Custom(cfg))
-        }
+            }),
     }
 }
 
@@ -377,7 +359,7 @@ async fn run_spkg(global_args: GlobalArgs, run_args: RunSpkgArgs) -> Result<(), 
                 dci_plugin,
             ),
         )]),
-        HashMap::new(),
+        Vec::new(),
     );
 
     let (extraction_tasks, mut other_tasks) = create_indexing_tasks(
@@ -741,11 +723,13 @@ async fn run_analyze_tokens(
 
 #[cfg(test)]
 mod tests {
+    use tycho_common::models::{ChainTokenConfig, TvlThresholds};
+
     use super::*;
 
     #[test]
     fn test_resolve_unknown_chain_fails() {
-        let err = resolve_chain("notachain", &HashMap::new()).unwrap_err();
+        let err = resolve_chain("notachain", &[]).unwrap_err();
         assert!(matches!(err, ExtractionError::Setup(msg) if msg.contains("notachain")));
     }
 
@@ -769,18 +753,18 @@ mod tests {
         let yaml = r#"
 extractors: {}
 chains:
-  mychain:
+  - name: mychain
     chain_id: 99999
     block_time_secs: 2
-    native_token:
+    native:
       address: "0x0000000000000000000000000000000000000000"
       symbol: "ETH"
       decimals: 18
-    wrapped_native_token:
+    wrapped_native:
       address: "0x4200000000000000000000000000000000000006"
       symbol: "WETH"
       decimals: 18
-    tvl_thresholds:
+    default_tvl_thresholds:
       low: 1000
       medium: 10000
 "#;

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -70,18 +70,11 @@ use tycho_storage::postgres::{builder::GatewayBuilder, cache::CachedGateway};
 mod ot;
 
 #[derive(Debug, Deserialize, Clone)]
-struct TokenConfig {
-    address: String,
-    symbol: String,
-    decimals: u8,
-}
-
-#[derive(Debug, Deserialize, Clone)]
 struct ChainConfig {
     chain_id: u64,
     block_time_secs: u64,
-    native_token: TokenConfig,
-    wrapped_native_token: TokenConfig,
+    native_token: ChainTokenConfig,
+    wrapped_native_token: ChainTokenConfig,
     tvl_thresholds: TvlThresholds,
 }
 
@@ -121,28 +114,15 @@ fn resolve_chain(
                     "Unknown chain '{name}': add it to the [chains] config section"
                 ))
             })?;
-            let map_err = |e: ChainConfigError| ExtractionError::Setup(e.to_string());
-            let native = ChainTokenConfig::try_new(
-                &entry.native_token.address,
-                &entry.native_token.symbol,
-                entry.native_token.decimals,
-            )
-            .map_err(map_err)?;
-            let wrapped_native = ChainTokenConfig::try_new(
-                &entry.wrapped_native_token.address,
-                &entry.wrapped_native_token.symbol,
-                entry.wrapped_native_token.decimals,
-            )
-            .map_err(map_err)?;
             let cfg = CustomChainConfig::try_new(
                 name,
                 entry.chain_id,
                 entry.block_time_secs,
-                native,
-                wrapped_native,
+                entry.native_token,
+                entry.wrapped_native_token,
                 entry.tvl_thresholds,
             )
-            .map_err(map_err)?;
+            .map_err(|e: ChainConfigError| ExtractionError::Setup(e.to_string()))?;
             Ok(Chain::Custom(cfg))
         }
     }

--- a/crates/tycho-indexer/src/services/api_docs.rs
+++ b/crates/tycho-indexer/src/services/api_docs.rs
@@ -1,13 +1,16 @@
-use tycho_common::dto::{
-    AccountOverrides, AccountUpdate, BlockParam, Chain, ChangeType, ComponentTvlRequestBody,
-    ComponentTvlRequestResponse, ContractId, EntryPoint, EntryPointWithTracingParams, Health,
-    PaginationParams, PaginationResponse, ProtocolComponent, ProtocolComponentRequestResponse,
-    ProtocolComponentsRequestBody, ProtocolId, ProtocolStateDelta, ProtocolStateRequestBody,
-    ProtocolStateRequestResponse, ProtocolSystemsRequestBody, ProtocolSystemsRequestResponse,
-    RPCTracerParams, ResponseAccount, ResponseProtocolState, ResponseToken, StateRequestBody,
-    StateRequestResponse, StorageOverride, TokensRequestBody, TokensRequestResponse,
-    TracedEntryPointRequestBody, TracedEntryPointRequestResponse, TracingParams, TracingResult,
-    VersionParam,
+use tycho_common::{
+    dto::{
+        AccountOverrides, AccountUpdate, BlockParam, Chain, ChangeType, ComponentTvlRequestBody,
+        ComponentTvlRequestResponse, ContractId, EntryPoint, EntryPointWithTracingParams, Health,
+        PaginationParams, PaginationResponse, ProtocolComponent, ProtocolComponentRequestResponse,
+        ProtocolComponentsRequestBody, ProtocolId, ProtocolStateDelta, ProtocolStateRequestBody,
+        ProtocolStateRequestResponse, ProtocolSystemsRequestBody, ProtocolSystemsRequestResponse,
+        RPCTracerParams, ResponseAccount, ResponseProtocolState, ResponseToken, StateRequestBody,
+        StateRequestResponse, StorageOverride, TokensRequestBody, TokensRequestResponse,
+        TracedEntryPointRequestBody, TracedEntryPointRequestResponse, TracingParams, TracingResult,
+        VersionParam,
+    },
+    models::{ChainTokenConfig, CustomChainConfig, TvlThresholds},
 };
 use utoipa::{
     openapi::security::{ApiKey, ApiKeyValue, SecurityScheme},
@@ -81,6 +84,9 @@ impl Modify for SecurityAddon {
         schemas(RPCTracerParams),
         schemas(AccountOverrides),
         schemas(StorageOverride),
+        schemas(CustomChainConfig),
+        schemas(ChainTokenConfig),
+        schemas(TvlThresholds),
     ),
     modifiers(&SecurityAddon),
 )]

--- a/crates/tycho-storage/src/postgres/cache.rs
+++ b/crates/tycho-storage/src/postgres/cache.rs
@@ -43,6 +43,7 @@ use tycho_common::{
 use super::{PostgresError, PostgresGateway};
 
 /// Represents different types of database write operations.
+#[allow(clippy::large_enum_variant)]
 #[derive(PartialEq, Clone, Debug)]
 pub(crate) enum WriteOp {
     // Simply merge


### PR DESCRIPTION
## Summary

- Adds a `Custom(CustomChainConfig)` variant to `models::Chain` and `dto::Chain`, allowing callers to define chains beyond the hardcoded set without forking the library
- Introduces `CustomChainConfig` — a fully `Copy`-compatible struct holding chain identity (`name`, `chain_id`, `block_time_secs`), native and wrapped native token config (`ChainTokenConfig`), and TVL thresholds (`TvlThresholds`). All fields use stack-allocated types (`ArrayString`, fixed-size byte arrays) to satisfy the `Copy` bound that `Chain` requires
- Adds `ChainAddress` — a `[u8; 32]` + length field for variable-length addresses up to 32 bytes, covering both EVM (20-byte) and Starknet (32-byte felt252)
- Replaces `EnumString`/`Display` strum derives on `Chain` with manual `FromStr` and `Display` impls. Known lowercase names map to their variants as before; `Custom` is never constructed by `FromStr` alone — full config is required. `dto::Chain` delegates both impls to `models::Chain`
- Wires `Custom` into all `Chain` methods: `id()`, `default_tvl_threshold()`, `native_token()`, `wrapped_native_token()`
- Adds `arrayvec` (with `serde` feature) as a direct dependency of `tycho-common`

## Test plan

- [ ]  `cargo clippy --workspace --all-features` passes
- [ ]  Construct a `Chain::Custom` with a known config and verify `Display`, `id()`, `native_token()`, and `default_tvl_threshold()` return the expected values
- [ ]  Confirm `Chain::from_str("custom")` returns `Err` (custom chains require full config, not just a name)