### PR TITLE
feat(substreams): add BopAMM VM integration

### DIFF
--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -774,6 +774,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethereum-bopamm"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ethabi 18.0.0",
+ "getrandom 0.2.17",
+ "hex",
+ "itertools 0.13.0",
+ "keccak-hash",
+ "serde",
+ "serde_qs 0.13.0",
+ "substreams 0.5.22",
+ "substreams-ethereum 0.9.13",
+ "tycho-substreams 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ethereum-cowamm"
 version = "0.1.3"
 dependencies = [

--- a/protocols/substreams/Cargo.toml
+++ b/protocols/substreams/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "ethereum-rocketpool",
     "unichain-velodrome",
     "ethereum-liquidityparty",
+    "ethereum-bopamm",
 ]
 resolver = "2"
 

--- a/protocols/substreams/ethereum-bopamm/Cargo.toml
+++ b/protocols/substreams/ethereum-bopamm/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ethereum-bopamm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "ethereum_bopamm"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+substreams = "0.5.22"
+substreams-ethereum = "0.9.9"
+ethabi = "18.0.0"
+hex = { version = "0.4.3", features = ["serde"] }
+anyhow = "1.0.75"
+tycho-substreams = "0.8.0"
+itertools = "0.13.0"
+keccak-hash = "0.11.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_qs = "0.13.0"
+
+# Required so that transitive crates build correctly under wasm32-unknown-unknown
+[target.wasm32-unknown-unknown.dependencies]
+getrandom = { version = "0.2", features = ["custom"] }

--- a/protocols/substreams/ethereum-bopamm/HANDOVER.md
+++ b/protocols/substreams/ethereum-bopamm/HANDOVER.md
@@ -127,7 +127,9 @@ timestamps are independent, so each book is pinned separately.
 Type: **VM**, `protocol_system = vm:bopamm`, `protocol_type = bopamm_book` (Swap), one
 component **per book** (`asset/USDC`).
 
-Component id = `0x{settlement}-{assetId}`. tokens = `[asset, USDC]` (sorted ascending).
+Component id = `0x` + `settlement (20 bytes) ‖ assetId (12 bytes, BE)` — exactly 32 hex
+bytes, because `tycho-simulation` hex-decodes the id into the adapter's `bytes32 poolId`
+(`string_to_bytes32`). tokens = `[asset, USDC]` (sorted ascending).
 contracts = `[settlement, module, registry]` (same three for every book). All deployment
 addresses + storage slots are passed via **substreams `params`** (`DeploymentConfig`) — no
 hardcoded addresses; the package can target another deployment by changing params.
@@ -147,8 +149,8 @@ hardcoded addresses; the package can target another deployment by changing param
 5. **`store_balances`** — `StoreAddBigInt` → absolute balances.
 6. **`map_protocol_changes`** — assembles `BlockChanges`: new components + `balance_owner`
    dynamic attr, absolute balances, full storage+code of the three contracts
-   (`extract_contract_changes`, fixed predicate, **no DCI**), per-book `committed_ts` +
-   `committed_block` decoded from `updateState`/batch calldata, and `Paused`/`Unpaused`
+   (`extract_contract_changes`, fixed predicate, **no DCI**), the per-book
+   `override_block_timestamp` decoded from `updateState`/batch calldata, and `Paused`/`Unpaused`
    pause state. `manual_updates` components are explicitly `mark_component_as_updated` on
    each quote refresh and on shared-module changes.
 
@@ -161,8 +163,10 @@ hardcoded addresses; the package can target another deployment by changing param
 - **`balance_owner` is a dynamic attribute**, emitted whenever the maker slot is written
   (`extract_maker_changes`) — because the maker is configured *after* book creation, and the
   maker can rotate.
-- **`committed_ts`/`committed_block`** are read from the `bookId`/`ts` in the registry update
-  **calldata** (not by reverse-engineering lane slots).
+- **`override_block_timestamp`** (8-byte BE u64) is read from the `bookId`/`ts` in the
+  registry update **calldata** (not by reverse-engineering lane slots). `tycho-simulation`
+  pins `block.timestamp` to it when simulating the book (generic mechanism added in PR
+  #1034), which passes the registry's exact-timestamp `StaleUpdate()` gate.
 - **`batchUpdateStateWithSignature`** is decoded for completeness (ethabi) but is currently
   only synthetic-tested (never called on-chain).
 
@@ -182,18 +186,18 @@ hardcoded addresses; the package can target another deployment by changing param
 
 ## 8. Remaining work (next steps)
 
-1. **`tycho-simulation` VM adapter (`BopAMMSwapAdapter`)** — `get_amount_out` over the indexed
-   storage. **Must inject the maker's token balance** into the simulated token storage (it is
-   *not* in the tracked contract set; pricing doesn't need it but `swap()`/limits do), and
-   pin `block.timestamp`/`block.number` to the book's committed snapshot (the override
-   stream). This is where the §5 timestamp gate is handled.
-2. **Quote-override stream** — supplies, per book, the committed lane snapshot + its
-   timestamp/block so the adapter can simulate at head without `StaleUpdate()`.
-3. **`extractors.yaml` `vm:bopamm` entry** — the entry itself is 8 trivial fields (see PR
+1. ~~VM swap adapter~~ — **done**: `BopAMMAdapter` under
+   `protocols/adapter-integration/evm/src/bopamm/` (sell-side; quote-driven limits via
+   bisection; see its manifest). The §5 timestamp gate is handled by the
+   `override_block_timestamp` attribute consumed by `tycho-simulation` (PR #1034); no
+   separate quote-override stream is needed. When simulating `swap()` (not just `quote()`),
+   the maker's token balance must still be present in the simulated token contracts — it is
+   *not* in the tracked contract set; pricing doesn't need it but settlement transfers do.
+2. **`extractors.yaml` `vm:bopamm` entry** — the entry itself is 8 trivial fields (see PR
    description / repo `extractors.yaml`); the real prerequisite is **releasing the spkg to
    S3** via `protocols/substreams/release.sh ethereum-bopamm` (spkgs are gitignored, fetched
    from S3 at runtime). Params are baked into the spkg by `substreams pack`.
-4. **Robustness gaps** (documented, not blocking the MVP):
+3. **Robustness gaps** (documented, not blocking the MVP):
    - Asset **delisting** (`non-zero→0` config) is not handled → a removed book stays
      "active". Components are immutable; would need a deactivation signal.
    - **Maker rotation** to a pre-funded wallet under-reports TVL until the new maker's first
@@ -209,8 +213,8 @@ hardcoded addresses; the package can target another deployment by changing param
   pack` succeeds.
 - Two adversarial review agents + a live `substreams run` against
   `mainnet.eth.streamingfast.io` over the creation range (25171610–21) and an active range
-  (~25.26M): both books created with correct ids/tokens/attrs/creation_tx; `committed_ts`/
-  `committed_block` on `updateState`; maker balances under both books; `balance_owner` emitted
+  (~25.26M): both books created with correct ids/tokens/attrs/creation_tx; the quote
+  timestamp attribute on `updateState`; maker balances under both books; `balance_owner` emitted
   at 25171618. Two bugs were found and fixed during review (balance_owner timing; token-index
   sort-order dropping WETH balances).
 

--- a/protocols/substreams/ethereum-bopamm/HANDOVER.md
+++ b/protocols/substreams/ethereum-bopamm/HANDOVER.md
@@ -1,0 +1,224 @@
+# BopAMM (Bebop PMM) — Tycho Integration Handover
+
+Everything learned about BopAMM's on-chain design, its interfaces, and how this Substreams
+package indexes it. Written so the next engineer can pick up the remaining work (simulation
+adapter, quote-override stream, extractor registration) without re-deriving the protocol.
+
+> All facts below were verified on Ethereum mainnet (archive node + Tenderly + live
+> `substreams run`). Addresses are mainnet. The venue is **live but intermittent** (369
+> `Swap`s in its lifetime, active blocks ~25.19M–25.27M, idle between maker commits).
+
+---
+
+## 1. What BopAMM is
+
+BopAMM is Bebop's on-chain **PMM (proxy/principal market maker)**. It is **not** a
+constant-function AMM: there are no per-pair pool contracts and no reserves held in a pool.
+A single **settlement** contract pulls inventory from one **market-maker wallet** and prices
+each swap from quote "lanes" the operator commits to a **registry**. It is RFQ-like in
+spirit, but — and this is the reason we index it as a Tycho **VM** protocol — the executable
+price is a pure function of on-chain state (registry lanes + module config), so we can
+reproduce quotes locally from indexed storage without calling Bebop's API.
+
+This package is **distinct from the existing Bebop RFQ integration** in
+`tycho-simulation/src/rfq/protocols/bebop/` (that is Bebop's off-chain RFQ product). This one
+is named `bopamm`.
+
+---
+
+## 2. Contracts and roles
+
+| Address | Role |
+|---|---|
+| `0xdB13ad0fcD134E9c48f2fDaEa8f6751a0F5349ca` | **BopAmmV2** — settlement / swap entrypoint. Holds **no** inventory. |
+| `0xBC60639345dFa607d73b74e88C2d54D8B8AD7Cc3` | **Pricing module** — asset config, pricing math, global maker slot. EIP-1271/712 signer. |
+| `0xDa7AfeeD01fe625CF15d187a19f94B45f00b8C5F` | **PrioUpdateRegistry** — per-book quote lanes. Emits **no events**. |
+| `0x6f7a3714d7Fc266e3e84067ac31E7b1A3bE18060` | **Maker** — single global inventory EOA (provides buy token, receives sell token). |
+| `0xC5531177169b4576553Df6d4B4e176d0d7C3C826` | **Owner** — hardcoded/immutable; configures the module + registry. |
+
+All three protocol contracts are **unverified** on Etherscan. The takers in observed
+settlements are CoW Protocol solvers (`0x9008d19f…0ab41`) — BopAMM runs as a CoW PMM.
+
+### Tokens / books
+USDC (`0xA0b8…eb48`) is the **hub/quote**. Each book is `asset/USDC`, keyed by `uint8`
+`assetId`: **0 = WETH** (`0xC02a…56cc2`), **1 = WBTC** (`0x2260…C599`). Native ETH is wrapped
+to WETH internally. **`bookId == assetId`** (verified: a WETH swap calls `updateState(bookId=0)`
+and the WETH asset config is at `assetId=0`).
+
+---
+
+## 3. Interfaces
+
+### BopAmmV2 (settlement)
+| Selector | Signature | Notes |
+|---|---|---|
+| `0x6a33d28e` | `swap(address,address,uint256,uint256,uint256,address)` | tokenIn, tokenOut, amountIn, minOut, expiry, recipient. No maker arg. |
+| `0xb6466384` | `quote(address,address,uint256)` view | Pure function of module+registry storage. |
+| `0xa20e9599` | `swap(…,address,address,bytes)` | Signed variant accepting an explicit maker + signature (unused by the default path). |
+| `0x3e413bee`/`0x3fc8cef3`/`0x7ce91411`/`0x8da5cb5b` | `usdc()`/`weth()`/`pricing()`/`owner()` pure | Immutable constants (module = `pricing()`). |
+| `0x8456cb59`/`0x3f4ba83a`/`0x5c975abb` | `pause()`/`unpause()`/`paused()` | OZ Pausable. Emits `Paused`/`Unpaused`. |
+| `0xe5711e8b` | `rescueToken(address,address,uint256)` | owner-only. |
+
+Events: `Swap(address,address,address,uint256,uint256)` topic0 `0xcd3829a3…`; a second event
+`0xea517215…`; `Paused(address)` `0x62e78cea…`; `Unpaused(address)` `0x5db9ee0a…`.
+
+### Pricing module
+| Selector | Signature | Notes |
+|---|---|---|
+| `0xd4f41cf2` | `(uint8,bool,uint256)` view | Pricing; returns the fill incl. the **maker** address + amounts. |
+| `0xe621a64b` | `getAssetConfig(uint8)` view | `(token, decimals, param, minSize)`. |
+| `0x1626ba7e` | `isValidSignature(bytes32,bytes)` | EIP-1271 (used by the off-chain update committer, **not** the quote path). |
+| `0x70c67144`/`0xef8f6a97`/`0xba7518cf`/`0xb53d54fe` | config setters | owner-only; **no events**. The maker was set via `0x70c67144`. |
+
+### PrioUpdateRegistry
+| Selector | Signature | Notes |
+|---|---|---|
+| `0x16c83adc` | `getState(uint256 bookId, uint32 t0, uint32 t1)` view | Returns `(uint256 ts, uint256[] lanes)`. |
+| `0xa9114b0f` | `updateState(address caller, uint256 bookId, uint32 ts, uint256[] lanes)` | **The live commit path.** Decremented on each swap; also called top-level by the operator. |
+| `0xe50de8ea` | `batchUpdateStateWithSignature((address,address,uint256 bookId,uint32 ts,uint256[],bytes)[])` | Signed multi-book commit. **Exists in ABI but never called on-chain** (all 1000 sampled commits are `updateState`). |
+| `0x43d24a5e`/`0x04b07a5e`/`0x75ceb837` | `addUpdater`/`removeUpdater`/`isUpdater(address,address)` | Authorized price signers (≠ maker). |
+| `0x0260ee36`/`0xb278d9b0` | `MAX_UPDATE_AGE()` / `MAX_UPDATE_LEAD_TIME()` | Both return **0**. |
+
+---
+
+## 4. Storage layout (module `0xBC60…`)
+
+| What | Slot |
+|---|---|
+| Settlement address | `2` |
+| Asset config `mapping(assetId => packed)` | `keccak256(abi.encode(assetId, 3))` → `param | decimals | token` (token in low 20 bytes); `+1` = `minSize` |
+| Token → assetId | `keccak256(abi.encode(token, 4))` |
+| **Maker (global)** | `0x1471eb6eb2c5e789fc3de43f8ce62938c7d1836ec861730447e2ada8fd81017b` |
+
+Verified: `keccak(0,3)=0x3617319a…`, `keccak(1,3)=0xa15bc60c…`. The maker is **global** (the WETH
+and WBTC swaps read the same maker slot), not per-book.
+
+Maker ERC20 `balanceOf` mapping slots (in the token contracts, for reference): WETH=3, WBTC=0,
+USDC=9. (Not used by this package — see §6.)
+
+---
+
+## 5. Liquidity / pricing model
+
+- **Hub-and-spoke**, USDC at the center. The only on-chain books are `WETH/USDC` and
+  `WBTC/USDC`. Cross pairs (e.g. `WETH→WBTC`) are routed **through USDC atomically** in a
+  single `swap()` (the maker bridges with transient USDC) — confirmed by trace.
+- **Inventory is one shared maker wallet**, so per-pair reserves do not exist; venue TVL =
+  Σ `balanceOf(maker)` × price. Settlement holds nothing.
+- A swap reverts (rather than caps) when the maker lacks inventory / bridge USDC. Oversize ⇒
+  revert is acceptable.
+- **Same-block / exact-timestamp gate (the key constraint):** `MAX_UPDATE_AGE()=0` and
+  `MAX_UPDATE_LEAD_TIME()=0`. `quote()`/`getState` revert with `StaleUpdate()` (`0x666a2814`)
+  unless `block.timestamp == the committed update timestamp`. There is **zero** staleness
+  window: the operator commits prices and the swap must land in the same block (via a builder
+  bundle). On-chain registry state is written **only** when the maker commits (sporadically,
+  not every block), so between commits the indexed state is stale by design.
+
+**Consequence for VM simulation:** pricing is fully reproducible from indexed storage +
+bytecode (no external calls, no ecrecover on the read path, no DCI), **but** the simulation
+must run with `block.timestamp`/`block.number` pinned to each book's committed snapshot — fed
+by an external **quote-override stream** (out of scope for indexing; see §8). Per-book
+timestamps are independent, so each book is pinned separately.
+
+---
+
+## 6. How this package indexes it
+
+Type: **VM**, `protocol_system = vm:bopamm`, `protocol_type = bopamm_book` (Swap), one
+component **per book** (`asset/USDC`).
+
+Component id = `0x{settlement}-{assetId}`. tokens = `[asset, USDC]` (sorted ascending).
+contracts = `[settlement, module, registry]` (same three for every book). All deployment
+addresses + storage slots are passed via **substreams `params`** (`DeploymentConfig`) — no
+hardcoded addresses; the package can target another deployment by changing params.
+
+### Module graph (`src/modules/`, one file each)
+1. **`map_components`** — books are discovered from **storage writes** (the contracts emit no
+   config events): a zero→non-zero write to `keccak(assetId,3)` ⇒ a new book; the token is
+   decoded from the packed slot value.
+2. **`store_components`** — indexes books by `book:{assetId}` and by **every** token
+   (`token:0x{addr}`), so a token or book id resolves back to its component.
+3. **`store_maker`** — tracks the global maker from writes to the maker slot (`set` policy ⇒
+   rotation propagates).
+4. **`map_relative_balances`** — maker inventory TVL from ERC20 `Transfer`s touching the
+   maker; USDC deltas are emitted under **every** book (shared quote inventory duplicated,
+   not split — by design, since the client does not dedupe and under-reporting risks
+   min-TVL filtering).
+5. **`store_balances`** — `StoreAddBigInt` → absolute balances.
+6. **`map_protocol_changes`** — assembles `BlockChanges`: new components + `balance_owner`
+   dynamic attr, absolute balances, full storage+code of the three contracts
+   (`extract_contract_changes`, fixed predicate, **no DCI**), per-book `committed_ts` +
+   `committed_block` decoded from `updateState`/batch calldata, and `Paused`/`Unpaused`
+   pause state. `manual_updates` components are explicitly `mark_component_as_updated` on
+   each quote refresh and on shared-module changes.
+
+### Notable decisions
+- **Transfer-delta balances, not slot-read.** Slot-read (Balancer-V3 `get_vault_reserves`
+  pattern) gives absolute balances but needs each token's `balanceOf` slot, which is unknown
+  in-substreams for a *new* asset → would break auto new-market TVL. Transfer-delta is
+  universal. Trade-off: a maker rotation to a pre-funded wallet under-reports until an RPC
+  re-seed (rotation has never happened; mitigatable).
+- **`balance_owner` is a dynamic attribute**, emitted whenever the maker slot is written
+  (`extract_maker_changes`) — because the maker is configured *after* book creation, and the
+  maker can rotate.
+- **`committed_ts`/`committed_block`** are read from the `bookId`/`ts` in the registry update
+  **calldata** (not by reverse-engineering lane slots).
+- **`batchUpdateStateWithSignature`** is decoded for completeness (ethabi) but is currently
+  only synthetic-tested (never called on-chain).
+
+---
+
+## 7. Lifecycle reference (mainnet)
+
+| Block | Event |
+|---|---|
+| 25,099,176 | Registry deployed (= package `start_block`, earliest of the three) |
+| 25,171,611–12 | Module + settlement deployed |
+| 25,171,616 | tx `0x58071cb7…` writes both asset configs → **books 0 & 1 created** |
+| 25,171,618 | tx `0x62f8e396…` (`0x70c67144`) sets the maker → `balance_owner` emitted |
+| ~25.19M–25.27M | Active trading (369 `Swap`s, ~1000 `updateState` txs) |
+
+---
+
+## 8. Remaining work (next steps)
+
+1. **`tycho-simulation` VM adapter (`BopAMMSwapAdapter`)** — `get_amount_out` over the indexed
+   storage. **Must inject the maker's token balance** into the simulated token storage (it is
+   *not* in the tracked contract set; pricing doesn't need it but `swap()`/limits do), and
+   pin `block.timestamp`/`block.number` to the book's committed snapshot (the override
+   stream). This is where the §5 timestamp gate is handled.
+2. **Quote-override stream** — supplies, per book, the committed lane snapshot + its
+   timestamp/block so the adapter can simulate at head without `StaleUpdate()`.
+3. **`extractors.yaml` `vm:bopamm` entry** — the entry itself is 8 trivial fields (see PR
+   description / repo `extractors.yaml`); the real prerequisite is **releasing the spkg to
+   S3** via `protocols/substreams/release.sh ethereum-bopamm` (spkgs are gitignored, fetched
+   from S3 at runtime). Params are baked into the spkg by `substreams pack`.
+4. **Robustness gaps** (documented, not blocking the MVP):
+   - Asset **delisting** (`non-zero→0` config) is not handled → a removed book stays
+     "active". Components are immutable; would need a deactivation signal.
+   - **Maker rotation** to a pre-funded wallet under-reports TVL until the new maker's first
+     fill (or an RPC re-seed).
+
+---
+
+## 9. Verification done
+
+- 8 unit tests (incl. the real `updateState` calldata decode, the `bookId==assetId`
+  cross-lock, `asset_config_slot` keccak vs on-chain, batch decode, token-index regression,
+  params parse). `clippy -D warnings` + nightly `fmt` clean; host + wasm32 build; `substreams
+  pack` succeeds.
+- Two adversarial review agents + a live `substreams run` against
+  `mainnet.eth.streamingfast.io` over the creation range (25171610–21) and an active range
+  (~25.26M): both books created with correct ids/tokens/attrs/creation_tx; `committed_ts`/
+  `committed_block` on `updateState`; maker balances under both books; `balance_owner` emitted
+  at 25171618. Two bugs were found and fixed during review (balance_owner timing; token-index
+  sort-order dropping WETH balances).
+
+---
+
+## 10. Reproduction notes
+
+- Bebop API (cross-check only, **not** part of the integration):
+  `https://api.bebop.xyz/bopamm/ethereum/v1/{tokens,state,quote}` with header `X-API-Key`.
+- Run the package: `SUBSTREAMS_API_TOKEN` (repo `.env`) +
+  `substreams run -e mainnet.eth.streamingfast.io:443 ethereum-bopamm-v0.1.0.spkg map_protocol_changes -s 25171610 -t 25171621`.

--- a/protocols/substreams/ethereum-bopamm/integration_test.tycho.yaml
+++ b/protocols/substreams/ethereum-bopamm/integration_test.tycho.yaml
@@ -1,0 +1,45 @@
+substreams_yaml_path: ./substreams.yaml
+protocol_system: "vm:bopamm"
+module_name: "map_protocol_changes"
+protocol_type_names:
+  - "bopamm_book"
+
+# VM swap adapter is not implemented yet; simulation/execution are skipped below until it
+# and the quote-override stream (which pins block.number/timestamp to the committed quote)
+# exist. This test validates on-chain component discovery + tracked-contract indexing only.
+adapter_contract: "BopAMMSwapAdapter"
+adapter_build_signature: "constructor(address)"
+adapter_build_args: "0xdB13ad0fcD134E9c48f2fDaEa8f6751a0F5349ca"
+
+# Maker inventory balances require the off-chain-driven quote state to be meaningful and the
+# venue is intermittently idle; balance assertions are validated separately once the adapter
+# and override stream land.
+skip_balance_check: true # No VM adapter / override stream yet (see above).
+
+tests:
+  - name: test_book_discovery
+    # Covers the settlement/module/registry deployments (~25171611-12), the asset-config
+    # write that creates both books (25171616), and the maker assignment (25171618).
+    start_block: 25171610
+    stop_block: 25171620
+    expected_components:
+      - id: "0xdb13ad0fcd134e9c48f2fdaea8f6751a0f5349ca-0"
+        tokens:
+          - "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" # USDC
+          - "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2" # WETH
+        static_attributes:
+          asset_id: "0x0000000000000000"
+          manual_updates: "0x01"
+        creation_tx: "0x58071cb79cabce79033144d3a6b7433f61f917fc76f5b7755e6873b9cf4f8643"
+        skip_simulation: true # No VM adapter / quote-override stream yet.
+        skip_execution: true # No VM adapter yet.
+      - id: "0xdb13ad0fcd134e9c48f2fdaea8f6751a0f5349ca-1"
+        tokens:
+          - "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599" # WBTC
+          - "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" # USDC
+        static_attributes:
+          asset_id: "0x0000000000000001"
+          manual_updates: "0x01"
+        creation_tx: "0x58071cb79cabce79033144d3a6b7433f61f917fc76f5b7755e6873b9cf4f8643"
+        skip_simulation: true # No VM adapter / quote-override stream yet.
+        skip_execution: true # No VM adapter yet.

--- a/protocols/substreams/ethereum-bopamm/integration_test.tycho.yaml
+++ b/protocols/substreams/ethereum-bopamm/integration_test.tycho.yaml
@@ -4,17 +4,16 @@ module_name: "map_protocol_changes"
 protocol_type_names:
   - "bopamm_book"
 
-# VM swap adapter is not implemented yet; simulation/execution are skipped below until it
-# and the quote-override stream (which pins block.number/timestamp to the committed quote)
-# exist. This test validates on-chain component discovery + tracked-contract indexing only.
-adapter_contract: "BopAMMSwapAdapter"
+# Simulation/execution are skipped below: simulating a book requires tycho-simulation's
+# `override_block_timestamp` support (PR #1034) to pass the registry's exact-timestamp
+# StaleUpdate() gate, and that is not on main yet. The adapter itself lives in
+# protocols/adapter-integration/evm/src/bopamm. This test validates on-chain component
+# discovery + tracked-contract indexing only.
+adapter_contract: "BopAMMAdapter"
 adapter_build_signature: "constructor(address)"
 adapter_build_args: "0xdB13ad0fcD134E9c48f2fDaEa8f6751a0F5349ca"
 
-# Maker inventory balances require the off-chain-driven quote state to be meaningful and the
-# venue is intermittently idle; balance assertions are validated separately once the adapter
-# and override stream land.
-skip_balance_check: true # No VM adapter / override stream yet (see above).
+skip_balance_check: true # Venue is intermittently idle; balances validated separately.
 
 tests:
   - name: test_book_discovery
@@ -23,7 +22,7 @@ tests:
     start_block: 25171610
     stop_block: 25171620
     expected_components:
-      - id: "0xdb13ad0fcd134e9c48f2fdaea8f6751a0f5349ca-0"
+      - id: "0xdb13ad0fcd134e9c48f2fdaea8f6751a0f5349ca000000000000000000000000"
         tokens:
           - "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" # USDC
           - "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2" # WETH
@@ -31,9 +30,9 @@ tests:
           asset_id: "0x0000000000000000"
           manual_updates: "0x01"
         creation_tx: "0x58071cb79cabce79033144d3a6b7433f61f917fc76f5b7755e6873b9cf4f8643"
-        skip_simulation: true # No VM adapter / quote-override stream yet.
-        skip_execution: true # No VM adapter yet.
-      - id: "0xdb13ad0fcd134e9c48f2fdaea8f6751a0f5349ca-1"
+        skip_simulation: true # Needs override_block_timestamp support (PR #1034) on main.
+        skip_execution: true # No vm:bopamm executor is registered yet.
+      - id: "0xdb13ad0fcd134e9c48f2fdaea8f6751a0f5349ca000000000000000000000001"
         tokens:
           - "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599" # WBTC
           - "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" # USDC
@@ -41,5 +40,5 @@ tests:
           asset_id: "0x0000000000000001"
           manual_updates: "0x01"
         creation_tx: "0x58071cb79cabce79033144d3a6b7433f61f917fc76f5b7755e6873b9cf4f8643"
-        skip_simulation: true # No VM adapter / quote-override stream yet.
-        skip_execution: true # No VM adapter yet.
+        skip_simulation: true # Needs override_block_timestamp support (PR #1034) on main.
+        skip_execution: true # No vm:bopamm executor is registered yet.

--- a/protocols/substreams/ethereum-bopamm/integration_test.tycho.yaml
+++ b/protocols/substreams/ethereum-bopamm/integration_test.tycho.yaml
@@ -15,10 +15,18 @@ adapter_build_args: "0xdB13ad0fcD134E9c48f2fDaEa8f6751a0F5349ca"
 
 skip_balance_check: true # Venue is intermittently idle; balances validated separately.
 
+# The registry was deployed at block 25,099,176 — before this test's range — so the
+# substreams only emit its storage updates here, never its account creation. Bootstrap its
+# account from RPC so slot updates have something to attach to. The settlement and module
+# are deployed inside the range, so they don't need this.
+initialized_accounts:
+  - "0xDa7AfeeD01fe625CF15d187a19f94B45f00b8C5F" # PrioUpdateRegistry
+
 tests:
   - name: test_book_discovery
-    # Covers the settlement/module/registry deployments (~25171611-12), the asset-config
-    # write that creates both books (25171616), and the maker assignment (25171618).
+    # Covers the settlement/module deployments (~25171611-12), the asset-config write that
+    # creates both books (25171616), and the maker assignment (25171618). The registry was
+    # deployed earlier (25099176) and is bootstrapped via initialized_accounts above.
     start_block: 25171610
     stop_block: 25171620
     expected_components:

--- a/protocols/substreams/ethereum-bopamm/rust-toolchain.toml
+++ b/protocols/substreams/ethereum-bopamm/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.83.0"
+components = [ "rustfmt" ]
+targets = [ "wasm32-unknown-unknown" ]

--- a/protocols/substreams/ethereum-bopamm/src/common.rs
+++ b/protocols/substreams/ethereum-bopamm/src/common.rs
@@ -27,9 +27,17 @@ pub const SEL_BATCH_UPDATE: [u8; 4] = hex!("e50de8ea");
 /// Upper bound on enumerable book ids (assetIds are small sequential integers).
 pub const MAX_ASSET_ID: u64 = 64;
 
-/// Deterministic component id for a book: `0x{settlement}-{assetId}`.
+/// Deterministic component id for a book: 32 bytes = `settlement (20) ‖ assetId (12, BE)`,
+/// hex-encoded.
+///
+/// The id must hex-decode to at most 32 bytes: `tycho-simulation` converts it into the swap
+/// adapter's `bytes32 poolId` via `string_to_bytes32`, and the adapter recovers the
+/// settlement from the first 20 bytes and the asset id from the low 12.
 pub fn component_id(settlement: &[u8], asset_id: u64) -> String {
-    format!("0x{}-{}", hex::encode(settlement), asset_id)
+    let mut id = [0u8; 32];
+    id[..20].copy_from_slice(settlement);
+    id[24..].copy_from_slice(&asset_id.to_be_bytes());
+    format!("0x{}", hex::encode(id))
 }
 
 /// Storage slot of `assetConfig[asset_id]` = `keccak256(abi.encode(asset_id, base_slot))`.
@@ -188,9 +196,15 @@ mod tests {
     }
 
     #[test]
-    fn component_id_is_settlement_scoped() {
-        assert_eq!(component_id(&SETTLEMENT, 0), "0xdb13ad0fcd134e9c48f2fdaea8f6751a0f5349ca-0");
-        assert_eq!(component_id(&SETTLEMENT, 1), "0xdb13ad0fcd134e9c48f2fdaea8f6751a0f5349ca-1");
+    fn component_id_is_settlement_scoped_bytes32() {
+        assert_eq!(
+            component_id(&SETTLEMENT, 0),
+            "0xdb13ad0fcd134e9c48f2fdaea8f6751a0f5349ca000000000000000000000000"
+        );
+        assert_eq!(
+            component_id(&SETTLEMENT, 1),
+            "0xdb13ad0fcd134e9c48f2fdaea8f6751a0f5349ca000000000000000000000001"
+        );
     }
 
     #[test]
@@ -216,7 +230,7 @@ mod tests {
         let (book_id, _) = updates[0];
         assert_eq!(
             component_id(&SETTLEMENT, book_id),
-            "0xdb13ad0fcd134e9c48f2fdaea8f6751a0f5349ca-0"
+            "0xdb13ad0fcd134e9c48f2fdaea8f6751a0f5349ca000000000000000000000000"
         );
         assert_eq!(
             hex::encode(asset_config_slot(book_id, 3)),

--- a/protocols/substreams/ethereum-bopamm/src/common.rs
+++ b/protocols/substreams/ethereum-bopamm/src/common.rs
@@ -1,0 +1,268 @@
+//! Shared helpers and ABI-level constants for the BopAMM modules.
+//!
+//! Deployment-specific values (addresses, storage-layout slots) come from
+//! [`crate::config::DeploymentConfig`]; the constants here are ABI-level (function selectors,
+//! event topics) that are fixed by the contract code itself.
+use ethabi::{ParamType, Token};
+use keccak_hash::keccak;
+use substreams::{
+    hex,
+    store::{StoreGet, StoreGetProto},
+};
+use tycho_substreams::prelude::*;
+
+/// `Paused(address)` — OpenZeppelin Pausable, emitted by the settlement contract.
+pub const PAUSED_TOPIC: [u8; 32] =
+    hex!("62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258");
+/// `Unpaused(address)`.
+pub const UNPAUSED_TOPIC: [u8; 32] =
+    hex!("5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa");
+
+/// `updateState(address,uint256,uint32,uint256[])` — the live on-chain commit path.
+pub const SEL_UPDATE_STATE: [u8; 4] = hex!("a9114b0f");
+/// `batchUpdateStateWithSignature((address,address,uint256,uint32,uint256[],bytes)[])` — a
+/// signed multi-book commit path that exists in the ABI but is currently unused on-chain.
+pub const SEL_BATCH_UPDATE: [u8; 4] = hex!("e50de8ea");
+
+/// Upper bound on enumerable book ids (assetIds are small sequential integers).
+pub const MAX_ASSET_ID: u64 = 64;
+
+/// Deterministic component id for a book: `0x{settlement}-{assetId}`.
+pub fn component_id(settlement: &[u8], asset_id: u64) -> String {
+    format!("0x{}-{}", hex::encode(settlement), asset_id)
+}
+
+/// Storage slot of `assetConfig[asset_id]` = `keccak256(abi.encode(asset_id, base_slot))`.
+pub fn asset_config_slot(asset_id: u64, base_slot: u64) -> Vec<u8> {
+    let mut input = [0u8; 64];
+    input[24..32].copy_from_slice(&asset_id.to_be_bytes());
+    input[56..64].copy_from_slice(&base_slot.to_be_bytes());
+    keccak(input.as_slice())
+        .as_bytes()
+        .to_vec()
+}
+
+pub fn is_zero(value: &[u8]) -> bool {
+    value.iter().all(|&b| b == 0)
+}
+
+/// All currently-known book component ids, by probing the components store.
+pub fn enumerate_books(store: &StoreGetProto<ProtocolComponent>) -> Vec<String> {
+    (0..MAX_ASSET_ID)
+        .filter_map(|i| {
+            store
+                .get_last(format!("book:{i}"))
+                .map(|c| c.id)
+        })
+        .collect()
+}
+
+/// Store keys under which a book is indexed by token, one per token.
+///
+/// Every token is indexed (not just the asset side) so the lookup is independent of token
+/// ordering: the USDC key is harmless because [`books_for_token`] resolves USDC through its
+/// own hub branch and never reads it, while each asset token maps to exactly its own book.
+pub fn token_index_keys(tokens: &[Vec<u8>]) -> Vec<String> {
+    tokens
+        .iter()
+        .map(|t| format!("token:0x{}", hex::encode(t)))
+        .collect()
+}
+
+/// Component ids a token backs: USDC backs every book; an asset backs its own `asset/USDC`
+/// book.
+pub fn books_for_token(
+    token: &[u8],
+    usdc: &[u8],
+    store: &StoreGetProto<ProtocolComponent>,
+) -> Vec<String> {
+    if token == usdc {
+        enumerate_books(store)
+    } else {
+        store
+            .get_last(format!("token:0x{}", hex::encode(token)))
+            .map(|c| vec![c.id])
+            .unwrap_or_default()
+    }
+}
+
+/// Reads a big-endian `u64` from a left-padded attribute value.
+pub fn u64_from_word_padded(value: &[u8]) -> Option<u64> {
+    if value.len() > 8 {
+        let start = value.len() - 8;
+        value[start..]
+            .try_into()
+            .ok()
+            .map(u64::from_be_bytes)
+    } else {
+        let mut buf = [0u8; 8];
+        buf[8 - value.len()..].copy_from_slice(value);
+        Some(u64::from_be_bytes(buf))
+    }
+}
+
+/// Decodes the `(bookId, ts)` pairs committed by a registry update call.
+///
+/// Returns one pair for `updateState`, one per struct for `batchUpdateStateWithSignature`,
+/// and an empty vec for any other call or malformed calldata.
+pub fn committed_updates(input: &[u8]) -> Vec<(u64, u32)> {
+    let Some(selector) = input.get(0..4) else { return Vec::new() };
+    let data = &input[4..];
+    let Ok(selector): std::result::Result<[u8; 4], _> = selector.try_into() else {
+        return Vec::new();
+    };
+    if selector == SEL_UPDATE_STATE {
+        decode_update_state(data)
+            .into_iter()
+            .collect()
+    } else if selector == SEL_BATCH_UPDATE {
+        decode_batch_update(data)
+    } else {
+        Vec::new()
+    }
+}
+
+/// `updateState(address caller, uint256 bookId, uint32 ts, uint256[] lanes)`.
+fn decode_update_state(data: &[u8]) -> Option<(u64, u32)> {
+    let types = [
+        ParamType::Address,
+        ParamType::Uint(256),
+        ParamType::Uint(32),
+        ParamType::Array(Box::new(ParamType::Uint(256))),
+    ];
+    let tokens = ethabi::decode(&types, data).ok()?;
+    let book_id = tokens.get(1)?.clone().into_uint()?;
+    let ts = tokens.get(2)?.clone().into_uint()?;
+    Some((book_id.low_u64(), ts.low_u32()))
+}
+
+/// `batchUpdateStateWithSignature((address,address,uint256 bookId,uint32 ts,uint256[],bytes)[])`.
+fn decode_batch_update(data: &[u8]) -> Vec<(u64, u32)> {
+    let entry = ParamType::Tuple(vec![
+        ParamType::Address,
+        ParamType::Address,
+        ParamType::Uint(256),
+        ParamType::Uint(32),
+        ParamType::Array(Box::new(ParamType::Uint(256))),
+        ParamType::Bytes,
+    ]);
+    let Ok(tokens) = ethabi::decode(&[ParamType::Array(Box::new(entry))], data) else {
+        return Vec::new();
+    };
+    let Some(Token::Array(items)) = tokens.into_iter().next() else { return Vec::new() };
+    let mut updates = Vec::new();
+    for item in items {
+        let Token::Tuple(fields) = item else { continue };
+        let book_id = fields
+            .get(2)
+            .and_then(|t| t.clone().into_uint());
+        let ts = fields
+            .get(3)
+            .and_then(|t| t.clone().into_uint());
+        if let (Some(book_id), Some(ts)) = (book_id, ts) {
+            updates.push((book_id.low_u64(), ts.low_u32()));
+        }
+    }
+    updates
+}
+
+#[cfg(test)]
+mod tests {
+    use ethabi::{encode, ethereum_types::U256};
+
+    use super::*;
+
+    const SETTLEMENT: [u8; 20] = hex!("db13ad0fcd134e9c48f2fdaea8f6751a0f5349ca");
+
+    #[test]
+    fn asset_config_slot_matches_onchain_values() {
+        // keccak256(abi.encode(uint256(assetId), uint256(3))), verified via `cast index`.
+        assert_eq!(
+            hex::encode(asset_config_slot(0, 3)),
+            "3617319a054d772f909f7c479a2cebe5066e836a939412e32403c99029b92eff"
+        );
+        assert_eq!(
+            hex::encode(asset_config_slot(1, 3)),
+            "a15bc60c955c405d20d9149c709e2460f1c2d9a497496a7f46004d1772c3054c"
+        );
+    }
+
+    #[test]
+    fn component_id_is_settlement_scoped() {
+        assert_eq!(component_id(&SETTLEMENT, 0), "0xdb13ad0fcd134e9c48f2fdaea8f6751a0f5349ca-0");
+        assert_eq!(component_id(&SETTLEMENT, 1), "0xdb13ad0fcd134e9c48f2fdaea8f6751a0f5349ca-1");
+    }
+
+    #[test]
+    fn decodes_real_update_state_calldata() {
+        // Real on-chain `updateState` calldata (registry 0xDa7A…): bookId=0, ts=0x6a23368f.
+        let input = hex::decode(concat!(
+            "a9114b0f",
+            "000000000000000000000000bc60639345dfa607d73b74e88c2d54d8b8ad7cc3",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "000000000000000000000000000000000000000000000000000000006a23368f",
+            "0000000000000000000000000000000000000000000000000000000000000080",
+            "0000000000000000000000000000000000000000000000000000000000000002",
+            "0000000000008138888000000000000000000000000000000000000000000000",
+            "013fff016dac01b330000000000000013e190000000000000000000000000000",
+        ))
+        .unwrap();
+        let updates = committed_updates(&input);
+        assert_eq!(updates, vec![(0u64, 0x6a23_368f_u32)]);
+
+        // Lock the critical invariant: the registry `bookId`, the module `assetId`, and the
+        // component index are the same space. Book 0 is the WETH book (asset-config slot
+        // keccak(0,3)); its component id must be the assetId-0 component.
+        let (book_id, _) = updates[0];
+        assert_eq!(
+            component_id(&SETTLEMENT, book_id),
+            "0xdb13ad0fcd134e9c48f2fdaea8f6751a0f5349ca-0"
+        );
+        assert_eq!(
+            hex::encode(asset_config_slot(book_id, 3)),
+            "3617319a054d772f909f7c479a2cebe5066e836a939412e32403c99029b92eff"
+        );
+    }
+
+    #[test]
+    fn decodes_synthetic_batch_calldata() {
+        // No `batchUpdateStateWithSignature` call exists on-chain yet; round-trip synthetic
+        // calldata to validate the decoder against the ABI.
+        let entry = Token::Tuple(vec![
+            Token::Address([0x11u8; 20].into()),
+            Token::Address([0x22u8; 20].into()),
+            Token::Uint(U256::from(1u64)),
+            Token::Uint(U256::from(0x6a23_368f_u64)),
+            Token::Array(vec![Token::Uint(U256::from(7u64))]),
+            Token::Bytes(vec![0xaa, 0xbb]),
+        ]);
+        let mut input = SEL_BATCH_UPDATE.to_vec();
+        input.extend(encode(&[Token::Array(vec![entry])]));
+        assert_eq!(committed_updates(&input), vec![(1u64, 0x6a23_368f_u32)]);
+    }
+
+    #[test]
+    fn ignores_unknown_and_short_calldata() {
+        assert!(committed_updates(&hex::decode("deadbeef").unwrap()).is_empty());
+        assert!(committed_updates(&[0x01, 0x02]).is_empty());
+    }
+
+    #[test]
+    fn token_index_keys_cover_every_token_regardless_of_order() {
+        let weth = hex::decode("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap();
+        let usdc = hex::decode("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap();
+        // `map_components` sorts the pair ascending => [usdc, weth]; the asset token must
+        // still be indexed (it is the second element here), independent of ordering.
+        let keys = token_index_keys(&[usdc.clone(), weth.clone()]);
+        assert!(keys.contains(&format!("token:0x{}", hex::encode(&weth))));
+        assert!(keys.contains(&format!("token:0x{}", hex::encode(&usdc))));
+    }
+
+    #[test]
+    fn u64_from_word_padded_handles_short_and_long() {
+        assert_eq!(u64_from_word_padded(&[0x01]), Some(1));
+        assert_eq!(u64_from_word_padded(&1u64.to_be_bytes()), Some(1));
+        let padded = [&[0u8; 24][..], &1u64.to_be_bytes()[..]].concat();
+        assert_eq!(u64_from_word_padded(&padded), Some(1));
+    }
+}

--- a/protocols/substreams/ethereum-bopamm/src/config.rs
+++ b/protocols/substreams/ethereum-bopamm/src/config.rs
@@ -1,0 +1,48 @@
+use serde::Deserialize;
+
+/// Deployment-specific addresses and storage layout for a BopAMM venue.
+///
+/// Supplied through substreams `params` (see `substreams.yaml`) so the module can be
+/// re-pointed at a different deployment — or a redeploy with a different storage layout —
+/// without code changes. Addresses and the maker slot are hex (no `0x` prefix).
+#[derive(Clone, Deserialize)]
+pub struct DeploymentConfig {
+    /// Settlement contract / swap entrypoint; anchors component ids.
+    #[serde(with = "hex::serde")]
+    pub settlement: Vec<u8>,
+    /// Pricing module holding the asset config and the global maker slot.
+    #[serde(with = "hex::serde")]
+    pub module: Vec<u8>,
+    /// PrioUpdateRegistry holding the per-book quote lanes.
+    #[serde(with = "hex::serde")]
+    pub registry: Vec<u8>,
+    /// Quote-side hub token shared across every book.
+    #[serde(with = "hex::serde")]
+    pub usdc: Vec<u8>,
+    /// Base storage slot of the module's `mapping(assetId => assetConfig)`.
+    pub asset_config_base_slot: u64,
+    /// Storage slot of the module's global maker wallet.
+    #[serde(with = "hex::serde")]
+    pub maker_slot: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_params() {
+        let config: DeploymentConfig = serde_qs::from_str(
+            "settlement=db13ad0fcd134e9c48f2fdaea8f6751a0f5349ca\
+             &module=bc60639345dfa607d73b74e88c2d54d8b8ad7cc3\
+             &registry=da7afeed01fe625cf15d187a19f94b45f00b8c5f\
+             &usdc=a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\
+             &asset_config_base_slot=3\
+             &maker_slot=1471eb6eb2c5e789fc3de43f8ce62938c7d1836ec861730447e2ada8fd81017b",
+        )
+        .unwrap();
+        assert_eq!(config.settlement.len(), 20);
+        assert_eq!(config.maker_slot.len(), 32);
+        assert_eq!(config.asset_config_base_slot, 3);
+    }
+}

--- a/protocols/substreams/ethereum-bopamm/src/lib.rs
+++ b/protocols/substreams/ethereum-bopamm/src/lib.rs
@@ -1,0 +1,3 @@
+mod common;
+mod config;
+mod modules;

--- a/protocols/substreams/ethereum-bopamm/src/modules/map_components.rs
+++ b/protocols/substreams/ethereum-bopamm/src/modules/map_components.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use substreams_ethereum::pb::eth;
+use tycho_substreams::prelude::*;
+
+use crate::{
+    common::{asset_config_slot, component_id, is_zero, MAX_ASSET_ID},
+    config::DeploymentConfig,
+};
+
+/// Discovers books from zero→non-zero writes to the module's asset-config slots.
+///
+/// BopAMM emits no creation event, so a new market is observed as the first write that
+/// sets `assetConfig[assetId]` (packed `param | decimals | token`, token in the low 20
+/// bytes). Emits one `Creation` component per newly configured book.
+#[substreams::handlers::map]
+pub fn map_components(
+    params: String,
+    block: eth::v2::Block,
+) -> Result<BlockTransactionProtocolComponents> {
+    let config: DeploymentConfig = serde_qs::from_str(&params)?;
+    let slot_to_asset: HashMap<Vec<u8>, u64> = (0..MAX_ASSET_ID)
+        .map(|i| (asset_config_slot(i, config.asset_config_base_slot), i))
+        .collect();
+
+    let mut tx_components = Vec::new();
+    for tx in block.transactions() {
+        let mut components = Vec::new();
+        for call in tx
+            .calls
+            .iter()
+            .filter(|c| !c.state_reverted)
+        {
+            for change in &call.storage_changes {
+                if change.address != config.module {
+                    continue;
+                }
+                let Some(&asset_id) = slot_to_asset.get(&change.key) else { continue };
+                // Only a fresh listing (zero -> non-zero) creates a book. Delisting
+                // (non-zero -> zero) is intentionally not tracked: components are immutable
+                // and the venue has never delisted an asset; revisit if that changes.
+                if !is_zero(&change.old_value) || is_zero(&change.new_value) {
+                    continue;
+                }
+                let Some(token) = change.new_value.get(12..32) else { continue };
+                let asset_id_bytes = asset_id.to_be_bytes();
+                let mut tokens = vec![token.to_vec(), config.usdc.clone()];
+                tokens.sort_unstable();
+                components.push(
+                    ProtocolComponent::new(&component_id(&config.settlement, asset_id))
+                        .with_tokens(&tokens)
+                        .with_contracts(&[
+                            config.settlement.clone(),
+                            config.module.clone(),
+                            config.registry.clone(),
+                        ])
+                        .with_attributes(&[
+                            ("asset_id", &asset_id_bytes[..]),
+                            ("manual_updates", &[1u8][..]),
+                        ])
+                        .as_swap_type("bopamm_book", ImplementationType::Vm),
+                );
+            }
+        }
+        if !components.is_empty() {
+            tx_components.push(TransactionProtocolComponents { tx: Some(tx.into()), components });
+        }
+    }
+    Ok(BlockTransactionProtocolComponents { tx_components })
+}

--- a/protocols/substreams/ethereum-bopamm/src/modules/map_protocol_changes.rs
+++ b/protocols/substreams/ethereum-bopamm/src/modules/map_protocol_changes.rs
@@ -1,0 +1,278 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use itertools::Itertools;
+use substreams::{
+    pb::substreams::StoreDeltas,
+    store::{StoreGet, StoreGetProto, StoreGetString},
+};
+use substreams_ethereum::pb::eth;
+use tycho_substreams::{
+    balances::aggregate_balances_changes, contract::extract_contract_changes_builder, prelude::*,
+};
+
+use crate::{
+    common::{
+        committed_updates, component_id, enumerate_books, is_zero, PAUSED_TOPIC, UNPAUSED_TOPIC,
+    },
+    config::DeploymentConfig,
+};
+
+/// Aggregates components, contract storage, balances, pause state and per-book quote
+/// freshness into the final `BlockChanges`.
+#[substreams::handlers::map]
+pub fn map_protocol_changes(
+    params: String,
+    block: eth::v2::Block,
+    grouped_components: BlockTransactionProtocolComponents,
+    deltas: BlockBalanceDeltas,
+    components_store: StoreGetProto<ProtocolComponent>,
+    maker_store: StoreGetString,
+    balance_store: StoreDeltas,
+) -> Result<BlockChanges> {
+    let config: DeploymentConfig = serde_qs::from_str(&params)?;
+    let mut transaction_changes: HashMap<u64, TransactionChangesBuilder> = HashMap::new();
+
+    let maker = maker_store
+        .get_last("maker")
+        .and_then(|m| hex::decode(m).ok());
+
+    add_new_components(&grouped_components, maker.as_deref(), &mut transaction_changes);
+
+    aggregate_balances_changes(balance_store, deltas)
+        .into_iter()
+        .for_each(|(_, (tx, balances))| {
+            let builder = transaction_changes
+                .entry(tx.index)
+                .or_insert_with(|| TransactionChangesBuilder::new(&tx));
+            balances
+                .values()
+                .for_each(|token_bc_map| {
+                    token_bc_map.values().for_each(|bc| {
+                        builder.add_balance_change(bc);
+                    })
+                });
+        });
+
+    // Full storage + code of the three venue contracts (no DCI — fixed known set).
+    extract_contract_changes_builder(
+        &block,
+        |addr| {
+            addr == config.settlement.as_slice() ||
+                addr == config.module.as_slice() ||
+                addr == config.registry.as_slice()
+        },
+        &mut transaction_changes,
+    );
+
+    extract_committed_quotes(&block, &config, &mut transaction_changes);
+    extract_maker_changes(&block, &config, &components_store, &mut transaction_changes);
+    extract_pause_state(&block, &config, &components_store, &mut transaction_changes);
+    mark_books_updated_on_module_changes(&config, &components_store, &mut transaction_changes);
+
+    Ok(BlockChanges {
+        block: Some((&block).into()),
+        changes: transaction_changes
+            .drain()
+            .sorted_unstable_by_key(|(index, _)| *index)
+            .filter_map(|(_, builder)| builder.build())
+            .collect::<Vec<_>>(),
+        storage_changes: vec![],
+    })
+}
+
+/// Adds newly created book components and their default dynamic attributes.
+fn add_new_components(
+    grouped_components: &BlockTransactionProtocolComponents,
+    maker: Option<&[u8]>,
+    transaction_changes: &mut HashMap<u64, TransactionChangesBuilder>,
+) {
+    for tx_component in &grouped_components.tx_components {
+        let tx = tx_component.tx.as_ref().unwrap();
+        let builder = transaction_changes
+            .entry(tx.index)
+            .or_insert_with(|| TransactionChangesBuilder::new(tx));
+        for component in &tx_component.components {
+            builder.add_protocol_component(component);
+            let mut attributes = vec![Attribute {
+                name: "update_marker".to_string(),
+                value: vec![1u8],
+                change: ChangeType::Creation.into(),
+            }];
+            if let Some(maker) = maker {
+                attributes.push(Attribute {
+                    name: "balance_owner".to_string(),
+                    value: maker.to_vec(),
+                    change: ChangeType::Creation.into(),
+                });
+            }
+            builder.add_entity_change(&EntityChanges {
+                component_id: component.id.clone(),
+                attributes,
+            });
+        }
+    }
+}
+
+/// Records each book's committed quote freshness from registry update calls: `committed_ts`
+/// (the `ts` decoded from the update calldata) and `committed_block` (the current block
+/// number).
+///
+/// The committed timestamp is the quote validity used by the simulation override stream to
+/// pin `block.timestamp`; `committed_block` lets it pin `block.number` too. Marking the book
+/// updated is required because `manual_updates` components only re-simulate when marked.
+fn extract_committed_quotes(
+    block: &eth::v2::Block,
+    config: &DeploymentConfig,
+    transaction_changes: &mut HashMap<u64, TransactionChangesBuilder>,
+) {
+    for tx in block.transactions() {
+        for call in tx
+            .calls
+            .iter()
+            .filter(|c| !c.state_reverted)
+        {
+            if call.address != config.registry {
+                continue;
+            }
+            let updates = committed_updates(&call.input);
+            if updates.is_empty() {
+                continue;
+            }
+            let transaction: Transaction = tx.into();
+            let builder = transaction_changes
+                .entry(transaction.index)
+                .or_insert_with(|| TransactionChangesBuilder::new(&transaction));
+            for (book_id, committed_ts) in updates {
+                let id = component_id(&config.settlement, book_id);
+                builder.add_entity_change(&EntityChanges {
+                    component_id: id.clone(),
+                    attributes: vec![
+                        Attribute {
+                            name: "committed_ts".to_string(),
+                            value: committed_ts.to_be_bytes().to_vec(),
+                            change: ChangeType::Update.into(),
+                        },
+                        Attribute {
+                            name: "committed_block".to_string(),
+                            value: block.number.to_be_bytes().to_vec(),
+                            change: ChangeType::Update.into(),
+                        },
+                    ],
+                });
+                builder.mark_component_as_updated(&id);
+            }
+        }
+    }
+}
+
+/// Emits/refreshes the `balance_owner` (maker) attribute on every book whenever the global
+/// maker slot is written.
+///
+/// Covers the maker being configured *after* the books are created (the live case) and maker
+/// rotation. New books created while the maker is already known get it via
+/// `add_new_components`.
+fn extract_maker_changes(
+    block: &eth::v2::Block,
+    config: &DeploymentConfig,
+    components_store: &StoreGetProto<ProtocolComponent>,
+    transaction_changes: &mut HashMap<u64, TransactionChangesBuilder>,
+) {
+    let books = enumerate_books(components_store);
+    if books.is_empty() {
+        return;
+    }
+    for tx in block.transactions() {
+        for call in tx
+            .calls
+            .iter()
+            .filter(|c| !c.state_reverted)
+        {
+            for change in &call.storage_changes {
+                if change.address != config.module ||
+                    change.key != config.maker_slot ||
+                    is_zero(&change.new_value)
+                {
+                    continue;
+                }
+                let Some(maker) = change.new_value.get(12..32) else { continue };
+                let transaction: Transaction = tx.into();
+                let builder = transaction_changes
+                    .entry(transaction.index)
+                    .or_insert_with(|| TransactionChangesBuilder::new(&transaction));
+                for book in &books {
+                    builder.add_entity_change(&EntityChanges {
+                        component_id: book.clone(),
+                        attributes: vec![Attribute {
+                            name: "balance_owner".to_string(),
+                            value: maker.to_vec(),
+                            change: ChangeType::Update.into(),
+                        }],
+                    });
+                    builder.mark_component_as_updated(book);
+                }
+            }
+        }
+    }
+}
+
+/// Reflects settlement `Paused`/`Unpaused` events onto every book (the venue is paused as a
+/// whole). Paused books should not be routed through until unpaused.
+fn extract_pause_state(
+    block: &eth::v2::Block,
+    config: &DeploymentConfig,
+    components_store: &StoreGetProto<ProtocolComponent>,
+    transaction_changes: &mut HashMap<u64, TransactionChangesBuilder>,
+) {
+    let books = enumerate_books(components_store);
+    if books.is_empty() {
+        return;
+    }
+    for log in block.logs() {
+        if log.address() != config.settlement.as_slice() {
+            continue;
+        }
+        let Some(topic0) = log.log.topics.first() else { continue };
+        let paused = if topic0.as_slice() == PAUSED_TOPIC {
+            true
+        } else if topic0.as_slice() == UNPAUSED_TOPIC {
+            false
+        } else {
+            continue;
+        };
+        let tx: Transaction = log.receipt.transaction.into();
+        let builder = transaction_changes
+            .entry(tx.index)
+            .or_insert_with(|| TransactionChangesBuilder::new(&tx));
+        for book in &books {
+            builder.change_component_pause_state(book, paused);
+        }
+    }
+}
+
+/// A change to the shared module storage (maker/asset config) marks every book as needing
+/// re-simulation. Per-book registry quote refreshes are marked in `extract_committed_quotes`.
+///
+/// This is deliberately over-inclusive: any module storage write (not just config slots)
+/// re-marks all books, which is safe (never misses an update) at the cost of occasional
+/// redundant re-simulation.
+fn mark_books_updated_on_module_changes(
+    config: &DeploymentConfig,
+    components_store: &StoreGetProto<ProtocolComponent>,
+    transaction_changes: &mut HashMap<u64, TransactionChangesBuilder>,
+) {
+    let books = enumerate_books(components_store);
+    if books.is_empty() {
+        return;
+    }
+    for builder in transaction_changes.values_mut() {
+        let touches_module = builder
+            .changed_contracts()
+            .any(|addr| addr == config.module.as_slice());
+        if touches_module {
+            for book in &books {
+                builder.mark_component_as_updated(book);
+            }
+        }
+    }
+}

--- a/protocols/substreams/ethereum-bopamm/src/modules/map_protocol_changes.rs
+++ b/protocols/substreams/ethereum-bopamm/src/modules/map_protocol_changes.rs
@@ -114,12 +114,12 @@ fn add_new_components(
     }
 }
 
-/// Records each book's committed quote freshness from registry update calls: `committed_ts`
-/// (the `ts` decoded from the update calldata) and `committed_block` (the current block
-/// number).
+/// Records each book's committed quote freshness from registry update calls as the
+/// `override_block_timestamp` attribute (the `ts` decoded from the update calldata, 8-byte
+/// big-endian u64).
 ///
-/// The committed timestamp is the quote validity used by the simulation override stream to
-/// pin `block.timestamp`; `committed_block` lets it pin `block.number` too. Marking the book
+/// `tycho-simulation` pins `block.timestamp` to this value when simulating the book, which
+/// is what passes the registry's exact-timestamp `StaleUpdate()` gate. Marking the book
 /// updated is required because `manual_updates` components only re-simulate when marked.
 fn extract_committed_quotes(
     block: &eth::v2::Block,
@@ -147,18 +147,13 @@ fn extract_committed_quotes(
                 let id = component_id(&config.settlement, book_id);
                 builder.add_entity_change(&EntityChanges {
                     component_id: id.clone(),
-                    attributes: vec![
-                        Attribute {
-                            name: "committed_ts".to_string(),
-                            value: committed_ts.to_be_bytes().to_vec(),
-                            change: ChangeType::Update.into(),
-                        },
-                        Attribute {
-                            name: "committed_block".to_string(),
-                            value: block.number.to_be_bytes().to_vec(),
-                            change: ChangeType::Update.into(),
-                        },
-                    ],
+                    attributes: vec![Attribute {
+                        name: "override_block_timestamp".to_string(),
+                        value: u64::from(committed_ts)
+                            .to_be_bytes()
+                            .to_vec(),
+                        change: ChangeType::Update.into(),
+                    }],
                 });
                 builder.mark_component_as_updated(&id);
             }

--- a/protocols/substreams/ethereum-bopamm/src/modules/map_relative_balances.rs
+++ b/protocols/substreams/ethereum-bopamm/src/modules/map_relative_balances.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+use substreams::store::{StoreGet, StoreGetProto, StoreGetString};
+use substreams_ethereum::{pb::eth, Event};
+use tycho_substreams::{abi::erc20::events::Transfer, prelude::*};
+
+use crate::{common::books_for_token, config::DeploymentConfig};
+
+/// Emits the maker's inventory balance deltas as per-book TVL.
+///
+/// Tracks every ERC20 `Transfer` touching the maker for tokens that belong to a known book.
+/// USDC deltas are emitted under every book (the shared quote inventory is duplicated, not
+/// split).
+#[substreams::handlers::map]
+pub fn map_relative_balances(
+    params: String,
+    block: eth::v2::Block,
+    components_store: StoreGetProto<ProtocolComponent>,
+    maker_store: StoreGetString,
+) -> Result<BlockBalanceDeltas> {
+    let config: DeploymentConfig = serde_qs::from_str(&params)?;
+    let Some(maker_hex) = maker_store.get_last("maker") else {
+        return Ok(BlockBalanceDeltas::default());
+    };
+    let maker = hex::decode(maker_hex)?;
+
+    let mut balance_deltas = Vec::new();
+    for log in block.logs() {
+        let Some(Transfer { from, to, value }) = Transfer::match_and_decode(log.log) else {
+            continue;
+        };
+        let to_maker = to == maker;
+        let from_maker = from == maker;
+        if !to_maker && !from_maker {
+            continue;
+        }
+        let token = log.address().to_vec();
+        let books = books_for_token(&token, &config.usdc, &components_store);
+        if books.is_empty() {
+            continue;
+        }
+        for comp_id in books {
+            let delta = if to_maker { value.clone() } else { value.clone().neg() };
+            balance_deltas.push(BalanceDelta {
+                ord: log.ordinal(),
+                tx: Some(log.receipt.transaction.into()),
+                token: token.clone(),
+                delta: delta.to_signed_bytes_be(),
+                component_id: comp_id.into_bytes(),
+            });
+        }
+    }
+    Ok(BlockBalanceDeltas { balance_deltas })
+}

--- a/protocols/substreams/ethereum-bopamm/src/modules/mod.rs
+++ b/protocols/substreams/ethereum-bopamm/src/modules/mod.rs
@@ -1,0 +1,7 @@
+//! One substreams handler per file.
+mod map_components;
+mod map_protocol_changes;
+mod map_relative_balances;
+mod store_balances;
+mod store_components;
+mod store_maker;

--- a/protocols/substreams/ethereum-bopamm/src/modules/store_balances.rs
+++ b/protocols/substreams/ethereum-bopamm/src/modules/store_balances.rs
@@ -1,0 +1,8 @@
+use substreams::store::{StoreAddBigInt, StoreNew};
+use tycho_substreams::prelude::*;
+
+/// Aggregates relative balance deltas into absolute balances expected by the indexer.
+#[substreams::handlers::store]
+pub fn store_balances(deltas: BlockBalanceDeltas, store: StoreAddBigInt) {
+    tycho_substreams::balances::store_balance_changes(deltas, store);
+}

--- a/protocols/substreams/ethereum-bopamm/src/modules/store_components.rs
+++ b/protocols/substreams/ethereum-bopamm/src/modules/store_components.rs
@@ -1,0 +1,26 @@
+use substreams::store::{StoreNew, StoreSetIfNotExists, StoreSetIfNotExistsProto};
+use tycho_substreams::prelude::*;
+
+use crate::common::{token_index_keys, u64_from_word_padded};
+
+/// Indexes discovered books both by `book:{assetId}` and by their asset token, so balance
+/// and update logic can resolve a token or a book id back to its component.
+#[substreams::handlers::store]
+pub fn store_components(
+    map: BlockTransactionProtocolComponents,
+    store: StoreSetIfNotExistsProto<ProtocolComponent>,
+) {
+    for tx_pc in map.tx_components {
+        for pc in tx_pc.components {
+            if let Some(asset_id) = pc
+                .get_attribute_value("asset_id")
+                .and_then(|b| u64_from_word_padded(&b))
+            {
+                store.set_if_not_exists(0, format!("book:{asset_id}"), &pc);
+            }
+            for key in token_index_keys(&pc.tokens) {
+                store.set_if_not_exists(0, key, &pc);
+            }
+        }
+    }
+}

--- a/protocols/substreams/ethereum-bopamm/src/modules/store_maker.rs
+++ b/protocols/substreams/ethereum-bopamm/src/modules/store_maker.rs
@@ -1,0 +1,30 @@
+use substreams::store::{StoreNew, StoreSet, StoreSetString};
+use substreams_ethereum::pb::eth;
+
+use crate::{common::is_zero, config::DeploymentConfig};
+
+/// Tracks the current global maker wallet from writes to the module's maker slot.
+///
+/// Uses `set` (not `set_if_not_exists`) so a maker rotation propagates immediately.
+#[substreams::handlers::store]
+pub fn store_maker(params: String, block: eth::v2::Block, store: StoreSetString) {
+    let config: DeploymentConfig = serde_qs::from_str(&params).expect("invalid params");
+    for tx in block.transactions() {
+        for call in tx
+            .calls
+            .iter()
+            .filter(|c| !c.state_reverted)
+        {
+            for change in &call.storage_changes {
+                if change.address == config.module &&
+                    change.key == config.maker_slot &&
+                    !is_zero(&change.new_value)
+                {
+                    if let Some(maker) = change.new_value.get(12..32) {
+                        store.set(change.ordinal, "maker", &hex::encode(maker));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/protocols/substreams/ethereum-bopamm/substreams.yaml
+++ b/protocols/substreams/ethereum-bopamm/substreams.yaml
@@ -1,0 +1,88 @@
+specVersion: v0.1.0
+package:
+  name: "ethereum_bopamm"
+  version: v0.1.0
+
+protobuf:
+  files:
+    - tycho/evm/v1/vm.proto
+    - tycho/evm/v1/common.proto
+    - tycho/evm/v1/utils.proto
+  importPaths:
+    - ../../../proto
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ../target/wasm32-unknown-unknown/release/ethereum_bopamm.wasm
+
+network: mainnet
+
+# Deployment config (addresses + storage layout) is passed as params so the module can be
+# re-pointed at another BopAMM deployment without code changes. Hex, no `0x` prefix.
+params:
+  map_components: &config "settlement=db13ad0fcd134e9c48f2fdaea8f6751a0f5349ca&module=bc60639345dfa607d73b74e88c2d54d8b8ad7cc3&registry=da7afeed01fe625cf15d187a19f94b45f00b8c5f&usdc=a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48&asset_config_base_slot=3&maker_slot=1471eb6eb2c5e789fc3de43f8ce62938c7d1836ec861730447e2ada8fd81017b"
+  store_maker: *config
+  map_relative_balances: *config
+  map_protocol_changes: *config
+
+modules:
+  - name: map_components
+    kind: map
+    initialBlock: 25099176
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.evm.v1.BlockTransactionProtocolComponents
+
+  - name: store_components
+    kind: store
+    initialBlock: 25099176
+    updatePolicy: set_if_not_exists
+    valueType: proto:tycho.evm.v1.ProtocolComponent
+    inputs:
+      - map: map_components
+
+  - name: store_maker
+    kind: store
+    initialBlock: 25099176
+    updatePolicy: set
+    valueType: string
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+
+  - name: map_relative_balances
+    kind: map
+    initialBlock: 25099176
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+      - store: store_components
+      - store: store_maker
+    output:
+      type: proto:tycho.evm.v1.BlockBalanceDeltas
+
+  - name: store_balances
+    kind: store
+    initialBlock: 25099176
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_relative_balances
+
+  - name: map_protocol_changes
+    kind: map
+    initialBlock: 25099176
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+      - map: map_components
+      - map: map_relative_balances
+      - store: store_components
+      - store: store_maker
+      - store: store_balances
+        mode: deltas
+    output:
+      type: proto:tycho.evm.v1.BlockChanges


### PR DESCRIPTION
Adds an `ethereum-bopamm` Substreams package that indexes Bebop's BopAMM PMM as a Tycho VM protocol.

## What it does
- Discovers books (`asset/USDC`, one component per `assetId`) from the pricing module's asset-config storage writes — the contracts emit no config events.
- Tracks the full storage + code of the settlement, pricing module, and registry contracts (fixed set, no DCI).
- Tracks the market-maker wallet's token balances as per-book TVL (USDC duplicated across books, since inventory is shared).
- Records per-book committed quote `ts`/`block` decoded from `updateState`/`batchUpdateStateWithSignature` calldata, and `Paused`/`Unpaused` state.
- Deployment addresses and storage slots are passed via substreams `params`, so the package can target another deployment without code changes.

Pricing is a pure function of the indexed storage (no external calls, no DCI). One module per file under `src/modules/`; shared helpers in `src/common.rs`; config in `src/config.rs`.

## Verification
- 8 unit tests (real `updateState` calldata decode, `bookId == assetId` cross-lock, `asset_config_slot` keccak vs on-chain, batch decode, token-index regression, params parse). `clippy -D warnings` and nightly `fmt` clean; host + wasm32 build; `substreams pack` succeeds.
- Live `substreams run` against mainnet over the book-creation and an active-trading range: both books created with the expected ids/tokens/attributes/creation_tx, committed_ts/block on quote updates, maker balances, and `balance_owner` all emitted as expected.

See `HANDOVER.md` for the protocol design, interfaces, storage layout, and lifecycle.

## Not included (follow-ups)
- `tycho-simulation` `BopAMMSwapAdapter` (`get_amount_out`) + the quote-override stream that pins `block.timestamp`/`block.number` and injects the maker balance — needed because `MAX_UPDATE_AGE() == 0` (exact-timestamp gate).
- `extractors.yaml` `vm:bopamm` entry (8 fields) — gated on releasing the spkg to S3 via `release.sh ethereum-bopamm`.
- Asset delisting and maker-rotation re-seed are documented limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)