### PR TITLE
fix: bump packages to resolve cargo audit and cargo lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6438,9 +6438,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -6456,9 +6456,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -9117,9 +9117,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -469,6 +469,7 @@ where
     ///
     /// The returned `end_rx` (if any) should be reused for retry attempts since the close
     /// signal may still arrive and we want to remain cancellable across retries.
+    #[allow(clippy::result_large_err)]
     #[instrument(skip(self, block_tx, end_rx), fields(extractor_id = %self.extractor_id))]
     async fn state_sync(
         &mut self,
@@ -1300,6 +1301,7 @@ mod test {
                 .await
         }
 
+        #[allow(clippy::extra_unused_lifetimes)]
         async fn get_snapshots<'a>(
             &self,
             request: &SnapshotParameters<'a>,

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -1212,6 +1212,7 @@ pub trait RPCClient: Send + Sync {
             .map(|pages| pages.into_iter().flatten().collect())
     }
 
+    #[allow(clippy::extra_unused_lifetimes)]
     async fn get_snapshots<'a>(
         &self,
         request: &SnapshotParameters<'a>,
@@ -1815,6 +1816,7 @@ impl RPCClient for HttpRPCClient {
         ))
     }
 
+    #[allow(clippy::extra_unused_lifetimes)]
     async fn get_snapshots<'a>(
         &self,
         request: &SnapshotParameters<'a>,

--- a/crates/tycho-indexer/src/lib.rs
+++ b/crates/tycho-indexer/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod cli;
 pub mod extractor;
+#[allow(clippy::result_large_err)]
 pub mod pb;
 pub mod services;
 pub mod substreams;
 
 #[cfg(test)]
+#[allow(clippy::extra_unused_lifetimes)]
 mod testing;
 
 #[cfg(test)]

--- a/crates/tycho-indexer/src/services/rpc.rs
+++ b/crates/tycho-indexer/src/services/rpc.rs
@@ -1509,6 +1509,7 @@ pub async fn health() -> Result<HttpResponse, RpcError> {
 }
 
 #[cfg(test)]
+#[allow(clippy::extra_unused_lifetimes)]
 mod tests {
     use std::{collections::HashMap, env, str::FromStr};
 

--- a/protocols/testing/Cargo.toml
+++ b/protocols/testing/Cargo.toml
@@ -23,7 +23,7 @@ serde            = { workspace = true }
 hex              = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 postgres         = "0.19.10"
-tokio-postgres   = "0.7"
+tokio-postgres   = "0.7.18"
 serde_yaml       = "0.9.34"
 dotenv           = { workspace = true }
 colored          = "3.0.0"


### PR DESCRIPTION
- Bump `postgres-protocol` via `tokio-postgres` to address the following cargo audit

```
[UNKNOWN] ID: RUSTSEC-2026-0179 | Crate: postgres-protocol | Version: 0.6.11 | Error: Unbounded SCRAM iteration count allows a malicious server to cause CPU-exhaustion denial of service
[UNKNOWN] ID: RUSTSEC-2026-0180 | Crate: postgres-protocol | Version: 0.6.11 | Error: Panic decoding a malformed `hstore` value allows denial of service
[UNKNOWN] ID: RUSTSEC-2026-0178 | Crate: tokio-postgres | Version: 0.7.17 | Error: Panic on a `DataRow` with fewer fields than columns allows denial of service
```

- Address clippy