### PR TITLE
test: fix Docker protocol-testing harness and add full mode

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
       - "4242:4242"
     volumes:
       - ./wait-for-postgres.sh:/usr/wait-for-postgres.sh
-      - ./extractors.yaml:/opt/tycho-indexer/extractors.yaml
+      - ../crates/tycho-indexer/extractors.yaml:/opt/tycho-indexer/extractors.yaml
       - ./substreams/:/opt/tycho-indexer/substreams/
     # Configure logging driver for better log collection
     logging:
@@ -81,7 +81,7 @@ services:
       - "service=tycho-indexer"
       - "version=0.76.0"
     entrypoint: [ "/usr/wait-for-postgres.sh", "db" ]
-    command: [ "/opt/tycho-indexer/tycho-indexer", "--endpoint", "https://mainnet.eth.streamingfast.io:443", "index", "--retention-horizon", "2025-07-23T00:00:00"]
+    command: [ "/opt/tycho-indexer/tycho-indexer", "--endpoint", "https://mainnet.eth.streamingfast.io:443", "index", "--retention-horizon", "2099-07-23T00:00:00"]
 
 volumes:
   postgres_data:

--- a/protocols/testing/README.md
+++ b/protocols/testing/README.md
@@ -7,7 +7,6 @@ docs [here](https://docs.propellerheads.xyz/tycho/for-dexs/protocol-integration/
 
 ```bash
 # Ensure PostgreSQL is running or start it via Docker
-docker buildx build -f protocol-testing/postgres.Dockerfile -t protocol-testing-db:latest --load .
 docker compose up db -d
 
 # Export necessary env vars
@@ -36,18 +35,26 @@ docker compose down
 ## How to Run with Docker
 
 ```bash
-# Build the images, from the project root dir
-docker buildx build -f protocol-testing/postgres.Dockerfile -t protocol-testing-db:latest --load .
-docker buildx build -f protocol-testing/run.Dockerfile -t protocol-testing-test-runner:latest --load .
-
 # Export necessary env vars
 export RPC_URL=..
 export SUBSTREAMS_API_TOKEN=..
 export PROTOCOLS="ethereum-balancer-v2=weighted_legacy_creation ethereum-ekubo-v2"
 
-# Start and show the test logs only
-docker compose up -d && docker compose logs test-runner --follow
+# Build both images (test-runner + db) and run the tests. --abort-on-container-exit stops the
+# stack when the one-shot test-runner finishes.
+docker compose up --build --abort-on-container-exit
 
 # Clean up
 docker compose down
+```
+
+By default this runs `range` tests. To run the `full` test (continuous sync from the initial block
+to the chain tip) set `MODE=full`. In full mode the optional `=` suffix is the start block
+(`--initial-block`). Full mode never exits, so omit `--abort-on-container-exit` and tear down
+manually:
+
+```bash
+export MODE=full
+export PROTOCOLS="ethereum-balancer-v2=12345678"
+docker compose up --build
 ```

--- a/protocols/testing/docker-compose.yaml
+++ b/protocols/testing/docker-compose.yaml
@@ -22,12 +22,21 @@ services:
       - postgres_data:/var/lib/postgresql/data
 
   test-runner:
+    build:
+      # Build context is the repo root: run.Dockerfile does `COPY . .` and needs the whole
+      # workspace (crates/, proto/, protocols/). BuildKit honors run.Dockerfile.dockerignore.
+      context: ../../
+      dockerfile: protocols/testing/run.Dockerfile
+      args:
+        PROTOCOLS: "${PROTOCOLS}"
     image: protocol-testing-test-runner:latest
     depends_on:
       db:
         condition: service_healthy
     environment:
       RUST_LOG: "${RUST_LOG:-protocol_testing=info}"
+      # Test mode: "range" (default) or "full" (continuous sync to chain tip, runs indefinitely).
+      MODE: "${MODE:-range}"
       DATABASE_URL: postgres://postgres:mypassword@db:5432/tycho_indexer_0
       RPC_URL: "${RPC_URL}"
       BASE_RPC_URL: "${BASE_RPC_URL:-}"

--- a/protocols/testing/entrypoint.sh
+++ b/protocols/testing/entrypoint.sh
@@ -55,19 +55,33 @@ get_rpc_url() {
     esac
 }
 
+# Test mode: "range" (block ranges from the yaml, default) or "full" (continuous sync from the
+# initial block to the chain tip). Full mode runs indefinitely.
+MODE="${MODE:-range}"
+case "$MODE" in
+	range|full) ;;
+	*) echo "Invalid MODE '$MODE' (expected 'range' or 'full')"; exit 1 ;;
+esac
+
 # Run tests
 for test in "${args[@]}"; do
 	protocol="${test%%=*}"
-	filter="${test#*=}"
+	suffix="${test#*=}"
 	chain=$(infer_chain "$protocol")
 	rpc_url=$(get_rpc_url "$protocol")
 	export RPC_URL="$rpc_url"
-	echo "Running tests for protocol: $protocol (chain: $chain)"
+	echo "Running '$MODE' tests for protocol: $protocol (chain: $chain)"
+	cmd=(tycho-protocol-sdk "$MODE" --package "$protocol" --chain "$chain" \
+		--rpc-url "$rpc_url" --db-url "$DATABASE_URL")
+	# The "=" suffix in PROTOCOLS means different things per mode:
+	#   range → --match-test (run one named test case)
+	#   full  → --initial-block (start syncing from this block)
 	if [[ "$test" == *"="* ]]; then
-		tycho-protocol-sdk range --package "$protocol" --chain "$chain" --rpc-url "$rpc_url" \
-			--db-url "$DATABASE_URL" --match-test "$filter"
-	else
-		tycho-protocol-sdk range --package "$protocol" --chain "$chain" --rpc-url "$rpc_url" \
-			--db-url "$DATABASE_URL"
+		if [ "$MODE" = "full" ]; then
+			cmd+=(--initial-block "$suffix")
+		else
+			cmd+=(--match-test "$suffix")
+		fi
 	fi
+	"${cmd[@]}"
 done

--- a/protocols/testing/run.Dockerfile
+++ b/protocols/testing/run.Dockerfile
@@ -103,7 +103,7 @@ RUN resolve_base() { \
 # =========== Final Runtime Image ===========
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y ca-certificates libssl3 libpq5 && \
+RUN apt-get update && apt-get install -y ca-certificates curl libssl3 libpq5 postgresql-client && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/* /usr/share/doc/* /usr/share/man/* /usr/share/locale/* && \
     find /usr/lib -name "*.a" -delete && \
     find /usr/lib -name "*.la" -delete
@@ -116,10 +116,12 @@ RUN chmod +x /entrypoint.sh
 
 # Create minimal directory structure matching expected layout:
 # The test runner looks for <root>/substreams/ and <root>/adapter-integration/evm/
-RUN mkdir -p /app/proto /app/adapter-integration/evm
+RUN mkdir -p /app/adapter-integration/evm
 
-# Copy proto files (needed for substreams pack)
-COPY --from=protocol-sdk-builder /build/tycho-protocol-sdk/proto /app/proto
+# Copy proto files (needed for `substreams pack`). Packages live at /app/substreams/<pkg> and their
+# substreams.yaml uses `importPaths: ../../../proto`, which from there resolves to /proto (the repo
+# layout is protocols/substreams/<pkg>, one level deeper). So the tycho protos must sit at /proto.
+COPY --from=protocol-sdk-builder /build/tycho-protocol-sdk/proto /proto
 
 # Copy EVM directory
 COPY --from=protocol-sdk-builder /build/tycho-protocol-sdk/protocols/adapter-integration/evm/out /app/adapter-integration/evm/out

--- a/protocols/testing/run.Dockerfile.dockerignore
+++ b/protocols/testing/run.Dockerfile.dockerignore
@@ -9,6 +9,11 @@ target/
 # Git history (not needed — forge deps are installed in-Dockerfile)
 .git/
 
+# Foundry submodule deps — installed in-Dockerfile via `forge install`. If the host has
+# initialized these submodules, copying them in makes that `forge install` fail
+# ("destination path already exists and is not an empty directory").
+protocols/adapter-integration/evm/lib/
+
 # IDE and local dev files
 .claude/
 .idea/

--- a/protocols/testing/scripts/import_token_prices.sh
+++ b/protocols/testing/scripts/import_token_prices.sh
@@ -54,7 +54,7 @@ CSV_URL="${S3_URL}/token-prices/${CHAIN}/latest/token-prices.csv"
 echo "Downloading latest token prices for $CHAIN..."
 echo "From: $CSV_URL"
 
-if ! curl -sf "$CSV_URL" -o "$CSV_FILE"; then
+if ! curl -sf --retry 5 --retry-delay 2 --retry-all-errors "$CSV_URL" -o "$CSV_FILE"; then
     echo "Error: Failed to download CSV from $CSV_URL"
     exit 1
 fi

--- a/protocols/testing/src/tycho_runner.rs
+++ b/protocols/testing/src/tycho_runner.rs
@@ -212,7 +212,7 @@ impl TychoRunner {
             "--chains",
             &self.chain.to_string(),
             "--retention-horizon",
-            "2026-01-01T00:00:00",
+            "2099-01-01T00:00:00",
         ]);
 
         cmd.stdout(Stdio::piped())


### PR DESCRIPTION
## Summary

Fixes to the `protocols/testing` harness so it builds and runs under Docker Compose, and adds a `full` (continuous-sync) test mode.

- Build the `test-runner` image via Compose (`context` = repo root, `run.Dockerfile`) instead of a manual `docker buildx` step; `PROTOCOLS` is passed as a build arg.
- Add `MODE=full` to run a continuous sync from the initial block to the chain tip. In `full` mode the `=` suffix in `PROTOCOLS` is the start block (`--initial-block`); in `range` mode it remains `--match-test`. `MODE` defaults to `range`.
- Install `curl` and `postgresql-client` in the runtime image — `TestRunner::run_tvl_import` shells out to embedded scripts that use both to fetch and load token prices.
- Retry the token-price CSV download (`curl --retry`) so a transient S3 failure does not abort the run.
- Copy the tycho protos to `/proto` so each package's `importPaths: ../../../proto` resolves and `substreams pack` works.
- Exclude `protocols/adapter-integration/evm/lib/` from the build context so a host-initialized submodule does not break the in-image `forge install`.
- Bump `--retention-horizon` to 2099 so synced blocks are not pruned during testing.

## Test plan

- [ ] `range` mode: `cd protocols/testing && PROTOCOLS="ethereum-fermiswap" docker compose up --build --abort-on-container-exit` runs the yaml test cases to completion.
- [ ] `full` mode: `MODE=full PROTOCOLS="ethereum-fermiswap=24936662" docker compose up --build` indexes to tip, imports token prices, and simulates indexed components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)