### PR TITLE
fix: pin postgres test image base by digest and bump clang/llvm to 21

### DIFF
--- a/protocols/testing/postgres.Dockerfile
+++ b/protocols/testing/postgres.Dockerfile
@@ -2,11 +2,13 @@
 # Includes the extensions: pg_partman, pg_cron.
 
 # Stage 1: Build pg_cron extension
-FROM ghcr.io/dbsystel/postgresql-partman:15-5 AS builder
+# Base image pinned by digest (tag 15-5 is mutable and drifted Alpine versions, breaking the clang/llvm pins).
+FROM ghcr.io/dbsystel/postgresql-partman:15-5@sha256:1c5f452535daf6060be8ddd95d42062c9fa212a1cd772648579098821ad486f3 AS builder
 ARG PGCRON_VERSION="1.6.2"
 USER root
 
-RUN apk update && apk add --no-cache build-base clang19 llvm19 wget
+# clang/llvm version must match the postgres base image's PGXS (it invokes clang-21 for JIT bitcode).
+RUN apk update && apk add --no-cache build-base clang21 llvm21 wget
 
 RUN cd /tmp \
     && wget "https://github.com/citusdata/pg_cron/archive/refs/tags/v${PGCRON_VERSION}.tar.gz" \
@@ -17,7 +19,7 @@ RUN cd /tmp \
     && cd .. && rm -r pg_cron-${PGCRON_VERSION} v${PGCRON_VERSION}.tar.gz
 
 # Stage 2: Final image, copy built extension
-FROM ghcr.io/dbsystel/postgresql-partman:15-5
+FROM ghcr.io/dbsystel/postgresql-partman:15-5@sha256:1c5f452535daf6060be8ddd95d42062c9fa212a1cd772648579098821ad486f3
 USER root
 
 COPY --from=builder /usr/local/lib/postgresql/pg_cron.so /usr/local/lib/postgresql/


### PR DESCRIPTION
## Summary
- The mutable base tag `ghcr.io/dbsystel/postgresql-partman:15-5` drifted to a newer Alpine that dropped `clang19`/`llvm19`, breaking the `protocol-testing` DB image build (`protocols/testing/postgres.Dockerfile`).
- Pin the base image by digest on both build stages so the Alpine version no longer drifts.
- Bump the build toolchain to `clang21`/`llvm21`, matching the base image's PGXS, which invokes `clang-21` for pg_cron's JIT bitcode step.

## Test plan
- [x] `docker buildx build -f protocols/testing/postgres.Dockerfile -t protocol-testing-db:latest --load .` completes from a clean cache
- [x] Verified `pg_cron.so` and extension control/SQL files are present in the final image