### PR TITLE
scaffold: Ekubo V3 signed swap executor and encoder

### DIFF
--- a/crates/tycho-execution/contracts/src/executors/EkuboV3Executor.sol
+++ b/crates/tycho-execution/contracts/src/executors/EkuboV3Executor.sol
@@ -43,6 +43,13 @@ address payable constant CORE_ADDRESS =
 ICore constant CORE = ICore(CORE_ADDRESS);
 address constant MEV_CAPTURE_ADDRESS =
     0x5555fF9Ff2757500BF4EE020DcfD0210CFfa41Be;
+// PLACEHOLDER non-zero address — must NOT be address(0). Signed Ekubo V3
+// (SignedExclusiveSwap, forward-only) pools set their pool config extension to
+// this address; the executor detects a signed hop by comparing each hop's
+// poolConfig.extension() against it and routes that hop through the signed path.
+// TODO: replace with the deployed SignedExclusiveSwap extension address.
+address constant SIGNED_EXCLUSIVE_SWAP_ADDRESS =
+    0x5519eD5e5e5E5E5e5E5E5e5e5e5E5e5e5e5E5E5E;
 
 contract EkuboV3Executor is IExecutor, ICallback {
     error EkuboV3Executor__InvalidDataLength();
@@ -51,6 +58,11 @@ contract EkuboV3Executor is IExecutor, ICallback {
 
     uint256 private constant _POOL_DATA_OFFSET = 56;
     uint256 private constant _HOP_BYTE_LEN = 52;
+    // A signed hop appends meta(32) | minBalanceUpdate(32) | sigLen(2) | sig.
+    // These name the fixed-width parts of that tail; the signature length is
+    // read from the 2-byte big-endian `sigLen` field.
+    uint256 private constant _SIGNED_FIXED_TAIL_LEN = 64;
+    uint256 private constant _SIG_LEN_BYTES = 2;
 
     uint256 private constant _SKIP_AHEAD = 0;
 
@@ -74,10 +86,36 @@ contract EkuboV3Executor is IExecutor, ICallback {
             bool outputToRouter
         )
     {
-        uint256 hopsLength =
-            (data.length - _POOL_DATA_OFFSET + 36) / _HOP_BYTE_LEN;
-        uint256 lastHopOffset = 20 + (hopsLength - 1) * _HOP_BYTE_LEN;
         tokenIn = address(bytes20(data[0:20]));
+
+        // Length-aware walk to find the last hop's tokenOut (the group output).
+        // Here `data` is tokenIn(20) followed by the hops, so the first hop
+        // starts at offset 20. A signed hop carries a self-describing tail, so
+        // its stride is 52 + 64 + 2 + sigLen; normal hops advance by 52.
+        uint256 offset = 20;
+        uint256 lastHopOffset = offset;
+        while (offset < data.length) {
+            if (offset + _HOP_BYTE_LEN > data.length) {
+                revert EkuboV3Executor__InvalidDataLength();
+            }
+            lastHopOffset = offset;
+            PoolConfig poolConfig =
+                PoolConfig.wrap(bytes32(data[offset + 20:offset + 52]));
+            if (poolConfig.extension() == SIGNED_EXCLUSIVE_SWAP_ADDRESS) {
+                uint256 sigLenOffset =
+                    offset + _HOP_BYTE_LEN + _SIGNED_FIXED_TAIL_LEN;
+                if (sigLenOffset + _SIG_LEN_BYTES > data.length) {
+                    revert EkuboV3Executor__InvalidDataLength();
+                }
+                uint256 sigLen = uint256(
+                    uint16(bytes2(data[sigLenOffset:sigLenOffset + 2]))
+                );
+                offset += _HOP_BYTE_LEN + _SIGNED_FIXED_TAIL_LEN
+                    + _SIG_LEN_BYTES + sigLen;
+            } else {
+                offset += _HOP_BYTE_LEN;
+            }
+        }
         tokenOut = address(bytes20(data[lastHopOffset:lastHopOffset + 20]));
         // Ekubo uses flash accounting: no pre-swap transfer needed.
         // Tokens are paid during the callback in the Dispatcher
@@ -180,17 +218,33 @@ contract EkuboV3Executor is IExecutor, ICallback {
 
         address nextTokenIn = tokenIn;
 
-        uint256 hopsLength =
-            (swapData.length - _POOL_DATA_OFFSET) / _HOP_BYTE_LEN;
-
+        // Length-aware walk over the hops. Normal hops advance by a fixed 52
+        // bytes (tokenOut + poolConfig); a signed hop carries a self-describing
+        // tail, so its stride is read from the embedded `sigLen`. For all-normal
+        // groups this is equivalent to the previous divide-by-52 iteration.
         uint256 offset = _POOL_DATA_OFFSET;
 
-        for (uint256 i = 0; i < hopsLength; i++) {
+        while (offset < swapData.length) {
+            // Each hop begins with tokenOut(20) | poolConfig(32) = 52 bytes.
+            if (offset + _HOP_BYTE_LEN > swapData.length) {
+                revert EkuboV3Executor__InvalidDataLength();
+            }
+
             nextTokenOut =
                 address(bytes20(LibBytes.loadCalldata(swapData, offset)));
             if (nextTokenOut == ETH_ADDRESS) nextTokenOut = address(0);
             PoolConfig poolConfig =
                 PoolConfig.wrap(LibBytes.loadCalldata(swapData, offset + 20));
+
+            if (poolConfig.extension() == SIGNED_EXCLUSIVE_SWAP_ADDRESS) {
+                // TODO: read meta(32), minBalanceUpdate(32), sigLen(2),
+                // signature(sigLen) from swapData;
+                // CORE.forward(extension, abi.encode(pk, swapParameters,
+                // bytes32 meta, bytes32 minBalanceUpdate, signature)); then chain
+                // nextAmountIn from the returned balanceUpdate and advance offset
+                // by 52 + 64 + 2 + sigLen.
+                revert("TODO: signed Ekubo swap not implemented");
+            }
 
             (
                 address token0,

--- a/crates/tycho-execution/src/encoding/evm/swap_encoder/ekubo_v3.rs
+++ b/crates/tycho-execution/src/encoding/evm/swap_encoder/ekubo_v3.rs
@@ -63,6 +63,26 @@ impl SwapEncoder for EkuboV3SwapEncoder {
         encoded.extend(token_out);
         encoded.extend((extension, fee, pool_type_config).abi_encode_packed());
 
+        // A signed (SignedExclusiveSwap, forward-only) hop carries a self-describing tail so the
+        // executor's length-aware walk can skip past it to any following hop. When `user_data` is
+        // absent the hop is byte-identical to a normal hop, preserving existing behavior.
+        if swap.user_data().is_some() {
+            // TODO: split user_data into meta(32) | minBalanceUpdate(32) | signature(N),
+            // then append meta | minBalanceUpdate | (signature length as u16 be) | signature.
+            // The `#[allow]` covers the warnings inherent to a diverging `todo!()` scaffold: the
+            // binding is "unused" and the `extend` call is "unreachable" only until this is
+            // implemented. Remove the attribute together with the `todo!()`.
+            #[allow(
+                unreachable_code,
+                unused_variables,
+                reason = "scaffold: todo!() diverges until the signed tail is implemented"
+            )]
+            {
+                let signed_tail: Vec<u8> = todo!("encode signed-swap tail from swap.user_data()");
+                encoded.extend(signed_tail);
+            }
+        }
+
         Ok(encoded)
     }
 
@@ -129,6 +149,73 @@ mod tests {
                 "a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
                 // pool config 1st swap
                 "517e506700271aea091b02f42756f5e174af5230000000000000000000000000",
+            ),
+        );
+    }
+
+    #[test]
+    #[ignore = "scaffold: signed-swap tail encoding is not yet implemented (todo!())"]
+    fn test_encode_signed_swap() {
+        let token_in = Bytes::from(Address::ZERO.as_slice());
+        let token_out = Bytes::from("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"); // USDC
+
+        let static_attributes = HashMap::from([
+            // SignedExclusiveSwap extension placeholder used by signed pools.
+            ("extension".to_string(), Bytes::from("0x5519ed5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e")),
+            ("fee".to_string(), Bytes::from(0_u64)),
+            ("pool_type_config".to_string(), Bytes::from(0_u32)),
+        ]);
+
+        let component = ProtocolComponent { static_attributes, ..Default::default() };
+
+        // `user_data` is the packed concatenation meta(32) | minBalanceUpdate(32) | signature(N).
+        // The encoder splits it and inserts the 2-byte big-endian signature length.
+        let meta = "1111111111111111111111111111111111111111111111111111111111111111";
+        let min_balance_update =
+            "2222222222222222222222222222222222222222222222222222222222222222";
+        let signature = "abcdef0123456789"; // 8-byte signature
+        let user_data =
+            Bytes::from_str(&format!("0x{meta}{min_balance_update}{signature}")).unwrap();
+
+        let swap = Swap::new(
+            component,
+            default_token(token_in.clone()),
+            default_token(token_out.clone()),
+            BigUint::ZERO,
+        )
+        .with_user_data(user_data);
+
+        let encoding_context = EncodingContext {
+            group_token_in: token_in.clone(),
+            group_token_out: token_out.clone(),
+            router_address: Some(Bytes::default()),
+        };
+
+        let encoder = EkuboV3SwapEncoder::new(Bytes::default(), Chain::Ethereum, None).unwrap();
+
+        let encoded_swap = encoder
+            .encode_swap(&swap, &encoding_context)
+            .unwrap();
+
+        let hex_swap = encode(&encoded_swap);
+
+        assert_eq!(
+            hex_swap,
+            concat!(
+                // group token in (ETH_ADDRESS)
+                "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                // token out
+                "a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                // pool config (extension = SIGNED_EXCLUSIVE_SWAP placeholder)
+                "5519ed5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e000000000000000000000000",
+                // meta(32)
+                "1111111111111111111111111111111111111111111111111111111111111111",
+                // minBalanceUpdate(32)
+                "2222222222222222222222222222222222222222222222222222222222222222",
+                // sigLen(2, u16 be) = 8
+                "0008",
+                // signature(8)
+                "abcdef0123456789",
             ),
         );
     }


### PR DESCRIPTION
Scaffolds support for executing Ekubo V3 SignedExclusiveSwap (forward-only) pools under the existing `ekubo_v3` protocol.

## What this adds

- `EkuboV3SwapEncoder` appends a self-describing signed-hop tail (`meta(32) | minBalanceUpdate(32) | sigLen(2) | signature`) when `Swap.user_data` is set. When `user_data` is absent the hop is byte-identical to a normal hop.
- `EkuboV3Executor` walks hops length-aware and detects a signed hop by its `poolConfig.extension()`, routing that hop through `CORE.forward` instead of `CORE.swap`. The existing fixed-width path and `group_swaps.rs` are unchanged, so signed hops group with normal Ekubo hops.

## Status

Scaffold only. The encoder tail and the executor `CORE.forward` call are stubbed (`todo!()` in Rust, `revert` in Solidity). `SIGNED_EXCLUSIVE_SWAP_ADDRESS` is a placeholder pending deployment of the extension (EkuboProtocol/evm-contracts#319).

`cargo check --workspace --all-features` and `forge build` pass; the stub paths are not yet exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
