### PR TITLE
feat: Cap integration-test swap inputs using token prices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10078,6 +10078,7 @@ dependencies = [
  "hex",
  "miette",
  "num-bigint",
+ "num-traits",
  "regex",
  "reqwest 0.13.2",
  "serde",

--- a/crates/tycho-integration-test/README.md
+++ b/crates/tycho-integration-test/README.md
@@ -53,6 +53,7 @@ This test runs continuously in the cluster but it can also be run locally for de
 # Set required environment variables
 export RUST_LOG=tycho_integration_test=info,tycho_test=debug,error
 export TYCHO_URL=tycho-dev.propellerheads.xyz
+export TYCHO_API_KEY=<your-tycho-key>
 export RPC_URL=https://your-rpc-endpoint
 
 # Run with default settings

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -27,7 +27,7 @@ use tokio::{signal, sync::Semaphore};
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::EnvFilter;
 use tycho_client::feed::SynchronizerState;
-use tycho_common::simulation::protocol_sim::ProtocolSim;
+use tycho_common::{simulation::protocol_sim::ProtocolSim, Bytes};
 use tycho_simulation::{
     evm::protocol::cowamm::constants::PROTOCOL_SYSTEM as COWAMM_PROTOCOL_SYSTEM,
     protocol::models::ProtocolComponent,
@@ -44,6 +44,7 @@ use tycho_test::{
         models::{TychoExecutionInput, TychoExecutionResult},
         simulate_swap_transaction, tenderly,
     },
+    token_prices::{cap_amount_to_eth_value, load_token_prices},
     validation::{batch_validate_components, get_validator, Validator},
 };
 
@@ -193,6 +194,19 @@ struct TychoState {
     component_ids_by_protocol: HashMap<String, HashSet<String>>,
 }
 
+/// Shared, periodically-refreshed token-price snapshot (raw token units per ETH).
+type SharedTokenPrices = Arc<RwLock<Arc<HashMap<Bytes, f64>>>>;
+
+/// How often to reload the token-price snapshot. The S3 dump is refreshed weekly; reloading every
+/// few hours picks up a new dump without restarting this long-running binary.
+const TOKEN_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+
+/// Swap input value used for simulation, denominated in ETH. Tick-based protocols (Uniswap V3/V4)
+/// report near-infinite `get_limits`, so swapping the raw limit produces unrealistic input amounts
+/// and gas estimates. Capping the input to a realistic value (~10k USD at recent ETH prices) keeps
+/// simulation and the dashboard gas estimates representative.
+const MAX_INPUT_VALUE_ETH: f64 = 5.0;
+
 #[tokio::main]
 async fn main() -> miette::Result<()> {
     miette::set_hook(Box::new(|_| Box::new(NarratableReportHandler::new())))?;
@@ -287,6 +301,13 @@ async fn run(cli: Cli) -> miette::Result<()> {
     .await
     .map_err(|e| miette!("Failed to load tokens: {e:?}"))?;
     info!("Loaded {} tokens", all_tokens.len());
+
+    let initial_prices = load_token_prices(chain)
+        .await
+        .wrap_err("Failed to load token prices for input capping")?;
+    info!("Loaded {} token prices", initial_prices.len());
+    let token_prices: SharedTokenPrices = Arc::new(RwLock::new(Arc::new(initial_prices)));
+    tokio::spawn(refresh_token_prices(chain, token_prices.clone(), TOKEN_PRICE_REFRESH_INTERVAL));
 
     // Run streams in background tasks with separate channels so RFQ processing
     // cannot block protocol update consumption
@@ -462,6 +483,7 @@ async fn run(cli: Cli) -> miette::Result<()> {
                         let rpc_tools = rpc_tools.clone();
                         let tycho_state = tycho_state.clone();
                         let statistics = statistics.clone();
+                        let token_prices = token_prices.clone();
                         let permit = protocol_semaphore
                             .clone()
                             .acquire_owned()
@@ -469,7 +491,7 @@ async fn run(cli: Cli) -> miette::Result<()> {
                             .into_diagnostic()
                             .wrap_err("Failed to acquire protocol permit")?;
                         tokio::spawn(async move {
-                            if let Err(e) = process_update(cli, chain, rpc_tools, tycho_state, statistics, &update).await {
+                            if let Err(e) = process_update(cli, chain, rpc_tools, tycho_state, statistics, token_prices, &update).await {
                                 warn!("{}", format_error_chain(&e));
                             }
                             drop(permit);
@@ -498,6 +520,7 @@ async fn run(cli: Cli) -> miette::Result<()> {
                         let rpc_tools = rpc_tools.clone();
                         let tycho_state = tycho_state.clone();
                         let statistics = statistics.clone();
+                        let token_prices = token_prices.clone();
                         let permit = rfq_semaphore
                             .clone()
                             .acquire_owned()
@@ -505,7 +528,7 @@ async fn run(cli: Cli) -> miette::Result<()> {
                             .into_diagnostic()
                             .wrap_err("Failed to acquire RFQ permit")?;
                         tokio::spawn(async move {
-                            if let Err(e) = process_update(cli, chain, rpc_tools, tycho_state, statistics, &update).await {
+                            if let Err(e) = process_update(cli, chain, rpc_tools, tycho_state, statistics, token_prices, &update).await {
                                 warn!("{}", format_error_chain(&e));
                             }
                             drop(permit);
@@ -540,6 +563,34 @@ enum BlockPollResult {
     Stale { target_block_timestamp: Option<u64> },
     /// RPC never reached the target block within the allowed attempts.
     Timeout,
+}
+
+/// Periodically reloads the token-price snapshot so a freshly published weekly dump is picked up
+/// without restarting the test. On a failed reload the previous snapshot is kept.
+async fn refresh_token_prices(chain: Chain, prices: SharedTokenPrices, interval: Duration) {
+    loop {
+        tokio::time::sleep(interval).await;
+        match load_token_prices(chain).await {
+            Ok(new_prices) => {
+                let count = new_prices.len();
+                match prices.write() {
+                    Ok(mut guard) => {
+                        *guard = Arc::new(new_prices);
+                        info!("Refreshed token prices ({count} entries)");
+                    }
+                    Err(e) => {
+                        error!("Failed to acquire write lock to refresh token prices: {e}");
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to refresh token prices, keeping previous snapshot: {}",
+                    format_error_chain(&e)
+                );
+            }
+        }
+    }
 }
 
 /// Polls the RPC until the queried block (`Latest` or `Pending`) matches `target_block`.
@@ -625,12 +676,14 @@ async fn poll_rpc_for_block(
     Ok(BlockPollResult::Timeout)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn process_update(
     cli: Arc<Cli>,
     chain: Chain,
     rpc_tools: tycho_test::RPCTools,
     tycho_state: Arc<RwLock<TychoState>>,
     statistics: Option<Arc<RwLock<TestStatistics>>>,
+    token_prices: SharedTokenPrices,
     update: &StreamUpdate,
 ) -> miette::Result<()> {
     info!(
@@ -639,6 +692,11 @@ async fn process_update(
         update.update.new_pairs.len(),
         update.update.states.len()
     );
+
+    let token_prices = token_prices
+        .read()
+        .map_err(|e| miette!("Failed to acquire read lock on token prices: {e}"))?
+        .clone();
 
     let block = if let UpdateType::Protocol = update.update_type {
         // Update state cache before block alignment check
@@ -847,6 +905,7 @@ async fn process_update(
     for (id, component, state) in components_to_process {
         let block = block.clone();
         let statistics = statistics.clone();
+        let token_prices = token_prices.clone();
         let permit = semaphore
             .clone()
             .acquire_owned()
@@ -856,9 +915,17 @@ async fn process_update(
 
         let task = tokio::spawn(async move {
             let simulation_id = generate_simulation_id(&component.protocol_system, &id);
-            let result =
-                process_state(&simulation_id, chain, component, &block, id, state, statistics)
-                    .await;
+            let result = process_state(
+                &simulation_id,
+                chain,
+                component,
+                &block,
+                id,
+                state,
+                statistics,
+                token_prices,
+            )
+            .await;
             drop(permit);
             result
         });
@@ -1090,6 +1157,7 @@ fn select_components_to_process(
         block_number = %block.header.number,
     )
 )]
+#[allow(clippy::too_many_arguments)]
 async fn process_state(
     simulation_id: &str,
     chain: Chain,
@@ -1098,6 +1166,7 @@ async fn process_state(
     state_id: String,
     state: Box<dyn ProtocolSim>,
     statistics: Option<Arc<RwLock<TestStatistics>>>,
+    token_prices: Arc<HashMap<Bytes, f64>>,
 ) -> HashMap<String, TychoExecutionInput> {
     let tokens_len = component.tokens.len();
     if tokens_len < 2 {
@@ -1200,19 +1269,23 @@ async fn process_state(
             token_in.symbol, token_out.symbol
         );
 
-        // Calculate amount_in as percentage of max_input
-        const PERCENTAGE: f64 = 0.001; // 0.1%
-        const PRECISION: u64 = 1_000; // Supports up to 3 decimal places
-        let numerator = (PERCENTAGE * PRECISION as f64) as u64;
-        let mut amount_in = (&max_input * numerator) / PRECISION;
+        // Cap the limit to a realistic input value (~10k USD) using the weekly token prices.
+        // Tick-based protocols (Uniswap V3/V4) report near-infinite limits; tokens missing
+        // from the price snapshot are left to the 96-bit safety bound below.
+        let mut amount_in = cap_amount_to_eth_value(
+            max_input,
+            &token_in.address,
+            &token_prices,
+            MAX_INPUT_VALUE_ETH,
+        );
         if amount_in.is_zero() {
             debug!("Calculated amount_in is zero, skipping...");
             continue;
         }
         amount_in = amount_in.max(min_amount.clone());
 
-        // Cap amount_in to avoid "amount exceeds 96 bits" error (it happens for uniswap v3 and v4
-        // sometimes because the returned limits can be very high)
+        // Safety bound for tokens missing from the price snapshot, whose limit is left uncapped:
+        // avoids the "amount exceeds 96 bits" error seen on Uniswap V3/V4 with very high limits.
         let max_96_bit = BigUint::from(2u128.pow(96) - 1);
         amount_in = amount_in.min(max_96_bit);
 
@@ -1222,8 +1295,7 @@ async fn process_state(
             .get_amount_out(amount_in.clone(), token_in, token_out)
             .into_diagnostic()
             .wrap_err(format!(
-                "Error calculating amount out at {:.1}% with input of {amount_in} {}.",
-                PERCENTAGE * 100.0,
+                "Error calculating amount out with input of {amount_in} {}.",
                 token_in.symbol,
             )) {
             Ok(res) => {

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -198,8 +198,8 @@ struct TychoState {
 type SharedTokenPrices = Arc<RwLock<Arc<HashMap<Bytes, f64>>>>;
 
 /// How often to reload the token-price snapshot. The S3 dump is refreshed weekly; reloading every
-/// few hours picks up a new dump without restarting this long-running binary.
-const TOKEN_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
+/// day picks up a new dump without restarting this long-running binary.
+const TOKEN_PRICE_REFRESH_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// Swap input value used for simulation, denominated in ETH. Tick-based protocols (Uniswap V3/V4)
 /// report near-infinite `get_limits`, so swapping the raw limit produces unrealistic input amounts

--- a/crates/tycho-test/Cargo.toml
+++ b/crates/tycho-test/Cargo.toml
@@ -16,6 +16,7 @@ colored = "3.0.0"
 hex = { workspace = true }
 miette = { version = "7.6.0" }
 num-bigint = { workspace = true }
+num-traits = { workspace = true }
 regex = "1.12.2"
 reqwest = { version = "0.13.2", features = ["json", "query"] }
 serde = { workspace = true }

--- a/crates/tycho-test/src/lib.rs
+++ b/crates/tycho-test/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod execution;
 pub mod rpc_tools;
+pub mod token_prices;
 pub mod validation;
 pub use rpc_tools::RPCTools;
 

--- a/crates/tycho-test/src/token_prices.rs
+++ b/crates/tycho-test/src/token_prices.rs
@@ -1,0 +1,144 @@
+//! Loads token prices and uses them to bound swap input amounts in tests.
+//!
+//! [`load_token_prices`] downloads the latest price snapshot for a chain;
+//! [`cap_amount_to_eth_value`] uses it to cap an amount to a target ETH value.
+//!
+//! Prices come from a weekly CSV snapshot published to S3. Each price is denominated in raw token
+//! units per 1 ETH (the raw amount of a token worth one ETH), so
+//! `value_in_eth(raw_amount) = raw_amount / price`.
+
+use std::{collections::HashMap, str::FromStr};
+
+use miette::{IntoDiagnostic, WrapErr};
+use num_bigint::BigUint;
+use num_traits::{FromPrimitive, Zero};
+use tracing::warn;
+use tycho_common::{models::Chain, Bytes};
+
+const S3_BASE_URL: &str =
+    "https://s3.eu-central-1.amazonaws.com/repo.propellerheads-propellerheads/token-prices";
+
+/// Downloads the latest token-price snapshot for `chain` and returns a map from token address to
+/// its price in raw token units per 1 ETH.
+pub async fn load_token_prices(chain: Chain) -> miette::Result<HashMap<Bytes, f64>> {
+    let url = format!("{S3_BASE_URL}/{chain}/latest/token-prices.csv");
+    let body = reqwest::get(&url)
+        .await
+        .and_then(reqwest::Response::error_for_status)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("Failed to download token prices from {url}"))?
+        .text()
+        .await
+        .into_diagnostic()?;
+
+    Ok(parse_token_prices(&body))
+}
+
+/// Parses the `address,price` CSV (with a header row) into an address-keyed price map. Rows with an
+/// unparseable address or price are skipped with a warning rather than failing the whole load.
+fn parse_token_prices(csv: &str) -> HashMap<Bytes, f64> {
+    let mut prices = HashMap::new();
+    for line in csv.lines().skip(1) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let mut fields = line.splitn(2, ',');
+        let (Some(address), Some(price)) = (fields.next(), fields.next()) else {
+            warn!("Skipping malformed token price row: {line}");
+            continue;
+        };
+        let Ok(address) = Bytes::from_str(address.trim()) else {
+            warn!("Skipping token price row with invalid address: {address}");
+            continue;
+        };
+        let Ok(price) = price.trim().parse::<f64>() else {
+            warn!("Skipping token price row with invalid price for {address}: {price}");
+            continue;
+        };
+        prices.insert(address, price);
+    }
+    prices
+}
+
+/// Caps `amount` so that its value does not exceed `max_value_eth` ETH, using `prices` (raw token
+/// units per 1 ETH, keyed by token address).
+///
+/// Returns `amount` unchanged when the token has no known price, when the price is not a positive
+/// number, or when `amount` is already below the cap. This keeps callers safe for tokens missing
+/// from the snapshot, leaving them to apply their own fallback bounds.
+pub fn cap_amount_to_eth_value(
+    amount: BigUint,
+    token: &Bytes,
+    prices: &HashMap<Bytes, f64>,
+    max_value_eth: f64,
+) -> BigUint {
+    let Some(price) = prices.get(token) else {
+        return amount;
+    };
+    if *price <= 0.0 || !price.is_finite() {
+        return amount;
+    }
+    // value_in_eth = amount / price, so the raw amount worth `max_value_eth` ETH is
+    // max_value_eth * price.
+    let Some(cap) = BigUint::from_f64(max_value_eth * price) else {
+        return amount;
+    };
+    if cap.is_zero() {
+        return amount;
+    }
+    amount.min(cap)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(hex: &str) -> Bytes {
+        Bytes::from_str(hex).unwrap()
+    }
+
+    #[test]
+    fn test_parses_valid_rows() {
+        let csv = "address,price\n\
+            0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48,1734922791\n\
+            0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2,1e+18\n\
+            not_an_address,123\n\
+            0xdac17f958d2ee523a2206206994597c13d831ec7,not_a_number\n\
+            \n";
+        let prices = parse_token_prices(csv);
+
+        assert_eq!(prices.len(), 2);
+        assert_eq!(
+            prices.get(&addr("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")),
+            Some(&1734922791.0)
+        );
+        assert_eq!(prices.get(&addr("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")), Some(&1e18));
+    }
+
+    #[test]
+    fn test_caps_amount_above_eth_value() {
+        // WETH: 1e18 raw units per ETH. A 100 ETH amount capped to 5 ETH -> 5e18 raw units.
+        let weth = addr("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+        let prices = HashMap::from([(weth.clone(), 1e18)]);
+
+        let capped = cap_amount_to_eth_value(
+            BigUint::from(100u128) * BigUint::from(10u128).pow(18),
+            &weth,
+            &prices,
+            5.0,
+        );
+
+        assert_eq!(capped, BigUint::from(5u128) * BigUint::from(10u128).pow(18));
+    }
+
+    #[test]
+    fn test_leaves_amount_below_cap_untouched() {
+        let weth = addr("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+        let prices = HashMap::from([(weth.clone(), 1e18)]);
+
+        let amount = BigUint::from(10u128).pow(18); // 1 ETH worth
+        let capped = cap_amount_to_eth_value(amount.clone(), &weth, &prices, 5.0);
+
+        assert_eq!(capped, amount);
+    }
+}


### PR DESCRIPTION
Swaps were sized at 0.1% of get_limits, which is near-infinite for tick-based protocols (Uniswap V3/V4), giving unrealistic gas estimates. Cap the input to ~10k USD (in ETH) using the weekly token prices instead.

Add a shared tycho_test::token_prices module to load the S3 price snapshot and cap an amount to a target ETH value. Prices load at startup (fatal on failure) and refresh every 6h so a new weekly dump is picked up without a restart.
