### PR TITLE
fix(tycho-simulation): Apply pool blocklist by default

### DIFF
--- a/crates/tycho-simulation/examples/quickstart/main.rs
+++ b/crates/tycho-simulation/examples/quickstart/main.rs
@@ -59,7 +59,7 @@ use tycho_simulation::{
     protocol::models::{ProtocolComponent, Update},
     tycho_client::feed::component_tracker::ComponentFilter,
     tycho_common::{dto::TvlThresholdTier, models::Chain},
-    utils::{get_default_url, load_all_tokens, load_blocklist},
+    utils::{get_default_url, load_all_tokens},
 };
 
 /// Represents a transaction to be executed.
@@ -84,9 +84,6 @@ struct Cli {
     tvl_threshold: Option<f64>,
     #[arg(long, default_value = "ethereum")]
     chain: Chain,
-    /// Path to blocklist TOML config file
-    #[arg(long)]
-    blocklist_file: Option<std::path::PathBuf>,
 }
 
 impl Cli {
@@ -247,10 +244,6 @@ async fn main() {
         }
         _ => {}
     }
-
-    let blocklist =
-        load_blocklist(cli.blocklist_file.as_deref()).expect("Failed to load blocklist");
-    protocol_stream = protocol_stream.blocklist_components(blocklist);
 
     let protocol_stream = protocol_stream
         .auth_key(Some(tycho_api_key.clone()))

--- a/crates/tycho-simulation/src/evm/stream.rs
+++ b/crates/tycho-simulation/src/evm/stream.rs
@@ -66,7 +66,6 @@
 //! use futures::StreamExt;
 //! use tycho_client::feed::component_tracker::ComponentFilter;
 //! use tycho_simulation::evm::protocol::uniswap_v2::state::UniswapV2State;
-//! use std::collections::HashSet;
 //!
 //! #[tokio::main]
 //! async fn main() {
@@ -89,7 +88,6 @@
 //!             .exchange::<UniswapV2State>(
 //!                 "uniswap_v2", ComponentFilter::with_tvl_range(5.0, 10.0), None
 //!             )
-//!             .blocklist_components(HashSet::new())
 //!             .set_tokens(all_tokens)
 //!             .await
 //!             .build()
@@ -139,6 +137,7 @@ use crate::{
         errors::InvalidSnapshotError,
         models::{DecoderContext, TryFromWithBlock, Update},
     },
+    utils::default_blocklist,
 };
 
 const EXCHANGES_REQUIRING_FILTER: [&str; 2] = ["vm:balancer_v2", "vm:curve"];
@@ -240,11 +239,16 @@ pub struct ProtocolStreamBuilder {
 impl ProtocolStreamBuilder {
     /// Creates a new builder for a multi-protocol stream.
     ///
+    /// The shipped pool blocklist is applied by default, excluding components known to break
+    /// simulation. Use [`blocklist_components`](Self::blocklist_components) to exclude additional
+    /// components.
+    ///
     /// See the [module-level docs](self) for full details on stream behavior and configuration.
     pub fn new(tycho_url: &str, chain: Chain) -> Self {
         Self {
             decoder: TychoStreamDecoder::new(),
-            stream_builder: TychoStreamBuilder::new(tycho_url, chain),
+            stream_builder: TychoStreamBuilder::new(tycho_url, chain)
+                .blocklisted_ids(default_blocklist()),
             stream_end_policy: StreamEndPolicy::default(),
             chain,
             pending_indexers: HashMap::new(),
@@ -443,7 +447,10 @@ impl ProtocolStreamBuilder {
         self
     }
 
-    /// Exclude specific component IDs from all registered exchanges.
+    /// Exclude additional component IDs from all registered exchanges.
+    ///
+    /// These IDs are added to the shipped blocklist that is already applied by default (see
+    /// [`new`](Self::new)).
     pub fn blocklist_components(mut self, ids: HashSet<String>) -> Self {
         if !ids.is_empty() {
             tracing::info!("Blocklisting {} components", ids.len());

--- a/docs/for-solvers/simulation.md
+++ b/docs/for-solvers/simulation.md
@@ -197,6 +197,8 @@ let mut protocol_stream = ProtocolStreamBuilder::new("tycho-beta.propellerheads.
 
 Some protocols, such as Balancer V2 and Curve, require a pool filter to be defined to filter out unsupported pools. If a protocol needs a pool filter and the user does not provide one, a warning will be raised during the stream setup process.
 
+`ProtocolStreamBuilder` applies a curated blocklist of pools that are known to break simulation (for example, rebasing-token and insolvent pools) by default, so the stream excludes them automatically. To exclude additional components, pass their IDs to `blocklist_components(...)`.
+
 The stream created emits `Update` messages which consist of:
 
 * `block number_or_timestamp`- the block this update message refers to


### PR DESCRIPTION
Done:
- ProtocolStreamBuilder now uses the default blocklist in new(); blocklist_components() adds to it. 
- Drop the now-redundant blocklist loading from the quickstart example
- Document the default in the solver simulation docs.
