### PR TITLE
feat(integration-test): Add number of pools per protocol metric

### DIFF
--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -671,6 +671,10 @@ async fn process_update(
                     .get_mut(&removed_component.protocol_system)
                     .map(|id_set| id_set.remove(removed_id));
             }
+
+            for (protocol, component_ids) in &current_state.component_ids_by_protocol {
+                metrics::record_protocol_pool_count(protocol, component_ids.len());
+            }
         }
 
         let update_block_number = update.update.block_number_or_timestamp;

--- a/crates/tycho-integration-test/src/metrics.rs
+++ b/crates/tycho-integration-test/src/metrics.rs
@@ -53,6 +53,10 @@ pub fn initialize_metrics() {
         "Current synchronization state per protocol (1=Started, 2=Ready, 3=Delayed, 4=Stale, \
          5=Advanced, 6=Ended, 7=Skipped — Tycho reported Ready but RPC block was ahead)"
     );
+    describe_gauge!(
+        "tycho_integration_protocol_pool_count",
+        "Current number of pools (components) being streamed per protocol"
+    );
     describe_counter!(
         "tycho_integration_protocol_updates_skipped_total",
         "Total number of protocol updates skipped due to being behind current block"
@@ -185,6 +189,15 @@ pub fn record_protocol_sync_state(protocol: &str, sync_state: &SynchronizerState
         "protocol" => protocol.to_string()
     )
     .set(state_value);
+}
+
+/// Record the current number of pools (components) being streamed for a protocol.
+pub fn record_protocol_pool_count(protocol: &str, count: usize) {
+    gauge!(
+        "tycho_integration_protocol_pool_count",
+        "protocol" => protocol.to_string()
+    )
+    .set(count as f64);
 }
 
 /// Record that an update was skipped because the RPC block was ahead of the update block.


### PR DESCRIPTION
<img width="537" height="270" alt="image" src="https://github.com/user-attachments/assets/9144efc7-8157-47c7-9cdd-75baee896a51" />

Corresponding terraform PR: https://github.com/propeller-heads/terraform-infrastructure/pull/189
Corresponding helm PR for new alert when there are 0 pools per protocol: https://github.com/propeller-heads/helm-configuration/pull/690