### PR TITLE
feat: live pAMM state-override stream integration

### DIFF
--- a/crates/tycho-simulation/Cargo.toml
+++ b/crates/tycho-simulation/Cargo.toml
@@ -113,6 +113,7 @@ evm = [
     "dep:revm-inspectors",
     "dep:alloy",
     "dep:reqwest",
+    "dep:tokio-tungstenite",
 ]
 rfq = [
     "dep:reqwest",

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -1089,7 +1089,6 @@ where
         }
         Ok(())
     }
-
 }
 
 /// Generate a proxy token address for a given token index

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -7,7 +7,7 @@ use std::{
 
 use alloy::primitives::{Address, U256};
 use thiserror::Error;
-use tokio::sync::{RwLock, RwLockReadGuard};
+use tokio::sync::{watch, RwLock, RwLockReadGuard};
 use tracing::{debug, error, info, warn};
 use tycho_client::feed::{synchronizer::ComponentWithState, BlockHeader, FeedMessage, HeaderLike};
 use tycho_common::{
@@ -30,6 +30,7 @@ use {
 use crate::{
     evm::{
         engine_db::{update_engine, SHARED_TYCHO_DB},
+        override_stream::{OverrideSnapshot, StateOverrideProvider},
         protocol::{
             utils::bytes_to_address,
             vm::{constants::ERC20_PROXY_BYTECODE, erc20_token::IMPLEMENTATION_SLOT},
@@ -68,7 +69,13 @@ struct DecoderState {
 type DecodeFut =
     Pin<Box<dyn Future<Output = Result<Box<dyn ProtocolSim>, InvalidSnapshotError>> + Send + Sync>>;
 type AccountBalances = HashMap<Bytes, HashMap<Bytes, Bytes>>;
-type RegistryFn<H> = dyn Fn(ComponentWithState, H, AccountBalances, Arc<RwLock<DecoderState>>) -> DecodeFut
+type RegistryFn<H> = dyn Fn(
+        ComponentWithState,
+        H,
+        AccountBalances,
+        Arc<RwLock<DecoderState>>,
+        Option<watch::Receiver<OverrideSnapshot>>,
+    ) -> DecodeFut
     + Send
     + Sync;
 type FilterFn = fn(&ComponentWithState) -> bool;
@@ -94,6 +101,9 @@ where
     min_token_quality: u32,
     registry: HashMap<String, Box<RegistryFn<H>>>,
     inclusion_filters: HashMap<String, FilterFn>,
+    /// Live override providers keyed by `protocol_system`. A pool of that protocol subscribes to
+    /// its provider at creation time and reads fresh overrides on every simulation.
+    override_providers: HashMap<String, Arc<dyn StateOverrideProvider>>,
 }
 
 impl<H> Default for TychoStreamDecoder<H>
@@ -116,7 +126,22 @@ where
             min_token_quality: 100,
             registry: HashMap::new(),
             inclusion_filters: HashMap::new(),
+            override_providers: HashMap::new(),
         }
+    }
+
+    /// Registers `provider` as the live override source for `protocol_system`.
+    ///
+    /// Pools of that protocol subscribe to it at creation time, so overrides apply from the first
+    /// simulation onward. A later call for the same `protocol_system` replaces the previous
+    /// provider.
+    pub fn set_override_provider(
+        &mut self,
+        protocol_system: String,
+        provider: Arc<dyn StateOverrideProvider>,
+    ) {
+        self.override_providers
+            .insert(protocol_system, provider);
     }
 
     /// Provides token metadata used to decode startup snapshots and initialize protocol states.
@@ -164,8 +189,10 @@ where
             move |component: ComponentWithState,
                   header: H,
                   account_balances: AccountBalances,
-                  state: Arc<RwLock<DecoderState>>| {
-                let context = context.clone();
+                  state: Arc<RwLock<DecoderState>>,
+                  live_override: Option<watch::Receiver<OverrideSnapshot>>| {
+                let mut context = context.clone();
+                context.live_override = live_override;
                 Box::pin(async move {
                     let guard = state.read().await;
                     T::try_from_with_header(
@@ -575,11 +602,16 @@ where
 
                     // Construct state from snapshot
                     if let Some(state_decode_f) = self.registry.get(protocol.as_str()) {
+                        let live_override = self
+                            .override_providers
+                            .get(protocol.as_str())
+                            .and_then(|provider| provider.subscribe(protocol.as_str()));
                         match state_decode_f(
                             snapshot,
                             header.clone(),
                             account_balances.clone(),
                             self.state.clone(),
+                            live_override,
                         )
                         .await
                         {
@@ -1057,6 +1089,7 @@ where
         }
         Ok(())
     }
+
 }
 
 /// Generate a proxy token address for a given token index

--- a/crates/tycho-simulation/src/evm/mod.rs
+++ b/crates/tycho-simulation/src/evm/mod.rs
@@ -4,6 +4,9 @@ use tycho_common::keccak256;
 pub mod account_storage;
 pub mod decoder;
 pub mod engine_db;
+/// Live per-block VM state-override streaming: generic core, default registry, and concrete
+/// providers (e.g. the Titan pAMM stream).
+pub mod override_stream;
 pub mod pending;
 pub mod protocol;
 pub mod query_pool_swap;

--- a/crates/tycho-simulation/src/evm/override_stream/mod.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/mod.rs
@@ -43,6 +43,22 @@ pub struct OverrideSnapshot {
     /// can read the latest snapshot on every simulation with a refcount bump rather than a deep
     /// clone of the nested map.
     pub storage: Arc<HashMap<Address, HashMap<U256, U256>>>,
+    /// Unix-seconds instant after which these overrides are stale and must not be used. Set by the
+    /// provider from its own freshness rules (e.g. Titan uses the quote timestamp plus one block
+    /// time). `None` means the snapshot never expires — e.g. the empty initial snapshot.
+    pub expires_at: Option<u64>,
+}
+
+impl OverrideSnapshot {
+    /// Returns whether these overrides are stale at `now` (unix seconds).
+    ///
+    /// A snapshot without an [`expires_at`](Self::expires_at) never expires. Callers that read the
+    /// snapshot on every simulation should skip it entirely once this returns `true`, falling back
+    /// to whatever state they held before.
+    pub fn is_expired(&self, now: u64) -> bool {
+        self.expires_at
+            .is_some_and(|expires_at| now >= expires_at)
+    }
 }
 
 /// Supplies a *live* stream of resolved per-block VM overrides for one or more protocols.
@@ -72,4 +88,23 @@ pub(crate) fn default_override_providers(
     let mut providers: HashMap<String, Arc<dyn StateOverrideProvider>> = HashMap::new();
     providers.extend(titan::default_providers(protocols));
     providers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_without_expiry_never_expires() {
+        let snapshot = OverrideSnapshot::default();
+        assert!(!snapshot.is_expired(u64::MAX));
+    }
+
+    #[test]
+    fn snapshot_expires_at_or_after_deadline() {
+        let snapshot = OverrideSnapshot { expires_at: Some(100), ..Default::default() };
+        assert!(!snapshot.is_expired(99));
+        assert!(snapshot.is_expired(100));
+        assert!(snapshot.is_expired(101));
+    }
 }

--- a/crates/tycho-simulation/src/evm/override_stream/mod.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/mod.rs
@@ -7,9 +7,11 @@
 //! block.
 //!
 //! This module defines the generic plumbing:
-//! - [`OverrideSnapshot`] — the resolved overrides for one protocol at a point in time.
-//! - [`StateOverrideProvider`] — a source that maintains a *live* [`watch`] channel of snapshots
-//!   per protocol (kept fresh in the background, e.g. from a WebSocket).
+//! - [`OverrideSnapshot`](crate::evm::override_stream::OverrideSnapshot) — the resolved overrides
+//!   for one protocol at a point in time.
+//! - [`StateOverrideProvider`](crate::evm::override_stream::StateOverrideProvider) — a source that
+//!   maintains a *live* [`watch`](tokio::sync::watch) channel of snapshots per protocol (kept fresh
+//!   in the background, e.g. from a WebSocket).
 //!
 //! Providers are registered per `protocol_system` (see
 //! [`ProtocolStreamBuilder::with_override_provider`](crate::evm::stream::ProtocolStreamBuilder::with_override_provider)).
@@ -17,7 +19,7 @@
 //! freshest snapshot at simulation time.
 //!
 //! It deliberately knows nothing about any specific venue or stream format; all such specifics live
-//! in the concrete provider implementations (see [`titan`]).
+//! in the concrete provider implementations (see [`titan`](crate::evm::override_stream::titan)).
 
 pub mod titan;
 
@@ -73,4 +75,3 @@ pub(crate) fn default_override_providers(
     providers.extend(titan::default_providers(registered_exchanges, covered));
     providers
 }
-

--- a/crates/tycho-simulation/src/evm/override_stream/mod.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/mod.rs
@@ -23,10 +23,7 @@
 
 pub mod titan;
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use alloy::primitives::{Address, U256};
 use tokio::sync::watch;
@@ -64,16 +61,15 @@ pub trait StateOverrideProvider: Send + Sync {
 
 /// The default registry of built-in override providers, keyed by `protocol_system`.
 ///
-/// Given the `registered_exchanges` and the set of protocols already `covered` by explicit
-/// consumer registrations, returns the providers that should serve the remaining protocols. This
-/// is the single place that wires concrete providers (e.g. the Titan pAMM stream) into the
-/// otherwise protocol-agnostic stream builder, keeping all venue-specific knowledge out of both the
-/// builder and the generic override core. Protocols in `covered` are left to the consumer.
+/// `protocols` yields the protocol systems the caller wants a built-in default for (i.e. registered
+/// exchanges minus any the consumer explicitly overrode — the builder computes that difference and
+/// forwards it as an owned iterator, avoiding clones). This is the single place that wires concrete
+/// providers (e.g. the Titan pAMM stream) into the otherwise protocol-agnostic stream builder,
+/// keeping all venue-specific knowledge out of both the builder and the generic override core.
 pub(crate) fn default_override_providers(
-    registered_exchanges: &[String],
-    covered: &HashSet<String>,
+    protocols: impl IntoIterator<Item = String>,
 ) -> HashMap<String, Arc<dyn StateOverrideProvider>> {
     let mut providers: HashMap<String, Arc<dyn StateOverrideProvider>> = HashMap::new();
-    providers.extend(titan::default_providers(registered_exchanges, covered));
+    providers.extend(titan::default_providers(protocols));
     providers
 }

--- a/crates/tycho-simulation/src/evm/override_stream/mod.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/mod.rs
@@ -1,0 +1,76 @@
+//! Generic, protocol-agnostic core for injecting live per-block VM state overrides into pools.
+//!
+//! Some protocols (e.g. pAMMs such as FermiSwap) rely on off-chain oracle prices that are not part
+//! of the on-chain state Tycho indexes, and that change *within* a block. To simulate them
+//! accurately, a side channel publishes per-block VM storage overrides and an overridden block
+//! environment that must be reflected by the pool on every simulation — not just once per Tycho
+//! block.
+//!
+//! This module defines the generic plumbing:
+//! - [`OverrideSnapshot`] — the resolved overrides for one protocol at a point in time.
+//! - [`StateOverrideProvider`] — a source that maintains a *live* [`watch`] channel of snapshots
+//!   per protocol (kept fresh in the background, e.g. from a WebSocket).
+//!
+//! Providers are registered per `protocol_system` (see
+//! [`ProtocolStreamBuilder::with_override_provider`](crate::evm::stream::ProtocolStreamBuilder::with_override_provider)).
+//! A pool subscribes to the provider registered for its protocol at creation time and reads the
+//! freshest snapshot at simulation time.
+//!
+//! It deliberately knows nothing about any specific venue or stream format; all such specifics live
+//! in the concrete provider implementations (see [`titan`]).
+
+pub mod titan;
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use alloy::primitives::{Address, U256};
+use tokio::sync::watch;
+
+/// Resolved per-block VM overrides for a single protocol at a point in time.
+///
+/// `block_number` and `block_timestamp` are already resolved by the provider (e.g. Titan computes
+/// `block_timestamp` from lane timestamps) so this core stays protocol-agnostic. Either field may
+/// be `None`, in which case the pool's existing block environment is left intact.
+#[derive(Clone, Default, Debug)]
+pub struct OverrideSnapshot {
+    /// The L1 block number these overrides apply to, if known.
+    pub block_number: Option<u64>,
+    /// The block timestamp to inject into the pool's simulation environment, if known.
+    pub block_timestamp: Option<u64>,
+    /// Storage overrides keyed by contract address, then by storage slot.
+    pub storage: HashMap<Address, HashMap<U256, U256>>,
+}
+
+/// Supplies a *live* stream of resolved per-block VM overrides for one or more protocols.
+///
+/// Implementations maintain their snapshots in the background (e.g. from a WebSocket stream) and
+/// expose them through a [`watch`] channel per protocol. A single provider may serve several
+/// protocols sharing one underlying connection; the same provider can be registered for each of
+/// them (it is shared via `Arc`, not duplicated).
+pub trait StateOverrideProvider: Send + Sync {
+    /// Returns the live override channel for `protocol_system`, or `None` if unsupported.
+    ///
+    /// The returned [`watch::Receiver`] always reflects the latest snapshot; reading it
+    /// ([`watch::Receiver::borrow`]) never blocks, so a pool may read it on every simulation.
+    fn subscribe(&self, protocol_system: &str) -> Option<watch::Receiver<OverrideSnapshot>>;
+}
+
+/// The default registry of built-in override providers, keyed by `protocol_system`.
+///
+/// Given the `registered_exchanges` and the set of protocols already `covered` by explicit
+/// consumer registrations, returns the providers that should serve the remaining protocols. This
+/// is the single place that wires concrete providers (e.g. the Titan pAMM stream) into the
+/// otherwise protocol-agnostic stream builder, keeping all venue-specific knowledge out of both the
+/// builder and the generic override core. Protocols in `covered` are left to the consumer.
+pub(crate) fn default_override_providers(
+    registered_exchanges: &[String],
+    covered: &HashSet<String>,
+) -> HashMap<String, Arc<dyn StateOverrideProvider>> {
+    let mut providers: HashMap<String, Arc<dyn StateOverrideProvider>> = HashMap::new();
+    providers.extend(titan::default_providers(registered_exchanges, covered));
+    providers
+}
+

--- a/crates/tycho-simulation/src/evm/override_stream/mod.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/mod.rs
@@ -42,8 +42,10 @@ pub struct OverrideSnapshot {
     pub block_number: Option<u64>,
     /// The block timestamp to inject into the pool's simulation environment, if known.
     pub block_timestamp: Option<u64>,
-    /// Storage overrides keyed by contract address, then by storage slot.
-    pub storage: HashMap<Address, HashMap<U256, U256>>,
+    /// Storage overrides keyed by contract address, then by storage slot. `Arc`-wrapped so a pool
+    /// can read the latest snapshot on every simulation with a refcount bump rather than a deep
+    /// clone of the nested map.
+    pub storage: Arc<HashMap<Address, HashMap<U256, U256>>>,
 }
 
 /// Supplies a *live* stream of resolved per-block VM overrides for one or more protocols.

--- a/crates/tycho-simulation/src/evm/override_stream/titan.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/titan.rs
@@ -345,7 +345,7 @@ impl TitanProvider {
         // as current.
         let block_timestamp = Self::max_lane_timestamp(&storage);
 
-        Ok(Some(OverrideSnapshot { block_number, block_timestamp, storage }))
+        Ok(Some(OverrideSnapshot { block_number, block_timestamp, storage: Arc::new(storage) }))
     }
 
     /// Returns the newest lane update timestamp (in seconds) across all overridden slots.

--- a/crates/tycho-simulation/src/evm/override_stream/titan.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/titan.rs
@@ -72,7 +72,8 @@ pub fn default_providers(
     if needed.is_empty() {
         return HashMap::new();
     }
-    let provider: Arc<dyn StateOverrideProvider> = Arc::new(TitanProvider::spawn(TITAN_URL.to_string()));
+    let provider: Arc<dyn StateOverrideProvider> =
+        Arc::new(TitanProvider::spawn(TITAN_URL.to_string()));
     needed
         .into_iter()
         .map(|protocol| (protocol.to_string(), provider.clone()))
@@ -320,7 +321,9 @@ mod tests {
 
     #[test]
     fn parse_message_extracts_venue_state_diff() {
-        let venue = FERMISWAP_VENUE.parse::<Address>().unwrap();
+        let venue = FERMISWAP_VENUE
+            .parse::<Address>()
+            .unwrap();
         let snapshot = TitanProvider::parse_message(SAMPLE_MESSAGE, &venue)
             .expect("parse must succeed")
             .expect("venue is present");
@@ -336,12 +339,20 @@ mod tests {
         let value = "0x000000000000000000000000000000000000000000000000000000017e405801"
             .parse::<U256>()
             .unwrap();
-        assert_eq!(snapshot.storage.get(&account).and_then(|s| s.get(&slot)), Some(&value));
+        assert_eq!(
+            snapshot
+                .storage
+                .get(&account)
+                .and_then(|s| s.get(&slot)),
+            Some(&value)
+        );
     }
 
     #[test]
     fn parse_message_returns_none_for_absent_venue() {
-        let venue = KIPSELI_VENUE.parse::<Address>().unwrap();
+        let venue = KIPSELI_VENUE
+            .parse::<Address>()
+            .unwrap();
         assert!(TitanProvider::parse_message(SAMPLE_MESSAGE, &venue)
             .unwrap()
             .is_none());
@@ -349,7 +360,9 @@ mod tests {
 
     #[test]
     fn max_lane_timestamp_picks_newest_plausible_top_word() {
-        let addr = FERMISWAP_VENUE.parse::<Address>().unwrap();
+        let addr = FERMISWAP_VENUE
+            .parse::<Address>()
+            .unwrap();
         // Two lane slots with the timestamp packed in the top 4 bytes, plus a non-lane slot
         // whose top bytes are zero (must be ignored).
         let older = U256::from(1_700_000_000u64) << 224;
@@ -368,8 +381,11 @@ mod tests {
 
     #[test]
     fn max_lane_timestamp_none_when_no_plausible_values() {
-        let addr = FERMISWAP_VENUE.parse::<Address>().unwrap();
-        let overrides = HashMap::from([(addr, HashMap::from([(U256::from(0u64), U256::from(7u64))]))]);
+        let addr = FERMISWAP_VENUE
+            .parse::<Address>()
+            .unwrap();
+        let overrides =
+            HashMap::from([(addr, HashMap::from([(U256::from(0u64), U256::from(7u64))]))]);
         assert!(TitanProvider::max_lane_timestamp(&overrides).is_none());
     }
 }

--- a/crates/tycho-simulation/src/evm/override_stream/titan.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/titan.rs
@@ -17,7 +17,7 @@ use std::{
 
 use alloy::primitives::{Address, U256};
 use futures::StreamExt;
-use serde_json::Value;
+use serde::Deserialize;
 use tokio::{
     sync::watch,
     time::{sleep, timeout},
@@ -29,6 +29,37 @@ use super::{OverrideSnapshot, StateOverrideProvider};
 
 /// Storage overrides keyed by contract address, then by storage slot.
 type VenueOverrides = HashMap<Address, HashMap<U256, U256>>;
+
+/// A parsed Titan quote-stream frame.
+///
+/// Only `blockNumber` is consumed at this level; every other top-level key (venue addresses,
+/// `slot`, `timestamp`, and any future fields) lands in `overrides` as raw JSON. Only the venue
+/// keys we look up are then deserialized into [`AddressEntry`], so an upstream schema change that
+/// adds top-level fields never breaks parsing.
+#[derive(Debug, Deserialize)]
+struct TitanMessage {
+    #[serde(rename = "blockNumber", default)]
+    block_number: Option<u64>,
+    #[serde(flatten)]
+    overrides: HashMap<String, serde_json::Value>,
+}
+
+/// A single venue's override set, following the eth_call State Override Set shape. Only
+/// `stateOverride` is consumed; account addresses are parsed straight from their `0x` hex keys.
+#[derive(Debug, Deserialize)]
+struct AddressEntry {
+    #[serde(rename = "stateOverride", default)]
+    state_override: HashMap<Address, AccountState>,
+}
+
+/// A single account's override. Only `stateDiff` (storage slot -> value) is used, deserialized
+/// directly from its `0x` hex string keys and values; balance / nonce / code are ignored (serde
+/// drops unknown fields).
+#[derive(Debug, Deserialize)]
+struct AccountState {
+    #[serde(rename = "stateDiff", default)]
+    state_diff: HashMap<U256, U256>,
+}
 
 /// Default Titan pAMM quote-stream WebSocket endpoint serving all known pAMM venues.
 const TITAN_URL: &str = "wss://eu.rpc.titanbuilder.xyz/ws/pamm_quote_stream";
@@ -156,27 +187,35 @@ impl TitanProvider {
                         };
 
                         match message {
-                            // Expected case: a JSON quote-stream frame. Parse it once per venue and
-                            // publish any resolved snapshot. Receiving a frame proves the
-                            // connection is healthy, so reset the reconnect backoff.
+                            // Expected case: a JSON quote-stream frame. Deserialize it once, then
+                            // extract each venue's snapshot from the parsed value. Receiving a
+                            // frame proves the connection is healthy,
+                            // so reset the reconnect backoff.
                             Ok(Message::Text(text)) => {
                                 attempt = 0;
-                                for (venue, sender) in &senders {
-                                    match Self::parse_message(text.as_str(), venue) {
-                                        Ok(Some(snapshot)) => {
-                                            // A send error here only means every receiver (the
-                                            // provider handle and all pools) has been dropped, i.e.
-                                            // nothing consumes overrides anymore; safe to ignore.
-                                            let _ = sender.send(snapshot);
-                                        }
-                                        // Venue not present in this message — nothing to update.
-                                        Ok(None) => {}
-                                        // Malformed payload for this venue: keep the connection and
-                                        // the last good snapshot, but surface the problem.
-                                        Err(e) => {
-                                            warn!(%venue, error = %e, "Failed to parse Titan message");
+                                match serde_json::from_str::<TitanMessage>(text.as_str()) {
+                                    Ok(message) => {
+                                        for (venue, sender) in &senders {
+                                            match Self::extract_venue(&message, venue) {
+                                                // A send error here only means every receiver (the
+                                                // provider handle and all pools) has been dropped,
+                                                // i.e. nothing consumes overrides anymore; ignore.
+                                                Ok(Some(snapshot)) => {
+                                                    let _ = sender.send(snapshot);
+                                                }
+                                                // Venue not present in this frame — nothing to do.
+                                                Ok(None) => {}
+                                                // Malformed payload for this venue: keep the
+                                                // connection and last good snapshot, but surface
+                                                // it.
+                                                Err(e) => {
+                                                    warn!(%venue, error = %e, "Failed to extract Titan venue snapshot");
+                                                }
+                                            }
                                         }
                                     }
+                                    // Unparseable frame: log and keep the connection.
+                                    Err(e) => warn!(error = %e, "Failed to parse Titan message"),
                                 }
                             }
                             // Titan only sends JSON text; a binary frame is unexpected. Skip it and
@@ -231,58 +270,33 @@ impl TitanProvider {
     }
 
     /// Extracts a single venue's snapshot (`stateDiff` overrides + resolved block environment)
-    /// from a Titan stream message.
+    /// from an already-parsed Titan stream frame (deserialized once by the caller, then queried per
+    /// venue).
     ///
-    /// Returns `Ok(None)` if the venue is absent from the message. The block timestamp is resolved
+    /// Returns `Ok(None)` if the venue is absent from the frame. The block timestamp is resolved
     /// from the freshest lane update timestamp (see
     /// [`max_lane_timestamp`](Self::max_lane_timestamp)) so the pool's oracle-staleness guard
     /// sees the overridden prices as current.
-    fn parse_message(text: &str, venue: &Address) -> Result<Option<OverrideSnapshot>, String> {
-        let root: Value = serde_json::from_str(text).map_err(|e| format!("invalid JSON: {e}"))?;
-
-        // Each message carries one top-level entry per venue address, alongside `slot`,
-        // `blockNumber` and a wall-clock `timestamp`. Absent venue => nothing to apply.
+    fn extract_venue(
+        message: &TitanMessage,
+        venue: &Address,
+    ) -> Result<Option<OverrideSnapshot>, String> {
+        // Each frame carries one top-level entry per venue address. Absent => nothing to apply.
         let venue_key = format!("{venue:#x}");
-        let Some(venue_entry) = root.get(&venue_key) else {
+        let Some(raw) = message.overrides.get(&venue_key) else {
             return Ok(None);
         };
+        let entry: AddressEntry = serde_json::from_value(raw.clone())
+            .map_err(|e| format!("invalid venue override: {e}"))?;
 
-        let block_number = root
-            .get("blockNumber")
-            .and_then(Value::as_u64);
+        let block_number = message.block_number;
 
-        // `stateOverride` mirrors the eth_call State Override Set: account -> { stateDiff: slot ->
-        // value, ... }. We only consume `stateDiff` storage; balance/nonce/code are ignored.
+        // We only consume `stateDiff` storage; balance / nonce / code are ignored. Slots and values
+        // were parsed into `U256` by serde, so we just drop accounts with no overrides.
         let mut storage: VenueOverrides = HashMap::new();
-        if let Some(state_override) = venue_entry
-            .get("stateOverride")
-            .and_then(Value::as_object)
-        {
-            for (account, account_state) in state_override {
-                let address = account
-                    .parse::<Address>()
-                    .map_err(|e| format!("invalid account address {account}: {e}"))?;
-                let Some(state_diff) = account_state
-                    .get("stateDiff")
-                    .and_then(Value::as_object)
-                else {
-                    continue;
-                };
-                let mut slots = HashMap::new();
-                for (slot, value) in state_diff {
-                    let slot = slot
-                        .parse::<U256>()
-                        .map_err(|e| format!("invalid storage slot {slot}: {e}"))?;
-                    let value = value
-                        .as_str()
-                        .ok_or_else(|| format!("storage value for slot {slot} is not a string"))?
-                        .parse::<U256>()
-                        .map_err(|e| format!("invalid storage value: {e}"))?;
-                    slots.insert(slot, value);
-                }
-                if !slots.is_empty() {
-                    storage.insert(address, slots);
-                }
+        for (account, account_override) in entry.state_override {
+            if !account_override.state_diff.is_empty() {
+                storage.insert(account, account_override.state_diff);
             }
         }
 
@@ -379,12 +393,13 @@ mod tests {
     }"#;
 
     #[test]
-    fn parse_message_extracts_venue_state_diff() {
+    fn extract_venue_reads_state_diff() {
         let venue = FERMISWAP_VENUE
             .parse::<Address>()
             .unwrap();
-        let snapshot = TitanProvider::parse_message(SAMPLE_MESSAGE, &venue)
-            .expect("parse must succeed")
+        let message = serde_json::from_str::<TitanMessage>(SAMPLE_MESSAGE).expect("valid JSON");
+        let snapshot = TitanProvider::extract_venue(&message, &venue)
+            .expect("extract must succeed")
             .expect("venue is present");
 
         assert_eq!(snapshot.block_number, Some(25051224));
@@ -408,11 +423,12 @@ mod tests {
     }
 
     #[test]
-    fn parse_message_returns_none_for_absent_venue() {
+    fn extract_venue_returns_none_for_absent_venue() {
         let venue = KIPSELI_VENUE
             .parse::<Address>()
             .unwrap();
-        assert!(TitanProvider::parse_message(SAMPLE_MESSAGE, &venue)
+        let message = serde_json::from_str::<TitanMessage>(SAMPLE_MESSAGE).expect("valid JSON");
+        assert!(TitanProvider::extract_venue(&message, &venue)
             .unwrap()
             .is_none());
     }

--- a/crates/tycho-simulation/src/evm/override_stream/titan.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/titan.rs
@@ -18,9 +18,12 @@ use std::{
 use alloy::primitives::{Address, U256};
 use futures::StreamExt;
 use serde_json::Value;
-use tokio::{sync::watch, time::sleep};
+use tokio::{
+    sync::watch,
+    time::{sleep, timeout},
+};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 
 use super::{OverrideSnapshot, StateOverrideProvider};
 
@@ -43,6 +46,14 @@ const FERMISWAP_VENUE: &str = "0xb1076fe3ab5e28005c7c323bac5ac06a680d452e";
 const KIPSELI_VENUE: &str = "0x5cdbe59400cc2efdcc2b54acca4a99fe00dd588c";
 /// bopAMM pAMM venue address on Titan's quote stream.
 const BOPAMM_VENUE: &str = "0x160141a205f5ddcf096ba3f48b7ed21eb52c62ea";
+
+/// Longest gap between Titan messages tolerated before the socket is treated as dead and
+/// re-established. Titan pushes several updates per second, so a multi-second silence means a
+/// stalled or half-open connection that [`StreamExt::next`] would otherwise wait on forever.
+const READ_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Reconnect backoff is `2^min(attempt, MAX_BACKOFF_EXP)` seconds, i.e. capped at 32s.
+const MAX_BACKOFF_EXP: u32 = 5;
 
 /// Returns the pAMM `protocol_system`s this provider knows how to serve.
 fn known_pamm_protocols() -> &'static [&'static str] {
@@ -110,50 +121,98 @@ impl TitanProvider {
         Self { receivers }
     }
 
-    /// Maintains the Titan WebSocket connection forever: parses each message into a per-venue
-    /// [`OverrideSnapshot`] and publishes it on the matching channel, reconnecting with capped
-    /// exponential backoff on any disconnect or error.
+    /// Maintains the Titan WebSocket connection for the lifetime of the process.
+    ///
+    /// Connects, reads messages, and publishes each parsed [`OverrideSnapshot`] on the matching
+    /// venue channel. Any disconnect, read error, server-side close, or idle timeout drops back to
+    /// the reconnect loop, which retries forever with capped exponential backoff. The backoff is
+    /// reset only after a message is actually received, so a socket that connects and immediately
+    /// drops still backs off instead of busy-looping. This task never returns and never panics:
+    /// every failure mode is logged and retried.
     async fn run(url: String, senders: Vec<(Address, watch::Sender<OverrideSnapshot>)>) {
         let mut attempt: u32 = 0;
         loop {
             match connect_async(url.as_str()).await {
                 Ok((mut ws_stream, _)) => {
                     info!(%url, "Connected to Titan pAMM quote stream");
-                    attempt = 0;
-                    while let Some(message) = ws_stream.next().await {
+                    loop {
+                        // Bound the wait so a half-open connection (no data and no close frame) is
+                        // detected and retried instead of blocking on `next()` indefinitely.
+                        let message = match timeout(READ_IDLE_TIMEOUT, ws_stream.next()).await {
+                            Ok(Some(message)) => message,
+                            // Stream ended: the server hung up without sending a close frame.
+                            Ok(None) => {
+                                warn!("Titan quote stream ended; reconnecting");
+                                break;
+                            }
+                            // No traffic within the idle window: assume a stalled socket.
+                            Err(_elapsed) => {
+                                warn!(
+                                    idle_secs = READ_IDLE_TIMEOUT.as_secs(),
+                                    "No Titan message within idle timeout; reconnecting"
+                                );
+                                break;
+                            }
+                        };
+
                         match message {
+                            // Expected case: a JSON quote-stream frame. Parse it once per venue and
+                            // publish any resolved snapshot. Receiving a frame proves the
+                            // connection is healthy, so reset the reconnect backoff.
                             Ok(Message::Text(text)) => {
+                                attempt = 0;
                                 for (venue, sender) in &senders {
                                     match Self::parse_message(text.as_str(), venue) {
                                         Ok(Some(snapshot)) => {
+                                            // A send error here only means every receiver (the
+                                            // provider handle and all pools) has been dropped, i.e.
+                                            // nothing consumes overrides anymore; safe to ignore.
                                             let _ = sender.send(snapshot);
                                         }
+                                        // Venue not present in this message — nothing to update.
                                         Ok(None) => {}
+                                        // Malformed payload for this venue: keep the connection and
+                                        // the last good snapshot, but surface the problem.
                                         Err(e) => {
                                             warn!(%venue, error = %e, "Failed to parse Titan message");
                                         }
                                     }
                                 }
                             }
-                            Ok(Message::Close(_)) => {
-                                info!("Titan quote stream closed by server");
+                            // Titan only sends JSON text; a binary frame is unexpected. Skip it and
+                            // keep the (otherwise healthy) connection rather than reconnecting.
+                            Ok(Message::Binary(bytes)) => {
+                                warn!(len = bytes.len(), "Ignoring unexpected binary Titan frame");
+                            }
+                            // Keep-alive frames. tokio-tungstenite answers pings with pongs
+                            // automatically while the stream is polled, so there is nothing to do.
+                            Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {}
+                            // Raw frames only surface with non-default tungstenite settings;
+                            // ignore.
+                            Ok(Message::Frame(_)) => {}
+                            // Server initiated a graceful close — reconnect.
+                            Ok(Message::Close(frame)) => {
+                                warn!(?frame, "Titan quote stream closed by server; reconnecting");
                                 break;
                             }
-                            Ok(_) => {}
+                            // Transport/protocol error (broken pipe, invalid frame, ...) —
+                            // reconnect.
                             Err(e) => {
-                                error!(error = %e, "Titan quote stream read error");
+                                warn!(error = %e, "Titan quote stream read error; reconnecting");
                                 break;
                             }
                         }
                     }
                 }
+                // Could not establish the connection at all — fall through to backoff and retry.
                 Err(e) => {
-                    error!(error = %e, "Failed to connect to Titan quote stream");
+                    warn!(error = %e, "Failed to connect to Titan quote stream; retrying");
                 }
             }
+
             attempt = attempt.saturating_add(1);
-            let backoff = Duration::from_secs(2u64.pow(attempt.min(5)));
-            warn!(seconds = backoff.as_secs(), attempt, "Reconnecting to Titan quote stream");
+            let backoff = Duration::from_secs(2u64.pow(attempt.min(MAX_BACKOFF_EXP)));
+            warn!(seconds = backoff.as_secs(), attempt, "Backing off before reconnecting to Titan");
             sleep(backoff).await;
         }
     }

--- a/crates/tycho-simulation/src/evm/override_stream/titan.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/titan.rs
@@ -1,0 +1,375 @@
+//! Concrete [`StateOverrideProvider`] backed by the Titan pAMM state-override stream.
+//!
+//! Connects to the Titan `pamm_quote_stream` WebSocket and tracks the latest per-block VM storage
+//! overrides published for the known pAMM venues (e.g. FermiSwap), exposing them through the
+//! generic [`StateOverrideProvider`] trait so the decoder can inject them into the matching
+//! `EVMPoolState` instances before simulation. See
+//! <https://docs.titanbuilder.xyz/propamms/takers>.
+//!
+//! All Titan/Fermi-specific knowledge (venue addresses, lane-timestamp resolution, endpoint URL)
+//! lives only in this module; the rest of the override machinery is protocol-agnostic.
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
+
+use alloy::primitives::{Address, U256};
+use futures::StreamExt;
+use serde_json::Value;
+use tokio::{sync::watch, time::sleep};
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tracing::{error, info, warn};
+
+use super::{OverrideSnapshot, StateOverrideProvider};
+
+/// Storage overrides keyed by contract address, then by storage slot.
+type VenueOverrides = HashMap<Address, HashMap<U256, U256>>;
+
+/// Default Titan pAMM quote-stream WebSocket endpoint serving all known pAMM venues.
+const TITAN_URL: &str = "wss://eu.rpc.titanbuilder.xyz/ws/pamm_quote_stream";
+
+/// FermiSwap protocol system identifier as indexed by Tycho.
+const FERMISWAP_PROTOCOL_SYSTEM: &str = "vm:fermiswap";
+/// Kipseli protocol system identifier as indexed by Tycho.
+const KIPSELI_PROTOCOL_SYSTEM: &str = "vm:kipseli";
+/// bopAMM protocol system identifier as indexed by Tycho.
+const BOPAMM_PROTOCOL_SYSTEM: &str = "vm:bopamm";
+
+/// FermiSwap pAMM venue address on Titan's quote stream.
+const FERMISWAP_VENUE: &str = "0xb1076fe3ab5e28005c7c323bac5ac06a680d452e";
+/// Kipseli pAMM venue address on Titan's quote stream.
+const KIPSELI_VENUE: &str = "0x5cdbe59400cc2efdcc2b54acca4a99fe00dd588c";
+/// bopAMM pAMM venue address on Titan's quote stream.
+const BOPAMM_VENUE: &str = "0x160141a205f5ddcf096ba3f48b7ed21eb52c62ea";
+
+/// Returns the pAMM `protocol_system`s this provider knows how to serve.
+fn known_pamm_protocols() -> &'static [&'static str] {
+    &[FERMISWAP_PROTOCOL_SYSTEM, KIPSELI_PROTOCOL_SYSTEM, BOPAMM_PROTOCOL_SYSTEM]
+}
+
+/// Default override providers contributed by Titan, keyed by `protocol_system`.
+///
+/// Returns one shared [`TitanProvider`] mapped under every known pAMM `protocol_system` that is
+/// both present in `registered_exchanges` and absent from `covered`. The provider is spawned only
+/// when at least one such venue needs serving — so a caller who overrides every Titan venue opens
+/// no connection. The single provider is shared across its protocols via `Arc`, not duplicated.
+pub fn default_providers(
+    registered_exchanges: &[String],
+    covered: &HashSet<String>,
+) -> HashMap<String, Arc<dyn StateOverrideProvider>> {
+    let needed: Vec<&'static str> = known_pamm_protocols()
+        .iter()
+        .copied()
+        .filter(|&protocol| {
+            registered_exchanges
+                .iter()
+                .any(|e| e.as_str() == protocol) &&
+                !covered.contains(protocol)
+        })
+        .collect();
+    if needed.is_empty() {
+        return HashMap::new();
+    }
+    let provider: Arc<dyn StateOverrideProvider> = Arc::new(TitanProvider::spawn(TITAN_URL.to_string()));
+    needed
+        .into_iter()
+        .map(|protocol| (protocol.to_string(), provider.clone()))
+        .collect()
+}
+
+/// A [`StateOverrideProvider`] backed by a single Titan pAMM WebSocket connection.
+///
+/// One connection serves all known pAMM venues; per-protocol snapshots are exposed through the
+/// `watch` receivers held here. Cheap to clone.
+pub struct TitanProvider {
+    /// Latest resolved snapshot per served `protocol_system`, kept fresh by the background task.
+    receivers: HashMap<String, watch::Receiver<OverrideSnapshot>>,
+}
+
+impl TitanProvider {
+    /// Opens ONE WebSocket connection to Titan serving all known pAMM venues and spawns the
+    /// background reconnect/parse task that keeps the per-protocol snapshots up to date.
+    ///
+    /// Returns immediately; the connection is established and maintained in the background, so a
+    /// transient WebSocket failure never blocks or crashes the caller.
+    pub fn spawn(url: String) -> Self {
+        let mut receivers = HashMap::new();
+        let mut senders = Vec::new();
+        for &protocol in known_pamm_protocols() {
+            let Some(venue) = Self::venue_for_protocol(protocol) else {
+                continue;
+            };
+            let (tx, rx) = watch::channel(OverrideSnapshot::default());
+            receivers.insert(protocol.to_string(), rx);
+            senders.push((venue, tx));
+        }
+        tokio::spawn(Self::run(url, senders));
+        Self { receivers }
+    }
+
+    /// Maintains the Titan WebSocket connection forever: parses each message into a per-venue
+    /// [`OverrideSnapshot`] and publishes it on the matching channel, reconnecting with capped
+    /// exponential backoff on any disconnect or error.
+    async fn run(url: String, senders: Vec<(Address, watch::Sender<OverrideSnapshot>)>) {
+        let mut attempt: u32 = 0;
+        loop {
+            match connect_async(url.as_str()).await {
+                Ok((mut ws_stream, _)) => {
+                    info!(%url, "Connected to Titan pAMM quote stream");
+                    attempt = 0;
+                    while let Some(message) = ws_stream.next().await {
+                        match message {
+                            Ok(Message::Text(text)) => {
+                                for (venue, sender) in &senders {
+                                    match Self::parse_message(text.as_str(), venue) {
+                                        Ok(Some(snapshot)) => {
+                                            let _ = sender.send(snapshot);
+                                        }
+                                        Ok(None) => {}
+                                        Err(e) => {
+                                            warn!(%venue, error = %e, "Failed to parse Titan message");
+                                        }
+                                    }
+                                }
+                            }
+                            Ok(Message::Close(_)) => {
+                                info!("Titan quote stream closed by server");
+                                break;
+                            }
+                            Ok(_) => {}
+                            Err(e) => {
+                                error!(error = %e, "Titan quote stream read error");
+                                break;
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!(error = %e, "Failed to connect to Titan quote stream");
+                }
+            }
+            attempt = attempt.saturating_add(1);
+            let backoff = Duration::from_secs(2u64.pow(attempt.min(5)));
+            warn!(seconds = backoff.as_secs(), attempt, "Reconnecting to Titan quote stream");
+            sleep(backoff).await;
+        }
+    }
+
+    /// Maps a known pAMM `protocol_system` to its Titan venue address, or `None` if unknown.
+    ///
+    /// Titan/Fermi specifics (the venue address mapping) live only here.
+    fn venue_for_protocol(protocol_system: &str) -> Option<Address> {
+        let raw = match protocol_system {
+            FERMISWAP_PROTOCOL_SYSTEM => FERMISWAP_VENUE,
+            KIPSELI_PROTOCOL_SYSTEM => KIPSELI_VENUE,
+            BOPAMM_PROTOCOL_SYSTEM => BOPAMM_VENUE,
+            _ => return None,
+        };
+        raw.parse().ok()
+    }
+
+    /// Extracts a single venue's snapshot (`stateDiff` overrides + resolved block environment)
+    /// from a Titan stream message.
+    ///
+    /// Returns `Ok(None)` if the venue is absent from the message. The block timestamp is resolved
+    /// from the freshest lane update timestamp (see
+    /// [`max_lane_timestamp`](Self::max_lane_timestamp)) so the pool's oracle-staleness guard
+    /// sees the overridden prices as current.
+    fn parse_message(text: &str, venue: &Address) -> Result<Option<OverrideSnapshot>, String> {
+        let root: Value = serde_json::from_str(text).map_err(|e| format!("invalid JSON: {e}"))?;
+
+        // Each message carries one top-level entry per venue address, alongside `slot`,
+        // `blockNumber` and a wall-clock `timestamp`. Absent venue => nothing to apply.
+        let venue_key = format!("{venue:#x}");
+        let Some(venue_entry) = root.get(&venue_key) else {
+            return Ok(None);
+        };
+
+        let block_number = root
+            .get("blockNumber")
+            .and_then(Value::as_u64);
+
+        // `stateOverride` mirrors the eth_call State Override Set: account -> { stateDiff: slot ->
+        // value, ... }. We only consume `stateDiff` storage; balance/nonce/code are ignored.
+        let mut storage: VenueOverrides = HashMap::new();
+        if let Some(state_override) = venue_entry
+            .get("stateOverride")
+            .and_then(Value::as_object)
+        {
+            for (account, account_state) in state_override {
+                let address = account
+                    .parse::<Address>()
+                    .map_err(|e| format!("invalid account address {account}: {e}"))?;
+                let Some(state_diff) = account_state
+                    .get("stateDiff")
+                    .and_then(Value::as_object)
+                else {
+                    continue;
+                };
+                let mut slots = HashMap::new();
+                for (slot, value) in state_diff {
+                    let slot = slot
+                        .parse::<U256>()
+                        .map_err(|e| format!("invalid storage slot {slot}: {e}"))?;
+                    let value = value
+                        .as_str()
+                        .ok_or_else(|| format!("storage value for slot {slot} is not a string"))?
+                        .parse::<U256>()
+                        .map_err(|e| format!("invalid storage value: {e}"))?;
+                    slots.insert(slot, value);
+                }
+                if !slots.is_empty() {
+                    storage.insert(address, slots);
+                }
+            }
+        }
+
+        // Resolve the block timestamp from the freshest lane update, not the wall-clock
+        // `timestamp` field, so the registry's oracle-staleness guard treats the streamed prices
+        // as current.
+        let block_timestamp = Self::max_lane_timestamp(&storage);
+
+        Ok(Some(OverrideSnapshot { block_number, block_timestamp, storage }))
+    }
+
+    /// Returns the newest lane update timestamp (in seconds) across all overridden slots.
+    ///
+    /// FermiSwap registry lanes pack a uint32 update timestamp in the first 4 bytes of the slot
+    /// value. This extracts that prefix from every overridden slot and returns the maximum value
+    /// that looks like a plausible unix timestamp, or `None` if there are none. The result is used
+    /// as the resolved `block_timestamp` so the registry's staleness guard treats the streamed
+    /// oracle prices as current.
+    fn max_lane_timestamp(overrides: &VenueOverrides) -> Option<u64> {
+        // Lane slots pack a uint32 unix-seconds timestamp in the top 4 bytes (`value >> 224`).
+        // Non-lane slots have other (usually zero) top bytes, so we keep only values inside a
+        // plausible window to discard them.
+        const MIN_PLAUSIBLE: u64 = 1_000_000_000; // ~2001-09
+        const MAX_PLAUSIBLE: u64 = u32::MAX as u64; // uint32 ceiling (~2106)
+        overrides
+            .values()
+            .flat_map(|slots| slots.values())
+            .filter_map(|value| {
+                let candidate = u64::try_from(*value >> 224).ok()?;
+                (MIN_PLAUSIBLE..=MAX_PLAUSIBLE)
+                    .contains(&candidate)
+                    .then_some(candidate)
+            })
+            .max()
+    }
+}
+
+impl StateOverrideProvider for TitanProvider {
+    fn subscribe(&self, protocol_system: &str) -> Option<watch::Receiver<OverrideSnapshot>> {
+        self.receivers
+            .get(protocol_system)
+            .cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The known-protocols list must contain the FermiSwap protocol so the builder auto-registers
+    /// the provider.
+    #[test]
+    fn known_pamm_protocols_contains_fermiswap() {
+        assert!(known_pamm_protocols().contains(&FERMISWAP_PROTOCOL_SYSTEM));
+    }
+
+    #[test]
+    fn venue_for_protocol_resolves_all_known_venues() {
+        let cases = [
+            (FERMISWAP_PROTOCOL_SYSTEM, FERMISWAP_VENUE),
+            (KIPSELI_PROTOCOL_SYSTEM, KIPSELI_VENUE),
+            (BOPAMM_PROTOCOL_SYSTEM, BOPAMM_VENUE),
+        ];
+        for (protocol, expected) in cases {
+            assert_eq!(
+                TitanProvider::venue_for_protocol(protocol).expect("venue must resolve"),
+                expected.parse::<Address>().unwrap(),
+                "venue mismatch for {protocol}",
+            );
+        }
+    }
+
+    #[test]
+    fn venue_for_protocol_returns_none_for_unknown() {
+        assert!(TitanProvider::venue_for_protocol("vm:unknown").is_none());
+    }
+
+    /// Sample message from the Titan docs (<https://docs.titanbuilder.xyz/propamms/takers>).
+    const SAMPLE_MESSAGE: &str = r#"{
+        "slot": 14285824,
+        "blockNumber": 25051224,
+        "timestamp": 1778253913749564761,
+        "0xb1076fe3ab5e28005c7c323bac5ac06a680d452e": {
+            "stateOverride": {
+                "0x1038c87766e36d1925889e6f26d10e0012d50fed": {
+                    "balance": "0x0",
+                    "nonce": "0x1",
+                    "stateDiff": {
+                        "0x156b1d71de08fed89d0fce38008e2b9d03a8998077e394b20597ef3d148f5ebc": "0x000000000000000000000000000000000000000000000000000000017e405801"
+                    }
+                }
+            }
+        }
+    }"#;
+
+    #[test]
+    fn parse_message_extracts_venue_state_diff() {
+        let venue = FERMISWAP_VENUE.parse::<Address>().unwrap();
+        let snapshot = TitanProvider::parse_message(SAMPLE_MESSAGE, &venue)
+            .expect("parse must succeed")
+            .expect("venue is present");
+
+        assert_eq!(snapshot.block_number, Some(25051224));
+
+        let account = "0x1038c87766e36d1925889e6f26d10e0012d50fed"
+            .parse::<Address>()
+            .unwrap();
+        let slot = "0x156b1d71de08fed89d0fce38008e2b9d03a8998077e394b20597ef3d148f5ebc"
+            .parse::<U256>()
+            .unwrap();
+        let value = "0x000000000000000000000000000000000000000000000000000000017e405801"
+            .parse::<U256>()
+            .unwrap();
+        assert_eq!(snapshot.storage.get(&account).and_then(|s| s.get(&slot)), Some(&value));
+    }
+
+    #[test]
+    fn parse_message_returns_none_for_absent_venue() {
+        let venue = KIPSELI_VENUE.parse::<Address>().unwrap();
+        assert!(TitanProvider::parse_message(SAMPLE_MESSAGE, &venue)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn max_lane_timestamp_picks_newest_plausible_top_word() {
+        let addr = FERMISWAP_VENUE.parse::<Address>().unwrap();
+        // Two lane slots with the timestamp packed in the top 4 bytes, plus a non-lane slot
+        // whose top bytes are zero (must be ignored).
+        let older = U256::from(1_700_000_000u64) << 224;
+        let newer = U256::from(1_800_000_000u64) << 224;
+        let non_lane = U256::from(42u64);
+        let overrides = HashMap::from([(
+            addr,
+            HashMap::from([
+                (U256::from(0u64), older),
+                (U256::from(1u64), newer),
+                (U256::from(2u64), non_lane),
+            ]),
+        )]);
+        assert_eq!(TitanProvider::max_lane_timestamp(&overrides), Some(1_800_000_000));
+    }
+
+    #[test]
+    fn max_lane_timestamp_none_when_no_plausible_values() {
+        let addr = FERMISWAP_VENUE.parse::<Address>().unwrap();
+        let overrides = HashMap::from([(addr, HashMap::from([(U256::from(0u64), U256::from(7u64))]))]);
+        assert!(TitanProvider::max_lane_timestamp(&overrides).is_none());
+    }
+}

--- a/crates/tycho-simulation/src/evm/override_stream/titan.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/titan.rs
@@ -9,11 +9,7 @@
 //! All Titan/Fermi-specific knowledge (venue addresses, lane-timestamp resolution, endpoint URL)
 //! lives only in this module; the rest of the override machinery is protocol-agnostic.
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use alloy::primitives::{Address, U256};
 use futures::StreamExt;
@@ -99,22 +95,21 @@ fn known_pamm_protocols() -> &'static [&'static str] {
 
 /// Default override providers contributed by Titan, keyed by `protocol_system`.
 ///
-/// Returns one shared [`TitanProvider`] mapped under every known pAMM `protocol_system` that is
-/// both present in `registered_exchanges` and absent from `covered`. The provider is spawned only
-/// when at least one such venue needs serving — so a caller who overrides every Titan venue opens
-/// no connection. The single provider is shared across its protocols via `Arc`, not duplicated.
+/// Returns one shared [`TitanProvider`] mapped under every known pAMM `protocol_system` yielded by
+/// `protocols` (the ones the caller wants a built-in default for). Takes an owned iterator so the
+/// caller can forward its strings without cloning. The provider is spawned only when at least one
+/// such venue needs serving — so an empty or fully-overridden `protocols` opens no connection. The
+/// single provider is shared across its protocols via `Arc`, not duplicated.
 pub fn default_providers(
-    registered_exchanges: &[String],
-    covered: &HashSet<String>,
+    protocols: impl IntoIterator<Item = String>,
 ) -> HashMap<String, Arc<dyn StateOverrideProvider>> {
-    let needed: Vec<&'static str> = known_pamm_protocols()
-        .iter()
-        .copied()
-        .filter(|&protocol| {
-            registered_exchanges
+    let needed: Vec<&'static str> = protocols
+        .into_iter()
+        .filter_map(|protocol| {
+            known_pamm_protocols()
                 .iter()
-                .any(|e| e.as_str() == protocol) &&
-                !covered.contains(protocol)
+                .copied()
+                .find(|&known| known == protocol.as_str())
         })
         .collect();
     if needed.is_empty() {
@@ -122,9 +117,9 @@ pub fn default_providers(
     }
     // Auto-registration endpoint: the `TITAN_PAMM_STREAM_URL` env override if set, else the
     // built-in default. Consumers needing a different endpoint can register their own
-    // `TitanProvider::spawn(url)` via `with_override_provider` instead.
+    // `TitanProvider::spawn(url, protocols)` via `with_override_provider` instead.
     let url = std::env::var(TITAN_URL_ENV).unwrap_or_else(|_| TITAN_URL.to_string());
-    let provider: Arc<dyn StateOverrideProvider> = Arc::new(TitanProvider::spawn(url));
+    let provider: Arc<dyn StateOverrideProvider> = Arc::new(TitanProvider::spawn(url, &needed));
     needed
         .into_iter()
         .map(|protocol| (protocol.to_string(), provider.clone()))
@@ -133,16 +128,17 @@ pub fn default_providers(
 
 /// A [`StateOverrideProvider`] backed by a single Titan pAMM WebSocket connection.
 ///
-/// One connection serves all known pAMM venues; per-protocol snapshots are exposed through the
-/// `watch` receivers held here. Cheap to clone.
+/// One connection serves the `protocols` it was spawned for; per-protocol snapshots are exposed
+/// through the `watch` receivers held here. Cheap to clone.
 pub struct TitanProvider {
     /// Latest resolved snapshot per served `protocol_system`, kept fresh by the background task.
     receivers: HashMap<String, watch::Receiver<OverrideSnapshot>>,
 }
 
 impl TitanProvider {
-    /// Opens ONE WebSocket connection to `url` serving all known pAMM venues and spawns the
-    /// background reconnect/parse task that keeps the per-protocol snapshots up to date.
+    /// Opens ONE WebSocket connection to `url` serving the given `protocols` and spawns the
+    /// background reconnect/parse task that keeps their per-protocol snapshots up to date. Only the
+    /// requested protocols get a channel, and the task only parses their venues.
     ///
     /// Public so a consumer can point a provider at a custom endpoint and register it via
     /// [`ProtocolStreamBuilder::with_override_provider`](crate::evm::stream::ProtocolStreamBuilder::with_override_provider),
@@ -150,11 +146,12 @@ impl TitanProvider {
     ///
     /// Returns immediately; the connection is established and maintained in the background, so a
     /// transient WebSocket failure never blocks or crashes the caller.
-    pub fn spawn(url: String) -> Self {
+    pub fn spawn(url: String, protocols: &[&str]) -> Self {
         let mut receivers = HashMap::new();
         let mut senders = Vec::new();
-        for &protocol in known_pamm_protocols() {
+        for &protocol in protocols {
             let Some(venue) = Self::venue_for_protocol(protocol) else {
+                warn!("Unknown protocol: {protocol}");
                 continue;
             };
             let (tx, rx) = watch::channel(OverrideSnapshot::default());
@@ -259,8 +256,9 @@ impl TitanProvider {
                             // Keep-alive frames. tokio-tungstenite answers pings with pongs
                             // automatically while the stream is polled, so there is nothing to do.
                             Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {}
-                            // Raw frames only surface with non-default tungstenite settings;
-                            // ignore.
+                            // `Frame` is only produced when *sending* raw frames; the read side
+                            // never yields it, so this arm is unreachable in practice — kept only
+                            // for match exhaustiveness.
                             Ok(Message::Frame(_)) => {}
                             // Server initiated a graceful close — reconnect.
                             Ok(Message::Close(frame)) => {

--- a/crates/tycho-simulation/src/evm/override_stream/titan.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/titan.rs
@@ -28,14 +28,17 @@ type VenueOverrides = HashMap<Address, HashMap<U256, U256>>;
 
 /// A parsed Titan quote-stream frame.
 ///
-/// Only `blockNumber` is consumed at this level; every other top-level key (venue addresses,
-/// `slot`, `timestamp`, and any future fields) lands in `overrides` as raw JSON. Only the venue
-/// keys we look up are then deserialized into [`AddressEntry`], so an upstream schema change that
-/// adds top-level fields never breaks parsing.
+/// `blockNumber` and `timestamp` (the nanosecond wall-clock instant Titan built the quote) are
+/// consumed at this level; every other top-level key (venue addresses, `slot`, and any future
+/// fields) lands in `overrides` as raw JSON. Only the venue keys we look up are then deserialized
+/// into [`AddressEntry`], so an upstream schema change that adds top-level fields never breaks
+/// parsing.
 #[derive(Debug, Deserialize)]
 struct TitanMessage {
     #[serde(rename = "blockNumber", default)]
     block_number: Option<u64>,
+    #[serde(default)]
+    timestamp: Option<u64>,
     #[serde(flatten)]
     overrides: HashMap<String, serde_json::Value>,
 }
@@ -87,6 +90,12 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Reconnect backoff is `2^min(attempt, MAX_BACKOFF_EXP)` seconds, i.e. capped at 32s.
 const MAX_BACKOFF_EXP: u32 = 5;
+
+/// How long a Titan quote stays usable after it was built, in seconds. Titan targets the pending
+/// L1 block, so one block time (12s) is the window in which the overridden prices are current; past
+/// it the snapshot is stale and the pool reverts to Tycho's indexed state. Used to derive each
+/// snapshot's [`OverrideSnapshot::expires_at`] from the frame's wall-clock `timestamp`.
+const TITAN_QUOTE_TTL_SECS: u64 = 12;
 
 /// Returns the pAMM `protocol_system`s this provider knows how to serve.
 fn known_pamm_protocols() -> &'static [&'static str] {
@@ -314,7 +323,8 @@ impl TitanProvider {
     /// Returns `Ok(None)` if the venue is absent from the frame. The block timestamp is resolved
     /// from the freshest lane update timestamp (see
     /// [`max_lane_timestamp`](Self::max_lane_timestamp)) so the pool's oracle-staleness guard
-    /// sees the overridden prices as current.
+    /// sees the overridden prices as current, and `expires_at` is set to the frame's wall-clock
+    /// `timestamp` plus [`TITAN_QUOTE_TTL_SECS`] so the pool stops using it once it goes stale.
     fn extract_venue(
         message: &TitanMessage,
         venue: &Address,
@@ -343,7 +353,19 @@ impl TitanProvider {
         // as current.
         let block_timestamp = Self::max_lane_timestamp(&storage);
 
-        Ok(Some(OverrideSnapshot { block_number, block_timestamp, storage: Arc::new(storage) }))
+        // Expire the snapshot one block time after Titan built it, using the frame's nanosecond
+        // wall-clock `timestamp`. Once past this the pool drops the override and reverts to Tycho's
+        // indexed state, so a stalled stream can never keep serving prices indefinitely.
+        let expires_at = message
+            .timestamp
+            .map(|ns| ns / 1_000_000_000 + TITAN_QUOTE_TTL_SECS);
+
+        Ok(Some(OverrideSnapshot {
+            block_number,
+            block_timestamp,
+            storage: Arc::new(storage),
+            expires_at,
+        }))
     }
 
     /// Returns the newest lane update timestamp (in seconds) across all overridden slots.
@@ -441,6 +463,8 @@ mod tests {
             .expect("venue is present");
 
         assert_eq!(snapshot.block_number, Some(25051224));
+        // 1778253913749564761 ns -> 1778253913 s, plus the 12s quote TTL.
+        assert_eq!(snapshot.expires_at, Some(1778253913 + TITAN_QUOTE_TTL_SECS));
 
         let account = "0x1038c87766e36d1925889e6f26d10e0012d50fed"
             .parse::<Address>()

--- a/crates/tycho-simulation/src/evm/override_stream/titan.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/titan.rs
@@ -83,6 +83,10 @@ const BOPAMM_VENUE: &str = "0x160141a205f5ddcf096ba3f48b7ed21eb52c62ea";
 /// stalled or half-open connection that [`StreamExt::next`] would otherwise wait on forever.
 const READ_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Longest a single connection attempt may take before it is aborted and retried, so a hung TCP/TLS
+/// handshake cannot block the background task forever.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Reconnect backoff is `2^min(attempt, MAX_BACKOFF_EXP)` seconds, i.e. capped at 32s.
 const MAX_BACKOFF_EXP: u32 = 5;
 
@@ -163,8 +167,8 @@ impl TitanProvider {
     async fn run(url: String, senders: Vec<(Address, watch::Sender<OverrideSnapshot>)>) {
         let mut attempt: u32 = 0;
         loop {
-            match connect_async(url.as_str()).await {
-                Ok((mut ws_stream, _)) => {
+            match timeout(CONNECT_TIMEOUT, connect_async(url.as_str())).await {
+                Ok(Ok((mut ws_stream, _))) => {
                     info!(%url, "Connected to Titan pAMM quote stream");
                     loop {
                         // Bound the wait so a half-open connection (no data and no close frame) is
@@ -243,9 +247,16 @@ impl TitanProvider {
                         }
                     }
                 }
-                // Could not establish the connection at all — fall through to backoff and retry.
-                Err(e) => {
+                // Connection refused / TLS error — fall through to backoff and retry.
+                Ok(Err(e)) => {
                     warn!(error = %e, "Failed to connect to Titan quote stream; retrying");
+                }
+                // Handshake did not complete within the timeout — retry after backoff.
+                Err(_elapsed) => {
+                    warn!(
+                        timeout_secs = CONNECT_TIMEOUT.as_secs(),
+                        "Titan connect timed out; retrying"
+                    );
                 }
             }
 

--- a/crates/tycho-simulation/src/evm/override_stream/titan.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/titan.rs
@@ -167,6 +167,18 @@ impl TitanProvider {
     async fn run(url: String, senders: Vec<(Address, watch::Sender<OverrideSnapshot>)>) {
         let mut attempt: u32 = 0;
         loop {
+            // Every receiver (the provider handle plus all pool clones) has been dropped, so
+            // nobody consumes overrides anymore: stop the task and release the connection.
+            // Because `subscribe` needs a live provider (which owns the master receivers), once
+            // this is true no future pool can obtain the channel either.
+            if senders
+                .iter()
+                .all(|(_, tx)| tx.is_closed())
+            {
+                warn!("All Titan override receivers dropped; stopping quote-stream task");
+                return;
+            }
+
             match timeout(CONNECT_TIMEOUT, connect_async(url.as_str())).await {
                 Ok(Ok((mut ws_stream, _))) => {
                     info!(%url, "Connected to Titan pAMM quote stream");
@@ -201,9 +213,9 @@ impl TitanProvider {
                                     Ok(message) => {
                                         for (venue, sender) in &senders {
                                             match Self::extract_venue(&message, venue) {
-                                                // A send error here only means every receiver (the
-                                                // provider handle and all pools) has been dropped,
-                                                // i.e. nothing consumes overrides anymore; ignore.
+                                                // A send error means every receiver has been
+                                                // dropped; the check after this loop stops the
+                                                // task, so ignoring it here is safe.
                                                 Ok(Some(snapshot)) => {
                                                     let _ = sender.send(snapshot);
                                                 }
@@ -220,6 +232,14 @@ impl TitanProvider {
                                     }
                                     // Unparseable frame: log and keep the connection.
                                     Err(e) => warn!(error = %e, "Failed to parse Titan message"),
+                                }
+                                // Stop promptly if every consumer went away while connected.
+                                if senders
+                                    .iter()
+                                    .all(|(_, tx)| tx.is_closed())
+                                {
+                                    warn!("All Titan override receivers dropped; stopping quote-stream task");
+                                    return;
                                 }
                             }
                             // Titan only sends JSON text; a binary frame is unexpected. Skip it and

--- a/crates/tycho-simulation/src/evm/override_stream/titan.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/titan.rs
@@ -63,6 +63,8 @@ struct AccountState {
 
 /// Default Titan pAMM quote-stream WebSocket endpoint serving all known pAMM venues.
 const TITAN_URL: &str = "wss://eu.rpc.titanbuilder.xyz/ws/pamm_quote_stream";
+/// Environment variable that overrides the default endpoint when no custom URL is passed.
+const TITAN_URL_ENV: &str = "TITAN_PAMM_STREAM_URL";
 
 /// FermiSwap protocol system identifier as indexed by Tycho.
 const FERMISWAP_PROTOCOL_SYSTEM: &str = "vm:fermiswap";
@@ -118,8 +120,11 @@ pub fn default_providers(
     if needed.is_empty() {
         return HashMap::new();
     }
-    let provider: Arc<dyn StateOverrideProvider> =
-        Arc::new(TitanProvider::spawn(TITAN_URL.to_string()));
+    // Auto-registration endpoint: the `TITAN_PAMM_STREAM_URL` env override if set, else the
+    // built-in default. Consumers needing a different endpoint can register their own
+    // `TitanProvider::spawn(url)` via `with_override_provider` instead.
+    let url = std::env::var(TITAN_URL_ENV).unwrap_or_else(|_| TITAN_URL.to_string());
+    let provider: Arc<dyn StateOverrideProvider> = Arc::new(TitanProvider::spawn(url));
     needed
         .into_iter()
         .map(|protocol| (protocol.to_string(), provider.clone()))
@@ -136,8 +141,12 @@ pub struct TitanProvider {
 }
 
 impl TitanProvider {
-    /// Opens ONE WebSocket connection to Titan serving all known pAMM venues and spawns the
+    /// Opens ONE WebSocket connection to `url` serving all known pAMM venues and spawns the
     /// background reconnect/parse task that keeps the per-protocol snapshots up to date.
+    ///
+    /// Public so a consumer can point a provider at a custom endpoint and register it via
+    /// [`ProtocolStreamBuilder::with_override_provider`](crate::evm::stream::ProtocolStreamBuilder::with_override_provider),
+    /// which takes precedence over the default registry.
     ///
     /// Returns immediately; the connection is established and maintained in the background, so a
     /// transient WebSocket failure never blocks or crashes the caller.

--- a/crates/tycho-simulation/src/evm/protocol/vm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/vm/decoder.rs
@@ -244,6 +244,10 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for EVMPoolState<PreCache
             .await
             .map_err(InvalidSnapshotError::VMError)?;
 
+        if let Some(receiver) = decoder_context.live_override.clone() {
+            pool_state.set_live_overrides(receiver);
+        }
+
         pool_state.set_spot_prices(all_tokens)?;
 
         Ok(pool_state)

--- a/crates/tycho-simulation/src/evm/protocol/vm/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/vm/state.rs
@@ -529,7 +529,7 @@ where
         // Live overrides (e.g. Titan pAMM oracle state) take precedence on conflict.
         if let Some(live) = live {
             if !live.storage.is_empty() {
-                merged_overwrites = self.merge(&merged_overwrites, &live.storage);
+                merged_overwrites = self.merge(&merged_overwrites, live.storage.as_ref());
             }
         }
 

--- a/crates/tycho-simulation/src/evm/protocol/vm/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/vm/state.rs
@@ -524,12 +524,12 @@ where
 
         // Merge `block_lasting_overwrites` with `token_overwrites`
         let mut merged_overwrites =
-            self.merge(&self.block_lasting_overwrites.clone(), &token_overwrites);
+            self.merge(self.block_lasting_overwrites.clone(), token_overwrites);
 
         // Live overrides (e.g. Titan pAMM oracle state) take precedence on conflict.
         if let Some(live) = live {
             if !live.storage.is_empty() {
-                merged_overwrites = self.merge(&merged_overwrites, live.storage.as_ref());
+                merged_overwrites = self.merge(merged_overwrites, live.storage.as_ref().clone());
             }
         }
 
@@ -579,7 +579,7 @@ where
         // Merge all overwrites into a single HashMap
         Ok(res
             .into_iter()
-            .fold(HashMap::new(), |acc, overwrite| self.merge(&acc, &overwrite)))
+            .fold(HashMap::new(), |acc, overwrite| self.merge(acc, overwrite)))
     }
 
     /// Gets all balance overwrites for the pool's tokens.
@@ -650,21 +650,20 @@ where
         Ok(balance_overwrites)
     }
 
+    /// Merges `source` into `target` and returns the result. On a per-slot conflict, `source` wins.
     fn merge(
         &self,
-        target: &HashMap<Address, Overwrites>,
-        source: &HashMap<Address, Overwrites>,
+        mut target: HashMap<Address, Overwrites>,
+        source: HashMap<Address, Overwrites>,
     ) -> HashMap<Address, Overwrites> {
-        let mut merged = target.clone();
-
         for (key, source_inner) in source {
-            merged
-                .entry(*key)
+            target
+                .entry(key)
                 .or_default()
-                .extend(source_inner.clone());
+                .extend(source_inner);
         }
 
-        merged
+        target
     }
 
     #[cfg(test)]
@@ -781,7 +780,7 @@ where
             sell_amount_limit,
             live_snapshot.as_ref(),
         )?;
-        let complete_overwrites = self.merge(&overwrites, &overwrites_with_sell_limit);
+        let complete_overwrites = self.merge(overwrites, overwrites_with_sell_limit);
 
         let (trade, state_changes) = self.adapter_contract.swap(
             &self.id,

--- a/crates/tycho-simulation/src/evm/protocol/vm/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/vm/state.rs
@@ -4,6 +4,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt::{self, Debug},
     str::FromStr,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use alloy::primitives::{Address, U256};
@@ -37,6 +38,15 @@ use crate::evm::{
     },
     simulation::BlockEnvOverrides,
 };
+
+/// Current unix time in seconds, or `0` if the system clock is before the epoch. Used to test live
+/// override snapshots against their expiry.
+fn unix_now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or(0)
+}
 
 #[derive(Clone)]
 pub struct EVMPoolState<D: EngineDatabaseInterface + Clone + Debug>
@@ -163,16 +173,24 @@ where
         self.live_overrides = Some(receiver);
     }
 
-    /// Reads the latest live override snapshot once, if a channel is attached.
+    /// Reads the latest live override snapshot once, if a channel is attached and still fresh.
     ///
     /// The `watch::Ref` guard is released immediately; the returned value is a clone. A single
     /// simulation resolves both its storage overwrites and its block environment from this one
     /// snapshot, so it can never mix storage from one snapshot with a block environment from
     /// another, and never holds the channel's read lock across EVM calls.
+    ///
+    /// Returns `None` once the snapshot has passed its provider-set expiry, so an expired override
+    /// is dropped and the pool transparently reverts to Tycho's indexed state.
     fn get_live_snapshot(&self) -> Option<OverrideSnapshot> {
-        self.live_overrides
+        let snapshot = self
+            .live_overrides
             .as_ref()
-            .map(|receiver| receiver.borrow().clone())
+            .map(|receiver| receiver.borrow().clone())?;
+        if snapshot.is_expired(unix_now_secs()) {
+            return None;
+        }
+        Some(snapshot)
     }
 
     /// The block environment to apply to adapter simulations, resolved from a single pre-read

--- a/crates/tycho-simulation/src/evm/protocol/vm/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/vm/state.rs
@@ -1586,4 +1586,163 @@ mod tests {
 
         assert!(deserialized.is_err());
     }
+
+    /// A live snapshot's block number/timestamp take precedence over the static block overrides,
+    /// field by field, while an absent or empty snapshot leaves them untouched.
+    #[tokio::test]
+    async fn test_block_env_prefers_live_overrides() {
+        let mut pool_state = setup_pool_state().await;
+        pool_state.block_overrides =
+            Some(BlockEnvOverrides { number: Some(100), timestamp: Some(1_000) });
+
+        // No live snapshot: the statically configured overrides are used unchanged.
+        assert_eq!(
+            pool_state.block_env(None),
+            Some(BlockEnvOverrides { number: Some(100), timestamp: Some(1_000) })
+        );
+
+        // A live snapshot with neither field set does not touch the static overrides.
+        let empty = OverrideSnapshot::default();
+        assert_eq!(
+            pool_state.block_env(Some(&empty)),
+            Some(BlockEnvOverrides { number: Some(100), timestamp: Some(1_000) })
+        );
+
+        // Present live fields win; unset live fields keep the static value.
+        let live = OverrideSnapshot {
+            block_number: Some(200),
+            block_timestamp: None,
+            ..Default::default()
+        };
+        assert_eq!(
+            pool_state.block_env(Some(&live)),
+            Some(BlockEnvOverrides { number: Some(200), timestamp: Some(1_000) })
+        );
+
+        // With no static overrides, the live block environment stands on its own.
+        pool_state.block_overrides = None;
+        let live = OverrideSnapshot {
+            block_number: Some(300),
+            block_timestamp: Some(3_000),
+            ..Default::default()
+        };
+        assert_eq!(
+            pool_state.block_env(Some(&live)),
+            Some(BlockEnvOverrides { number: Some(300), timestamp: Some(3_000) })
+        );
+    }
+
+    /// Live storage is merged into the computed overwrites: a fresh contract is added, a value on a
+    /// slot the baseline already sets is overridden (live wins on conflict), and empty live storage
+    /// is a no-op.
+    #[tokio::test]
+    async fn test_get_overwrites_applies_live_storage() {
+        let pool_state = setup_pool_state().await;
+        let tokens = vec![dai_addr(), bal_addr()];
+        let max = *MAX_BALANCE / U256::from(100);
+
+        let baseline = pool_state
+            .get_overwrites(tokens.clone(), max, None)
+            .unwrap();
+
+        // An empty live snapshot leaves the overwrites unchanged.
+        let empty = OverrideSnapshot::default();
+        assert_eq!(
+            pool_state
+                .get_overwrites(tokens.clone(), max, Some(&empty))
+                .unwrap(),
+            baseline
+        );
+
+        // Pick an address/slot the baseline already sets, so we can assert live wins the conflict.
+        let (conflict_addr, conflict_slot, baseline_val) = {
+            let (addr, slots) = baseline
+                .iter()
+                .next()
+                .expect("baseline has overwrites");
+            let (slot, val) = slots
+                .iter()
+                .next()
+                .expect("address has slots");
+            (*addr, *slot, *val)
+        };
+        let sentinel = baseline_val + U256::from(1);
+        let fresh = Address::from([0xAB; 20]);
+        assert!(
+            !baseline.contains_key(&fresh),
+            "fresh address must originate from the live snapshot"
+        );
+
+        let live = OverrideSnapshot {
+            storage: std::sync::Arc::new(HashMap::from([
+                (fresh, HashMap::from([(U256::from(7), U256::from(123))])),
+                (conflict_addr, HashMap::from([(conflict_slot, sentinel)])),
+            ])),
+            ..Default::default()
+        };
+        let with_live = pool_state
+            .get_overwrites(tokens, max, Some(&live))
+            .unwrap();
+
+        assert_eq!(
+            with_live
+                .get(&fresh)
+                .and_then(|slots| slots.get(&U256::from(7))),
+            Some(&U256::from(123)),
+            "live storage for a fresh contract must be merged in"
+        );
+        assert_eq!(
+            with_live
+                .get(&conflict_addr)
+                .and_then(|slots| slots.get(&conflict_slot)),
+            Some(&sentinel),
+            "live override must win on slot conflict"
+        );
+    }
+
+    /// `get_live_snapshot` returns the attached snapshot only while it is fresh: an expired one is
+    /// dropped (so the pool reverts to indexed state), and no channel means no snapshot. Expiry is
+    /// pinned to the extremes (`1` = long past, `u64::MAX` = effectively never) so the assertions
+    /// are independent of the wall clock.
+    #[tokio::test]
+    async fn test_get_live_snapshot_drops_expired() {
+        let mut pool_state = setup_pool_state().await;
+
+        // No channel attached: nothing to read.
+        assert!(pool_state.get_live_snapshot().is_none());
+
+        // A snapshot without an expiry never goes stale.
+        let never =
+            OverrideSnapshot { block_number: Some(1), expires_at: None, ..Default::default() };
+        let (_never_tx, never_rx) = watch::channel(never);
+        pool_state.set_live_overrides(never_rx);
+        assert_eq!(
+            pool_state
+                .get_live_snapshot()
+                .and_then(|snapshot| snapshot.block_number),
+            Some(1)
+        );
+
+        // A snapshot whose expiry is far in the future is returned.
+        let fresh = OverrideSnapshot {
+            block_number: Some(42),
+            expires_at: Some(u64::MAX),
+            ..Default::default()
+        };
+        let (_fresh_tx, fresh_rx) = watch::channel(fresh);
+        pool_state.set_live_overrides(fresh_rx);
+        assert_eq!(
+            pool_state
+                .get_live_snapshot()
+                .and_then(|snapshot| snapshot.block_number),
+            Some(42)
+        );
+
+        // A snapshot whose expiry is in the past is dropped.
+        let expired =
+            OverrideSnapshot { block_number: Some(42), expires_at: Some(1), ..Default::default() };
+        let (_expired_tx, expired_rx) = watch::channel(expired);
+        pool_state.set_live_overrides(expired_rx);
+        assert!(pool_state.get_live_snapshot().is_none());
+    }
 }

--- a/crates/tycho-simulation/src/evm/protocol/vm/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/vm/state.rs
@@ -39,15 +39,6 @@ use crate::evm::{
     simulation::BlockEnvOverrides,
 };
 
-/// Current unix time in seconds, or `0` if the system clock is before the epoch. Used to test live
-/// override snapshots against their expiry.
-fn unix_now_secs() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|elapsed| elapsed.as_secs())
-        .unwrap_or(0)
-}
-
 #[derive(Clone)]
 pub struct EVMPoolState<D: EngineDatabaseInterface + Clone + Debug>
 where
@@ -187,7 +178,11 @@ where
             .live_overrides
             .as_ref()
             .map(|receiver| receiver.borrow().clone())?;
-        if snapshot.is_expired(unix_now_secs()) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_secs())
+            .unwrap_or(0);
+        if snapshot.is_expired(now) {
             return None;
         }
         Some(snapshot)

--- a/crates/tycho-simulation/src/evm/protocol/vm/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/vm/state.rs
@@ -11,6 +11,7 @@ use itertools::Itertools;
 use num_bigint::BigUint;
 use revm::DatabaseRef;
 use serde::{Deserialize, Serialize};
+use tokio::sync::watch;
 use tycho_common::{
     dto::ProtocolStateDelta,
     models::token::Token,
@@ -29,6 +30,7 @@ use super::{
 };
 use crate::evm::{
     engine_db::{engine_db_interface::EngineDatabaseInterface, tycho_db::PreCachedDB},
+    override_stream::OverrideSnapshot,
     protocol::{
         u256_num::{u256_to_biguint, u256_to_f64},
         utils::bytes_to_address,
@@ -82,6 +84,13 @@ where
     self_contained_tokens: HashSet<Address>,
     /// Block context overrides applied to this pool's adapter simulations.
     block_overrides: Option<BlockEnvOverrides>,
+    /// Live per-block VM overrides (e.g. Titan pAMM oracle prices) read at simulation time.
+    ///
+    /// When set, the latest [`OverrideSnapshot`] is merged into the pool's storage overwrites and
+    /// block environment on every simulation, so sub-block updates are reflected without a Tycho
+    /// block update. Takes precedence over [`Self::block_lasting_overwrites`] and
+    /// [`Self::block_overrides`] on conflict.
+    live_overrides: Option<watch::Receiver<OverrideSnapshot>>,
 }
 
 impl<D> Debug for EVMPoolState<D>
@@ -143,7 +152,46 @@ where
             disable_overwrite_tokens,
             self_contained_tokens,
             block_overrides,
+            live_overrides: None,
         }
+    }
+
+    /// Attaches a live override channel (e.g. from a Titan pAMM provider).
+    ///
+    /// Once set, the latest snapshot is read on every simulation; see [`Self::live_overrides`].
+    pub fn set_live_overrides(&mut self, receiver: watch::Receiver<OverrideSnapshot>) {
+        self.live_overrides = Some(receiver);
+    }
+
+    /// Storage overwrites from the live override channel, if one is attached and has data.
+    fn live_storage_overwrites(&self) -> Option<HashMap<Address, Overwrites>> {
+        let snapshot = self.live_overrides.as_ref()?.borrow();
+        if snapshot.storage.is_empty() {
+            None
+        } else {
+            Some(snapshot.storage.clone())
+        }
+    }
+
+    /// The block environment to apply to adapter simulations, preferring the live snapshot's
+    /// resolved block number/timestamp over the statically configured [`Self::block_overrides`].
+    fn effective_block_overrides(&self) -> Option<BlockEnvOverrides> {
+        let base = self.block_overrides.to_owned();
+        let Some(receiver) = self.live_overrides.as_ref() else {
+            return base;
+        };
+        let snapshot = receiver.borrow();
+        if snapshot.block_number.is_none() && snapshot.block_timestamp.is_none() {
+            return base;
+        }
+        let mut overrides = base.unwrap_or_default();
+        if snapshot.block_number.is_some() {
+            overrides.number = snapshot.block_number;
+        }
+        if snapshot.block_timestamp.is_some() {
+            overrides.timestamp = snapshot.block_timestamp;
+        }
+        Some(overrides)
     }
 
     /// Ensures the pool supports the given capability
@@ -230,7 +278,7 @@ where
                         buy_token_address,
                         vec![sell_amount_limit / U256::from(100)],
                         overwrites,
-                        self.block_overrides.clone(),
+                        self.effective_block_overrides(),
                     )?;
 
                     let price = if self
@@ -290,7 +338,7 @@ where
                             false,
                             x1,
                             overwrites.clone(),
-                            self.block_overrides.clone(),
+                            self.effective_block_overrides(),
                         )?
                         .0
                         .received_amount;
@@ -306,7 +354,7 @@ where
                             false,
                             x2,
                             overwrites,
-                            self.block_overrides.clone(),
+                            self.effective_block_overrides(),
                         )?
                         .0
                         .received_amount;
@@ -381,7 +429,7 @@ where
             tokens[0],
             tokens[1],
             overwrites,
-            self.block_overrides.clone(),
+            self.effective_block_overrides(),
         )?;
 
         Ok(limits)
@@ -466,8 +514,13 @@ where
         let token_overwrites = self.get_token_overwrites(tokens, max_amount)?;
 
         // Merge `block_lasting_overwrites` with `token_overwrites`
-        let merged_overwrites =
+        let mut merged_overwrites =
             self.merge(&self.block_lasting_overwrites.clone(), &token_overwrites);
+
+        // Live overrides (e.g. Titan pAMM oracle state) take precedence on conflict.
+        if let Some(live_overwrites) = self.live_storage_overwrites() {
+            merged_overwrites = self.merge(&merged_overwrites, &live_overwrites);
+        }
 
         Ok(merged_overwrites)
     }
@@ -625,7 +678,7 @@ where
 
     #[cfg(test)]
     pub fn get_block_overrides(&self) -> Option<BlockEnvOverrides> {
-        self.block_overrides.clone()
+        self.effective_block_overrides()
     }
 }
 
@@ -717,7 +770,7 @@ where
             false,
             sell_amount_respecting_limit,
             Some(complete_overwrites),
-            self.block_overrides.clone(),
+            self.effective_block_overrides(),
         )?;
 
         let mut new_state = self.clone();

--- a/crates/tycho-simulation/src/evm/protocol/vm/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/vm/state.rs
@@ -163,24 +163,26 @@ where
         self.live_overrides = Some(receiver);
     }
 
-    /// Storage overwrites from the live override channel, if one is attached and has data.
-    fn live_storage_overwrites(&self) -> Option<HashMap<Address, Overwrites>> {
-        let snapshot = self.live_overrides.as_ref()?.borrow();
-        if snapshot.storage.is_empty() {
-            None
-        } else {
-            Some(snapshot.storage.clone())
-        }
+    /// Reads the latest live override snapshot once, if a channel is attached.
+    ///
+    /// The `watch::Ref` guard is released immediately; the returned value is a clone. A single
+    /// simulation resolves both its storage overwrites and its block environment from this one
+    /// snapshot, so it can never mix storage from one snapshot with a block environment from
+    /// another, and never holds the channel's read lock across EVM calls.
+    fn get_live_snapshot(&self) -> Option<OverrideSnapshot> {
+        self.live_overrides
+            .as_ref()
+            .map(|receiver| receiver.borrow().clone())
     }
 
-    /// The block environment to apply to adapter simulations, preferring the live snapshot's
-    /// resolved block number/timestamp over the statically configured [`Self::block_overrides`].
-    fn effective_block_overrides(&self) -> Option<BlockEnvOverrides> {
+    /// The block environment to apply to adapter simulations, resolved from a single pre-read
+    /// `live` snapshot: its block number/timestamp take precedence over the statically configured
+    /// [`Self::block_overrides`].
+    fn block_env(&self, live: Option<&OverrideSnapshot>) -> Option<BlockEnvOverrides> {
         let base = self.block_overrides.to_owned();
-        let Some(receiver) = self.live_overrides.as_ref() else {
+        let Some(snapshot) = live else {
             return base;
         };
-        let snapshot = receiver.borrow();
         if snapshot.block_number.is_none() && snapshot.block_timestamp.is_none() {
             return base;
         }
@@ -252,6 +254,11 @@ where
         &mut self,
         tokens: &HashMap<Bytes, Token>,
     ) -> Result<(), SimulationError> {
+        // Read the live snapshot once and resolve the block environment from it, so every pair
+        // (and both sub-swaps in the no-capability branch) simulates against one consistent
+        // snapshot.
+        let live_snapshot = self.get_live_snapshot();
+        let block_overrides = self.block_env(live_snapshot.as_ref());
         match self.ensure_capability(Capability::PriceFunction) {
             Ok(_) => {
                 for [sell_token_address, buy_token_address] in self
@@ -266,11 +273,13 @@ where
                     let overwrites = Some(self.get_overwrites(
                         vec![sell_token_address, buy_token_address],
                         *MAX_BALANCE / U256::from(100),
+                        live_snapshot.as_ref(),
                     )?);
 
                     let (sell_amount_limit, _) = self.get_amount_limits(
                         vec![sell_token_address, buy_token_address],
                         overwrites.clone(),
+                        block_overrides.clone(),
                     )?;
                     let price_result = self.adapter_contract.price(
                         &self.id,
@@ -278,7 +287,7 @@ where
                         buy_token_address,
                         vec![sell_amount_limit / U256::from(100)],
                         overwrites,
-                        self.effective_block_overrides(),
+                        block_overrides.clone(),
                     )?;
 
                     let price = if self
@@ -314,14 +323,20 @@ where
                     let t0 = bytes_to_address(iter_tokens[0])?;
                     let t1 = bytes_to_address(iter_tokens[1])?;
 
-                    let overwrites =
-                        Some(self.get_overwrites(vec![t0, t1], *MAX_BALANCE / U256::from(100))?);
+                    let overwrites = Some(self.get_overwrites(
+                        vec![t0, t1],
+                        *MAX_BALANCE / U256::from(100),
+                        live_snapshot.as_ref(),
+                    )?);
 
                     // Calculate the first sell amount (x1) as 1% of the maximum limit.
-                    let x1 = self
-                        .get_amount_limits(vec![t0, t1], overwrites.clone())?
-                        .0 /
-                        U256::from(100);
+                    let x1 =
+                        self.get_amount_limits(
+                            vec![t0, t1],
+                            overwrites.clone(),
+                            block_overrides.clone(),
+                        )?
+                        .0 / U256::from(100);
 
                     // Calculate the second sell amount (x2) as x1 + 1% of x1. 1.01% of the max
                     // limit
@@ -338,7 +353,7 @@ where
                             false,
                             x1,
                             overwrites.clone(),
-                            self.effective_block_overrides(),
+                            block_overrides.clone(),
                         )?
                         .0
                         .received_amount;
@@ -347,15 +362,7 @@ where
                     // amount (y2).
                     let y2 = self
                         .adapter_contract
-                        .swap(
-                            &self.id,
-                            t0,
-                            t1,
-                            false,
-                            x2,
-                            overwrites,
-                            self.effective_block_overrides(),
-                        )?
+                        .swap(&self.id, t0, t1, false, x2, overwrites, block_overrides.clone())?
                         .0
                         .received_amount;
 
@@ -423,13 +430,14 @@ where
         &self,
         tokens: Vec<Address>,
         overwrites: Option<HashMap<Address, HashMap<U256, U256>>>,
+        block_overrides: Option<BlockEnvOverrides>,
     ) -> Result<(U256, U256), SimulationError> {
         let limits = self.adapter_contract.get_limits(
             &self.id,
             tokens[0],
             tokens[1],
             overwrites,
-            self.effective_block_overrides(),
+            block_overrides,
         )?;
 
         Ok(limits)
@@ -510,6 +518,7 @@ where
         &self,
         tokens: Vec<Address>,
         max_amount: U256,
+        live: Option<&OverrideSnapshot>,
     ) -> Result<HashMap<Address, Overwrites>, SimulationError> {
         let token_overwrites = self.get_token_overwrites(tokens, max_amount)?;
 
@@ -518,8 +527,10 @@ where
             self.merge(&self.block_lasting_overwrites.clone(), &token_overwrites);
 
         // Live overrides (e.g. Titan pAMM oracle state) take precedence on conflict.
-        if let Some(live_overwrites) = self.live_storage_overwrites() {
-            merged_overwrites = self.merge(&merged_overwrites, &live_overwrites);
+        if let Some(live) = live {
+            if !live.storage.is_empty() {
+                merged_overwrites = self.merge(&merged_overwrites, &live.storage);
+            }
         }
 
         Ok(merged_overwrites)
@@ -678,7 +689,8 @@ where
 
     #[cfg(test)]
     pub fn get_block_overrides(&self) -> Option<BlockEnvOverrides> {
-        self.effective_block_overrides()
+        let live_snapshot = self.get_live_snapshot();
+        self.block_env(live_snapshot.as_ref())
     }
 }
 
@@ -741,13 +753,18 @@ where
         let sell_token_address = bytes_to_address(&token_in.address)?;
         let buy_token_address = bytes_to_address(&token_out.address)?;
         let sell_amount = U256::from_be_slice(&amount_in.to_bytes_be());
+        // Read the live snapshot once so overwrites, limits and the swap use one snapshot.
+        let live_snapshot = self.get_live_snapshot();
+        let block_overrides = self.block_env(live_snapshot.as_ref());
         let overwrites = self.get_overwrites(
             vec![sell_token_address, buy_token_address],
             *MAX_BALANCE / U256::from(100),
+            live_snapshot.as_ref(),
         )?;
         let (sell_amount_limit, _) = self.get_amount_limits(
             vec![sell_token_address, buy_token_address],
             Some(overwrites.clone()),
+            block_overrides.clone(),
         )?;
         let (sell_amount_respecting_limit, sell_amount_exceeds_limit) = if self
             .capabilities
@@ -759,8 +776,11 @@ where
             (sell_amount, false)
         };
 
-        let overwrites_with_sell_limit =
-            self.get_overwrites(vec![sell_token_address, buy_token_address], sell_amount_limit)?;
+        let overwrites_with_sell_limit = self.get_overwrites(
+            vec![sell_token_address, buy_token_address],
+            sell_amount_limit,
+            live_snapshot.as_ref(),
+        )?;
         let complete_overwrites = self.merge(&overwrites, &overwrites_with_sell_limit);
 
         let (trade, state_changes) = self.adapter_contract.swap(
@@ -770,7 +790,7 @@ where
             false,
             sell_amount_respecting_limit,
             Some(complete_overwrites),
-            self.effective_block_overrides(),
+            block_overrides,
         )?;
 
         let mut new_state = self.clone();
@@ -827,9 +847,17 @@ where
     ) -> Result<(BigUint, BigUint), SimulationError> {
         let sell_token = bytes_to_address(&sell_token)?;
         let buy_token = bytes_to_address(&buy_token)?;
-        let overwrites =
-            self.get_overwrites(vec![sell_token, buy_token], *MAX_BALANCE / U256::from(100))?;
-        let limits = self.get_amount_limits(vec![sell_token, buy_token], Some(overwrites))?;
+        let live_snapshot = self.get_live_snapshot();
+        let overwrites = self.get_overwrites(
+            vec![sell_token, buy_token],
+            *MAX_BALANCE / U256::from(100),
+            live_snapshot.as_ref(),
+        )?;
+        let limits = self.get_amount_limits(
+            vec![sell_token, buy_token],
+            Some(overwrites),
+            self.block_env(live_snapshot.as_ref()),
+        )?;
         Ok((u256_to_biguint(limits.0), u256_to_biguint(limits.1)))
     }
 
@@ -1250,10 +1278,15 @@ mod tests {
                     bytes_to_address(&pool_state.tokens[1]).unwrap(),
                 ],
                 *MAX_BALANCE / U256::from(100),
+                None,
             )
             .unwrap();
         let (dai_limit, _) = pool_state
-            .get_amount_limits(vec![dai_addr(), bal_addr()], Some(overwrites.clone()))
+            .get_amount_limits(
+                vec![dai_addr(), bal_addr()],
+                Some(overwrites.clone()),
+                pool_state.block_env(None),
+            )
             .unwrap();
         assert_eq!(dai_limit, U256::from_str("100279494253364362835").unwrap());
 
@@ -1264,6 +1297,7 @@ mod tests {
                     bytes_to_address(&pool_state.tokens[0]).unwrap(),
                 ],
                 Some(overwrites),
+                pool_state.block_env(None),
             )
             .unwrap();
         assert_eq!(bal_limit, U256::from_str("13997408640689987484").unwrap());

--- a/crates/tycho-simulation/src/evm/stream.rs
+++ b/crates/tycho-simulation/src/evm/stream.rs
@@ -668,8 +668,8 @@ impl ProtocolStreamBuilder {
     /// Installs override providers onto the decoder before the stream is built.
     ///
     /// Explicit consumer registrations win; the built-in default registry (see
-    /// [`default_override_providers`](crate::evm::override_stream::default_override_providers)) then
-    /// fills every remaining protocol it can serve.
+    /// [`default_override_providers`](crate::evm::override_stream::default_override_providers))
+    /// then fills every remaining protocol it can serve.
     fn install_override_providers(&mut self) {
         let explicit = std::mem::take(&mut self.override_providers);
         let covered: HashSet<String> = explicit.keys().cloned().collect();

--- a/crates/tycho-simulation/src/evm/stream.rs
+++ b/crates/tycho-simulation/src/evm/stream.rs
@@ -127,7 +127,7 @@ use tycho_common::{
 use crate::{
     evm::{
         decoder::{StreamDecodeError, TychoStreamDecoder},
-        override_stream::StateOverrideProvider,
+        override_stream::{self, StateOverrideProvider},
         pending::PendingBlockProcessor,
         protocol::{
             native_wrapper::state::NativeWrapperState,
@@ -673,10 +673,8 @@ impl ProtocolStreamBuilder {
     fn install_override_providers(&mut self) {
         let explicit = std::mem::take(&mut self.override_providers);
         let covered: HashSet<String> = explicit.keys().cloned().collect();
-        let defaults = crate::evm::override_stream::default_override_providers(
-            &self.registered_exchanges,
-            &covered,
-        );
+        let defaults =
+            override_stream::default_override_providers(&self.registered_exchanges, &covered);
         for (protocol_system, provider) in defaults.into_iter().chain(explicit) {
             self.decoder
                 .set_override_provider(protocol_system, provider);

--- a/crates/tycho-simulation/src/evm/stream.rs
+++ b/crates/tycho-simulation/src/evm/stream.rs
@@ -127,6 +127,7 @@ use tycho_common::{
 use crate::{
     evm::{
         decoder::{StreamDecodeError, TychoStreamDecoder},
+        override_stream::StateOverrideProvider,
         pending::PendingBlockProcessor,
         protocol::{
             native_wrapper::state::NativeWrapperState,
@@ -234,6 +235,13 @@ pub struct ProtocolStreamBuilder {
     /// Receiver half of the trigger channel. Held here until `build()` / `build_with_pending()`
     /// transfers ownership to the gating task. `Some` iff step-control mode is active.
     step_trigger_rx: Option<tokio::sync::mpsc::UnboundedReceiver<()>>,
+    /// State-override providers explicitly registered by the consumer, keyed by `protocol_system`.
+    /// These take precedence over the built-in default registry and are installed onto the decoder
+    /// at build time.
+    override_providers: HashMap<String, Arc<dyn StateOverrideProvider>>,
+    /// Names of all exchanges registered on the builder, used to decide which built-in override
+    /// providers to auto-register at build time.
+    registered_exchanges: Vec<String>,
 }
 
 impl ProtocolStreamBuilder {
@@ -254,6 +262,8 @@ impl ProtocolStreamBuilder {
             pending_indexers: HashMap::new(),
             step_peek_tx: None,
             step_trigger_rx: None,
+            override_providers: HashMap::new(),
+            registered_exchanges: Vec::new(),
         }
     }
 
@@ -292,6 +302,8 @@ impl ProtocolStreamBuilder {
         self.stream_builder = self
             .stream_builder
             .exchange(name, filter);
+        self.registered_exchanges
+            .push(name.to_string());
         self.decoder.register_decoder::<T>(name);
         if let Some(predicate) = filter_fn {
             self.decoder
@@ -346,6 +358,8 @@ impl ProtocolStreamBuilder {
         self.stream_builder = self
             .stream_builder
             .exchange(name, filter);
+        self.registered_exchanges
+            .push(name.to_string());
         self.decoder
             .register_decoder_with_context::<T>(name, decoder_context);
         if let Some(predicate) = filter_fn {
@@ -636,6 +650,39 @@ impl ProtocolStreamBuilder {
         });
     }
 
+    /// Registers `provider` as the live override source for `protocol_system`.
+    ///
+    /// Explicit registrations take precedence over the built-in default registry, so this is how
+    /// you swap a venue (e.g. `vm:bopamm`) onto a different provider. Registering the same provider
+    /// for several protocols is cheap — it is shared via `Arc`, not duplicated.
+    pub fn with_override_provider(
+        mut self,
+        protocol_system: impl Into<String>,
+        provider: Arc<dyn StateOverrideProvider>,
+    ) -> Self {
+        self.override_providers
+            .insert(protocol_system.into(), provider);
+        self
+    }
+
+    /// Installs override providers onto the decoder before the stream is built.
+    ///
+    /// Explicit consumer registrations win; the built-in default registry (see
+    /// [`default_override_providers`](crate::evm::override_stream::default_override_providers)) then
+    /// fills every remaining protocol it can serve.
+    fn install_override_providers(&mut self) {
+        let explicit = std::mem::take(&mut self.override_providers);
+        let covered: HashSet<String> = explicit.keys().cloned().collect();
+        let defaults = crate::evm::override_stream::default_override_providers(
+            &self.registered_exchanges,
+            &covered,
+        );
+        for (protocol_system, provider) in defaults.into_iter().chain(explicit) {
+            self.decoder
+                .set_override_provider(protocol_system, provider);
+        }
+    }
+
     /// Builds the confirmed protocol stream and a [`PendingBlockProcessor`] that stays
     /// in sync with it automatically.
     ///
@@ -648,7 +695,7 @@ impl ProtocolStreamBuilder {
     /// Call [`generate_pending_update`](PendingBlockProcessor::generate_pending_update) to
     /// simulate a candidate bundle; it drains the channel automatically before computing.
     pub async fn build_with_pending(
-        self,
+        mut self,
     ) -> Result<
         (impl Stream<Item = Result<Update, StreamDecodeError>>, PendingBlockProcessor),
         StreamError,
@@ -656,6 +703,7 @@ impl ProtocolStreamBuilder {
         initialize_hook_handlers().map_err(|e| {
             StreamError::SetUpError(format!("Error initializing hook handlers: {e:?}"))
         })?;
+        self.install_override_providers();
         let (_, rx) = self.stream_builder.build().await?;
         let decoder = Arc::new(self.decoder);
 
@@ -724,11 +772,12 @@ impl ProtocolStreamBuilder {
     /// See the module-level docs for details on stream behavior and emitted messages.
     /// This method applies all builder settings and starts the stream.
     pub async fn build(
-        self,
+        mut self,
     ) -> Result<impl Stream<Item = Result<Update, StreamDecodeError>>, StreamError> {
         initialize_hook_handlers().map_err(|e| {
             StreamError::SetUpError(format!("Error initializing hook handlers: {e:?}"))
         })?;
+        self.install_override_providers();
         let (_, rx) = self.stream_builder.build().await?;
         let decoder = Arc::new(self.decoder);
         let chain = self.chain;

--- a/crates/tycho-simulation/src/evm/stream.rs
+++ b/crates/tycho-simulation/src/evm/stream.rs
@@ -241,7 +241,7 @@ pub struct ProtocolStreamBuilder {
     override_providers: HashMap<String, Arc<dyn StateOverrideProvider>>,
     /// Names of all exchanges registered on the builder, used to decide which built-in override
     /// providers to auto-register at build time.
-    registered_exchanges: Vec<String>,
+    registered_exchanges: HashSet<String>,
 }
 
 impl ProtocolStreamBuilder {
@@ -263,7 +263,7 @@ impl ProtocolStreamBuilder {
             step_peek_tx: None,
             step_trigger_rx: None,
             override_providers: HashMap::new(),
-            registered_exchanges: Vec::new(),
+            registered_exchanges: HashSet::new(),
         }
     }
 
@@ -303,7 +303,7 @@ impl ProtocolStreamBuilder {
             .stream_builder
             .exchange(name, filter);
         self.registered_exchanges
-            .push(name.to_string());
+            .insert(name.to_string());
         self.decoder.register_decoder::<T>(name);
         if let Some(predicate) = filter_fn {
             self.decoder
@@ -359,7 +359,7 @@ impl ProtocolStreamBuilder {
             .stream_builder
             .exchange(name, filter);
         self.registered_exchanges
-            .push(name.to_string());
+            .insert(name.to_string());
         self.decoder
             .register_decoder_with_context::<T>(name, decoder_context);
         if let Some(predicate) = filter_fn {
@@ -672,9 +672,14 @@ impl ProtocolStreamBuilder {
     /// then fills every remaining protocol it can serve.
     fn install_override_providers(&mut self) {
         let explicit = std::mem::take(&mut self.override_providers);
-        let covered: HashSet<String> = explicit.keys().cloned().collect();
-        let defaults =
-            override_stream::default_override_providers(&self.registered_exchanges, &covered);
+        // Protocols eligible for a built-in default provider: registered exchanges not explicitly
+        // overridden by the consumer.
+        let uncovered = self
+            .registered_exchanges
+            .clone()
+            .into_iter()
+            .filter(|exchange| !explicit.contains_key(exchange));
+        let defaults = override_stream::default_override_providers(uncovered);
         for (protocol_system, provider) in defaults.into_iter().chain(explicit) {
             self.decoder
                 .set_override_provider(protocol_system, provider);

--- a/crates/tycho-simulation/src/protocol/models.rs
+++ b/crates/tycho-simulation/src/protocol/models.rs
@@ -28,12 +28,15 @@ use std::{collections::HashMap, default::Default, future::Future};
 
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
+use tokio::sync::watch;
 use tycho_client::feed::{HeaderLike, SynchronizerState};
 use tycho_common::{
     models::{token::Token, Chain},
     simulation::protocol_sim::ProtocolSim,
     Bytes,
 };
+
+use crate::evm::override_stream::OverrideSnapshot;
 
 /// Context struct containing attributes for decoders
 ///
@@ -42,11 +45,16 @@ use tycho_common::{
 pub struct DecoderContext {
     pub adapter_path: Option<String>,
     pub vm_traces: Option<bool>,
+    /// Live per-block VM state override channel, wired into the pool at construction time.
+    ///
+    /// Set internally by the decoder from its registered override providers; not part of the
+    /// public API. External consumers never set this — overrides are fully handled by the library.
+    pub(crate) live_override: Option<watch::Receiver<OverrideSnapshot>>,
 }
 
 impl DecoderContext {
     pub fn new() -> Self {
-        Self { adapter_path: None, vm_traces: None }
+        Self { adapter_path: None, vm_traces: None, live_override: None }
     }
 
     pub fn vm_adapter_path<S: Into<String>>(mut self, path: S) -> Self {


### PR DESCRIPTION
## Summary

Adds a generic, protocol-agnostic layer in `tycho-simulation` that injects live per-block VM storage overrides and block environment into pAMM pools, sourced from the Titan pAMM quote stream. Consumers keep using `ProtocolStreamBuilder`; the Titan provider auto-registers when a known pAMM venue is in the stream.

Jira: [ENG-6118](https://propeller-heads.atlassian.net/browse/ENG-6118)

## How it works

- A `StateOverrideProvider` maintains a live `watch` channel of `OverrideSnapshot`s (block number/timestamp + storage) per `protocol_system`.
- The matching receiver is wired into each `EVMPoolState` at construction (via `DecoderContext`), so there is no per-block re-attachment or downcasting.
- The pool reads the freshest snapshot at simulation time (`get_amount_out`, `get_limits`, spot prices), so sub-block oracle price changes are reflected without waiting for a Tycho block update.
- Live storage overrides and block environment take precedence over the pool's static values on conflict, and are dropped once the snapshot passes its provider-set TTL — reverting the pool to Tycho's indexed state, so a stalled stream never keeps serving stale prices.

## Registration

- Providers are registered per `protocol_system`. A default registry supplies built-in providers (Titan) for any pAMM venue that is a registered exchange and not already claimed by the consumer.
- `ProtocolStreamBuilder::with_override_provider(protocol_system, provider)` swaps a single protocol onto a custom provider; explicit registrations win over the default registry.
- A multi-venue provider is shared via `Arc`, so one Titan connection serves all its venues.

## Titan provider

- `TitanProvider` connects to the Titan pAMM quote stream over WebSocket, parses each message into per-venue `OverrideSnapshot`s, and publishes them on the matching channel, reconnecting with capped exponential backoff.
- Serves FermiSwap, Kipseli and bopAMM. The block timestamp is resolved from the freshest registry lane timestamp so the oracle-staleness guard treats streamed prices as current.
- `tokio-tungstenite` moved to the `evm` feature, since the override stream is an EVM concern, not an RFQ one.

## Changes

- `evm/override_stream/` (new): `OverrideSnapshot`, `StateOverrideProvider`, the default registry, and `TitanProvider`.
- `evm/protocol/vm/state.rs`: `EVMPoolState` live read-through (`live_overrides`, live-aware `get_overwrites` and block env).
- `evm/protocol/vm/decoder.rs` + `protocol/models.rs`: receiver wired in at construction through `DecoderContext`.
- `evm/decoder.rs`: per-`protocol_system` provider registry.
- `evm/stream.rs`: `with_override_provider`, default-registry install at build time.

## Test plan

- [x] Unit tests for message parsing, lane-timestamp resolution, venue mapping, registration, snapshot expiry, and live-override resolution in pool state (block-env precedence + storage merge).
- [x] Validated live mid-block price movement against tycho-dev with FermiSwap (prices update between blocks, faster than block cadence).

[ENG-6118]: https://propeller-heads.atlassian.net/browse/ENG-6118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
