### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 for RUSTSEC-2026-0185

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6927,9 +6927,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## What

Bumps the transitive dependency `quinn-proto` from `0.11.14` to `0.11.15` in `Cargo.lock`.

## Why

`cargo audit` (Security Audit CI) fails on the current lockfile due to **RUSTSEC-2026-0185**:

> quinn-proto: Remote memory exhaustion from unbounded out-of-order stream reassembly (CVSS 7.5 HIGH, DoS).

The advisory is patched in `>=0.11.15`. `quinn-proto` is a transitive dependency, so this is a `Cargo.lock`-only change — no `Cargo.toml` edits, semver-compatible patch bump.

## Notes for reviewer

- The advisory was published 2026-06-22 and already affects `main`; it is unrelated to any feature work.
- Verified `cargo check -p tycho-ethereum` builds cleanly with the bump.