### PR TITLE
fix: fix cargo audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6907,9 +6907,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",

--- a/crates/tycho-client/src/deltas.rs
+++ b/crates/tycho-client/src/deltas.rs
@@ -253,7 +253,6 @@ impl Inner {
     }
 
     /// Registers a new pending subscription.
-    #[allow(clippy::result_large_err)]
     fn new_subscription(
         &mut self,
         id: &ExtractorIdentity,
@@ -304,7 +303,6 @@ impl Inner {
     }
 
     /// Sends a message to a subscription's receiver.
-    #[allow(clippy::result_large_err)]
     fn send(&mut self, id: &Uuid, msg: BlockAggregatedChanges) -> Result<(), DeltasError> {
         if let Some(sender) = self.sender.get_mut(id) {
             sender
@@ -406,7 +404,6 @@ impl Inner {
 /// Tycho client websocket implementation.
 impl WsDeltasClient {
     // Construct a new client with 5 reconnection attempts.
-    #[allow(clippy::result_large_err)]
     pub fn new(ws_uri: &str, auth_key: Option<&str>) -> Result<Self, DeltasError> {
         let uri = ws_uri
             .parse::<Uri>()
@@ -425,7 +422,6 @@ impl WsDeltasClient {
     }
 
     // Construct a new client with a custom number of reconnection attempts.
-    #[allow(clippy::result_large_err)]
     pub fn new_with_reconnects(
         ws_uri: &str,
         auth_key: Option<&str>,
@@ -451,7 +447,6 @@ impl WsDeltasClient {
 
     // Construct a new client with custom buffer sizes (for testing)
     #[cfg(test)]
-    #[allow(clippy::result_large_err)]
     pub fn new_with_custom_buffers(
         ws_uri: &str,
         auth_key: Option<&str>,

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -469,6 +469,8 @@ where
     ///
     /// The returned `end_rx` (if any) should be reused for retry attempts since the close
     /// signal may still arrive and we want to remain cancellable across retries.
+    // Newer clippy versions detect this large Err type. Keep the existing API and allow the lint
+    // explicitly.
     #[allow(clippy::result_large_err)]
     #[instrument(skip(self, block_tx, end_rx), fields(extractor_id = %self.extractor_id))]
     async fn state_sync(
@@ -1301,6 +1303,8 @@ mod test {
                 .await
         }
 
+        // clippy false positive: `'a` is required by the trait method signature and is
+        // used in `SnapshotParameters<'a>`, but `async_trait` makes Clippy miss it.
         #[allow(clippy::extra_unused_lifetimes)]
         async fn get_snapshots<'a>(
             &self,

--- a/crates/tycho-client/src/feed/synchronizer.rs
+++ b/crates/tycho-client/src/feed/synchronizer.rs
@@ -72,6 +72,7 @@ pub enum SynchronizerError {
 }
 
 pub type SyncResult<T> = Result<T, SynchronizerError>;
+pub type SyncError = (SynchronizerError, Option<oneshot::Receiver<()>>);
 
 impl SynchronizerError {
     /// Returns true if the error is transient and the failing operation can be retried.
@@ -469,15 +470,12 @@ where
     ///
     /// The returned `end_rx` (if any) should be reused for retry attempts since the close
     /// signal may still arrive and we want to remain cancellable across retries.
-    // Newer clippy versions detect this large Err type. Keep the existing API and allow the lint
-    // explicitly.
-    #[allow(clippy::result_large_err)]
     #[instrument(skip(self, block_tx, end_rx), fields(extractor_id = %self.extractor_id))]
     async fn state_sync(
         &mut self,
         block_tx: &mut Sender<SyncResult<StateSyncMessage<BlockHeader>>>,
         mut end_rx: oneshot::Receiver<()>,
-    ) -> Result<(), (SynchronizerError, Option<oneshot::Receiver<()>>)> {
+    ) -> Result<(), Box<SyncError>> {
         // initialisation
         let subscription_options = SubscriptionOptions::new()
             .with_state(self.include_snapshots)
@@ -489,7 +487,7 @@ where
             .await
         {
             Ok(result) => result,
-            Err(e) => return Err((e.into(), Some(end_rx))),
+            Err(e) => return Err(Box::new((e.into(), Some(end_rx)))),
         };
 
         let result = async {
@@ -881,7 +879,7 @@ where
                 // The error came from the inner async block. Since the async block
                 // can receive close signals (which would return Ok), any error means
                 // the close signal was NOT received, so we can return the end_rx for retry
-                Err((e, Some(end_rx)))
+                Err(Box::new((e, Some(end_rx))))
             }
         }
     }
@@ -1140,7 +1138,8 @@ where
                         );
                         return;
                     }
-                    Err((e, maybe_end_rx)) => {
+                    Err(e) => {
+                        let (e, maybe_end_rx) = *e;
                         warn!(
                             extractor_id=%&self.extractor_id,
                             retry_count,
@@ -1303,9 +1302,6 @@ mod test {
                 .await
         }
 
-        // clippy false positive: `'a` is required by the trait method signature and is
-        // used in `SnapshotParameters<'a>`, but `async_trait` makes Clippy miss it.
-        #[allow(clippy::extra_unused_lifetimes)]
         async fn get_snapshots<'a>(
             &self,
             request: &SnapshotParameters<'a>,

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -1818,9 +1818,6 @@ impl RPCClient for HttpRPCClient {
         ))
     }
 
-    // clippy false positive: `'a` is required by the trait method signature and is
-    // used in `SnapshotParameters<'a>`, but `async_trait` makes Clippy miss it.
-    #[allow(clippy::extra_unused_lifetimes)]
     async fn get_snapshots<'a>(
         &self,
         request: &SnapshotParameters<'a>,

--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -1212,6 +1212,8 @@ pub trait RPCClient: Send + Sync {
             .map(|pages| pages.into_iter().flatten().collect())
     }
 
+    // clippy false positive: `'a` is required by the trait method signature and is
+    // used in `SnapshotParameters<'a>`, but `async_trait` makes Clippy miss it.
     #[allow(clippy::extra_unused_lifetimes)]
     async fn get_snapshots<'a>(
         &self,
@@ -1816,6 +1818,8 @@ impl RPCClient for HttpRPCClient {
         ))
     }
 
+    // clippy false positive: `'a` is required by the trait method signature and is
+    // used in `SnapshotParameters<'a>`, but `async_trait` makes Clippy miss it.
     #[allow(clippy::extra_unused_lifetimes)]
     async fn get_snapshots<'a>(
         &self,

--- a/crates/tycho-indexer/src/lib.rs
+++ b/crates/tycho-indexer/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod cli;
 pub mod extractor;
+// `tonic::Status` is large enough to trigger `result_large_err`; this is an
+// existing API shape, and boxing it here would be a larger compatibility change.
 #[allow(clippy::result_large_err)]
 pub mod pb;
 pub mod services;

--- a/crates/tycho-indexer/src/services/rpc.rs
+++ b/crates/tycho-indexer/src/services/rpc.rs
@@ -1509,6 +1509,10 @@ pub async fn health() -> Result<HttpResponse, RpcError> {
 }
 
 #[cfg(test)]
+// mockall::mock! parses method signatures as tokens and does not apply lifetime
+// elision, so the mocked trait methods need explicit lifetime parameters.
+// The allow is on the module because Clippy does not apply this lint allow
+// reliably when it is placed on the macro invocation itself.
 #[allow(clippy::extra_unused_lifetimes)]
 mod tests {
     use std::{collections::HashMap, env, str::FromStr};
@@ -1580,7 +1584,7 @@ mod tests {
                 &self,
                 f: &dyn Fn(&BlockAggregatedChanges) -> bool,
                 protocol_system: &'a str,
-            ) -> Result<Option<BlockAggregatedChanges>,PendingDeltasError>;
+            ) -> Result<Option<BlockAggregatedChanges>, PendingDeltasError>;
         }
     }
 


### PR DESCRIPTION
- Fixes:
[UNKNOWN] ID: RUSTSEC-2026-0185 | Crate: quinn-proto | Version: 0.11.14 | Error:  Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly
- Add comments to allows