### PR TITLE
TEST: verify fork CI gate (do not merge)

### DIFF
--- a/protocols/testing/.gate-test.md
+++ b/protocols/testing/.gate-test.md
@@ -1,1 +1,0 @@
-Fork CI gate verification — safe to delete.

--- a/protocols/testing/.gate-test.md
+++ b/protocols/testing/.gate-test.md
@@ -1,0 +1,1 @@
+Fork CI gate verification — safe to delete.

--- a/protocols/testing/run.Dockerfile
+++ b/protocols/testing/run.Dockerfile
@@ -158,3 +158,5 @@ RUN strip /usr/local/bin/* 2>/dev/null || true
 
 WORKDIR /app
 ENTRYPOINT ["/entrypoint.sh"]
+
+# fork CI gate verification — safe to revert


### PR DESCRIPTION
Throwaway PR to confirm the required-reviewer environment gate pauses fork PRs before they touch secrets.

Expected: detect-changes runs; build-images and test-protocols show "Waiting" with a Review deployments button. Close + delete fork after verifying.