### PR TITLE
fix(ci): gate remaining pull_request_target fork runs

### DIFF
--- a/.github/workflows/ci-foundry.yaml
+++ b/.github/workflows/ci-foundry.yaml
@@ -52,6 +52,9 @@ jobs:
     if: needs.changes.outputs.foundry == 'true' || github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # forge test runs fork-controlled Solidity (and can shell out via ffi) with
+    # RPC secrets in scope; gate fork PRs behind required-reviewer approval.
+    environment: ${{ github.event.pull_request.head.repo.fork && 'integration-tests' || '' }}
     strategy:
       matrix:
         project:
@@ -128,6 +131,8 @@ jobs:
     if: needs.changes.outputs.foundry == 'true' || github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # No secrets here, but it compiles fork code; gate for consistency.
+    environment: ${{ github.event.pull_request.head.repo.fork && 'integration-tests' || '' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:

--- a/.github/workflows/ci-rust-evm.yaml
+++ b/.github/workflows/ci-rust-evm.yaml
@@ -52,6 +52,9 @@ jobs:
     if: needs.changes.outputs.rust == 'true' || github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Runs fork code (cargo build/test) with RPC secrets in scope; gate fork PRs
+    # behind required-reviewer approval. Internal-branch PRs run without approval.
+    environment: ${{ github.event.pull_request.head.repo.fork && 'integration-tests' || '' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:


### PR DESCRIPTION
ci-rust-evm (test-evm) and ci-foundry (forge-test, slither) check out the fork PR head and run its code with RPC secrets in scope, with no approval gate. cargo build/test executes fork build scripts and proc macros; forge test can shell out via ffi from a fork-controlled foundry.toml. Either exfiltrates the secrets.

Gate these jobs behind the integration-tests required-reviewer environment when the PR head is a fork, matching ci-substreams- integration. Internal-branch PRs resolve to no environment and run without approval.