### PR TITLE
fix(simulation): isolate self-contained token proxies in shared DB

### DIFF
--- a/crates/tycho-simulation/src/evm/protocol/vm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/vm/decoder.rs
@@ -100,6 +100,24 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for EVMPoolState<PreCache
             HashSet::new()
         };
 
+        // Tokens whose protocol does not emit token contract storage. Their proxy must not bind to
+        // an implementation another protocol may have left in the shared DB.
+        let self_contained_tokens: HashSet<Address> = if let Some(bytes) = snapshot
+            .component
+            .static_attributes
+            .get("self_contained_tokens")
+        {
+            if let Ok(vecs) = json_deserialize_address_list(bytes) {
+                vecs.into_iter()
+                    .map(|addr| Address::from_slice(&addr))
+                    .collect()
+            } else {
+                HashSet::new()
+            }
+        } else {
+            HashSet::new()
+        };
+
         // Decode balances
         let balance_owner = snapshot
             .state
@@ -206,6 +224,7 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for EVMPoolState<PreCache
             EVMPoolStateBuilder::new(id.clone(), tokens.clone(), adapter_contract_address)
                 .balances(component_balances)
                 .disable_overwrite_tokens(potential_rebase_tokens)
+                .self_contained_tokens(self_contained_tokens)
                 .account_balances(account_balances)
                 .adapter_contract_bytecode(adapter_bytecode)
                 .involved_contracts(involved_contracts)

--- a/crates/tycho-simulation/src/evm/protocol/vm/erc20_token.rs
+++ b/crates/tycho-simulation/src/evm/protocol/vm/erc20_token.rs
@@ -65,6 +65,17 @@ impl TokenProxyOverwriteFactory {
             .insert(*IMPLEMENTATION_SLOT, U256::from_be_slice(implementation.as_slice()));
     }
 
+    /// Forces the proxy to behave as a self-contained token by zeroing the implementation slot.
+    ///
+    /// With a zero implementation the proxy never delegatecalls a backing contract: transfers to
+    /// recipients without a custom balance start them at zero instead. This is required for tokens
+    /// whose owning protocol does not emit token contract storage, so they are never accidentally
+    /// bound to a foreign implementation left in the shared DB by another protocol.
+    pub(crate) fn clear_implementation(&mut self) {
+        self.overwrites
+            .insert(*IMPLEMENTATION_SLOT, U256::ZERO);
+    }
+
     pub(crate) fn set_balance(&mut self, balance: U256, owner: Address) {
         // Set the balance in the custom storage slot
         let storage_index =
@@ -192,6 +203,14 @@ mod tests {
         let expected_value = U256::from_be_bytes(expected_bytes);
 
         assert_eq!(factory.overwrites[&*IMPLEMENTATION_SLOT], expected_value);
+    }
+
+    #[test]
+    fn test_token_proxy_clear_implementation() {
+        let mut factory = TokenProxyOverwriteFactory::new(Address::random(), None);
+        factory.clear_implementation();
+
+        assert_eq!(factory.overwrites[&*IMPLEMENTATION_SLOT], U256::ZERO);
     }
 
     #[test]

--- a/crates/tycho-simulation/src/evm/protocol/vm/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/vm/state.rs
@@ -72,6 +72,11 @@ where
     adapter_contract: TychoSimulationContract<D>,
     /// Tokens for which balance overwrites should be disabled.
     disable_overwrite_tokens: HashSet<Address>,
+    /// Tokens whose owning protocol does not emit token contract storage, so they have no real
+    /// implementation backing in the shared DB. Their `TokenProxy` implementation slot is forced
+    /// to zero per simulation so they are never bound to a foreign implementation left in the
+    /// shared DB by another protocol. See [`TokenProxyOverwriteFactory::clear_implementation`].
+    self_contained_tokens: HashSet<Address>,
     /// Block context overrides applied to this pool's adapter simulations.
     block_overrides: Option<BlockEnvOverrides>,
 }
@@ -117,6 +122,7 @@ where
         manual_updates: bool,
         adapter_contract: TychoSimulationContract<D>,
         disable_overwrite_tokens: HashSet<Address>,
+        self_contained_tokens: HashSet<Address>,
         block_overrides: Option<BlockEnvOverrides>,
     ) -> Self {
         Self {
@@ -132,6 +138,7 @@ where
             manual_updates,
             adapter_contract,
             disable_overwrite_tokens,
+            self_contained_tokens,
             block_overrides,
         }
     }
@@ -462,6 +469,26 @@ where
         Ok(merged_overwrites)
     }
 
+    /// Builds a token proxy overwrite factory for `token`.
+    ///
+    /// For self-contained tokens (those whose protocol emits no token contract storage) the proxy
+    /// implementation slot is forced to zero, so the proxy is never bound to a foreign
+    /// implementation left in the shared DB by another protocol. Rebase/fee tokens listed in
+    /// `disable_overwrite_tokens` are excluded — they require their real implementation.
+    fn token_proxy_factory(&self, token: &Address) -> TokenProxyOverwriteFactory {
+        let mut overwrites = TokenProxyOverwriteFactory::new(*token, None);
+        if self
+            .self_contained_tokens
+            .contains(token) &&
+            !self
+                .disable_overwrite_tokens
+                .contains(token)
+        {
+            overwrites.clear_implementation();
+        }
+        overwrites
+    }
+
     fn get_token_overwrites(
         &self,
         tokens: Vec<Address>,
@@ -476,7 +503,7 @@ where
             res.push(self.get_balance_overwrites()?);
         }
 
-        let mut overwrites = TokenProxyOverwriteFactory::new(*sell_token, None);
+        let mut overwrites = self.token_proxy_factory(sell_token);
 
         overwrites.set_balance(max_amount, Address::from_slice(&*EXTERNAL_ACCOUNT.0));
 
@@ -519,7 +546,7 @@ where
             // Only override balances that are explicitly provided in self.balances
             // This preserves existing balances for tokens not updated in delta transitions
             for (token, bal) in &self.balances {
-                let mut overwrites = TokenProxyOverwriteFactory::new(*token, None);
+                let mut overwrites = self.token_proxy_factory(token);
                 overwrites.set_balance(*bal, address);
                 balance_overwrites.extend(overwrites.get_overwrites());
             }
@@ -529,7 +556,7 @@ where
         // for a contract we explicitly track balances for)
         for (contract, balances) in &self.contract_balances {
             for (token, balance) in balances {
-                let mut overwrites = TokenProxyOverwriteFactory::new(*token, None);
+                let mut overwrites = self.token_proxy_factory(token);
                 overwrites.set_balance(*balance, *contract);
                 balance_overwrites.extend(overwrites.get_overwrites());
             }

--- a/crates/tycho-simulation/src/evm/protocol/vm/state_builder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/vm/state_builder.rs
@@ -96,6 +96,7 @@ where
     adapter_contract: Option<TychoSimulationContract<D>>,
     adapter_contract_bytecode: Option<Bytecode>,
     disable_overwrite_tokens: HashSet<Address>,
+    self_contained_tokens: HashSet<Address>,
     block_overrides: Option<BlockEnvOverrides>,
 }
 
@@ -122,6 +123,7 @@ where
             adapter_contract: None,
             adapter_contract_bytecode: None,
             disable_overwrite_tokens: HashSet::new(),
+            self_contained_tokens: HashSet::new(),
             block_overrides: None,
         }
     }
@@ -195,6 +197,11 @@ where
         self
     }
 
+    pub fn self_contained_tokens(mut self, self_contained_tokens: HashSet<Address>) -> Self {
+        self.self_contained_tokens = self_contained_tokens;
+        self
+    }
+
     pub fn block_overrides(mut self, block_overrides: Option<BlockEnvOverrides>) -> Self {
         self.block_overrides = block_overrides;
         self
@@ -251,6 +258,7 @@ where
             self.manual_updates.unwrap_or(false),
             adapter_contract,
             self.disable_overwrite_tokens,
+            self.self_contained_tokens,
             self.block_overrides,
         ))
     }

--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-fermiswap"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/protocols/substreams/ethereum-fermiswap/Cargo.toml
+++ b/protocols/substreams/ethereum-fermiswap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-fermiswap"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-fermiswap/src/modules.rs
+++ b/protocols/substreams/ethereum-fermiswap/src/modules.rs
@@ -31,6 +31,7 @@ use substreams_ethereum::{
 use substreams_helper::event_handler::EventHandler;
 use tycho_substreams::{
     abi::{erc20, weth},
+    attributes::json_serialize_address_list,
     balances::aggregate_balances_changes,
     contract::extract_contract_changes_builder,
     prelude::*,
@@ -60,6 +61,13 @@ fn get_new_pairs(
                 config.trader_vault.as_slice(),
                 config.registry_address.as_slice(),
             ])
+            // FermiSwap does not emit token contract storage, so its tokens are self-contained
+            // proxies in the shared simulation DB. Flag them so simulation never binds them to an
+            // implementation another VM protocol indexed for the same token.
+            .with_attributes(&[(
+                "self_contained_tokens",
+                json_serialize_address_list(&[event.base_asset.clone(), event.quote_asset.clone()]),
+            )])
             .as_swap_type("fermiswap_pool", ImplementationType::Vm);
 
         new_pair_changes.push(TransactionEntityChanges {


### PR DESCRIPTION
## What

Fixes [ENG-6161](https://propeller-heads.atlassian.net/browse/ENG-6161): FermiSwap `get_amount_out` reverts with `SafeERC20FailedOperation` on the output token when other VM protocols run concurrently.

## Storage layering

A VM simulation reads token storage through two layers:

1. `OverriddenSimulationDB` — per-simulation, sparse override map (balances/allowances). Slots not present fall through.
2. `SHARED_TYCHO_DB` (`PreCachedDB`) — persistent, shared across all VM protocols. Holds the `TokenProxy` account including `IMPLEMENTATION_SLOT` and code.

The per-simulation overwrites never set `IMPLEMENTATION_SLOT`, so it always reads through to the shared layer.

## Cause

Protocols that emit token contract storage (curve, balancer) mount the shared token account with a real `IMPLEMENTATION_SLOT`. FermiSwap, which does not emit token storage, inherits that value from the shared account. `TokenProxy.transfer` to a recipient without a custom balance then delegatecalls the storage-stripped implementation and reverts.

## Fix

FermiSwap tags its tokens with a `self_contained_tokens` static attribute. Simulation forces `IMPLEMENTATION_SLOT` to zero in the override layer for those tokens, so the proxy stays self-contained regardless of what another protocol wrote to the shared account. Rebase/fee tokens listed in `disable_overwrite_tokens` are excluded — they require their real implementation.

The simulation-side handling is generic; only the FermiSwap substreams emits the attribute in this PR. The same latent issue affects `vm:maverick_v2` and `vm:liquidityparty` and is left for follow-up.

## Notes

- Wire-format change: the FermiSwap substreams emits a new static attribute (package version bumped).
- Integration tests need the substreams runtime and are not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-6161]: https://propeller-heads.atlassian.net/browse/ENG-6161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ