### PR TITLE
fix(ci): scope substreams secrets to the test job

### DIFF
--- a/.github/workflows/ci-substreams-integration.yaml
+++ b/.github/workflows/ci-substreams-integration.yaml
@@ -1,14 +1,8 @@
 name: Substreams Integration Tests
 
 env:
-  RPC_URL: ${{ secrets.RPC_URL_ARCHIVE }}
-  BASE_RPC_URL: ${{ secrets.BASE_RPC_URL_ARCHIVE }}
-  ARBITRUM_RPC_URL: ${{ secrets.ARBITRUM_RPC_URL_ARCHIVE }}
-  UNICHAIN_RPC_URL: ${{ secrets.UNICHAIN_RPC_URL_ARCHIVE }}
-  BSC_RPC_URL: ${{ secrets.BSC_RPC_URL_ARCHIVE }}
-  POLYGON_RPC_URL: ${{ secrets.POLYGON_RPC_URL_ARCHIVE }}
-  SUBSTREAMS_API_TOKEN: ${{ secrets.SUBSTREAMS_API_TOKEN }}
-  AUTH_API_KEY: ${{ secrets.AUTH_API_KEY }}
+  # Secrets are intentionally NOT defined here to keep them out of detect-changes scope.
+  # They are set at job level in test-protocols, the only job that needs them.
   EXCLUDED_SUBSTREAMS: target|crates|ethereum-template-factory|ethereum-template-singleton|ethereum-fluid
 
 on:
@@ -257,6 +251,15 @@ jobs:
     if: needs.detect-changes.outputs.target-protocols != ''
     # See build-images: gate fork PRs behind required-reviewer approval.
     environment: ${{ github.event.pull_request.head.repo.fork && 'integration-tests' || '' }}
+    env:
+      RPC_URL: ${{ secrets.RPC_URL_ARCHIVE }}
+      BASE_RPC_URL: ${{ secrets.BASE_RPC_URL_ARCHIVE }}
+      ARBITRUM_RPC_URL: ${{ secrets.ARBITRUM_RPC_URL_ARCHIVE }}
+      UNICHAIN_RPC_URL: ${{ secrets.UNICHAIN_RPC_URL_ARCHIVE }}
+      BSC_RPC_URL: ${{ secrets.BSC_RPC_URL_ARCHIVE }}
+      POLYGON_RPC_URL: ${{ secrets.POLYGON_RPC_URL_ARCHIVE }}
+      SUBSTREAMS_API_TOKEN: ${{ secrets.SUBSTREAMS_API_TOKEN }}
+      AUTH_API_KEY: ${{ secrets.AUTH_API_KEY }}
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ Temporary Items
 
 */.env
 .vscode
+.zed
 .idea
 *.log
 


### PR DESCRIPTION
## What

Moves the 8 RPC/API secrets in `ci-substreams-integration.yaml` out of the workflow-level `env:` block and onto the `test-protocols` job that actually consumes them.

## Why

Under `pull_request_target`, `detect-changes` and `build-images` check out fork code while the secrets were in scope workflow-wide. Neither job uses them:
- `detect-changes` only parses files and runs `git diff` / changed-files.
- `build-images` only passes `--build-arg PROTOCOLS=`; the Dockerfiles read RPC URLs at container runtime, not build time.

The sole consumer is the `substreams-docker-single` composite action, invoked only in `test-protocols`. Job-level `env:` reaches that action identically to the previous workflow-level `env:`, so behavior is unchanged — the secrets are just no longer exposed to the fork-checkout jobs.

This builds on #1109 (template-injection fix + fork environment gate); scoping the secrets narrows the blast radius further.

Also ignores the `.zed` editor directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)