### PR TITLE
feat: add ChainConfigRegistry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9809,6 +9809,7 @@ dependencies = [
  "rstest 0.24.0",
  "serde",
  "serde_json",
+ "serde_yaml",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",

--- a/crates/tycho-common/Cargo.toml
+++ b/crates/tycho-common/Cargo.toml
@@ -22,6 +22,7 @@ thiserror.workspace = true
 hex.workspace = true
 chrono.workspace = true
 serde_json.workspace = true
+serde_yaml = "0.9.32"
 strum.workspace = true
 strum_macros.workspace = true
 utoipa.workspace = true

--- a/crates/tycho-common/src/dto.rs
+++ b/crates/tycho-common/src/dto.rs
@@ -21,7 +21,10 @@ use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
 use crate::{
-    models::{self, Address, Balance, Code, ComponentId, CustomChainConfig, StoreKey, StoreVal},
+    models::{
+        self, chain_config::CustomChainConfig, Address, Balance, Code, ComponentId, StoreKey,
+        StoreVal,
+    },
     serde_primitives::{
         hex_bytes, hex_bytes_option, hex_hashmap_key, hex_hashmap_key_value, hex_hashmap_value,
     },
@@ -46,7 +49,7 @@ pub enum Chain {
     Custom(CustomChainConfig),
 }
 
-pub use models::TvlThresholdTier;
+pub use models::chain_config::TvlThresholdTier;
 
 impl Chain {
     /// Returns a default TVL threshold in native token units for the given tier.

--- a/crates/tycho-common/src/models/chain_config.rs
+++ b/crates/tycho-common/src/models/chain_config.rs
@@ -1,6 +1,8 @@
 //! Value types describing a blockchain's configuration: token metadata, TVL thresholds, and the
 //! full `CustomChainConfig` used to describe user-defined chains. Re-exported from `models`.
 
+use std::{collections::HashMap, sync::OnceLock};
+
 use arrayvec::ArrayString;
 use deepsize::DeepSizeOf;
 use serde::{Deserialize, Serialize};
@@ -61,6 +63,8 @@ pub enum ChainConfigError {
     SymbolTooLong(String),
     #[error("chain name '{0}' too long (max 32 chars)")]
     NameTooLong(String),
+    #[error("unknown chain '{0}': not a built-in chain and no custom config registered")]
+    UnknownChain(String),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
@@ -162,4 +166,177 @@ pub enum TvlThresholdTier {
     Low,
     /// Filters for pools with meaningful liquidity (~$200K USD equivalent in native token).
     Medium,
+}
+
+/// Env var overriding the path the registry reads custom-chain config from.
+const CHAIN_CONFIG_ENV: &str = "TYCHO_CHAIN_CONFIG";
+/// Default path used when `TYCHO_CHAIN_CONFIG` is unset.
+const DEFAULT_CHAIN_CONFIG_PATH: &str = "./chain.yaml";
+
+/// On-disk shape of the custom-chain config file: a top-level `chains:` list. Matches the
+/// `chains:` section of the indexer's extractor config, so a consumer can point
+/// `TYCHO_CHAIN_CONFIG` at the same file the indexer uses.
+#[derive(Debug, Default, Deserialize)]
+struct ChainConfigFile {
+    #[serde(default)]
+    chains: Vec<CustomChainConfig>,
+}
+
+#[derive(Debug, Error)]
+pub enum ChainConfigFileError {
+    #[error("failed to read chain config file: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("failed to parse chain config: {0}")]
+    Parse(#[from] serde_yaml::Error),
+}
+
+/// Resolves the full configuration of custom chains by name.
+///
+/// Built-in chains are resolved without this registry; it only holds user-defined chains loaded
+/// from a YAML source. Build it explicitly via [`ChainConfigRegistry::from_configs`] (e.g. the
+/// indexer reusing its `chains:` config) or rely on the lazily-loaded global [`chain_registry`].
+#[derive(Debug, Default, Clone)]
+pub struct ChainConfigRegistry {
+    custom: HashMap<String, CustomChainConfig>,
+}
+
+impl ChainConfigRegistry {
+    /// An empty registry — only built-in chains will resolve.
+    pub fn empty() -> Self {
+        Self { custom: HashMap::new() }
+    }
+
+    /// Builds a registry from custom chain configs, keyed by chain name.
+    pub fn from_configs(configs: impl IntoIterator<Item = CustomChainConfig>) -> Self {
+        let custom = configs
+            .into_iter()
+            .map(|cfg| (cfg.name().to_owned(), cfg))
+            .collect();
+        Self { custom }
+    }
+
+    /// Reads custom chain configs from `TYCHO_CHAIN_CONFIG` (default `./chain.yaml`).
+    ///
+    /// Returns an empty registry when the file is absent, so runs on built-in chains need no config
+    /// file. Panics with context if the file exists but cannot be read or parsed.
+    pub fn load_default() -> Self {
+        let path = std::env::var(CHAIN_CONFIG_ENV)
+            .unwrap_or_else(|_| DEFAULT_CHAIN_CONFIG_PATH.to_owned());
+        if !std::path::Path::new(&path).exists() {
+            return Self::empty();
+        }
+        Self::from_yaml_file(&path)
+            .unwrap_or_else(|e| panic!("failed to load chain config from '{path}': {e}"))
+    }
+
+    /// Parses a registry from a YAML file with a top-level `chains:` list.
+    pub fn from_yaml_file(path: &str) -> Result<Self, ChainConfigFileError> {
+        let contents = std::fs::read_to_string(path)?;
+        Self::from_yaml_str(&contents)
+    }
+
+    /// Parses a registry from a YAML string with a top-level `chains:` list.
+    pub fn from_yaml_str(contents: &str) -> Result<Self, ChainConfigFileError> {
+        let file: ChainConfigFile = serde_yaml::from_str(contents)?;
+        Ok(Self::from_configs(file.chains))
+    }
+
+    /// Returns the config for a custom chain by name, if registered.
+    pub fn get(&self, name: &str) -> Option<&CustomChainConfig> {
+        self.custom.get(name)
+    }
+
+    /// Whether a custom chain with this name is registered.
+    pub fn contains(&self, name: &str) -> bool {
+        self.custom.contains_key(name)
+    }
+}
+
+static CHAIN_REGISTRY: OnceLock<ChainConfigRegistry> = OnceLock::new();
+
+/// Returns the process-wide chain config registry, lazily loading it from the configured file on
+/// first access (see [`ChainConfigRegistry::load_default`]).
+pub fn chain_registry() -> &'static ChainConfigRegistry {
+    CHAIN_REGISTRY.get_or_init(ChainConfigRegistry::load_default)
+}
+
+/// Installs the process-wide chain config registry explicitly, before any call to
+/// [`chain_registry`]. Returns the passed registry back as `Err` if it was already initialised.
+pub fn init_chain_registry(registry: ChainConfigRegistry) -> Result<(), ChainConfigRegistry> {
+    CHAIN_REGISTRY.set(registry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_YAML: &str = r#"
+chains:
+  - name: testchain
+    chain_id: 9999
+    block_time_secs: 5
+    native:
+      address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      symbol: TST
+      decimals: 18
+    wrapped_native:
+      address: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      symbol: WTST
+      decimals: 18
+    default_tvl_thresholds:
+      low: 50.0
+      medium: 500.0
+"#;
+
+    #[test]
+    fn parses_yaml_and_resolves_by_name() {
+        let registry = ChainConfigRegistry::from_yaml_str(SAMPLE_YAML).unwrap();
+        assert!(registry.contains("testchain"));
+        let cfg = registry
+            .get("testchain")
+            .expect("testchain present");
+        assert_eq!(cfg.name(), "testchain");
+        assert_eq!(cfg.chain_id, 9999);
+        assert_eq!(cfg.block_time_secs, 5);
+    }
+
+    #[test]
+    fn unknown_chain_is_absent() {
+        let registry = ChainConfigRegistry::from_yaml_str(SAMPLE_YAML).unwrap();
+        assert!(!registry.contains("nope"));
+        assert!(registry.get("nope").is_none());
+    }
+
+    #[test]
+    fn empty_registry_has_no_custom_chains() {
+        assert!(!ChainConfigRegistry::empty().contains("testchain"));
+    }
+
+    #[test]
+    fn from_configs_keys_by_name() {
+        let cfg = CustomChainConfig::try_new(
+            "mychain",
+            42,
+            2,
+            ChainTokenConfig::try_new("0x00", "AAA", 18).unwrap(),
+            ChainTokenConfig::try_new("0x01", "WAAA", 18).unwrap(),
+            TvlThresholds::new(1.0, 2.0),
+        )
+        .unwrap();
+        let registry = ChainConfigRegistry::from_configs([cfg]);
+        assert!(registry.contains("mychain"));
+        assert_eq!(
+            registry
+                .get("mychain")
+                .unwrap()
+                .chain_id,
+            42
+        );
+    }
+
+    #[test]
+    fn empty_chains_list_parses_to_empty_registry() {
+        let registry = ChainConfigRegistry::from_yaml_str("chains: []").unwrap();
+        assert!(!registry.contains("anything"));
+    }
 }

--- a/crates/tycho-common/src/models/chain_config.rs
+++ b/crates/tycho-common/src/models/chain_config.rs
@@ -194,7 +194,8 @@ pub enum ChainConfigFileError {
 ///
 /// Built-in chains are resolved without this registry; it only holds user-defined chains loaded
 /// from a YAML source. Build it explicitly via [`ChainConfigRegistry::from_configs`] (e.g. the
-/// indexer reusing its `chains:` config) or rely on the lazily-loaded global [`chain_registry`].
+/// indexer reusing its `chains:` config) or [`ChainConfigRegistry::load_default`], then install it
+/// as the process-wide registry with [`init_chain_registry`].
 #[derive(Debug, Default, Clone)]
 pub struct ChainConfigRegistry {
     custom: HashMap<String, CustomChainConfig>,
@@ -218,15 +219,16 @@ impl ChainConfigRegistry {
     /// Reads custom chain configs from `TYCHO_CHAIN_CONFIG` (default `./chain.yaml`).
     ///
     /// Returns an empty registry when the file is absent, so runs on built-in chains need no config
-    /// file. Panics with context if the file exists but cannot be read or parsed.
-    pub fn load_default() -> Self {
+    /// file. Returns an error if the file exists but cannot be read or parsed, leaving it to the
+    /// caller to decide how to react. Install the result with [`init_chain_registry`] to make it
+    /// the process-wide registry.
+    pub fn load_default() -> Result<Self, ChainConfigFileError> {
         let path = std::env::var(CHAIN_CONFIG_ENV)
             .unwrap_or_else(|_| DEFAULT_CHAIN_CONFIG_PATH.to_owned());
         if !std::path::Path::new(&path).exists() {
-            return Self::empty();
+            return Ok(Self::empty());
         }
         Self::from_yaml_file(&path)
-            .unwrap_or_else(|e| panic!("failed to load chain config from '{path}': {e}"))
     }
 
     /// Parses a registry from a YAML file with a top-level `chains:` list.
@@ -254,10 +256,13 @@ impl ChainConfigRegistry {
 
 static CHAIN_REGISTRY: OnceLock<ChainConfigRegistry> = OnceLock::new();
 
-/// Returns the process-wide chain config registry, lazily loading it from the configured file on
-/// first access (see [`ChainConfigRegistry::load_default`]).
+/// Returns the process-wide chain config registry.
+///
+/// Defaults to an empty registry — only built-in chains resolve — unless one was installed with
+/// [`init_chain_registry`]. This never reads from disk; load custom chains explicitly via
+/// [`ChainConfigRegistry::load_default`] and install them before first access.
 pub fn chain_registry() -> &'static ChainConfigRegistry {
-    CHAIN_REGISTRY.get_or_init(ChainConfigRegistry::load_default)
+    CHAIN_REGISTRY.get_or_init(ChainConfigRegistry::empty)
 }
 
 /// Installs the process-wide chain config registry explicitly, before any call to

--- a/crates/tycho-common/src/models/chain_config.rs
+++ b/crates/tycho-common/src/models/chain_config.rs
@@ -1,0 +1,165 @@
+//! Value types describing a blockchain's configuration: token metadata, TVL thresholds, and the
+//! full `CustomChainConfig` used to describe user-defined chains. Re-exported from `models`.
+
+use arrayvec::ArrayString;
+use deepsize::DeepSizeOf;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ChainAddress {
+    bytes: [u8; 32],
+    len: u8,
+}
+
+impl ChainAddress {
+    pub fn new(bytes: &[u8]) -> Result<Self, ChainAddressError> {
+        if bytes.len() > 32 {
+            return Err(ChainAddressError::TooLong(bytes.len()));
+        }
+        let mut arr = [0u8; 32];
+        arr[..bytes.len()].copy_from_slice(bytes);
+        Ok(Self { bytes: arr, len: bytes.len() as u8 })
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes[..self.len as usize]
+    }
+}
+
+/// Serialized as a `0x`-prefixed hex string so config files and wire payloads use the same
+/// representation a human writes (e.g. `"0x0000...0000"`).
+impl Serialize for ChainAddress {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&format!("0x{}", hex::encode(self.as_bytes())))
+    }
+}
+
+impl<'de> Deserialize<'de> for ChainAddress {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        let raw = hex::decode(s.trim_start_matches("0x"))
+            .map_err(|e| serde::de::Error::custom(format!("invalid hex address '{s}': {e}")))?;
+        ChainAddress::new(&raw).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ChainAddressError {
+    #[error("address is {0} bytes, max is 32")]
+    TooLong(usize),
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ChainConfigError {
+    #[error("invalid hex address '{0}': {1}")]
+    InvalidAddress(String, String),
+    #[error("address '{0}': {1}")]
+    AddressTooLong(String, String),
+    #[error("symbol '{0}' too long (max 8 chars)")]
+    SymbolTooLong(String),
+    #[error("chain name '{0}' too long (max 32 chars)")]
+    NameTooLong(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+pub struct ChainTokenConfig {
+    #[schema(value_type = String)]
+    pub(crate) address: ChainAddress,
+    #[schema(value_type = String)]
+    pub(crate) symbol: ArrayString<8>,
+    pub(crate) decimals: u8,
+}
+
+impl ChainTokenConfig {
+    pub fn try_new(
+        address_hex: &str,
+        symbol: &str,
+        decimals: u8,
+    ) -> Result<Self, ChainConfigError> {
+        let raw = hex::decode(address_hex.trim_start_matches("0x"))
+            .map_err(|e| ChainConfigError::InvalidAddress(address_hex.to_owned(), e.to_string()))?;
+        let address = ChainAddress::new(&raw)
+            .map_err(|e| ChainConfigError::AddressTooLong(address_hex.to_owned(), e.to_string()))?;
+        let symbol = ArrayString::from(symbol)
+            .map_err(|_| ChainConfigError::SymbolTooLong(symbol.to_owned()))?;
+        Ok(Self { address, symbol, decimals })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema)]
+pub struct TvlThresholds {
+    pub(crate) low: f64,
+    pub(crate) medium: f64,
+}
+
+impl TvlThresholds {
+    pub fn new(low: f64, medium: f64) -> Self {
+        Self { low, medium }
+    }
+}
+
+impl PartialEq for TvlThresholds {
+    fn eq(&self, other: &Self) -> bool {
+        self.low.to_bits() == other.low.to_bits() && self.medium.to_bits() == other.medium.to_bits()
+    }
+}
+
+impl Eq for TvlThresholds {}
+
+impl std::hash::Hash for TvlThresholds {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.low.to_bits().hash(state);
+        self.medium.to_bits().hash(state);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+pub struct CustomChainConfig {
+    #[schema(value_type = String)]
+    pub(crate) name: ArrayString<32>,
+    pub(crate) chain_id: u64,
+    pub block_time_secs: u64,
+    pub(crate) native: ChainTokenConfig,
+    pub(crate) wrapped_native: ChainTokenConfig,
+    pub(crate) default_tvl_thresholds: TvlThresholds,
+}
+
+impl CustomChainConfig {
+    pub fn try_new(
+        name: &str,
+        chain_id: u64,
+        block_time_secs: u64,
+        native: ChainTokenConfig,
+        wrapped_native: ChainTokenConfig,
+        default_tvl_thresholds: TvlThresholds,
+    ) -> Result<Self, ChainConfigError> {
+        let name =
+            ArrayString::from(name).map_err(|_| ChainConfigError::NameTooLong(name.to_owned()))?;
+        Ok(Self { name, chain_id, block_time_secs, native, wrapped_native, default_tvl_thresholds })
+    }
+
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+}
+
+impl DeepSizeOf for CustomChainConfig {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
+        0
+    }
+}
+
+/// TVL threshold tiers for chain-aware filtering defaults.
+///
+/// TVL is denominated in each chain's native token. Since native tokens have different USD values,
+/// the same numeric threshold produces wildly different USD-equivalent filters across chains.
+/// These tiers provide sensible defaults targeting equivalent USD values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TvlThresholdTier {
+    /// Filters out dust pools (~$20K USD equivalent in native token).
+    Low,
+    /// Filters for pools with meaningful liquidity (~$200K USD equivalent in native token).
+    Medium,
+}

--- a/crates/tycho-common/src/models/chain_config.rs
+++ b/crates/tycho-common/src/models/chain_config.rs
@@ -59,6 +59,8 @@ pub enum ChainConfigError {
     NameTooLong(String),
     #[error("unknown chain '{0}': not a built-in chain and no custom config registered")]
     UnknownChain(String),
+    #[error("duplicate custom chain config for '{0}'")]
+    DuplicateChain(String),
     #[error("failed to read chain config file: {0}")]
     Io(String),
     #[error("failed to parse chain config: {0}")]
@@ -196,13 +198,23 @@ impl ChainConfigRegistry {
         Self { custom: HashMap::new() }
     }
 
-    /// Builds a registry from custom chain configs, keyed by chain name.
-    pub fn from_configs(configs: impl IntoIterator<Item = CustomChainConfig>) -> Self {
-        let custom = configs
-            .into_iter()
-            .map(|cfg| (cfg.name().to_owned(), cfg))
-            .collect();
-        Self { custom }
+    /// Builds a registry from custom chain configs, keyed by chain name. Rejects duplicate names
+    /// with [`ChainConfigError::DuplicateChain`] rather than silently overriding, so an ambiguous
+    /// config fails loudly at construction.
+    pub fn from_configs(
+        configs: impl IntoIterator<Item = CustomChainConfig>,
+    ) -> Result<Self, ChainConfigError> {
+        let mut custom = HashMap::new();
+        for cfg in configs {
+            let name = cfg.name().to_owned();
+            if custom
+                .insert(name.clone(), cfg)
+                .is_some()
+            {
+                return Err(ChainConfigError::DuplicateChain(name));
+            }
+        }
+        Ok(Self { custom })
     }
 
     /// Reads custom chain configs from `TYCHO_CHAIN_CONFIG` (default `./chain.yaml`).
@@ -222,8 +234,8 @@ impl ChainConfigRegistry {
 
     /// Parses a registry from a YAML file with a top-level `chains:` list.
     pub fn from_yaml_file(path: &str) -> Result<Self, ChainConfigError> {
-        let contents = std::fs::read_to_string(path)
-            .map_err(|e| ChainConfigError::Io(e.to_string()))?;
+        let contents =
+            std::fs::read_to_string(path).map_err(|e| ChainConfigError::Io(e.to_string()))?;
         Self::from_yaml_str(&contents)
     }
 
@@ -231,7 +243,7 @@ impl ChainConfigRegistry {
     pub fn from_yaml_str(contents: &str) -> Result<Self, ChainConfigError> {
         let file: ChainConfigFile =
             serde_yaml::from_str(contents).map_err(|e| ChainConfigError::Parse(e.to_string()))?;
-        Ok(Self::from_configs(file.chains))
+        Self::from_configs(file.chains)
     }
 
     /// Returns the config for a custom chain by name, if registered.
@@ -319,7 +331,7 @@ chains:
             TvlThresholds::new(1.0, 2.0),
         )
         .unwrap();
-        let registry = ChainConfigRegistry::from_configs([cfg]);
+        let registry = ChainConfigRegistry::from_configs([cfg]).unwrap();
         assert!(registry.contains("mychain"));
         assert_eq!(
             registry
@@ -334,5 +346,31 @@ chains:
     fn empty_chains_list_parses_to_empty_registry() {
         let registry = ChainConfigRegistry::from_yaml_str("chains: []").unwrap();
         assert!(!registry.contains("anything"));
+    }
+
+    #[test]
+    fn from_configs_duplicate_name_errors() {
+        let first = CustomChainConfig::try_new(
+            "dup",
+            1,
+            2,
+            ChainTokenConfig::try_new("0x00", "AAA", 18).unwrap(),
+            ChainTokenConfig::try_new("0x01", "WAAA", 18).unwrap(),
+            TvlThresholds::new(1.0, 2.0),
+        )
+        .unwrap();
+        let second = CustomChainConfig::try_new(
+            "dup",
+            2,
+            2,
+            ChainTokenConfig::try_new("0x00", "AAA", 18).unwrap(),
+            ChainTokenConfig::try_new("0x01", "WAAA", 18).unwrap(),
+            TvlThresholds::new(1.0, 2.0),
+        )
+        .unwrap();
+        assert_eq!(
+            ChainConfigRegistry::from_configs([first, second]).unwrap_err(),
+            ChainConfigError::DuplicateChain("dup".to_owned())
+        );
     }
 }

--- a/crates/tycho-common/src/models/chain_config.rs
+++ b/crates/tycho-common/src/models/chain_config.rs
@@ -16,9 +16,9 @@ pub struct ChainAddress {
 }
 
 impl ChainAddress {
-    pub fn new(bytes: &[u8]) -> Result<Self, ChainAddressError> {
+    pub fn new(bytes: &[u8]) -> Result<Self, ChainConfigError> {
         if bytes.len() > 32 {
-            return Err(ChainAddressError::TooLong(bytes.len()));
+            return Err(ChainConfigError::AddressTooLong(bytes.len()));
         }
         let mut arr = [0u8; 32];
         arr[..bytes.len()].copy_from_slice(bytes);
@@ -48,17 +48,11 @@ impl<'de> Deserialize<'de> for ChainAddress {
 }
 
 #[derive(Error, Debug, PartialEq)]
-pub enum ChainAddressError {
-    #[error("address is {0} bytes, max is 32")]
-    TooLong(usize),
-}
-
-#[derive(Error, Debug, PartialEq)]
 pub enum ChainConfigError {
     #[error("invalid hex address '{0}': {1}")]
     InvalidAddress(String, String),
-    #[error("address '{0}': {1}")]
-    AddressTooLong(String, String),
+    #[error("address is {0} bytes, max is 32")]
+    AddressTooLong(usize),
     #[error("symbol '{0}' too long (max 8 chars)")]
     SymbolTooLong(String),
     #[error("chain name '{0}' too long (max 32 chars)")]
@@ -84,8 +78,7 @@ impl ChainTokenConfig {
     ) -> Result<Self, ChainConfigError> {
         let raw = hex::decode(address_hex.trim_start_matches("0x"))
             .map_err(|e| ChainConfigError::InvalidAddress(address_hex.to_owned(), e.to_string()))?;
-        let address = ChainAddress::new(&raw)
-            .map_err(|e| ChainConfigError::AddressTooLong(address_hex.to_owned(), e.to_string()))?;
+        let address = ChainAddress::new(&raw)?;
         let symbol = ArrayString::from(symbol)
             .map_err(|_| ChainConfigError::SymbolTooLong(symbol.to_owned()))?;
         Ok(Self { address, symbol, decimals })

--- a/crates/tycho-common/src/models/chain_config.rs
+++ b/crates/tycho-common/src/models/chain_config.rs
@@ -59,6 +59,10 @@ pub enum ChainConfigError {
     NameTooLong(String),
     #[error("unknown chain '{0}': not a built-in chain and no custom config registered")]
     UnknownChain(String),
+    #[error("failed to read chain config file: {0}")]
+    Io(String),
+    #[error("failed to parse chain config: {0}")]
+    Parse(String),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
@@ -175,14 +179,6 @@ struct ChainConfigFile {
     chains: Vec<CustomChainConfig>,
 }
 
-#[derive(Debug, Error)]
-pub enum ChainConfigFileError {
-    #[error("failed to read chain config file: {0}")]
-    Io(#[from] std::io::Error),
-    #[error("failed to parse chain config: {0}")]
-    Parse(#[from] serde_yaml::Error),
-}
-
 /// Resolves the full configuration of custom chains by name.
 ///
 /// Built-in chains are resolved without this registry; it only holds user-defined chains loaded
@@ -215,7 +211,7 @@ impl ChainConfigRegistry {
     /// file. Returns an error if the file exists but cannot be read or parsed, leaving it to the
     /// caller to decide how to react. Install the result with [`init_chain_registry`] to make it
     /// the process-wide registry.
-    pub fn load_default() -> Result<Self, ChainConfigFileError> {
+    pub fn load_default() -> Result<Self, ChainConfigError> {
         let path = std::env::var(CHAIN_CONFIG_ENV)
             .unwrap_or_else(|_| DEFAULT_CHAIN_CONFIG_PATH.to_owned());
         if !std::path::Path::new(&path).exists() {
@@ -225,14 +221,16 @@ impl ChainConfigRegistry {
     }
 
     /// Parses a registry from a YAML file with a top-level `chains:` list.
-    pub fn from_yaml_file(path: &str) -> Result<Self, ChainConfigFileError> {
-        let contents = std::fs::read_to_string(path)?;
+    pub fn from_yaml_file(path: &str) -> Result<Self, ChainConfigError> {
+        let contents = std::fs::read_to_string(path)
+            .map_err(|e| ChainConfigError::Io(e.to_string()))?;
         Self::from_yaml_str(&contents)
     }
 
     /// Parses a registry from a YAML string with a top-level `chains:` list.
-    pub fn from_yaml_str(contents: &str) -> Result<Self, ChainConfigFileError> {
-        let file: ChainConfigFile = serde_yaml::from_str(contents)?;
+    pub fn from_yaml_str(contents: &str) -> Result<Self, ChainConfigError> {
+        let file: ChainConfigFile =
+            serde_yaml::from_str(contents).map_err(|e| ChainConfigError::Parse(e.to_string()))?;
         Ok(Self::from_configs(file.chains))
     }
 

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -1,5 +1,5 @@
 pub mod blockchain;
-mod chain_config;
+pub mod chain_config;
 pub mod contract;
 pub mod error;
 pub mod protocol;
@@ -7,7 +7,7 @@ pub mod token;
 
 use std::{collections::HashMap, fmt::Display, str::FromStr};
 
-pub use chain_config::*;
+use chain_config::{CustomChainConfig, TvlThresholdTier};
 use deepsize::DeepSizeOf;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -482,7 +482,10 @@ pub enum MergeError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{
+        chain_config::{ChainAddress, ChainAddressError, ChainTokenConfig, TvlThresholds},
+        *,
+    };
 
     fn test_config() -> CustomChainConfig {
         CustomChainConfig::try_new(

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod blockchain;
+mod chain_config;
 pub mod contract;
 pub mod error;
 pub mod protocol;
@@ -6,12 +7,11 @@ pub mod token;
 
 use std::{collections::HashMap, fmt::Display, str::FromStr};
 
-use arrayvec::ArrayString;
+pub use chain_config::*;
 use deepsize::DeepSizeOf;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use token::Token;
-use utoipa::ToSchema;
 
 use crate::{dto, Bytes};
 
@@ -58,163 +58,6 @@ pub type ProtocolSystem = String;
 
 /// Entry point id literal type to uniquely identify an entry point.
 pub type EntryPointId = String;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct ChainAddress {
-    bytes: [u8; 32],
-    len: u8,
-}
-
-impl ChainAddress {
-    pub fn new(bytes: &[u8]) -> Result<Self, ChainAddressError> {
-        if bytes.len() > 32 {
-            return Err(ChainAddressError::TooLong(bytes.len()));
-        }
-        let mut arr = [0u8; 32];
-        arr[..bytes.len()].copy_from_slice(bytes);
-        Ok(Self { bytes: arr, len: bytes.len() as u8 })
-    }
-
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.bytes[..self.len as usize]
-    }
-}
-
-/// Serialized as a `0x`-prefixed hex string so config files and wire payloads use the same
-/// representation a human writes (e.g. `"0x0000...0000"`).
-impl Serialize for ChainAddress {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&format!("0x{}", hex::encode(self.as_bytes())))
-    }
-}
-
-impl<'de> Deserialize<'de> for ChainAddress {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let s = String::deserialize(deserializer)?;
-        let raw = hex::decode(s.trim_start_matches("0x"))
-            .map_err(|e| serde::de::Error::custom(format!("invalid hex address '{s}': {e}")))?;
-        ChainAddress::new(&raw).map_err(serde::de::Error::custom)
-    }
-}
-
-#[derive(Error, Debug, PartialEq)]
-pub enum ChainAddressError {
-    #[error("address is {0} bytes, max is 32")]
-    TooLong(usize),
-}
-
-#[derive(Error, Debug, PartialEq)]
-pub enum ChainConfigError {
-    #[error("invalid hex address '{0}': {1}")]
-    InvalidAddress(String, String),
-    #[error("address '{0}': {1}")]
-    AddressTooLong(String, String),
-    #[error("symbol '{0}' too long (max 8 chars)")]
-    SymbolTooLong(String),
-    #[error("chain name '{0}' too long (max 32 chars)")]
-    NameTooLong(String),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
-pub struct ChainTokenConfig {
-    #[schema(value_type = String)]
-    address: ChainAddress,
-    #[schema(value_type = String)]
-    symbol: ArrayString<8>,
-    decimals: u8,
-}
-
-impl ChainTokenConfig {
-    pub fn try_new(
-        address_hex: &str,
-        symbol: &str,
-        decimals: u8,
-    ) -> Result<Self, ChainConfigError> {
-        let raw = hex::decode(address_hex.trim_start_matches("0x"))
-            .map_err(|e| ChainConfigError::InvalidAddress(address_hex.to_owned(), e.to_string()))?;
-        let address = ChainAddress::new(&raw)
-            .map_err(|e| ChainConfigError::AddressTooLong(address_hex.to_owned(), e.to_string()))?;
-        let symbol = ArrayString::from(symbol)
-            .map_err(|_| ChainConfigError::SymbolTooLong(symbol.to_owned()))?;
-        Ok(Self { address, symbol, decimals })
-    }
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema)]
-pub struct TvlThresholds {
-    low: f64,
-    medium: f64,
-}
-
-impl TvlThresholds {
-    pub fn new(low: f64, medium: f64) -> Self {
-        Self { low, medium }
-    }
-}
-
-impl PartialEq for TvlThresholds {
-    fn eq(&self, other: &Self) -> bool {
-        self.low.to_bits() == other.low.to_bits() && self.medium.to_bits() == other.medium.to_bits()
-    }
-}
-
-impl Eq for TvlThresholds {}
-
-impl std::hash::Hash for TvlThresholds {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.low.to_bits().hash(state);
-        self.medium.to_bits().hash(state);
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
-pub struct CustomChainConfig {
-    #[schema(value_type = String)]
-    name: ArrayString<32>,
-    chain_id: u64,
-    pub block_time_secs: u64,
-    native: ChainTokenConfig,
-    wrapped_native: ChainTokenConfig,
-    default_tvl_thresholds: TvlThresholds,
-}
-
-impl CustomChainConfig {
-    pub fn try_new(
-        name: &str,
-        chain_id: u64,
-        block_time_secs: u64,
-        native: ChainTokenConfig,
-        wrapped_native: ChainTokenConfig,
-        default_tvl_thresholds: TvlThresholds,
-    ) -> Result<Self, ChainConfigError> {
-        let name =
-            ArrayString::from(name).map_err(|_| ChainConfigError::NameTooLong(name.to_owned()))?;
-        Ok(Self { name, chain_id, block_time_secs, native, wrapped_native, default_tvl_thresholds })
-    }
-
-    pub fn name(&self) -> &str {
-        self.name.as_str()
-    }
-}
-
-impl DeepSizeOf for CustomChainConfig {
-    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
-        0
-    }
-}
-
-/// TVL threshold tiers for chain-aware filtering defaults.
-///
-/// TVL is denominated in each chain's native token. Since native tokens have different USD values,
-/// the same numeric threshold produces wildly different USD-equivalent filters across chains.
-/// These tiers provide sensible defaults targeting equivalent USD values.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum TvlThresholdTier {
-    /// Filters out dust pools (~$20K USD equivalent in native token).
-    Low,
-    /// Filters for pools with meaningful liquidity (~$200K USD equivalent in native token).
-    Medium,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default, DeepSizeOf)]
 #[serde(rename_all = "lowercase")]
@@ -642,22 +485,17 @@ mod tests {
     use super::*;
 
     fn test_config() -> CustomChainConfig {
-        CustomChainConfig {
-            name: ArrayString::from("testchain").unwrap(),
-            chain_id: 9999,
-            block_time_secs: 5,
-            native: ChainTokenConfig {
-                address: ChainAddress::new(&[0xAA; 20]).unwrap(),
-                symbol: ArrayString::from("TST").unwrap(),
-                decimals: 18,
-            },
-            wrapped_native: ChainTokenConfig {
-                address: ChainAddress::new(&[0xBB; 20]).unwrap(),
-                symbol: ArrayString::from("WTST").unwrap(),
-                decimals: 18,
-            },
-            default_tvl_thresholds: TvlThresholds { low: 50.0, medium: 500.0 },
-        }
+        CustomChainConfig::try_new(
+            "testchain",
+            9999,
+            5,
+            ChainTokenConfig::try_new("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "TST", 18)
+                .unwrap(),
+            ChainTokenConfig::try_new("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "WTST", 18)
+                .unwrap(),
+            TvlThresholds::new(50.0, 500.0),
+        )
+        .unwrap()
     }
 
     #[test]

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -483,7 +483,7 @@ pub enum MergeError {
 #[cfg(test)]
 mod tests {
     use super::{
-        chain_config::{ChainAddress, ChainAddressError, ChainTokenConfig, TvlThresholds},
+        chain_config::{ChainAddress, ChainConfigError, ChainTokenConfig, TvlThresholds},
         *,
     };
 
@@ -545,7 +545,7 @@ mod tests {
 
     #[test]
     fn test_chain_address_new_rejects_oversized_input() {
-        assert_eq!(ChainAddress::new(&[0u8; 33]), Err(ChainAddressError::TooLong(33)));
+        assert_eq!(ChainAddress::new(&[0u8; 33]), Err(ChainConfigError::AddressTooLong(33)));
     }
 
     #[test]

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -37,7 +37,7 @@ use tracing_subscriber::EnvFilter;
 use tycho_common::{
     models::{
         blockchain::{Block, Transaction},
-        chain_config::CustomChainConfig,
+        chain_config::{ChainConfigRegistry, CustomChainConfig},
         contract::AccountDelta,
         Address, Chain, ExtractionState, ImplementationType,
     },
@@ -93,15 +93,11 @@ impl ExtractorConfigs {
     }
 }
 
-fn resolve_chain(
-    name: &str,
-    custom_chains: &[CustomChainConfig],
-) -> Result<Chain, ExtractionError> {
+fn resolve_chain(name: &str, registry: &ChainConfigRegistry) -> Result<Chain, ExtractionError> {
     match Chain::from_str(name) {
         Ok(chain) => Ok(chain),
-        Err(_) => custom_chains
-            .iter()
-            .find(|cfg| cfg.name() == name)
+        Err(_) => registry
+            .get(name)
             .map(|cfg| Chain::Custom(*cfg))
             .ok_or_else(|| {
                 ExtractionError::Setup(format!(
@@ -271,10 +267,14 @@ fn run_indexer(global_args: GlobalArgs, index_args: IndexArgs) -> Result<(), Ext
                 .parse()
                 .expect("Failed to parse retention horizon");
 
+            let chain_registry =
+                ChainConfigRegistry::from_configs(extractors_config.chains.clone())
+                    .map_err(|e| ExtractionError::Setup(e.to_string()))?;
+
             let chains = index_args
                 .chains
                 .iter()
-                .map(|name| resolve_chain(name, &extractors_config.chains))
+                .map(|name| resolve_chain(name, &chain_registry))
                 .collect::<Result<Vec<_>, _>>()?;
 
             let (extraction_tasks, other_tasks) = create_indexing_tasks(
@@ -730,7 +730,7 @@ mod tests {
 
     #[test]
     fn test_resolve_unknown_chain_fails() {
-        let err = resolve_chain("notachain", &[]).unwrap_err();
+        let err = resolve_chain("notachain", &ChainConfigRegistry::empty()).unwrap_err();
         assert!(matches!(err, ExtractionError::Setup(msg) if msg.contains("notachain")));
     }
 
@@ -770,7 +770,9 @@ chains:
       medium: 10000
 "#;
         let config: ExtractorConfigs = serde_yaml::from_str(yaml).expect("yaml parse failed");
-        let Chain::Custom(cfg) = resolve_chain("mychain", &config.chains).expect("resolve failed")
+        let registry =
+            ChainConfigRegistry::from_configs(config.chains).expect("registry build failed");
+        let Chain::Custom(cfg) = resolve_chain("mychain", &registry).expect("resolve failed")
         else {
             panic!("expected Chain::Custom")
         };

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -37,8 +37,9 @@ use tracing_subscriber::EnvFilter;
 use tycho_common::{
     models::{
         blockchain::{Block, Transaction},
+        chain_config::CustomChainConfig,
         contract::AccountDelta,
-        Address, Chain, CustomChainConfig, ExtractionState, ImplementationType,
+        Address, Chain, ExtractionState, ImplementationType,
     },
     storage::{ChainGateway, ContractStateGateway, ExtractionStateGateway},
     traits::{AccountExtractor, StorageSnapshotRequest},
@@ -723,7 +724,7 @@ async fn run_analyze_tokens(
 
 #[cfg(test)]
 mod tests {
-    use tycho_common::models::{ChainTokenConfig, TvlThresholds};
+    use tycho_common::models::chain_config::{ChainTokenConfig, TvlThresholds};
 
     use super::*;
 

--- a/crates/tycho-indexer/src/services/api_docs.rs
+++ b/crates/tycho-indexer/src/services/api_docs.rs
@@ -10,7 +10,7 @@ use tycho_common::{
         TracedEntryPointRequestBody, TracedEntryPointRequestResponse, TracingParams, TracingResult,
         VersionParam,
     },
-    models::{ChainTokenConfig, CustomChainConfig, TvlThresholds},
+    models::chain_config::{ChainTokenConfig, CustomChainConfig, TvlThresholds},
 };
 use utoipa::{
     openapi::security::{ApiKey, ApiKeyValue, SecurityScheme},

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -35,7 +35,7 @@ use tycho_simulation::{
         hashflow::{client::HashflowClient, state::HashflowState},
         liquorice::{client::LiquoriceClient, state::LiquoriceState},
     },
-    tycho_common::models::{Chain, TvlThresholdTier},
+    tycho_common::models::{chain_config::TvlThresholdTier, Chain},
     utils::load_all_tokens,
 };
 use tycho_test::{
@@ -1018,7 +1018,10 @@ async fn process_update(
         }
     }
     if n_reverts > 0 || n_failures > 0 {
-        warn!("For block {}, simulated {total_simulations} executions, {n_reverts} simulations reverted, {n_failures} executions setup failed", block.number())
+        warn!(
+            "For block {}, simulated {total_simulations} executions, {n_reverts} simulations reverted, {n_failures} executions setup failed",
+            block.number()
+        )
     }
 
     Ok(())


### PR DESCRIPTION
Introduce the registry and config loading without touching the Chain enum.

# Changes

- Move chain value types (ChainAddress, ChainConfigError, ChainTokenConfig, TvlThresholds,
  TvlThresholdTier, CustomChainConfig) into tycho-common/src/models/chain_config.rs; re-export from
  models/mod.rs so existing import paths are unchanged.
- Add ChainConfigRegistry { custom: HashMap<String, CustomChainConfig> } with empty / from_configs /
  load_default / get / contains. load_default reads TYCHO_CHAIN_CONFIG else ./chain.yaml; missing file
  => empty registry.
- Add a lazily-initialised global accessor chain_registry() (OnceLock) plus init_chain_registry() for
  explicit init (used by the indexer).
- Add ChainConfigError::UnknownChain(String).

# Suggested commits

1. refactor(common): move chain value types into chain_config module
2. feat(common): add ChainConfigRegistry with file/env config loading

# Acceptance criteria

- No existing behavior changes; registry not yet wired into Chain.
- Tests: YAML round-trip; load_default with/without file; get/contains; explicit init wins.
- cargo test -p tycho-common passes.

# Files

tycho-common/src/models/chain_config.rs (new), tycho-common/src/models/mod.rs, tycho-common/Cargo.toml