### PR TITLE
feat: represent custom chains by name, resolve config via registry

### DIFF
--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -66,7 +66,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # nightly
         id: toolchain
         with:
-          toolchain: nightly
+          toolchain: nightly-2026-06-28
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6  # v2.7.8

--- a/crates/tycho-client-py/python/tests/test_decode.py
+++ b/crates/tycho-client-py/python/tests/test_decode.py
@@ -4,15 +4,13 @@ from hexbytes import HexBytes
 
 from tycho_indexer_client.dto import (
     Chain,
-    ChainTokenConfig,
     ContractId,
     ContractStateParams,
-    CustomChainConfig,
+    CustomChain,
     ExtractorIdentity,
     FeedMessage,
     SynchronizerState,
     SynchronizerStateEnum,
-    TvlThresholds,
     Header,
 )
 
@@ -51,29 +49,9 @@ def test_decode_deltas(asset_dir):
     )
 
 
-# JSON shaped exactly as Tycho serialises `Chain::Custom(..)` (serde, externally tagged, lowercase
-# variant name), mirroring the Rust `test_config()` in tycho-common/src/models/mod.rs. The TVL
-# thresholds are deliberately fractional: Rust serialises them as f64, so this guards that the
-# Python client preserves the fractional part instead of truncating to int. If the Rust wire
-# format changes, this fixture must change with it.
-CUSTOM_CHAIN_JSON = {
-    "custom": {
-        "name": "testchain",
-        "chain_id": 9999,
-        "block_time_secs": 5,
-        "native": {
-            "address": "0x" + "aa" * 20,
-            "symbol": "TST",
-            "decimals": 18,
-        },
-        "wrapped_native": {
-            "address": "0x" + "bb" * 20,
-            "symbol": "WTST",
-            "decimals": 18,
-        },
-        "default_tvl_thresholds": {"low": 50.5, "medium": 500.25},
-    }
-}
+# JSON shaped exactly as Tycho serialises `Chain::Custom("name")`: externally tagged with the chain
+# name as a string. If the Rust wire format changes, this fixture must change with it.
+CUSTOM_CHAIN_JSON = {"custom": "testchain"}
 
 
 def test_decode_extractor_identity_known_chain():
@@ -86,22 +64,10 @@ def test_decode_extractor_identity_known_chain():
 def test_decode_extractor_identity_custom_chain():
     ident = ExtractorIdentity(chain=CUSTOM_CHAIN_JSON, name="my_extractor")
 
-    assert isinstance(ident.chain, CustomChainConfig)
-    assert ident.chain == CustomChainConfig(
-        name="testchain",
-        chain_id=9999,
-        block_time_secs=5,
-        native=ChainTokenConfig(
-            address="0x" + "aa" * 20, symbol="TST", decimals=18
-        ),
-        wrapped_native=ChainTokenConfig(
-            address="0x" + "bb" * 20, symbol="WTST", decimals=18
-        ),
-        default_tvl_thresholds=TvlThresholds(low=50.5, medium=500.25),
-    )
-    # Guard against silent int truncation of the f64 thresholds.
-    assert ident.chain.default_tvl_thresholds.low == 50.5
-    assert ident.chain.default_tvl_thresholds.medium == 500.25
+    assert isinstance(ident.chain, CustomChain)
+    assert ident.chain == CustomChain(name="testchain")
+    assert ident.chain.name == "testchain"
+    assert str(ident.chain) == "testchain"
 
 
 def test_decode_contract_state_params_backward_compatibility():

--- a/crates/tycho-client-py/python/tycho_indexer_client/__init__.py
+++ b/crates/tycho-client-py/python/tycho_indexer_client/__init__.py
@@ -11,9 +11,7 @@ from .rpc_client import (
 )
 from .dto import (
     Chain,
-    CustomChainConfig,
-    ChainTokenConfig,
-    TvlThresholds,
+    CustomChain,
     ProtocolComponent,
     ResponseProtocolState,
     ResponseAccount,

--- a/crates/tycho-client-py/python/tycho_indexer_client/dto.py
+++ b/crates/tycho-client-py/python/tycho_indexer_client/dto.py
@@ -48,36 +48,21 @@ class Chain(str, Enum):
     polygon = "polygon"
 
 
-class ChainTokenConfig(BaseModel):
-    address: str
-    symbol: str
-    decimals: int
+class CustomChain(BaseModel):
+    """A user-defined chain. Only the chain name travels on the wire; the full config lives
+    server-side. Rust serialises ``Custom("name")`` as ``{"custom": "name"}``."""
 
-
-class TvlThresholds(BaseModel):
-    low: float
-    medium: float
-
-
-class CustomChainConfig(BaseModel):
     name: str
-    chain_id: int
-    block_time_secs: int
-    native: ChainTokenConfig
-    wrapped_native: ChainTokenConfig
-    default_tvl_thresholds: TvlThresholds
 
     def __str__(self) -> str:
         return self.name
 
     @root_validator(pre=True)
     def _unwrap_serde_tag(cls, values):
-        # Rust serialises Custom(cfg) as {"custom": {...}} — unwrap the tag.
+        # Rust serialises Custom("name") as {"custom": "name"} — unwrap the tag to the name.
         if "custom" in values and len(values) == 1:
-            return values["custom"]
+            return {"name": values["custom"]}
         return values
-
-
 
 
 class ChangeType(str, Enum):
@@ -88,7 +73,7 @@ class ChangeType(str, Enum):
 
 
 class ExtractorIdentity(BaseModel):
-    chain: Union[Chain, CustomChainConfig]
+    chain: Union[Chain, CustomChain]
     name: str
 
 
@@ -125,13 +110,13 @@ class Block(BaseModel):
     number: int
     hash: HexBytes
     parent_hash: HexBytes
-    chain: Union[Chain, CustomChainConfig]
+    chain: Union[Chain, CustomChain]
     ts: datetime
 
 
 class BlockParam(BaseModel):
     hash: Optional[HexBytes] = None
-    chain: Optional[Union[Chain, CustomChainConfig]] = None
+    chain: Optional[Union[Chain, CustomChain]] = None
     number: Optional[int] = None
 
 
@@ -152,7 +137,7 @@ class TokenBalances(BaseModel):
 
 class AccountUpdate(BaseModel):
     address: HexBytes
-    chain: Union[Chain, CustomChainConfig]
+    chain: Union[Chain, CustomChain]
     slots: Dict[HexBytes, HexBytes]
     balance: Optional[HexBytes] = None
     code: Optional[HexBytes] = None
@@ -169,7 +154,7 @@ class ProtocolComponent(BaseModel):
     id: str
     protocol_system: str
     protocol_type_name: str
-    chain: Union[Chain, CustomChainConfig]
+    chain: Union[Chain, CustomChain]
     tokens: List[HexBytes]
     contract_ids: List[HexBytes]
     static_attributes: Dict[str, HexBytes]
@@ -179,7 +164,7 @@ class ProtocolComponent(BaseModel):
 
 
 class ResponseToken(BaseModel):
-    chain: Union[Chain, CustomChainConfig]
+    chain: Union[Chain, CustomChain]
     address: HexBytes = Field(..., example="0xc9f2e6ea1637E499406986ac50ddC92401ce1f58")
     symbol: str = Field(..., example="WETH")
     decimals: int
@@ -190,7 +175,7 @@ class ResponseToken(BaseModel):
 
 class BlockChanges(BaseModel):
     extractor: str
-    chain: Union[Chain, CustomChainConfig]
+    chain: Union[Chain, CustomChain]
     block: Block
     finalized_block_height: int
     revert: bool
@@ -218,7 +203,7 @@ class ComponentWithState(BaseModel):
 
 
 class ResponseAccount(BaseModel):
-    chain: Union[Chain, CustomChainConfig]
+    chain: Union[Chain, CustomChain]
     address: HexBytes
     title: str
     slots: Dict[HexBytes, HexBytes]
@@ -289,13 +274,13 @@ class PaginationParams(BaseModel):
 
 
 class ProtocolId(BaseModel):
-    chain: Union[Chain, CustomChainConfig]
+    chain: Union[Chain, CustomChain]
     id: str
 
 
 class ContractId(BaseModel):
     address: HexBytes
-    chain: Union[Chain, CustomChainConfig]
+    chain: Union[Chain, CustomChain]
 
 
 class VersionParams(BaseModel):
@@ -356,7 +341,7 @@ class TokensParams(BaseModel):
 
 
 class ProtocolSystemsParams(BaseModel):
-    chain: Optional[Union[Chain, CustomChainConfig]] = None
+    chain: Optional[Union[Chain, CustomChain]] = None
     pagination: Optional[PaginationParams] = None
 
     class Config:
@@ -364,7 +349,7 @@ class ProtocolSystemsParams(BaseModel):
 
 
 class ComponentTvlParams(BaseModel):
-    chain: Optional[Union[Chain, CustomChainConfig]] = None
+    chain: Optional[Union[Chain, CustomChain]] = None
     protocol_system: Optional[str] = Field(default=None, alias="protocolSystem")
     component_ids: Optional[List[str]] = Field(default=None)
     pagination: Optional[PaginationParams] = None
@@ -374,7 +359,7 @@ class ComponentTvlParams(BaseModel):
 
 
 class TracedEntryPointParams(BaseModel):
-    chain: Optional[Union[Chain, CustomChainConfig]] = None
+    chain: Optional[Union[Chain, CustomChain]] = None
     protocol_system: str
     component_ids: Optional[List[str]] = Field(default=None)
     pagination: Optional[PaginationParams] = None

--- a/crates/tycho-client-py/python/tycho_indexer_client/rpc_client.py
+++ b/crates/tycho-client-py/python/tycho_indexer_client/rpc_client.py
@@ -5,7 +5,7 @@ import requests
 
 from .dto import (
     Chain,
-    CustomChainConfig,
+    CustomChain,
     ProtocolComponentsParams,
     ProtocolStateParams,
     ContractStateParams,
@@ -58,7 +58,7 @@ class TychoRPCClient:
         self,
         rpc_url: str = "http://0.0.0.0:4242",
         auth_token: str = None,
-        chain: Union[Chain, CustomChainConfig] = Chain.ethereum,
+        chain: Union[Chain, CustomChain] = Chain.ethereum,
     ):
         """
         Initialize the Tycho RPC client.

--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -100,7 +100,6 @@ impl HeaderLike for BlockHeader {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Error, Debug)]
 pub enum BlockSynchronizerError {
     #[error("Failed to initialize extractor '{extractor}': {source}")]
@@ -243,7 +242,6 @@ impl SynchronizerStream {
             rx,
         }
     }
-    #[allow(clippy::result_large_err)]
     async fn try_advance(
         &mut self,
         block_history: &BlockHistory,
@@ -307,7 +305,6 @@ impl SynchronizerStream {
     ///
     /// ## Note
     /// This method assumes that the current state is `Ready`.
-    #[allow(clippy::result_large_err)]
     async fn try_recv_next_expected(
         &mut self,
         max_wait: std::time::Duration,
@@ -353,7 +350,6 @@ impl SynchronizerStream {
     /// If a synchronizer is delayed, this method will try to catch up to the next expected block
     /// by consuming all waiting messages in its queue and waiting for any new block messages
     /// within a timeout. Finally, all update messages are merged into one and returned.
-    #[allow(clippy::result_large_err)]
     async fn try_catch_up(
         &mut self,
         block_history: &BlockHistory,
@@ -421,7 +417,6 @@ impl SynchronizerStream {
     }
 
     /// Helper method to check if synchronizer should transition to stale based on time elapsed
-    #[allow(clippy::result_large_err)]
     fn check_and_transition_to_stale_if_needed(
         &mut self,
         stale_threshold: std::time::Duration,
@@ -460,7 +455,6 @@ impl SynchronizerStream {
     /// - Next expected block -> Ready state
     /// - Latest/Delayed block -> Either Delayed or Stale (if >60s since last update)
     /// - Advanced block -> Advanced state (block ahead of expected position)
-    #[allow(clippy::result_large_err)]
     fn transition(
         &mut self,
         latest_retrieved: BlockHeader,
@@ -668,7 +662,6 @@ where
     ///
     /// Will error directly if the startup fails. Once the startup is complete, it will
     /// communicate any fatal errors through the stream before closing it.
-    #[allow(clippy::result_large_err)]
     pub async fn run(
         mut self,
     ) -> BlockSyncResult<(JoinHandle<()>, Receiver<BlockSyncResult<FeedMessage<BlockHeader>>>)>
@@ -870,7 +863,6 @@ where
     ///
     /// The result is written into `ready_sync_messages`. Errors only if there is a
     /// non-recoverable error or all synchronizers have ended.
-    #[allow(clippy::result_large_err)]
     async fn handle_next_message(
         &self,
         sync_streams: &mut [SynchronizerStream],
@@ -948,7 +940,6 @@ where
     /// ## Note
     /// This method assumes that at least one synchronizer is in Advanced, Ready or
     /// Delayed state, it will return an error in case this is not the case.
-    #[allow(clippy::result_large_err)]
     fn reinit_block_history(
         sync_streams: &mut [SynchronizerStream],
         block_history: &mut BlockHistory,
@@ -992,7 +983,6 @@ where
     ///
     /// Used once before entering the main loop, where all-Stale is a fatal configuration
     /// problem (nothing to sync from), not a temporary disconnect.
-    #[allow(clippy::result_large_err)]
     fn require_active_stream(sync_streams: &[SynchronizerStream]) -> BlockSyncResult<()> {
         if sync_streams
             .iter()
@@ -1016,7 +1006,6 @@ where
     ///
     /// Returns `Err` if at least one synchronizer has permanently ended while all
     /// remaining ones are stale — no recovery path exists.
-    #[allow(clippy::result_large_err)]
     fn check_streams(sync_streams: &[SynchronizerStream]) -> BlockSyncResult<()> {
         let mut has_any_ended = false;
         let mut latest_ended_stream: Option<&SynchronizerStream> = None;

--- a/crates/tycho-client/src/stream.rs
+++ b/crates/tycho-client/src/stream.rs
@@ -117,7 +117,10 @@ impl TychoStreamBuilder {
             Chain::Bsc => (1, 12, 50),
             Chain::Unichain => (1, 10, 100),
             Chain::Polygon => (2, 12, 50), // ~2s block time
-            Chain::Custom(cfg) => (cfg.block_time_secs, cfg.block_time_secs * 3, 50),
+            Chain::Custom(_) => {
+                let block_time = chain.block_time_secs();
+                (block_time, block_time * 3, 50)
+            }
         }
     }
 

--- a/crates/tycho-common/src/dto.rs
+++ b/crates/tycho-common/src/dto.rs
@@ -12,6 +12,7 @@ use std::{
     str::FromStr,
 };
 
+use arrayvec::ArrayString;
 use chrono::{NaiveDateTime, Utc};
 use deepsize::{Context, DeepSizeOf};
 use serde::{de, Deserialize, Deserializer, Serialize};
@@ -21,7 +22,7 @@ use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
 use crate::{
-    models::{self, Address, Balance, Code, ComponentId, CustomChainConfig, StoreKey, StoreVal},
+    models::{self, Address, Balance, Code, ComponentId, StoreKey, StoreVal},
     serde_primitives::{
         hex_bytes, hex_bytes_option, hex_hashmap_key, hex_hashmap_key_value, hex_hashmap_value,
     },
@@ -29,9 +30,7 @@ use crate::{
 };
 
 /// Currently supported Blockchains
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default, ToSchema, DeepSizeOf,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Chain {
     #[default]
@@ -43,7 +42,14 @@ pub enum Chain {
     Bsc,
     Unichain,
     Polygon,
-    Custom(CustomChainConfig),
+    #[schema(value_type = String)]
+    Custom(ArrayString<32>),
+}
+
+impl DeepSizeOf for Chain {
+    fn deep_size_of_children(&self, _context: &mut Context) -> usize {
+        0
+    }
 }
 
 pub use models::TvlThresholdTier;
@@ -62,7 +68,7 @@ impl fmt::Display for Chain {
 }
 
 impl FromStr for Chain {
-    type Err = strum::ParseError;
+    type Err = models::ChainConfigError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         models::Chain::from_str(s).map(Self::from)
@@ -102,7 +108,7 @@ impl From<models::Chain> for Chain {
             models::Chain::Bsc => Chain::Bsc,
             models::Chain::Unichain => Chain::Unichain,
             models::Chain::Polygon => Chain::Polygon,
-            models::Chain::Custom(cfg) => Chain::Custom(cfg),
+            models::Chain::Custom(name) => Chain::Custom(name),
         }
     }
 }

--- a/crates/tycho-common/src/dto.rs
+++ b/crates/tycho-common/src/dto.rs
@@ -108,7 +108,10 @@ impl From<models::Chain> for Chain {
             models::Chain::Bsc => Chain::Bsc,
             models::Chain::Unichain => Chain::Unichain,
             models::Chain::Polygon => Chain::Polygon,
-            models::Chain::Custom(name) => Chain::Custom(name),
+            models::Chain::Custom(id) => Chain::Custom(
+                ArrayString::from(id.as_str())
+                    .expect("custom chain name is already within 32 bytes"),
+            ),
         }
     }
 }

--- a/crates/tycho-common/src/models/chain_config.rs
+++ b/crates/tycho-common/src/models/chain_config.rs
@@ -154,6 +154,35 @@ impl DeepSizeOf for CustomChainConfig {
     }
 }
 
+/// Name of a custom chain, guaranteed at construction time to have a matching config in the chain
+/// registry. The inner name is private, so a `CustomChainId` — and therefore a `Chain::Custom` —
+/// can only be minted through the crate's validating constructors (`Chain::custom`,
+/// `Chain::from_str`, `From<dto::Chain>`), never fabricated directly. Serializes transparently as
+/// the bare chain name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CustomChainId(ArrayString<32>);
+
+impl CustomChainId {
+    /// Builds an id after confirming `name` is registered, returning
+    /// [`ChainConfigError::UnknownChain`] when it is absent and [`ChainConfigError::NameTooLong`]
+    /// when it exceeds 32 bytes.
+    pub(crate) fn checked(
+        name: &str,
+        registry: &ChainConfigRegistry,
+    ) -> Result<Self, ChainConfigError> {
+        if !registry.contains(name) {
+            return Err(ChainConfigError::UnknownChain(name.to_owned()));
+        }
+        ArrayString::from(name)
+            .map(Self)
+            .map_err(|_| ChainConfigError::NameTooLong(name.to_owned()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
 /// TVL threshold tiers for chain-aware filtering defaults.
 ///
 /// TVL is denominated in each chain's native token. Since native tokens have different USD values,

--- a/crates/tycho-common/src/models/chain_config.rs
+++ b/crates/tycho-common/src/models/chain_config.rs
@@ -170,10 +170,10 @@ pub enum TvlThresholdTier {
 /// Env var overriding the path the registry reads custom-chain config from.
 const CHAIN_CONFIG_ENV: &str = "TYCHO_CHAIN_CONFIG";
 /// Default path used when `TYCHO_CHAIN_CONFIG` is unset.
-const DEFAULT_CHAIN_CONFIG_PATH: &str = "./chain.yaml";
+const DEFAULT_CHAIN_CONFIG_PATH: &str = "./chains.yaml";
 
-/// On-disk shape of the custom-chain config file: a top-level `chains:` list. Matches the
-/// `chains:` section of the indexer's extractor config, so a consumer can point
+/// On-disk shape of the custom-chain config file: a top-level `chains:` list. This is the format of
+/// the indexer's `chains.yaml` (its `--chain-config` file), so a consumer can point
 /// `TYCHO_CHAIN_CONFIG` at the same file the indexer uses.
 #[derive(Debug, Default, Deserialize)]
 struct ChainConfigFile {
@@ -184,9 +184,9 @@ struct ChainConfigFile {
 /// Resolves the full configuration of custom chains by name.
 ///
 /// Built-in chains are resolved without this registry; it only holds user-defined chains loaded
-/// from a YAML source. Build it explicitly via [`ChainConfigRegistry::from_configs`] (e.g. the
-/// indexer reusing its `chains:` config) or [`ChainConfigRegistry::load_default`], then install it
-/// as the process-wide registry with [`init_chain_registry`].
+/// from a YAML source. Build it explicitly via [`ChainConfigRegistry::from_configs`],
+/// [`ChainConfigRegistry::from_yaml_file`], or [`ChainConfigRegistry::load_default`], then install
+/// it as the process-wide registry with [`init_chain_registry`].
 #[derive(Debug, Default, Clone)]
 pub struct ChainConfigRegistry {
     custom: HashMap<String, CustomChainConfig>,
@@ -217,7 +217,7 @@ impl ChainConfigRegistry {
         Ok(Self { custom })
     }
 
-    /// Reads custom chain configs from `TYCHO_CHAIN_CONFIG` (default `./chain.yaml`).
+    /// Reads custom chain configs from `TYCHO_CHAIN_CONFIG` (default `./chains.yaml`).
     ///
     /// Returns an empty registry when the file is absent, so runs on built-in chains need no config
     /// file. Returns an error if the file exists but cannot be read or parsed, leaving it to the

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -7,9 +7,9 @@ pub mod token;
 
 use std::{collections::HashMap, fmt::Display, str::FromStr};
 
-use arrayvec::ArrayString;
 use chain_config::{
-    chain_registry, ChainConfigError, ChainConfigRegistry, CustomChainConfig, TvlThresholdTier,
+    chain_registry, ChainConfigError, ChainConfigRegistry, CustomChainConfig, CustomChainId,
+    TvlThresholdTier,
 };
 use deepsize::DeepSizeOf;
 use serde::{Deserialize, Serialize};
@@ -74,7 +74,7 @@ pub enum Chain {
     Bsc,
     Unichain,
     Polygon,
-    Custom(ArrayString<32>),
+    Custom(CustomChainId),
 }
 
 impl DeepSizeOf for Chain {
@@ -99,12 +99,11 @@ impl Chain {
         }
     }
 
-    /// Builds a custom-chain identity from its name. Does not validate against the registry;
-    /// callers that need validation should go through [`Chain::from_str`].
+    /// Builds a custom-chain identity, validating that `name` has a config in the chain registry.
+    /// Returns [`ChainConfigError::UnknownChain`] when it is absent so typos never silently become
+    /// custom chains.
     pub fn custom(name: &str) -> Result<Self, ChainConfigError> {
-        ArrayString::from(name)
-            .map(Chain::Custom)
-            .map_err(|_| ChainConfigError::NameTooLong(name.to_owned()))
+        CustomChainId::checked(name, chain_registry()).map(Chain::Custom)
     }
 }
 
@@ -118,11 +117,7 @@ impl FromStr for Chain {
         if let Some(chain) = Self::builtin_from_str(s) {
             return Ok(chain);
         }
-        if chain_registry().contains(s) {
-            Self::custom(s)
-        } else {
-            Err(ChainConfigError::UnknownChain(s.to_owned()))
-        }
+        Self::custom(s)
     }
 }
 
@@ -153,7 +148,13 @@ impl From<dto::Chain> for Chain {
             dto::Chain::Bsc => Chain::Bsc,
             dto::Chain::Unichain => Chain::Unichain,
             dto::Chain::Polygon => Chain::Polygon,
-            dto::Chain::Custom(name) => Chain::Custom(name),
+            dto::Chain::Custom(name) => Chain::custom(name.as_str()).unwrap_or_else(|e| {
+                panic!(
+                    "received custom chain '{name}' with no registered config: {e}; install it via \
+                     the chain config file (TYCHO_CHAIN_CONFIG, default ./chains.yaml) or \
+                     init_chain_registry before decoding wire data"
+                )
+            }),
         }
     }
 }
@@ -209,17 +210,20 @@ fn native_pol(chain: Chain) -> Token {
     )
 }
 
-/// Looks up a custom chain's config in the registry, panicking with guidance when it is missing.
+/// Looks up a custom chain's config in the registry. Panicking here is an unreachable invariant
+/// guard: a [`CustomChainId`] is only minted after registry validation and the registry is
+/// set-once, so a missing entry signals an internal bug rather than bad input.
 fn resolve_custom<'a>(
-    name: &ArrayString<32>,
+    id: &CustomChainId,
     registry: &'a ChainConfigRegistry,
 ) -> &'a CustomChainConfig {
     registry
-        .get(name.as_str())
+        .get(id.as_str())
         .unwrap_or_else(|| {
             panic!(
-                "no configuration registered for custom chain '{name}'; provide it via the chain \
-             config file (TYCHO_CHAIN_CONFIG, default ./chains.yaml) or init_chain_registry"
+                "no configuration registered for custom chain '{}'; Chain::Custom is validated \
+                 against the registry at construction, so this is an internal invariant violation",
+                id.as_str()
             )
         })
 }
@@ -559,6 +563,8 @@ pub enum MergeError {
 // registry; under a shared-process runner they would contend over the same global.
 #[cfg(test)]
 mod tests {
+    use arrayvec::ArrayString;
+
     use super::{
         chain_config::{
             init_chain_registry, ChainAddress, ChainConfigError, ChainTokenConfig, TvlThresholds,
@@ -587,6 +593,7 @@ mod tests {
 
     #[test]
     fn test_custom_chain_display() {
+        init_test_registry();
         assert_eq!(
             Chain::custom("testchain")
                 .unwrap()
@@ -599,6 +606,29 @@ mod tests {
     fn test_from_str_custom_returns_err() {
         assert!("custom".parse::<Chain>().is_err());
         assert!("unknown".parse::<Chain>().is_err());
+    }
+
+    #[test]
+    fn test_custom_unregistered_returns_err() {
+        init_test_registry();
+        assert_eq!(Chain::custom("nope"), Err(ChainConfigError::UnknownChain("nope".to_owned())));
+    }
+
+    #[test]
+    fn test_from_dto_registered_custom_roundtrips() {
+        init_test_registry();
+        let dto_chain: dto::Chain = Chain::custom("testchain")
+            .unwrap()
+            .into();
+        let chain: Chain = dto_chain.into();
+        assert_eq!(chain.id(), 9999);
+    }
+
+    #[test]
+    #[should_panic(expected = "no registered config")]
+    fn test_from_dto_unregistered_custom_panics() {
+        let dto_chain = dto::Chain::Custom(ArrayString::from("nope").unwrap());
+        let _: Chain = dto_chain.into();
     }
 
     #[test]

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -265,10 +265,6 @@ fn wrapped_native_custom(chain: Chain, cfg: &CustomChainConfig) -> Token {
 
 impl Chain {
     pub fn id(&self) -> u64 {
-        self.id_in(chain_registry())
-    }
-
-    pub(crate) fn id_in(&self, registry: &ChainConfigRegistry) -> u64 {
         match self {
             Chain::Ethereum => 1,
             Chain::ZkSync => 324,
@@ -278,7 +274,7 @@ impl Chain {
             Chain::Bsc => 56,
             Chain::Unichain => 130,
             Chain::Polygon => 137,
-            Chain::Custom(name) => resolve_custom(name, registry).chain_id,
+            Chain::Custom(name) => resolve_custom(name, chain_registry()).chain_id,
         }
     }
 
@@ -289,14 +285,6 @@ impl Chain {
     /// These prices are volatile, and used as a reference. They should not be updated often,
     /// unless big price movements occour, making an update necessary.
     pub fn default_tvl_threshold(&self, tier: TvlThresholdTier) -> f64 {
-        self.default_tvl_threshold_in(tier, chain_registry())
-    }
-
-    pub(crate) fn default_tvl_threshold_in(
-        &self,
-        tier: TvlThresholdTier,
-        registry: &ChainConfigRegistry,
-    ) -> f64 {
         match (self, tier) {
             // ETH-native chains: 10 ETH ≈ $20K, 100 ETH ≈ $200K.
             // Starknet uses ETH-denominated TVL in Tycho (STRK tracked separately).
@@ -328,12 +316,12 @@ impl Chain {
             (Chain::Bsc, TvlThresholdTier::Medium) => 320.0,
 
             (Chain::Custom(name), TvlThresholdTier::Low) => {
-                resolve_custom(name, registry)
+                resolve_custom(name, chain_registry())
                     .default_tvl_thresholds
                     .low
             }
             (Chain::Custom(name), TvlThresholdTier::Medium) => {
-                resolve_custom(name, registry)
+                resolve_custom(name, chain_registry())
                     .default_tvl_thresholds
                     .medium
             }
@@ -342,10 +330,6 @@ impl Chain {
 
     /// Returns the native token for the chain.
     pub fn native_token(&self) -> Token {
-        self.native_token_in(chain_registry())
-    }
-
-    pub(crate) fn native_token_in(&self, registry: &ChainConfigRegistry) -> Token {
         match self {
             Chain::Ethereum => native_eth(Chain::Ethereum),
             // It was decided that STRK token will be tracked as a dedicated AccountBalance on
@@ -357,16 +341,12 @@ impl Chain {
             Chain::Bsc => native_bsc(Chain::Bsc),
             Chain::Unichain => native_eth(Chain::Unichain),
             Chain::Polygon => native_pol(Chain::Polygon),
-            Chain::Custom(name) => native_custom(*self, resolve_custom(name, registry)),
+            Chain::Custom(name) => native_custom(*self, resolve_custom(name, chain_registry())),
         }
     }
 
     /// Returns the wrapped native token for the chain.
     pub fn wrapped_native_token(&self) -> Token {
-        self.wrapped_native_token_in(chain_registry())
-    }
-
-    pub(crate) fn wrapped_native_token_in(&self, registry: &ChainConfigRegistry) -> Token {
         match self {
             Chain::Ethereum => {
                 wrapped_native_eth(Chain::Ethereum, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
@@ -393,16 +373,14 @@ impl Chain {
             Chain::Polygon => {
                 wrapped_native_pol(Chain::Polygon, "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270")
             }
-            Chain::Custom(name) => wrapped_native_custom(*self, resolve_custom(name, registry)),
+            Chain::Custom(name) => {
+                wrapped_native_custom(*self, resolve_custom(name, chain_registry()))
+            }
         }
     }
 
     /// Returns the expected block time in seconds for the chain.
     pub fn block_time_secs(&self) -> u64 {
-        self.block_time_secs_in(chain_registry())
-    }
-
-    pub(crate) fn block_time_secs_in(&self, registry: &ChainConfigRegistry) -> u64 {
         match self {
             Chain::Ethereum => 12,
             Chain::Starknet => 2,
@@ -412,7 +390,7 @@ impl Chain {
             Chain::Bsc => 1,
             Chain::Unichain => 1,
             Chain::Polygon => 2,
-            Chain::Custom(name) => resolve_custom(name, registry).block_time_secs,
+            Chain::Custom(name) => resolve_custom(name, chain_registry()).block_time_secs,
         }
     }
 }
@@ -576,10 +554,15 @@ pub enum MergeError {
     InvalidState(String),
 }
 
+// The custom-chain tests below install the process-wide chain registry, which is a set-once
+// `OnceLock`. They must run in isolated processes (we use nextest), so each test gets a fresh
+// registry; under a shared-process runner they would contend over the same global.
 #[cfg(test)]
 mod tests {
     use super::{
-        chain_config::{ChainAddress, ChainConfigError, ChainTokenConfig, TvlThresholds},
+        chain_config::{
+            init_chain_registry, ChainAddress, ChainConfigError, ChainTokenConfig, TvlThresholds,
+        },
         *,
     };
 
@@ -595,6 +578,11 @@ mod tests {
             TvlThresholds::new(50.0, 500.0),
         )
         .unwrap()
+    }
+
+    fn init_test_registry() {
+        init_chain_registry(ChainConfigRegistry::from_configs([test_config()]).unwrap())
+            .expect("chain registry already initialised; run tests under nextest");
     }
 
     #[test]
@@ -626,24 +614,24 @@ mod tests {
 
     #[test]
     fn test_custom_chain_id() {
-        let registry = ChainConfigRegistry::from_configs([test_config()]).unwrap();
+        init_test_registry();
         let chain = Chain::custom("testchain").unwrap();
-        assert_eq!(chain.id_in(&registry), 9999);
+        assert_eq!(chain.id(), 9999);
     }
 
     #[test]
     fn test_custom_chain_tvl_thresholds() {
-        let registry = ChainConfigRegistry::from_configs([test_config()]).unwrap();
+        init_test_registry();
         let chain = Chain::custom("testchain").unwrap();
-        assert_eq!(chain.default_tvl_threshold_in(TvlThresholdTier::Low, &registry), 50.0);
-        assert_eq!(chain.default_tvl_threshold_in(TvlThresholdTier::Medium, &registry), 500.0);
+        assert_eq!(chain.default_tvl_threshold(TvlThresholdTier::Low), 50.0);
+        assert_eq!(chain.default_tvl_threshold(TvlThresholdTier::Medium), 500.0);
     }
 
     #[test]
     fn test_custom_chain_native_token() {
-        let registry = ChainConfigRegistry::from_configs([test_config()]).unwrap();
+        init_test_registry();
         let chain = Chain::custom("testchain").unwrap();
-        let token = chain.native_token_in(&registry);
+        let token = chain.native_token();
         assert_eq!(token.symbol, "TST");
         assert_eq!(token.decimals, 18);
         assert_eq!(token.chain, chain);
@@ -652,9 +640,9 @@ mod tests {
 
     #[test]
     fn test_custom_chain_wrapped_native_token() {
-        let registry = ChainConfigRegistry::from_configs([test_config()]).unwrap();
+        init_test_registry();
         let chain = Chain::custom("testchain").unwrap();
-        let token = chain.wrapped_native_token_in(&registry);
+        let token = chain.wrapped_native_token();
         assert_eq!(token.symbol, "WTST");
         assert_eq!(token.chain, chain);
         assert_eq!(token.address, Bytes::from(vec![0xBB; 20]));

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -219,7 +219,7 @@ fn resolve_custom<'a>(
         .unwrap_or_else(|| {
             panic!(
                 "no configuration registered for custom chain '{name}'; provide it via the chain \
-             config file (TYCHO_CHAIN_CONFIG, default ./chain.yaml) or init_chain_registry"
+             config file (TYCHO_CHAIN_CONFIG, default ./chains.yaml) or init_chain_registry"
             )
         })
 }

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -7,6 +7,7 @@ pub mod token;
 
 use std::{collections::HashMap, fmt::Display, str::FromStr};
 
+use arrayvec::ArrayString;
 pub use chain_config::*;
 use deepsize::DeepSizeOf;
 use serde::{Deserialize, Serialize};
@@ -59,7 +60,7 @@ pub type ProtocolSystem = String;
 /// Entry point id literal type to uniquely identify an entry point.
 pub type EntryPointId = String;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default, DeepSizeOf)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum Chain {
     #[default]
@@ -71,23 +72,54 @@ pub enum Chain {
     Bsc,
     Unichain,
     Polygon,
-    Custom(CustomChainConfig),
+    Custom(ArrayString<32>),
+}
+
+impl DeepSizeOf for Chain {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
+        0
+    }
+}
+
+impl Chain {
+    /// Parses only the built-in chains, ignoring any custom-chain registry.
+    pub fn builtin_from_str(s: &str) -> Option<Self> {
+        match s {
+            "ethereum" => Some(Chain::Ethereum),
+            "starknet" => Some(Chain::Starknet),
+            "zksync" => Some(Chain::ZkSync),
+            "arbitrum" => Some(Chain::Arbitrum),
+            "base" => Some(Chain::Base),
+            "bsc" => Some(Chain::Bsc),
+            "unichain" => Some(Chain::Unichain),
+            "polygon" => Some(Chain::Polygon),
+            _ => None,
+        }
+    }
+
+    /// Builds a custom-chain identity from its name. Does not validate against the registry;
+    /// callers that need validation should go through [`Chain::from_str`].
+    pub fn custom(name: &str) -> Result<Self, ChainConfigError> {
+        ArrayString::from(name)
+            .map(Chain::Custom)
+            .map_err(|_| ChainConfigError::NameTooLong(name.to_owned()))
+    }
 }
 
 impl FromStr for Chain {
-    type Err = strum::ParseError;
+    type Err = ChainConfigError;
 
+    /// Resolves a chain name. Built-in chains parse directly; any other name is accepted only if it
+    /// is registered in the global chain config registry, otherwise
+    /// [`ChainConfigError::UnknownChain`] is returned so typos never silently become custom chains.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "ethereum" => Ok(Chain::Ethereum),
-            "starknet" => Ok(Chain::Starknet),
-            "zksync" => Ok(Chain::ZkSync),
-            "arbitrum" => Ok(Chain::Arbitrum),
-            "base" => Ok(Chain::Base),
-            "bsc" => Ok(Chain::Bsc),
-            "unichain" => Ok(Chain::Unichain),
-            "polygon" => Ok(Chain::Polygon),
-            _ => Err(strum::ParseError::VariantNotFound),
+        if let Some(chain) = Self::builtin_from_str(s) {
+            return Ok(chain);
+        }
+        if chain_registry().contains(s) {
+            Self::custom(s)
+        } else {
+            Err(ChainConfigError::UnknownChain(s.to_owned()))
         }
     }
 }
@@ -103,7 +135,7 @@ impl Display for Chain {
             Chain::Bsc => f.write_str("bsc"),
             Chain::Unichain => f.write_str("unichain"),
             Chain::Polygon => f.write_str("polygon"),
-            Chain::Custom(cfg) => f.write_str(cfg.name.as_str()),
+            Chain::Custom(name) => f.write_str(name.as_str()),
         }
     }
 }
@@ -119,7 +151,7 @@ impl From<dto::Chain> for Chain {
             dto::Chain::Bsc => Chain::Bsc,
             dto::Chain::Unichain => Chain::Unichain,
             dto::Chain::Polygon => Chain::Polygon,
-            dto::Chain::Custom(cfg) => Chain::Custom(cfg),
+            dto::Chain::Custom(name) => Chain::Custom(name),
         }
     }
 }
@@ -175,7 +207,22 @@ fn native_pol(chain: Chain) -> Token {
     )
 }
 
-fn native_custom(cfg: &CustomChainConfig) -> Token {
+/// Looks up a custom chain's config in the registry, panicking with guidance when it is missing.
+fn resolve_custom<'a>(
+    name: &ArrayString<32>,
+    registry: &'a ChainConfigRegistry,
+) -> &'a CustomChainConfig {
+    registry
+        .get(name.as_str())
+        .unwrap_or_else(|| {
+            panic!(
+                "no configuration registered for custom chain '{name}'; provide it via the chain \
+             config file (TYCHO_CHAIN_CONFIG, default ./chain.yaml) or init_chain_registry"
+            )
+        })
+}
+
+fn native_custom(chain: Chain, cfg: &CustomChainConfig) -> Token {
     let addr = Bytes::from(cfg.native.address.as_bytes().to_vec());
     Token::new(
         &addr,
@@ -183,7 +230,7 @@ fn native_custom(cfg: &CustomChainConfig) -> Token {
         cfg.native.decimals as u32,
         0,
         &[Some(2300)],
-        Chain::Custom(*cfg),
+        chain,
         100,
     )
 }
@@ -196,7 +243,7 @@ fn wrapped_native_pol(chain: Chain, address: &str) -> Token {
     Token::new(&Bytes::from_str(address).unwrap(), "WMATIC", 18, 0, &[Some(2300)], chain, 100)
 }
 
-fn wrapped_native_custom(cfg: &CustomChainConfig) -> Token {
+fn wrapped_native_custom(chain: Chain, cfg: &CustomChainConfig) -> Token {
     let addr = Bytes::from(
         cfg.wrapped_native
             .address
@@ -209,13 +256,17 @@ fn wrapped_native_custom(cfg: &CustomChainConfig) -> Token {
         cfg.wrapped_native.decimals as u32,
         0,
         &[Some(2300)],
-        Chain::Custom(*cfg),
+        chain,
         100,
     )
 }
 
 impl Chain {
     pub fn id(&self) -> u64 {
+        self.id_in(chain_registry())
+    }
+
+    pub(crate) fn id_in(&self, registry: &ChainConfigRegistry) -> u64 {
         match self {
             Chain::Ethereum => 1,
             Chain::ZkSync => 324,
@@ -225,7 +276,7 @@ impl Chain {
             Chain::Bsc => 56,
             Chain::Unichain => 130,
             Chain::Polygon => 137,
-            Chain::Custom(cfg) => cfg.chain_id,
+            Chain::Custom(name) => resolve_custom(name, registry).chain_id,
         }
     }
 
@@ -236,6 +287,14 @@ impl Chain {
     /// These prices are volatile, and used as a reference. They should not be updated often,
     /// unless big price movements occour, making an update necessary.
     pub fn default_tvl_threshold(&self, tier: TvlThresholdTier) -> f64 {
+        self.default_tvl_threshold_in(tier, chain_registry())
+    }
+
+    pub(crate) fn default_tvl_threshold_in(
+        &self,
+        tier: TvlThresholdTier,
+        registry: &ChainConfigRegistry,
+    ) -> f64 {
         match (self, tier) {
             // ETH-native chains: 10 ETH ≈ $20K, 100 ETH ≈ $200K.
             // Starknet uses ETH-denominated TVL in Tycho (STRK tracked separately).
@@ -266,13 +325,25 @@ impl Chain {
             (Chain::Bsc, TvlThresholdTier::Low) => 32.0,
             (Chain::Bsc, TvlThresholdTier::Medium) => 320.0,
 
-            (Chain::Custom(cfg), TvlThresholdTier::Low) => cfg.default_tvl_thresholds.low,
-            (Chain::Custom(cfg), TvlThresholdTier::Medium) => cfg.default_tvl_thresholds.medium,
+            (Chain::Custom(name), TvlThresholdTier::Low) => {
+                resolve_custom(name, registry)
+                    .default_tvl_thresholds
+                    .low
+            }
+            (Chain::Custom(name), TvlThresholdTier::Medium) => {
+                resolve_custom(name, registry)
+                    .default_tvl_thresholds
+                    .medium
+            }
         }
     }
 
     /// Returns the native token for the chain.
     pub fn native_token(&self) -> Token {
+        self.native_token_in(chain_registry())
+    }
+
+    pub(crate) fn native_token_in(&self, registry: &ChainConfigRegistry) -> Token {
         match self {
             Chain::Ethereum => native_eth(Chain::Ethereum),
             // It was decided that STRK token will be tracked as a dedicated AccountBalance on
@@ -284,12 +355,16 @@ impl Chain {
             Chain::Bsc => native_bsc(Chain::Bsc),
             Chain::Unichain => native_eth(Chain::Unichain),
             Chain::Polygon => native_pol(Chain::Polygon),
-            Chain::Custom(cfg) => native_custom(cfg),
+            Chain::Custom(name) => native_custom(*self, resolve_custom(name, registry)),
         }
     }
 
     /// Returns the wrapped native token for the chain.
     pub fn wrapped_native_token(&self) -> Token {
+        self.wrapped_native_token_in(chain_registry())
+    }
+
+    pub(crate) fn wrapped_native_token_in(&self, registry: &ChainConfigRegistry) -> Token {
         match self {
             Chain::Ethereum => {
                 wrapped_native_eth(Chain::Ethereum, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
@@ -316,7 +391,26 @@ impl Chain {
             Chain::Polygon => {
                 wrapped_native_pol(Chain::Polygon, "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270")
             }
-            Chain::Custom(cfg) => wrapped_native_custom(cfg),
+            Chain::Custom(name) => wrapped_native_custom(*self, resolve_custom(name, registry)),
+        }
+    }
+
+    /// Returns the expected block time in seconds for the chain.
+    pub fn block_time_secs(&self) -> u64 {
+        self.block_time_secs_in(chain_registry())
+    }
+
+    pub(crate) fn block_time_secs_in(&self, registry: &ChainConfigRegistry) -> u64 {
+        match self {
+            Chain::Ethereum => 12,
+            Chain::Starknet => 2,
+            Chain::ZkSync => 3,
+            Chain::Arbitrum => 1,
+            Chain::Base => 2,
+            Chain::Bsc => 1,
+            Chain::Unichain => 1,
+            Chain::Polygon => 2,
+            Chain::Custom(name) => resolve_custom(name, registry).block_time_secs,
         }
     }
 }
@@ -500,7 +594,12 @@ mod tests {
 
     #[test]
     fn test_custom_chain_display() {
-        assert_eq!(Chain::Custom(test_config()).to_string(), "testchain");
+        assert_eq!(
+            Chain::custom("testchain")
+                .unwrap()
+                .to_string(),
+            "testchain"
+        );
     }
 
     #[test]
@@ -510,21 +609,36 @@ mod tests {
     }
 
     #[test]
+    fn test_chain_stays_small() {
+        // Regression: Custom carries only a 32-char name, so Chain stays a small Copy enum rather
+        // than embedding the full config (~200 bytes) as it did when Custom held CustomChainConfig.
+        assert!(
+            std::mem::size_of::<Chain>() <= 40,
+            "Chain is {} bytes",
+            std::mem::size_of::<Chain>()
+        );
+    }
+
+    #[test]
     fn test_custom_chain_id() {
-        assert_eq!(Chain::Custom(test_config()).id(), 9999);
+        let registry = ChainConfigRegistry::from_configs([test_config()]);
+        let chain = Chain::custom("testchain").unwrap();
+        assert_eq!(chain.id_in(&registry), 9999);
     }
 
     #[test]
     fn test_custom_chain_tvl_thresholds() {
-        let chain = Chain::Custom(test_config());
-        assert_eq!(chain.default_tvl_threshold(TvlThresholdTier::Low), 50.0);
-        assert_eq!(chain.default_tvl_threshold(TvlThresholdTier::Medium), 500.0);
+        let registry = ChainConfigRegistry::from_configs([test_config()]);
+        let chain = Chain::custom("testchain").unwrap();
+        assert_eq!(chain.default_tvl_threshold_in(TvlThresholdTier::Low, &registry), 50.0);
+        assert_eq!(chain.default_tvl_threshold_in(TvlThresholdTier::Medium, &registry), 500.0);
     }
 
     #[test]
     fn test_custom_chain_native_token() {
-        let chain = Chain::Custom(test_config());
-        let token = chain.native_token();
+        let registry = ChainConfigRegistry::from_configs([test_config()]);
+        let chain = Chain::custom("testchain").unwrap();
+        let token = chain.native_token_in(&registry);
         assert_eq!(token.symbol, "TST");
         assert_eq!(token.decimals, 18);
         assert_eq!(token.chain, chain);
@@ -533,8 +647,9 @@ mod tests {
 
     #[test]
     fn test_custom_chain_wrapped_native_token() {
-        let chain = Chain::Custom(test_config());
-        let token = chain.wrapped_native_token();
+        let registry = ChainConfigRegistry::from_configs([test_config()]);
+        let chain = Chain::custom("testchain").unwrap();
+        let token = chain.wrapped_native_token_in(&registry);
         assert_eq!(token.symbol, "WTST");
         assert_eq!(token.chain, chain);
         assert_eq!(token.address, Bytes::from(vec![0xBB; 20]));

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -62,6 +62,23 @@ pub type ProtocolSystem = String;
 /// Entry point id literal type to uniquely identify an entry point.
 pub type EntryPointId = String;
 
+/// A blockchain Tycho indexes or simulates over.
+///
+/// Built-in chains are first-class variants: their config (id, native token, block time, TVL
+/// tiers) is compile-time and total, so they never fail to resolve. `Custom` is the escape hatch
+/// for a chain a self-hoster runs without upstreaming a variant — its config lives in the
+/// process-wide registry (see [`chain_config`]) rather than in the enum.
+///
+/// `Custom` wraps a [`CustomChainId`] whose inner name is private, so a `Chain::Custom` can only be
+/// built through the crate's registry-validating constructors ([`Chain::custom`],
+/// [`Chain::from_str`], `From<dto::Chain>`) — it cannot be fabricated directly. Because the
+/// registry is set-once, a validated `Chain::Custom` stays resolvable for its whole lifetime, so
+/// the config accessors only panic on an unreachable invariant; [`Chain::try_id`] and its siblings
+/// expose non-panicking variants. The one reachable failure is decoding wire data for a chain the
+/// local registry lacks (`From<dto::Chain>`), which panics at the decode boundary.
+///
+/// Prefer adding a first-class variant for any chain Tycho officially supports; reserve `Custom`
+/// for the self-host case. Full rationale in the custom-chain decision record.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum Chain {
@@ -74,6 +91,7 @@ pub enum Chain {
     Bsc,
     Unichain,
     Polygon,
+    /// User-defined chain resolved via the [`chain_config`] registry; see the enum docs.
     Custom(CustomChainId),
 }
 

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -210,22 +210,27 @@ fn native_pol(chain: Chain) -> Token {
     )
 }
 
-/// Looks up a custom chain's config in the registry. Panicking here is an unreachable invariant
-/// guard: a [`CustomChainId`] is only minted after registry validation and the registry is
-/// set-once, so a missing entry signals an internal bug rather than bad input.
-fn resolve_custom<'a>(
+/// Looks up a custom chain's config in the registry, returning [`ChainConfigError::UnknownChain`]
+/// when it is absent.
+fn try_resolve_custom<'a>(
     id: &CustomChainId,
     registry: &'a ChainConfigRegistry,
-) -> &'a CustomChainConfig {
+) -> Result<&'a CustomChainConfig, ChainConfigError> {
     registry
         .get(id.as_str())
-        .unwrap_or_else(|| {
-            panic!(
-                "no configuration registered for custom chain '{}'; Chain::Custom is validated \
-                 against the registry at construction, so this is an internal invariant violation",
-                id.as_str()
-            )
-        })
+        .ok_or_else(|| ChainConfigError::UnknownChain(id.as_str().to_owned()))
+}
+
+/// Unwraps a registry lookup that cannot fail for a validly-constructed `Chain::Custom`: a
+/// [`CustomChainId`] is only minted after registry validation and the registry is set-once, so a
+/// missing entry is an internal invariant violation rather than bad input.
+fn expect_registered<T>(result: Result<T, ChainConfigError>) -> T {
+    result.unwrap_or_else(|e| {
+        panic!(
+            "internal invariant violation resolving custom chain config: {e}; Chain::Custom is \
+             validated against the set-once chain registry at construction"
+        )
+    })
 }
 
 fn native_custom(chain: Chain, cfg: &CustomChainConfig) -> Token {
@@ -268,8 +273,17 @@ fn wrapped_native_custom(chain: Chain, cfg: &CustomChainConfig) -> Token {
 }
 
 impl Chain {
+    /// Returns the numeric chain id. Panics if a custom chain has no registered config — an
+    /// unreachable invariant for a validly-constructed `Chain::Custom`; use [`Chain::try_id`] for a
+    /// non-panicking variant.
     pub fn id(&self) -> u64 {
-        match self {
+        expect_registered(self.try_id())
+    }
+
+    /// Returns the numeric chain id, or [`ChainConfigError::UnknownChain`] when a custom chain has
+    /// no registered config.
+    pub fn try_id(&self) -> Result<u64, ChainConfigError> {
+        Ok(match self {
             Chain::Ethereum => 1,
             Chain::ZkSync => 324,
             Chain::Arbitrum => 42161,
@@ -278,8 +292,8 @@ impl Chain {
             Chain::Bsc => 56,
             Chain::Unichain => 130,
             Chain::Polygon => 137,
-            Chain::Custom(name) => resolve_custom(name, chain_registry()).chain_id,
-        }
+            Chain::Custom(id) => try_resolve_custom(id, chain_registry())?.chain_id,
+        })
     }
 
     /// Returns a default TVL threshold in native token units for the given tier.
@@ -288,8 +302,20 @@ impl Chain {
     /// Native token prices used: ETH ~$2,000, POL ~$0.10, BNB ~$630.
     /// These prices are volatile, and used as a reference. They should not be updated often,
     /// unless big price movements occour, making an update necessary.
+    ///
+    /// Panics if a custom chain has no registered config; use [`Chain::try_default_tvl_threshold`]
+    /// for a non-panicking variant.
     pub fn default_tvl_threshold(&self, tier: TvlThresholdTier) -> f64 {
-        match (self, tier) {
+        expect_registered(self.try_default_tvl_threshold(tier))
+    }
+
+    /// Like [`Chain::default_tvl_threshold`] but returns [`ChainConfigError::UnknownChain`] when a
+    /// custom chain has no registered config.
+    pub fn try_default_tvl_threshold(
+        &self,
+        tier: TvlThresholdTier,
+    ) -> Result<f64, ChainConfigError> {
+        Ok(match (self, tier) {
             // ETH-native chains: 10 ETH ≈ $20K, 100 ETH ≈ $200K.
             // Starknet uses ETH-denominated TVL in Tycho (STRK tracked separately).
             (
@@ -319,22 +345,29 @@ impl Chain {
             (Chain::Bsc, TvlThresholdTier::Low) => 32.0,
             (Chain::Bsc, TvlThresholdTier::Medium) => 320.0,
 
-            (Chain::Custom(name), TvlThresholdTier::Low) => {
-                resolve_custom(name, chain_registry())
+            (Chain::Custom(id), TvlThresholdTier::Low) => {
+                try_resolve_custom(id, chain_registry())?
                     .default_tvl_thresholds
                     .low
             }
-            (Chain::Custom(name), TvlThresholdTier::Medium) => {
-                resolve_custom(name, chain_registry())
+            (Chain::Custom(id), TvlThresholdTier::Medium) => {
+                try_resolve_custom(id, chain_registry())?
                     .default_tvl_thresholds
                     .medium
             }
-        }
+        })
     }
 
-    /// Returns the native token for the chain.
+    /// Returns the native token for the chain. Panics if a custom chain has no registered config;
+    /// use [`Chain::try_native_token`] for a non-panicking variant.
     pub fn native_token(&self) -> Token {
-        match self {
+        expect_registered(self.try_native_token())
+    }
+
+    /// Like [`Chain::native_token`] but returns [`ChainConfigError::UnknownChain`] when a custom
+    /// chain has no registered config.
+    pub fn try_native_token(&self) -> Result<Token, ChainConfigError> {
+        Ok(match self {
             Chain::Ethereum => native_eth(Chain::Ethereum),
             // It was decided that STRK token will be tracked as a dedicated AccountBalance on
             // Starknet accounts and ETH balances will be tracked as a native balance.
@@ -345,13 +378,20 @@ impl Chain {
             Chain::Bsc => native_bsc(Chain::Bsc),
             Chain::Unichain => native_eth(Chain::Unichain),
             Chain::Polygon => native_pol(Chain::Polygon),
-            Chain::Custom(name) => native_custom(*self, resolve_custom(name, chain_registry())),
-        }
+            Chain::Custom(id) => native_custom(*self, try_resolve_custom(id, chain_registry())?),
+        })
     }
 
-    /// Returns the wrapped native token for the chain.
+    /// Returns the wrapped native token for the chain. Panics if a custom chain has no registered
+    /// config; use [`Chain::try_wrapped_native_token`] for a non-panicking variant.
     pub fn wrapped_native_token(&self) -> Token {
-        match self {
+        expect_registered(self.try_wrapped_native_token())
+    }
+
+    /// Like [`Chain::wrapped_native_token`] but returns [`ChainConfigError::UnknownChain`] when a
+    /// custom chain has no registered config.
+    pub fn try_wrapped_native_token(&self) -> Result<Token, ChainConfigError> {
+        Ok(match self {
             Chain::Ethereum => {
                 wrapped_native_eth(Chain::Ethereum, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
             }
@@ -377,15 +417,22 @@ impl Chain {
             Chain::Polygon => {
                 wrapped_native_pol(Chain::Polygon, "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270")
             }
-            Chain::Custom(name) => {
-                wrapped_native_custom(*self, resolve_custom(name, chain_registry()))
+            Chain::Custom(id) => {
+                wrapped_native_custom(*self, try_resolve_custom(id, chain_registry())?)
             }
-        }
+        })
     }
 
-    /// Returns the expected block time in seconds for the chain.
+    /// Returns the expected block time in seconds for the chain. Panics if a custom chain has no
+    /// registered config; use [`Chain::try_block_time_secs`] for a non-panicking variant.
     pub fn block_time_secs(&self) -> u64 {
-        match self {
+        expect_registered(self.try_block_time_secs())
+    }
+
+    /// Like [`Chain::block_time_secs`] but returns [`ChainConfigError::UnknownChain`] when a custom
+    /// chain has no registered config.
+    pub fn try_block_time_secs(&self) -> Result<u64, ChainConfigError> {
+        Ok(match self {
             Chain::Ethereum => 12,
             Chain::Starknet => 2,
             Chain::ZkSync => 3,
@@ -394,8 +441,8 @@ impl Chain {
             Chain::Bsc => 1,
             Chain::Unichain => 1,
             Chain::Polygon => 2,
-            Chain::Custom(name) => resolve_custom(name, chain_registry()).block_time_secs,
-        }
+            Chain::Custom(id) => try_resolve_custom(id, chain_registry())?.block_time_secs,
+        })
     }
 }
 
@@ -629,6 +676,37 @@ mod tests {
     fn test_from_dto_unregistered_custom_panics() {
         let dto_chain = dto::Chain::Custom(ArrayString::from("nope").unwrap());
         let _: Chain = dto_chain.into();
+    }
+
+    #[test]
+    fn test_try_accessors_ok_for_registered_custom() {
+        init_test_registry();
+        let chain = Chain::custom("testchain").unwrap();
+        assert_eq!(chain.try_id().unwrap(), 9999);
+        assert_eq!(chain.try_block_time_secs().unwrap(), 5);
+        assert_eq!(
+            chain
+                .try_default_tvl_threshold(TvlThresholdTier::Low)
+                .unwrap(),
+            50.0
+        );
+        assert_eq!(chain.try_native_token().unwrap().symbol, "TST");
+        assert_eq!(
+            chain
+                .try_wrapped_native_token()
+                .unwrap()
+                .symbol,
+            "WTST"
+        );
+    }
+
+    #[test]
+    fn test_try_accessors_err_for_unregistered_custom() {
+        // A `CustomChainId` that bypassed registry validation (only reachable via direct
+        // deserialization) surfaces as an error rather than a panic through the `try_*` accessors.
+        let ghost: Chain = serde_json::from_str(r#"{"custom":"ghostchain"}"#).unwrap();
+        assert_eq!(ghost.try_id(), Err(ChainConfigError::UnknownChain("ghostchain".to_owned())));
+        assert!(ghost.try_native_token().is_err());
     }
 
     #[test]

--- a/crates/tycho-indexer/src/cli.rs
+++ b/crates/tycho-indexer/src/cli.rs
@@ -163,6 +163,10 @@ pub struct IndexArgs {
     #[clap(long, env, default_value = "./extractors.yaml")]
     pub extractors_config: String,
 
+    /// Custom chains configuration file
+    #[clap(long, env, default_value = "./chains.yaml")]
+    pub chain_config: String,
+
     /// A comma separated list of blockchains to index on
     #[clap(long, default_value = "ethereum", value_delimiter = ',')]
     pub chains: Vec<String>,
@@ -184,6 +188,10 @@ pub struct RunSpkgArgs {
     /// The blockchain to index on
     #[clap(long, default_value = "ethereum")]
     pub chain: String,
+
+    /// Custom chains configuration file
+    #[clap(long, env, default_value = "./chains.yaml")]
+    pub chain_config: String,
 
     #[clap(flatten)]
     pub substreams_args: SubstreamsArgs,
@@ -329,6 +337,7 @@ mod cli_tests {
             },
             command: Command::Run(RunSpkgArgs {
                 chain: "ethereum".to_string(),
+                chain_config: "./chains.yaml".to_string(),
                 spkg: "package.spkg".to_string(),
                 module: "module_name".to_string(),
                 protocol_type_names: vec!["pt1".to_string(), "pt2".to_string()],
@@ -401,6 +410,7 @@ mod cli_tests {
                 },
                 chains: vec!["ethereum".to_string()],
                 extractors_config: "/opt/extractors.yaml".to_string(),
+                chain_config: "./chains.yaml".to_string(),
                 retention_horizon: "2024-01-01T00:00:00".to_string(),
                 settlement_contract: "0xc9f2e6ea1637E499406986ac50ddC92401ce1f58"
                     .parse()

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -38,7 +38,8 @@ use tycho_common::{
     models::{
         blockchain::{Block, Transaction},
         contract::AccountDelta,
-        Address, Chain, CustomChainConfig, ExtractionState, ImplementationType,
+        init_chain_registry, Address, Chain, ChainConfigRegistry, CustomChainConfig,
+        ExtractionState, ImplementationType,
     },
     storage::{ChainGateway, ContractStateGateway, ExtractionStateGateway},
     traits::{AccountExtractor, StorageSnapshotRequest},
@@ -92,21 +93,16 @@ impl ExtractorConfigs {
     }
 }
 
-fn resolve_chain(
-    name: &str,
-    custom_chains: &[CustomChainConfig],
-) -> Result<Chain, ExtractionError> {
-    match Chain::from_str(name) {
-        Ok(chain) => Ok(chain),
-        Err(_) => custom_chains
-            .iter()
-            .find(|cfg| cfg.name() == name)
-            .map(|cfg| Chain::Custom(*cfg))
-            .ok_or_else(|| {
-                ExtractionError::Setup(format!(
-                    "Unknown chain '{name}': add it to the [chains] config section"
-                ))
-            }),
+fn resolve_chain(name: &str, registry: &ChainConfigRegistry) -> Result<Chain, ExtractionError> {
+    if let Some(chain) = Chain::builtin_from_str(name) {
+        return Ok(chain);
+    }
+    if registry.contains(name) {
+        Chain::custom(name).map_err(|e| ExtractionError::Setup(e.to_string()))
+    } else {
+        Err(ExtractionError::Setup(format!(
+            "Unknown chain '{name}': add it to the [chains] config section"
+        )))
     }
 }
 
@@ -270,10 +266,16 @@ fn run_indexer(global_args: GlobalArgs, index_args: IndexArgs) -> Result<(), Ext
                 .parse()
                 .expect("Failed to parse retention horizon");
 
+            let chain_registry =
+                ChainConfigRegistry::from_configs(extractors_config.chains.clone());
+            init_chain_registry(chain_registry.clone()).map_err(|_| {
+                ExtractionError::Setup("chain config registry already initialised".to_string())
+            })?;
+
             let chains = index_args
                 .chains
                 .iter()
-                .map(|name| resolve_chain(name, &extractors_config.chains))
+                .map(|name| resolve_chain(name, &chain_registry))
                 .collect::<Result<Vec<_>, _>>()?;
 
             let (extraction_tasks, other_tasks) = create_indexing_tasks(
@@ -729,7 +731,7 @@ mod tests {
 
     #[test]
     fn test_resolve_unknown_chain_fails() {
-        let err = resolve_chain("notachain", &[]).unwrap_err();
+        let err = resolve_chain("notachain", &ChainConfigRegistry::empty()).unwrap_err();
         assert!(matches!(err, ExtractionError::Setup(msg) if msg.contains("notachain")));
     }
 
@@ -769,10 +771,12 @@ chains:
       medium: 10000
 "#;
         let config: ExtractorConfigs = serde_yaml::from_str(yaml).expect("yaml parse failed");
-        let Chain::Custom(cfg) = resolve_chain("mychain", &config.chains).expect("resolve failed")
-        else {
-            panic!("expected Chain::Custom")
-        };
+        let registry = ChainConfigRegistry::from_configs(config.chains.clone());
+        let chain = resolve_chain("mychain", &registry).expect("resolve failed");
+        assert_eq!(chain, Chain::custom("mychain").unwrap());
+        let cfg = registry
+            .get("mychain")
+            .expect("config present");
 
         let expected_native =
             ChainTokenConfig::try_new("0x0000000000000000000000000000000000000000", "ETH", 18)
@@ -789,7 +793,7 @@ chains:
             TvlThresholds::new(1000.0, 10000.0),
         )
         .unwrap();
-        assert_eq!(cfg, expected_cfg);
+        assert_eq!(cfg, &expected_cfg);
     }
 }
 

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -335,12 +335,15 @@ async fn run_spkg(global_args: GlobalArgs, run_args: RunSpkgArgs) -> Result<(), 
             _ => Err(ExtractionError::Setup(format!("Unknown DCI plugin: {s}"))),
         })?;
 
+    let chain = Chain::from_str(&run_args.chain)
+        .map_err(|e| ExtractionError::Setup(format!("Invalid chain '{}': {e}", run_args.chain)))?;
+
     let config = ExtractorConfigs::new(
         HashMap::from([(
             run_args.protocol_system.clone(),
             ExtractorConfig::new(
                 run_args.protocol_system.clone(),
-                Chain::from_str(&run_args.chain).unwrap(),
+                chain,
                 ImplementationType::Vm,
                 1, /* TODO: if we want to increase this, we need to commit the cache when we
                     * reached `end_block` */
@@ -367,7 +370,7 @@ async fn run_spkg(global_args: GlobalArgs, run_args: RunSpkgArgs) -> Result<(), 
     let (extraction_tasks, mut other_tasks) = create_indexing_tasks(
         &global_args,
         &run_args.substreams_args,
-        &[Chain::from_str(&run_args.chain).unwrap()],
+        &[chain],
         Utc::now().naive_utc(),
         config,
         None,

--- a/crates/tycho-indexer/src/main.rs
+++ b/crates/tycho-indexer/src/main.rs
@@ -37,7 +37,7 @@ use tracing_subscriber::EnvFilter;
 use tycho_common::{
     models::{
         blockchain::{Block, Transaction},
-        chain_config::{init_chain_registry, ChainConfigRegistry, CustomChainConfig},
+        chain_config::{init_chain_registry, ChainConfigRegistry},
         contract::AccountDelta,
         Address, Chain, ExtractionState, ImplementationType,
     },
@@ -72,16 +72,11 @@ mod ot;
 #[derive(Debug, Deserialize)]
 struct ExtractorConfigs {
     extractors: std::collections::HashMap<String, ExtractorConfig>,
-    #[serde(default)]
-    chains: Vec<CustomChainConfig>,
 }
 
 impl ExtractorConfigs {
-    fn new(
-        extractors: std::collections::HashMap<String, ExtractorConfig>,
-        chains: Vec<CustomChainConfig>,
-    ) -> Self {
-        Self { extractors, chains }
+    fn new(extractors: std::collections::HashMap<String, ExtractorConfig>) -> Self {
+        Self { extractors }
     }
 
     fn from_yaml(path: &str) -> Result<Self, Box<dyn std::error::Error>> {
@@ -93,17 +88,18 @@ impl ExtractorConfigs {
     }
 }
 
-fn resolve_chain(name: &str, registry: &ChainConfigRegistry) -> Result<Chain, ExtractionError> {
-    if let Some(chain) = Chain::builtin_from_str(name) {
-        return Ok(chain);
-    }
-    if registry.contains(name) {
-        Chain::custom(name).map_err(|e| ExtractionError::Setup(e.to_string()))
+/// Loads custom chains from `path` (empty registry if the file is absent) and installs it as the
+/// process-wide registry, so `Chain::from_str` can resolve custom chains by name.
+fn init_chains(path: &str) -> Result<(), ExtractionError> {
+    let registry = if std::path::Path::new(path).exists() {
+        ChainConfigRegistry::from_yaml_file(path)
+            .map_err(|e| ExtractionError::Setup(e.to_string()))?
     } else {
-        Err(ExtractionError::Setup(format!(
-            "Unknown chain '{name}': add it to the [chains] config section"
-        )))
-    }
+        ChainConfigRegistry::empty()
+    };
+    init_chain_registry(registry).map_err(|_| {
+        ExtractionError::Setup("chain config registry already initialised".to_string())
+    })
 }
 
 type ExtractionTasks = Vec<JoinHandle<Result<(), ExtractionError>>>;
@@ -266,17 +262,19 @@ fn run_indexer(global_args: GlobalArgs, index_args: IndexArgs) -> Result<(), Ext
                 .parse()
                 .expect("Failed to parse retention horizon");
 
-            let chain_registry =
-                ChainConfigRegistry::from_configs(extractors_config.chains.clone())
-                    .map_err(|e| ExtractionError::Setup(e.to_string()))?;
-            init_chain_registry(chain_registry.clone()).map_err(|_| {
-                ExtractionError::Setup("chain config registry already initialised".to_string())
-            })?;
+            init_chains(&index_args.chain_config)?;
 
             let chains = index_args
                 .chains
                 .iter()
-                .map(|name| resolve_chain(name, &chain_registry))
+                .map(|name| {
+                    Chain::from_str(name).map_err(|e| {
+                        ExtractionError::Setup(format!(
+                            "Unknown chain '{name}': {e}; add it to {}",
+                            index_args.chain_config
+                        ))
+                    })
+                })
                 .collect::<Result<Vec<_>, _>>()?;
 
             let (extraction_tasks, other_tasks) = create_indexing_tasks(
@@ -336,37 +334,36 @@ async fn run_spkg(global_args: GlobalArgs, run_args: RunSpkgArgs) -> Result<(), 
             _ => Err(ExtractionError::Setup(format!("Unknown DCI plugin: {s}"))),
         })?;
 
+    init_chains(&run_args.chain_config)?;
+
     let chain = Chain::from_str(&run_args.chain)
         .map_err(|e| ExtractionError::Setup(format!("Invalid chain '{}': {e}", run_args.chain)))?;
 
-    let config = ExtractorConfigs::new(
-        HashMap::from([(
+    let config = ExtractorConfigs::new(HashMap::from([(
+        run_args.protocol_system.clone(),
+        ExtractorConfig::new(
             run_args.protocol_system.clone(),
-            ExtractorConfig::new(
-                run_args.protocol_system.clone(),
-                chain,
-                ImplementationType::Vm,
-                1, /* TODO: if we want to increase this, we need to commit the cache when we
-                    * reached `end_block` */
-                run_args.start_block,
-                run_args.stop_block(),
-                run_args
-                    .protocol_type_names
-                    .into_iter()
-                    .map(|name| {
-                        ProtocolTypeConfig::new(name, tycho_common::models::FinancialType::Swap)
-                    })
-                    .collect::<Vec<_>>(),
-                run_args.spkg,
-                run_args.module,
-                run_args.initialized_accounts,
-                run_args.initialization_block,
-                None,
-                dci_plugin,
-            ),
-        )]),
-        Vec::new(),
-    );
+            chain,
+            ImplementationType::Vm,
+            1, /* TODO: if we want to increase this, we need to commit the cache when we
+                * reached `end_block` */
+            run_args.start_block,
+            run_args.stop_block(),
+            run_args
+                .protocol_type_names
+                .into_iter()
+                .map(|name| {
+                    ProtocolTypeConfig::new(name, tycho_common::models::FinancialType::Swap)
+                })
+                .collect::<Vec<_>>(),
+            run_args.spkg,
+            run_args.module,
+            run_args.initialized_accounts,
+            run_args.initialization_block,
+            None,
+            dci_plugin,
+        ),
+    )]));
 
     let (extraction_tasks, mut other_tasks) = create_indexing_tasks(
         &global_args,
@@ -729,15 +726,7 @@ async fn run_analyze_tokens(
 
 #[cfg(test)]
 mod tests {
-    use tycho_common::models::chain_config::{ChainTokenConfig, TvlThresholds};
-
-    use super::*;
-
-    #[test]
-    fn test_resolve_unknown_chain_fails() {
-        let err = resolve_chain("notachain", &ChainConfigRegistry::empty()).unwrap_err();
-        assert!(matches!(err, ExtractionError::Setup(msg) if msg.contains("notachain")));
-    }
+    use tycho_common::models::chain_config::ChainTokenConfig;
 
     #[test]
     fn test_chain_token_invalid_hex() {
@@ -752,53 +741,6 @@ mod tests {
             18
         )
         .is_err());
-    }
-
-    #[test]
-    fn test_resolve_custom_chain_from_yaml() {
-        let yaml = r#"
-extractors: {}
-chains:
-  - name: mychain
-    chain_id: 99999
-    block_time_secs: 2
-    native:
-      address: "0x0000000000000000000000000000000000000000"
-      symbol: "ETH"
-      decimals: 18
-    wrapped_native:
-      address: "0x4200000000000000000000000000000000000006"
-      symbol: "WETH"
-      decimals: 18
-    default_tvl_thresholds:
-      low: 1000
-      medium: 10000
-"#;
-        let config: ExtractorConfigs = serde_yaml::from_str(yaml).expect("yaml parse failed");
-        let registry =
-            ChainConfigRegistry::from_configs(config.chains).expect("registry build failed");
-        let chain = resolve_chain("mychain", &registry).expect("resolve failed");
-        assert_eq!(chain, Chain::custom("mychain").unwrap());
-        let cfg = registry
-            .get("mychain")
-            .expect("config present");
-
-        let expected_native =
-            ChainTokenConfig::try_new("0x0000000000000000000000000000000000000000", "ETH", 18)
-                .unwrap();
-        let expected_wrapped =
-            ChainTokenConfig::try_new("0x4200000000000000000000000000000000000006", "WETH", 18)
-                .unwrap();
-        let expected_cfg = CustomChainConfig::try_new(
-            "mychain",
-            99999,
-            2,
-            expected_native,
-            expected_wrapped,
-            TvlThresholds::new(1000.0, 10000.0),
-        )
-        .unwrap();
-        assert_eq!(cfg, &expected_cfg);
     }
 }
 

--- a/crates/tycho-indexer/src/services/api_docs.rs
+++ b/crates/tycho-indexer/src/services/api_docs.rs
@@ -1,16 +1,13 @@
-use tycho_common::{
-    dto::{
-        AccountOverrides, AccountUpdate, BlockParam, Chain, ChangeType, ComponentTvlRequestBody,
-        ComponentTvlRequestResponse, ContractId, EntryPoint, EntryPointWithTracingParams, Health,
-        PaginationParams, PaginationResponse, ProtocolComponent, ProtocolComponentRequestResponse,
-        ProtocolComponentsRequestBody, ProtocolId, ProtocolStateDelta, ProtocolStateRequestBody,
-        ProtocolStateRequestResponse, ProtocolSystemsRequestBody, ProtocolSystemsRequestResponse,
-        RPCTracerParams, ResponseAccount, ResponseProtocolState, ResponseToken, StateRequestBody,
-        StateRequestResponse, StorageOverride, TokensRequestBody, TokensRequestResponse,
-        TracedEntryPointRequestBody, TracedEntryPointRequestResponse, TracingParams, TracingResult,
-        VersionParam,
-    },
-    models::{ChainTokenConfig, CustomChainConfig, TvlThresholds},
+use tycho_common::dto::{
+    AccountOverrides, AccountUpdate, BlockParam, Chain, ChangeType, ComponentTvlRequestBody,
+    ComponentTvlRequestResponse, ContractId, EntryPoint, EntryPointWithTracingParams, Health,
+    PaginationParams, PaginationResponse, ProtocolComponent, ProtocolComponentRequestResponse,
+    ProtocolComponentsRequestBody, ProtocolId, ProtocolStateDelta, ProtocolStateRequestBody,
+    ProtocolStateRequestResponse, ProtocolSystemsRequestBody, ProtocolSystemsRequestResponse,
+    RPCTracerParams, ResponseAccount, ResponseProtocolState, ResponseToken, StateRequestBody,
+    StateRequestResponse, StorageOverride, TokensRequestBody, TokensRequestResponse,
+    TracedEntryPointRequestBody, TracedEntryPointRequestResponse, TracingParams, TracingResult,
+    VersionParam,
 };
 use utoipa::{
     openapi::security::{ApiKey, ApiKeyValue, SecurityScheme},
@@ -84,9 +81,6 @@ impl Modify for SecurityAddon {
         schemas(RPCTracerParams),
         schemas(AccountOverrides),
         schemas(StorageOverride),
-        schemas(CustomChainConfig),
-        schemas(ChainTokenConfig),
-        schemas(TvlThresholds),
     ),
     modifiers(&SecurityAddon),
 )]

--- a/crates/tycho-simulation/src/rfq/protocols/bebop/client.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/bebop/client.rs
@@ -130,7 +130,9 @@ impl BebopClient {
         if !price_data.bids.is_empty() {
             let bids_pairs: Vec<(f32, f32)> = price_data
                 .bids
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|chunk| (chunk[0], chunk[1]))
                 .collect();
             let bids_json = serde_json::to_string(&bids_pairs).unwrap_or_default();
@@ -139,7 +141,9 @@ impl BebopClient {
         if !price_data.asks.is_empty() {
             let asks_pairs: Vec<(f32, f32)> = price_data
                 .asks
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|chunk| (chunk[0], chunk[1]))
                 .collect();
             let asks_json = serde_json::to_string(&asks_pairs).unwrap_or_default();

--- a/crates/tycho-simulation/src/rfq/protocols/bebop/models.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/bebop/models.rs
@@ -34,7 +34,9 @@ impl BebopPriceData {
     /// Output: [(price1, size1), (price2, size2), ...]
     pub fn to_price_size_pairs(array: &[f32]) -> Vec<(f64, f64)> {
         array
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|chunk| (chunk[0] as f64, chunk[1] as f64))
             .collect()
     }


### PR DESCRIPTION
# Summary

Depends on PR 1. Flips Chain::Custom to name-only and wires resolution through the registry. The enum  change forces all custom-chain construction/match sites to change together, so the core commit is atomic; the rest are additive. The ~60 chain.id()/native_token()/... call sites in tycho-simulation/tycho-execution/tests are untouched because the method signatures are preserved.

# Changes

- models::Chain::Custom(ArrayString<32>) and dto::Chain::Custom(ArrayString<32>) (stay Copy; default serde => known "ethereum", custom {"custom":"name"}; #[schema(value_type = String)] on the payload).
- Custom arms of id/default_tvl_threshold/native_token/wrapped_native_token read chain_registry() and panic with a clear message if absent; signatures unchanged. Add Chain::block_time_secs() for the client. Collapse native_custom/wrapped_native_custom into token_from(&ChainTokenConfig, Chain).
- FromStr: known => variant; else registry.contains => Custom; else Err(UnknownChain). From impls become passthrough Custom(name) => Custom(name).
- Indexer: init_chain_registry from the existing chains: config; replace resolve_chain with registry-aware parsing; validate configured chains at startup with actionable errors.
- Client: stream.rs default_timing uses block_time_secs(). Storage: chain-cache reconstruction works via registry-aware FromStr.
- Python client decodes {"custom":"name"}; drop the CustomChainConfig / ChainTokenConfig / TvlThresholds pydantic models and exports; update test_decode.py.
- Drop the 3 custom-chain schemas from OpenAPI (api_docs.rs).
- Remove the obsolete result_large_err / large_enum_variant clippy allows.

# Acceptance criteria

- `size_of::<Chain>() <= 40`; serde round-trips "ethereum" and {"custom":"x"}.
- FromStr handles known/registry/typo cases; panic on missing custom config has a clear message.
- Known chains work with no config file; indexer rejects unknown chains at startup.
- pytest crates/tycho-client-py passes; clippy on nightly with -D warnings is clean; CI green.