### PR TITLE
fix(integration-test): Fetch router fee from FeeCalculator contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9591,6 +9591,7 @@ dependencies = [
  "tracing-subscriber 0.3.20",
  "tycho-client",
  "tycho-common",
+ "tycho-execution",
  "tycho-simulation",
  "tycho-test",
 ]

--- a/crates/tycho-integration-test/Cargo.toml
+++ b/crates/tycho-integration-test/Cargo.toml
@@ -21,5 +21,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tycho-client = { workspace = true }
 tycho-common = { workspace = true }
+tycho-execution = { workspace = true }
 tycho-simulation = { workspace = true, features = ["evm"] }
 tycho-test = { workspace = true }

--- a/crates/tycho-integration-test/README.md
+++ b/crates/tycho-integration-test/README.md
@@ -45,7 +45,6 @@ This test runs continuously in the cluster but it can also be run locally for de
 | `--block-wait-time`        | `12`       | Time to wait (seconds) for block N+1 before executing debug_traceCall                                            |
 | `--always-test-components` | -          | Comma-separated list of component IDs to test every block                                                        |
 | `--max-blocks`             | `0`        | Maximum number of blocks to process before exiting (0 = run indefinitely). When set, prints a summary at the end |
-| `--router-fee`             | `10`       | Router fee on output in bps (must be ≥ 1). Deducted from the executed amount before slippage is calculated       |
 
 ## Running Locally
 

--- a/crates/tycho-integration-test/src/fee_fetcher.rs
+++ b/crates/tycho-integration-test/src/fee_fetcher.rs
@@ -1,0 +1,122 @@
+//! One-shot reader for the TychoRouter's on-chain router fee on output.
+//!
+//! The integration test backs the router fee out of the simulated amount out before comparing it
+//! against the on-chain executed amount. Rather than hard-coding that fee, this module reads it
+//! from the deployed FeeCalculator at start-up so the test tracks fee changes automatically.
+
+use alloy::{
+    network::Ethereum,
+    primitives::{Address, Bytes as AlloyBytes, TxKind},
+    providers::{Provider, RootProvider},
+    rpc::types::TransactionRequest,
+    sol,
+    sol_types::SolCall,
+};
+use miette::miette;
+use tycho_common::Bytes;
+
+sol! {
+    interface ITychoRouter {
+        function getFeeCalculator() external view returns (address);
+    }
+
+    interface IFeeCalculator {
+        function MAX_FEE_BPS() external view returns (uint32);
+        function getRouterFeeOnOutput() external view returns (uint32);
+    }
+}
+
+/// Router fee on output, expressed as a fraction (`numerator / denominator`) in the
+/// FeeCalculator's fee-unit scale (100% = `denominator` units).
+#[derive(Clone, Copy, Debug)]
+pub struct RouterFeeOnOutput {
+    numerator: u64,
+    denominator: u64,
+}
+
+impl RouterFeeOnOutput {
+    /// The fee numerator in the FeeCalculator's fee-unit scale.
+    pub fn numerator(&self) -> u64 {
+        self.numerator
+    }
+
+    /// The fee denominator (the FeeCalculator's precision scale, where this value represents 100%).
+    pub fn denominator(&self) -> u64 {
+        self.denominator
+    }
+}
+
+/// Reads the default router fee on output from the on-chain FeeCalculator.
+///
+/// Resolves the FeeCalculator address from `router_address` (`getFeeCalculator`), then reads its
+/// precision scale (`MAX_FEE_BPS`) and the default fee on output (`getRouterFeeOnOutput`). The
+/// integration test simulates swaps with no client fee and no per-client override, so the default
+/// fee is the rate the router applies on-chain.
+///
+/// # Errors
+///
+/// Returns an error if `router_address` is not 20 bytes, any `eth_call` fails or returns
+/// undecodable data, or the FeeCalculator reports a zero precision scale.
+pub async fn fetch_router_fee_on_output(
+    provider: &RootProvider<Ethereum>,
+    router_address: &Bytes,
+) -> miette::Result<RouterFeeOnOutput> {
+    if router_address.len() != 20 {
+        return Err(miette!("router address {router_address:?} is not 20 bytes"));
+    }
+    let router = Address::from_slice(router_address.as_ref());
+
+    let fee_calculator = eth_call::<ITychoRouter::getFeeCalculatorCall>(
+        provider,
+        router,
+        "getFeeCalculator",
+        ITychoRouter::getFeeCalculatorCall {}.abi_encode(),
+    )
+    .await?;
+
+    let denominator = u64::from(
+        eth_call::<IFeeCalculator::MAX_FEE_BPSCall>(
+            provider,
+            fee_calculator,
+            "MAX_FEE_BPS",
+            IFeeCalculator::MAX_FEE_BPSCall {}.abi_encode(),
+        )
+        .await?,
+    );
+    if denominator == 0 {
+        return Err(miette!(
+            "FeeCalculator {fee_calculator} reported a zero MAX_FEE_BPS precision scale"
+        ));
+    }
+
+    let numerator = u64::from(
+        eth_call::<IFeeCalculator::getRouterFeeOnOutputCall>(
+            provider,
+            fee_calculator,
+            "getRouterFeeOnOutput",
+            IFeeCalculator::getRouterFeeOnOutputCall {}.abi_encode(),
+        )
+        .await?,
+    );
+
+    Ok(RouterFeeOnOutput { numerator, denominator })
+}
+
+/// Performs an `eth_call` of `calldata` against `contract` and decodes the return value.
+async fn eth_call<C: SolCall>(
+    provider: &RootProvider<Ethereum>,
+    contract: Address,
+    method: &'static str,
+    calldata: Vec<u8>,
+) -> miette::Result<C::Return> {
+    let response = provider
+        .call(TransactionRequest {
+            to: Some(TxKind::Call(contract)),
+            input: AlloyBytes::from(calldata).into(),
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| miette!("{method} call to {contract} failed: {e}"))?;
+    C::abi_decode_returns(response.as_ref())
+        .map_err(|e| miette!("failed to decode {method} response from {contract}: {e}"))
+}

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -1,3 +1,4 @@
+mod fee_fetcher;
 mod metrics;
 mod statistics;
 mod stream_processor;
@@ -28,6 +29,7 @@ use tracing::{debug, error, info, warn};
 use tracing_subscriber::EnvFilter;
 use tycho_client::feed::SynchronizerState;
 use tycho_common::{simulation::protocol_sim::ProtocolSim, Bytes};
+use tycho_execution::encoding::evm::get_router_address;
 use tycho_simulation::{
     evm::protocol::cowamm::constants::PROTOCOL_SYSTEM as COWAMM_PROTOCOL_SYSTEM,
     protocol::models::ProtocolComponent,
@@ -49,6 +51,7 @@ use tycho_test::{
 };
 
 use crate::{
+    fee_fetcher::{fetch_router_fee_on_output, RouterFeeOnOutput},
     statistics::TestStatistics,
     stream_processor::{
         protocol_stream_processor::ProtocolStreamProcessor,
@@ -163,10 +166,6 @@ struct Cli {
     /// Seconds without a protocol update before marking all known protocols as stale in metrics.
     #[arg(long, default_value_t = 30)]
     stale_threshold_secs: u64,
-
-    /// Router fee on output in bps (defaults to 10 bps)
-    #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u16).range(1..))]
-    router_fee: u16,
 
     /// Disable on-chain swap execution validation (RPC simulation only, no swap encoding or
     /// execution). Useful for diagnosing stream latency without execution overhead.
@@ -286,6 +285,20 @@ async fn run(cli: Cli) -> miette::Result<()> {
     let cli = Arc::new(cli);
 
     let rpc_tools = tycho_test::RPCTools::new(&cli.rpc_url, &chain).await?;
+
+    // Read the router fee on output from the on-chain FeeCalculator once at start-up. Slippage is
+    // computed after backing this fee out of the simulated amount out, so a stale or wrong fee
+    // would skew every slippage result.
+    let router_address = get_router_address(&chain)
+        .map_err(|e| miette!("No Tycho router address configured for chain {chain:?}: {e}"))?;
+    let router_fee = fetch_router_fee_on_output(&rpc_tools.provider, router_address)
+        .await
+        .wrap_err("Failed to read router fee on output from the on-chain FeeCalculator")?;
+    info!(
+        numerator = router_fee.numerator(),
+        denominator = router_fee.denominator(),
+        "Loaded router fee on output from on-chain FeeCalculator"
+    );
 
     // Load tokens from Tycho
     info!(%cli.tycho_url, "Loading tokens...");
@@ -491,7 +504,7 @@ async fn run(cli: Cli) -> miette::Result<()> {
                             .into_diagnostic()
                             .wrap_err("Failed to acquire protocol permit")?;
                         tokio::spawn(async move {
-                            if let Err(e) = process_update(cli, chain, rpc_tools, tycho_state, statistics, token_prices, &update).await {
+                            if let Err(e) = process_update(cli, chain, rpc_tools, tycho_state, statistics, token_prices, router_fee, &update).await {
                                 warn!("{}", format_error_chain(&e));
                             }
                             drop(permit);
@@ -528,7 +541,7 @@ async fn run(cli: Cli) -> miette::Result<()> {
                             .into_diagnostic()
                             .wrap_err("Failed to acquire RFQ permit")?;
                         tokio::spawn(async move {
-                            if let Err(e) = process_update(cli, chain, rpc_tools, tycho_state, statistics, token_prices, &update).await {
+                            if let Err(e) = process_update(cli, chain, rpc_tools, tycho_state, statistics, token_prices, router_fee, &update).await {
                                 warn!("{}", format_error_chain(&e));
                             }
                             drop(permit);
@@ -684,6 +697,7 @@ async fn process_update(
     tycho_state: Arc<RwLock<TychoState>>,
     statistics: Option<Arc<RwLock<TestStatistics>>>,
     token_prices: SharedTokenPrices,
+    router_fee: RouterFeeOnOutput,
     update: &StreamUpdate,
 ) -> miette::Result<()> {
     info!(
@@ -1006,7 +1020,7 @@ async fn process_update(
             &mut n_reverts,
             &mut n_failures,
             statistics.clone(),
-            cli.router_fee,
+            router_fee,
         );
 
         // Record statistics
@@ -1417,7 +1431,7 @@ fn process_execution_result(
     n_reverts: &mut i32,
     n_failures: &mut i32,
     statistics: Option<Arc<RwLock<TestStatistics>>>,
-    router_fee: u16,
+    router_fee: RouterFeeOnOutput,
 ) {
     match result {
         TychoExecutionResult::Success {
@@ -1435,12 +1449,13 @@ fn process_execution_result(
 
             metrics::record_simulation_execution_success(&execution_info.protocol_system);
 
-            // Remove the router fee from the expected simulated amount out.
-            let simulated_amount_out_without_fee = execution_info
-                .expected_amount_out
-                .clone() -
-                (execution_info.expected_amount_out * BigUint::from(router_fee)) /
-                    BigUint::from(10000u64);
+            // Remove the router fee from the expected simulated amount out. The on-chain router
+            // deducts this fee from the swap output, so the simulated amount out (which is
+            // fee-free) must be reduced by the same fraction before comparing against the
+            // executed amount.
+            let simulated_amount_out_without_fee = &execution_info.expected_amount_out -
+                (&execution_info.expected_amount_out * BigUint::from(router_fee.numerator())) /
+                    BigUint::from(router_fee.denominator());
 
             // Calculate slippage: positive = simulated > expected, negative = simulated <
             // expected


### PR DESCRIPTION
This is done only once at startup. There is no need for a complicated auto updating mechanism. The integration test is restarted often enough.

Before we had the router fee hardcoded to 10bps. Now that we reduced the fee we forgot to update this 🫠 so all the slippage results were skewed at 0.1%
<img width="1680" height="720" alt="image" src="https://github.com/user-attachments/assets/366dbdf2-1eac-4450-b688-866f975e0384" />

after this fix they are all centered back at 0 ✨ 
<img width="1675" height="737" alt="image" src="https://github.com/user-attachments/assets/3712733e-d767-4693-86a0-955c1eedb58c" />

