### PR TITLE
fix(simulation): use as_chunks for bebop price pairs

### DIFF
--- a/crates/tycho-simulation/src/rfq/protocols/bebop/client.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/bebop/client.rs
@@ -130,7 +130,9 @@ impl BebopClient {
         if !price_data.bids.is_empty() {
             let bids_pairs: Vec<(f32, f32)> = price_data
                 .bids
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|chunk| (chunk[0], chunk[1]))
                 .collect();
             let bids_json = serde_json::to_string(&bids_pairs).unwrap_or_default();
@@ -139,7 +141,9 @@ impl BebopClient {
         if !price_data.asks.is_empty() {
             let asks_pairs: Vec<(f32, f32)> = price_data
                 .asks
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|chunk| (chunk[0], chunk[1]))
                 .collect();
             let asks_json = serde_json::to_string(&asks_pairs).unwrap_or_default();

--- a/crates/tycho-simulation/src/rfq/protocols/bebop/models.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/bebop/models.rs
@@ -34,7 +34,9 @@ impl BebopPriceData {
     /// Output: [(price1, size1), (price2, size2), ...]
     pub fn to_price_size_pairs(array: &[f32]) -> Vec<(f64, f64)> {
         array
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|chunk| (chunk[0] as f64, chunk[1] as f64))
             .collect()
     }


### PR DESCRIPTION
## What

Replaces the three `.chunks_exact(2)` calls in the bebop RFQ client and models with `.as_chunks::<2>()`:

- `crates/tycho-simulation/src/rfq/protocols/bebop/client.rs` (bids, asks)
- `crates/tycho-simulation/src/rfq/protocols/bebop/models.rs` (`to_price_size_pairs`)

## Why

The `Lint (fmt + clippy)` CI job runs clippy on the nightly toolchain with `-D warnings`. Nightly denies `clippy::chunks_exact_to_as_chunks`, so these pre-existing calls fail the lint job on every PR branched off `main`.

Behaviour is unchanged: `as_chunks::<2>().0` yields the same fixed-size chunks and drops a trailing odd element exactly like `chunks_exact(2)`.

## Verification

- `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings` — passes
- `cargo +nightly fmt --all --check` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)