### PR TITLE
feat: update maximodel

### DIFF
--- a/crates/tycho-execution/contracts/src/TychoRouter.sol
+++ b/crates/tycho-execution/contracts/src/TychoRouter.sol
@@ -728,7 +728,7 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
         if (expectedAmountOut == 0) {
             revert TychoRouter__AmountOutZero();
         }
-        if (maxSlippageBps > MAX_SLIPPAGE_BPS) {
+        if (maxSlippageBps >= MAX_SLIPPAGE_BPS) {
             revert TychoRouter__SlippageBpsTooHigh(maxSlippageBps);
         }
         uint256 minAmountOut = expectedAmountOut
@@ -816,7 +816,7 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
         if (expectedAmountOut == 0) {
             revert TychoRouter__AmountOutZero();
         }
-        if (maxSlippageBps > MAX_SLIPPAGE_BPS) {
+        if (maxSlippageBps >= MAX_SLIPPAGE_BPS) {
             revert TychoRouter__SlippageBpsTooHigh(maxSlippageBps);
         }
         uint256 minAmountOut = expectedAmountOut
@@ -902,7 +902,7 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
         if (expectedAmountOut == 0) {
             revert TychoRouter__AmountOutZero();
         }
-        if (maxSlippageBps > MAX_SLIPPAGE_BPS) {
+        if (maxSlippageBps >= MAX_SLIPPAGE_BPS) {
             revert TychoRouter__SlippageBpsTooHigh(maxSlippageBps);
         }
         uint256 minAmountOut = expectedAmountOut

--- a/crates/tycho-execution/model/src/config.rs
+++ b/crates/tycho-execution/model/src/config.rs
@@ -28,6 +28,12 @@ pub const WORKER_THREAD_COUNT: usize = 10;
 /// at the cost of needing longer to run.
 pub const ENABLE_NONZERO_FEE_BPS: bool = false;
 
+/// Whether to simulate positive slippage scenarios
+/// (actual_amount_out > expected_amount_out).
+/// When enabled, the fee calculator splits surplus between
+/// the router and the client.
+pub const ENABLE_POSITIVE_SLIPPAGE: bool = false;
+
 /// Setting this to `true` introduces a fault,
 /// a transfer of 1000 WETH to `msg.sender` inside `singleSwap`,
 /// and should result in the output of suspicious [Outcome](crate::Outcome)s.

--- a/crates/tycho-execution/model/src/model/dispatcher.rs
+++ b/crates/tycho-execution/model/src/model/dispatcher.rs
@@ -170,19 +170,9 @@ pub fn _call_handle_callback_on_executor(
     Ok(())
 }
 
-/// <https://github.com/propeller-heads/tycho-execution/blob/9b0512c9580617224c7a0d7de781674a2cdc6b62/foundry/src/Dispatcher.sol#L337>
+/// Mirrors `Dispatcher._callMustInterceptOutput` in Solidity.
 ///
-/// <https://github.com/propeller-heads/tycho-execution/blob/9b0512c9580617224c7a0d7de781674a2cdc6b62/foundry/src/FeeCalculator.sol#L223>
-pub fn _call_get_effective_router_fee_on_output(
-    params: &Params,
-    _state: &mut State,
-) -> Result<i64, Error> {
-    Ok(if crate::config::ENABLE_NONZERO_FEE_BPS {
-        params.request(
-            ParamKey::String("router_fee_on_output_bps"),
-            [0, crate::model::fee_calculator::MAX_FEE_BPS],
-        )?
-    } else {
-        0
-    })
+/// Delegates to `FeeCalculator.must_intercept_output`.
+pub fn _call_must_intercept_output(params: &Params, client_fee_bps: i64) -> Result<bool, Error> {
+    crate::model::fee_calculator::must_intercept_output(params, client_fee_bps)
 }

--- a/crates/tycho-execution/model/src/model/dispatcher.rs
+++ b/crates/tycho-execution/model/src/model/dispatcher.rs
@@ -170,9 +170,3 @@ pub fn _call_handle_callback_on_executor(
     Ok(())
 }
 
-/// Mirrors `Dispatcher._callMustInterceptOutput` in Solidity.
-///
-/// Delegates to `FeeCalculator.must_intercept_output`.
-pub fn _call_must_intercept_output(params: &Params, client_fee_bps: i64) -> Result<bool, Error> {
-    crate::model::fee_calculator::must_intercept_output(params, client_fee_bps)
-}

--- a/crates/tycho-execution/model/src/model/dispatcher.rs
+++ b/crates/tycho-execution/model/src/model/dispatcher.rs
@@ -169,4 +169,3 @@ pub fn _call_handle_callback_on_executor(
 
     Ok(())
 }
-

--- a/crates/tycho-execution/model/src/model/fee_calculator.rs
+++ b/crates/tycho-execution/model/src/model/fee_calculator.rs
@@ -2,6 +2,7 @@
 use crate::{address::Address, error::Error, math::checked_subtract, params::Params};
 
 pub const MAX_BPS: i64 = 100_000_000;
+const MAX_BPS_SQUARED: i64 = 10_000_000_000_000_000;
 
 /// <https://github.com/propeller-heads/tycho-execution/blob/9b0512c9580617224c7a0d7de781674a2cdc6b62/foundry/lib/FeeStructs.sol#L9>
 pub struct FeeRecipient {
@@ -131,7 +132,7 @@ fn _calculate_fee(
 
         if fee_info.router_fee_on_client_fee_bps > 0 {
             router_fee_on_client_fee =
-                client_fee_numerator * fee_info.router_fee_on_client_fee_bps / (MAX_BPS * MAX_BPS);
+                client_fee_numerator * fee_info.router_fee_on_client_fee_bps / MAX_BPS_SQUARED;
         }
 
         client_portion = checked_subtract(total_client_fee, router_fee_on_client_fee)?;

--- a/crates/tycho-execution/model/src/model/fee_calculator.rs
+++ b/crates/tycho-execution/model/src/model/fee_calculator.rs
@@ -185,6 +185,8 @@ fn _merge_fee_recipients(
 
     // fees[0] = router fees, slippage[0] = router slippage
     // fees[1] = client fees, slippage[1] = client slippage
+    debug_assert!(fees.len() == 2, "expected exactly 2 fee recipients (router, client)");
+    debug_assert!(slippage.len() == 2, "expected exactly 2 slippage recipients (router, client)");
     fees[0].fee_amount += slippage[0].fee_amount;
     fees[1].fee_amount += slippage[1].fee_amount;
 

--- a/crates/tycho-execution/model/src/model/fee_calculator.rs
+++ b/crates/tycho-execution/model/src/model/fee_calculator.rs
@@ -2,7 +2,6 @@
 use crate::{address::Address, error::Error, math::checked_subtract, params::Params};
 
 pub const MAX_BPS: i64 = 100_000_000;
-const MAX_BPS_SQUARED: i64 = 10_000_000_000_000_000;
 
 /// <https://github.com/propeller-heads/tycho-execution/blob/9b0512c9580617224c7a0d7de781674a2cdc6b62/foundry/lib/FeeStructs.sol#L9>
 pub struct FeeRecipient {
@@ -132,7 +131,8 @@ fn _calculate_fee(
 
         if fee_info.router_fee_on_client_fee_bps > 0 {
             router_fee_on_client_fee =
-                client_fee_numerator * fee_info.router_fee_on_client_fee_bps / MAX_BPS_SQUARED;
+                client_fee_numerator * fee_info.router_fee_on_client_fee_bps
+                    / (MAX_BPS * MAX_BPS);
         }
 
         client_portion = checked_subtract(total_client_fee, router_fee_on_client_fee)?;

--- a/crates/tycho-execution/model/src/model/fee_calculator.rs
+++ b/crates/tycho-execution/model/src/model/fee_calculator.rs
@@ -131,8 +131,7 @@ fn _calculate_fee(
 
         if fee_info.router_fee_on_client_fee_bps > 0 {
             router_fee_on_client_fee =
-                client_fee_numerator * fee_info.router_fee_on_client_fee_bps
-                    / (MAX_BPS * MAX_BPS);
+                client_fee_numerator * fee_info.router_fee_on_client_fee_bps / (MAX_BPS * MAX_BPS);
         }
 
         client_portion = checked_subtract(total_client_fee, router_fee_on_client_fee)?;

--- a/crates/tycho-execution/model/src/model/fee_calculator.rs
+++ b/crates/tycho-execution/model/src/model/fee_calculator.rs
@@ -1,7 +1,8 @@
 //! <https://github.com/propeller-heads/tycho-execution/blob/main/foundry/src/FeeCalculator.sol>
 use crate::{address::Address, error::Error, math::checked_subtract, params::Params};
 
-pub const MAX_FEE_BPS: i64 = 10000;
+pub const MAX_BPS: i64 = 100_000_000;
+const MAX_BPS_SQUARED: i64 = 10_000_000_000_000_000;
 
 /// <https://github.com/propeller-heads/tycho-execution/blob/9b0512c9580617224c7a0d7de781674a2cdc6b62/foundry/lib/FeeStructs.sol#L9>
 pub struct FeeRecipient {
@@ -12,58 +13,126 @@ pub struct FeeRecipient {
 struct FeeInfo {
     router_fee_on_output_bps: i64,
     router_fee_on_client_fee_bps: i64,
+    positive_slippage_enabled: bool,
+    client_slippage_share_bps: i64,
 }
 
 fn _get_fee_info(params: &Params) -> Result<FeeInfo, Error> {
-    if crate::config::ENABLE_NONZERO_FEE_BPS {
-        let has_client_custom_fee_on_input =
-            params.request("has_client_custom_fee_on_input", vec![true, false])?;
+    let (router_fee_on_output_bps, router_fee_on_client_fee_bps) =
+        if crate::config::ENABLE_NONZERO_FEE_BPS {
+            let has_client_custom_fee_on_input =
+                params.request("has_client_custom_fee_on_input", vec![true, false])?;
 
-        let router_fee_on_output_bps = if has_client_custom_fee_on_input {
-            params.request("client_fee_bps_on_output", vec![0, MAX_FEE_BPS])?
+            let router_fee_on_output_bps = if has_client_custom_fee_on_input {
+                params.request("client_fee_bps_on_output", vec![0, MAX_BPS])?
+            } else {
+                params.request("router_fee_on_output_bps", vec![0, MAX_BPS])?
+            };
+
+            let has_client_custom_fee_on_client_fee =
+                params.request("has_client_custom_fee_on_client_fee", vec![true, false])?;
+            let router_fee_on_client_fee_bps = if has_client_custom_fee_on_client_fee {
+                params.request("client_fee_bps_on_client_fee", vec![0, MAX_BPS])?
+            } else {
+                params.request("router_fee_on_client_fee_bps", vec![0, MAX_BPS])?
+            };
+
+            (router_fee_on_output_bps, router_fee_on_client_fee_bps)
         } else {
-            params.request("router_fee_on_output_bps", vec![0, MAX_FEE_BPS])?
+            (0, 0)
         };
 
-        let has_client_custom_fee_on_client_fee =
-            params.request("has_client_custom_fee_on_client_fee", vec![true, false])?;
-        let router_fee_on_client_fee_bps = if has_client_custom_fee_on_client_fee {
-            params.request("client_fee_bps_on_client_fee", vec![0, MAX_FEE_BPS])?
+    let (positive_slippage_enabled, client_slippage_share_bps) =
+        if crate::config::ENABLE_POSITIVE_SLIPPAGE {
+            let enabled = params.request("positive_slippage_enabled", vec![true, false])?;
+            let has_custom_client_slippage_share =
+                params.request("has_custom_client_slippage_share", vec![true, false])?;
+            let client_slippage_share_bps = if has_custom_client_slippage_share {
+                params.request("custom_client_slippage_share_bps", vec![0, MAX_BPS])?
+            } else {
+                params.request("default_client_slippage_share_bps", vec![0, MAX_BPS])?
+            };
+            (enabled, client_slippage_share_bps)
         } else {
-            params.request("router_fee_on_client_fee_bps", vec![0, MAX_FEE_BPS])?
+            (false, 0)
         };
 
-        Ok(FeeInfo { router_fee_on_output_bps, router_fee_on_client_fee_bps })
-    } else {
-        Ok(FeeInfo { router_fee_on_output_bps: 0, router_fee_on_client_fee_bps: 0 })
-    }
+    Ok(FeeInfo {
+        router_fee_on_output_bps,
+        router_fee_on_client_fee_bps,
+        positive_slippage_enabled,
+        client_slippage_share_bps,
+    })
 }
 
-/// <https://github.com/propeller-heads/tycho-execution/blob/9b0512c9580617224c7a0d7de781674a2cdc6b62/foundry/src/FeeCalculator.sol#L78>
+/// Mirrors `FeeCalculator.calculateFee` in Solidity.
+///
+/// Returns fee recipients (router + client) with amounts combining both
+/// positive slippage surplus and standard fees.
 pub fn calculate_fee(
     params: &Params,
-    amount_in: i64,
+    actual_amount_out: i64,
+    expected_amount_out: i64,
     client_fee_bps: i64,
-) -> Result<(i64, Vec<FeeRecipient>), Error> {
+) -> Result<Vec<FeeRecipient>, Error> {
     let fee_info = _get_fee_info(params)?;
 
-    if (client_fee_bps + fee_info.router_fee_on_output_bps > MAX_FEE_BPS) ||
-        fee_info.router_fee_on_client_fee_bps > MAX_FEE_BPS
-    {
-        return Err(Error::revert("calculate_fee: fee bps too large"));
+    let slippage = _calculate_positive_slippage(actual_amount_out, expected_amount_out, &fee_info);
+
+    let mut fee_base = actual_amount_out;
+    if !slippage.is_empty() {
+        fee_base -= slippage[0].fee_amount + slippage[1].fee_amount;
     }
 
-    let mut amount_out = amount_in;
+    let fees = _calculate_fee(fee_base, client_fee_bps, &fee_info)?;
+
+    Ok(_merge_fee_recipients(fees, slippage))
+}
+
+/// Mirrors `FeeCalculator.mustInterceptOutput` in Solidity.
+///
+/// Returns true if funds must pass through the router after the final swap
+/// instead of going directly to the receiver.
+pub fn must_intercept_output(params: &Params, client_fee_bps: i64) -> Result<bool, Error> {
+    let fee_info = _get_fee_info(params)?;
+
+    if fee_info.positive_slippage_enabled {
+        return Ok(true);
+    }
+    if client_fee_bps > 0 {
+        return Ok(true);
+    }
+    if fee_info.router_fee_on_output_bps > 0 {
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+/// Mirrors `FeeCalculator._calculateFee` in Solidity.
+///
+/// Returns 2-element array: [0] = router, [1] = client.
+fn _calculate_fee(
+    fee_base: i64,
+    client_fee_bps: i64,
+    fee_info: &FeeInfo,
+) -> Result<Vec<FeeRecipient>, Error> {
+    if (client_fee_bps + fee_info.router_fee_on_output_bps > MAX_BPS) ||
+        fee_info.router_fee_on_client_fee_bps > MAX_BPS
+    {
+        return Err(Error::revert("_calculate_fee: fee bps too large"));
+    }
+
     let mut router_fee_on_client_fee = 0;
     let mut client_portion = 0;
 
     if client_fee_bps > 0 {
-        let client_fee_numerator = amount_out * client_fee_bps;
-        let total_client_fee = client_fee_numerator / 10000;
+        let client_fee_numerator = fee_base * client_fee_bps;
+        let total_client_fee = client_fee_numerator / MAX_BPS;
 
         if fee_info.router_fee_on_client_fee_bps > 0 {
             router_fee_on_client_fee =
-                client_fee_numerator * fee_info.router_fee_on_client_fee_bps / 100_000_000;
+                client_fee_numerator * fee_info.router_fee_on_client_fee_bps / MAX_BPS_SQUARED;
         }
 
         client_portion = checked_subtract(total_client_fee, router_fee_on_client_fee)?;
@@ -72,16 +141,53 @@ pub fn calculate_fee(
     let mut total_router_fee = router_fee_on_client_fee;
 
     if fee_info.router_fee_on_output_bps > 0 {
-        total_router_fee += amount_out * fee_info.router_fee_on_output_bps / 10000;
+        total_router_fee += fee_base * fee_info.router_fee_on_output_bps / MAX_BPS;
     }
 
-    amount_out = checked_subtract(amount_out, client_portion + total_router_fee)?;
+    Ok(vec![
+        FeeRecipient { recipient: Address::RouterFeeReceiver, fee_amount: total_router_fee },
+        FeeRecipient { recipient: Address::ClientFeeReceiver, fee_amount: client_portion },
+    ])
+}
 
-    Ok((
-        amount_out,
-        vec![
-            FeeRecipient { recipient: Address::RouterFeeReceiver, fee_amount: total_router_fee },
-            FeeRecipient { recipient: Address::ClientFeeReceiver, fee_amount: client_portion },
-        ],
-    ))
+/// Mirrors `FeeCalculator._calculatePositiveSlippage` in Solidity.
+///
+/// Returns empty vec if disabled or no surplus; otherwise 2-element vec:
+/// [0] = router, [1] = client.
+fn _calculate_positive_slippage(
+    actual_amount_out: i64,
+    expected_amount_out: i64,
+    fee_info: &FeeInfo,
+) -> Vec<FeeRecipient> {
+    if !fee_info.positive_slippage_enabled || actual_amount_out <= expected_amount_out {
+        return vec![];
+    }
+
+    let surplus = actual_amount_out - expected_amount_out;
+    let client_cut = surplus * fee_info.client_slippage_share_bps / MAX_BPS;
+    let router_cut = surplus - client_cut;
+
+    vec![
+        FeeRecipient { recipient: Address::RouterFeeReceiver, fee_amount: router_cut },
+        FeeRecipient { recipient: Address::ClientFeeReceiver, fee_amount: client_cut },
+    ]
+}
+
+/// Mirrors `FeeCalculator._mergeFeeRecipients` in Solidity.
+///
+/// Merges slippage amounts into fee amounts for the same recipients.
+fn _merge_fee_recipients(
+    mut fees: Vec<FeeRecipient>,
+    slippage: Vec<FeeRecipient>,
+) -> Vec<FeeRecipient> {
+    if slippage.is_empty() {
+        return fees;
+    }
+
+    // fees[0] = router fees, slippage[0] = router slippage
+    // fees[1] = client fees, slippage[1] = client slippage
+    fees[0].fee_amount += slippage[0].fee_amount;
+    fees[1].fee_amount += slippage[1].fee_amount;
+
+    fees
 }

--- a/crates/tycho-execution/model/src/model/tycho_router.rs
+++ b/crates/tycho-execution/model/src/model/tycho_router.rs
@@ -318,8 +318,8 @@ fn _split_swap_checked(
     if amount_in == 0 {
         return Err(Error::revert("_split_swap_checked: amount_in == 0"));
     }
-    if receiver == Address::Zero {
-        return Err(Error::revert("_split_swap_checked: receiver == address(0)"));
+    if receiver == Address::Zero || token_in == Address::Zero || token_out == Address::Zero {
+        return Err(Error::revert("_split_swap_checked: address(0)"));
     }
     if expected_amount_out == 0 {
         return Err(Error::revert("_split_swap_checked: expected_amount_out == 0"));
@@ -341,7 +341,7 @@ fn _split_swap_checked(
 
     let must_intercept = must_intercept_output(params, client_fee_bps)?;
 
-    let final_receiver = determine_final_receiver(must_intercept, receiver);
+    let final_receiver = if must_intercept { Address::Router } else { receiver };
 
     let actual_amount_out = _split_swap(
         params,
@@ -409,8 +409,8 @@ fn _single_swap(
     if amount_in == 0 {
         return Err(Error::revert("_single_swap: amount_in == 0"));
     }
-    if receiver == Address::Zero {
-        return Err(Error::revert("_single_swap: receiver == address(0)"));
+    if receiver == Address::Zero || token_in == Address::Zero || token_out == Address::Zero {
+        return Err(Error::revert("_single_swap: address(0)"));
     }
     if expected_amount_out == 0 {
         return Err(Error::revert("_single_swap: expected_amount_out == 0"));
@@ -432,7 +432,7 @@ fn _single_swap(
 
     let must_intercept = must_intercept_output(params, client_fee_bps)?;
 
-    let final_receiver = determine_final_receiver(must_intercept, receiver);
+    let final_receiver = if must_intercept { Address::Router } else { receiver };
 
     let swap_index = 0;
     let executor = params.request(ParamKey::Executor { swap_index }, Executor::VARIANTS)?;
@@ -505,8 +505,8 @@ fn _sequential_swap_checked(
     if amount_in == 0 {
         return Err(Error::revert("_sequential_swap_checked: amount_in == 0"));
     }
-    if receiver == Address::Zero {
-        return Err(Error::revert("_sequential_swap_checked: receiver == address(0)"));
+    if receiver == Address::Zero || token_in == Address::Zero || token_out == Address::Zero {
+        return Err(Error::revert("_sequential_swap_checked: address(0)"));
     }
     if expected_amount_out == 0 {
         return Err(Error::revert("_sequential_swap_checked: expected_amount_out == 0"));
@@ -528,7 +528,7 @@ fn _sequential_swap_checked(
 
     let must_intercept = must_intercept_output(params, client_fee_bps)?;
 
-    let final_receiver = determine_final_receiver(must_intercept, receiver);
+    let final_receiver = if must_intercept { Address::Router } else { receiver };
 
     let actual_amount_out = _sequential_swap(params, state, vault, log, amount_in, final_receiver)?;
 
@@ -687,7 +687,7 @@ fn _split_swap(
             amounts[usize::try_from(token_out_index).unwrap()] += current_amount_out;
         }
         remaining_amounts[usize::try_from(token_out_index).unwrap()] += current_amount_out;
-        remaining_amounts[usize::try_from(token_in_index).unwrap()] -= current_amount_out;
+        remaining_amounts[usize::try_from(token_in_index).unwrap()] -= current_amount_in;
     }
     Ok(if is_cyclical {
         cyclic_swap_amount_out
@@ -887,7 +887,3 @@ fn _maybe_add_client_contribution(
     }
 }
 
-/// <https://github.com/propeller-heads/tycho-execution/blob/0454514f4f6ccff55dcaa8e3abbb4ac494d89eba/foundry/src/TychoRouter.sol#L1125>
-fn determine_final_receiver(must_intercept: bool, receiver: Address) -> Address {
-    if must_intercept { Address::Router } else { receiver }
-}

--- a/crates/tycho-execution/model/src/model/tycho_router.rs
+++ b/crates/tycho-execution/model/src/model/tycho_router.rs
@@ -611,11 +611,11 @@ fn _settle_output(
         }
     }
 
+    vault._finalize_balances(state, state.msg_sender(), token_in, amount_in)?;
+
     if amount_out < min_amount_out {
         return Err(Error::revert("_settle_output: slippage exceeded"));
     }
-
-    vault._finalize_balances(state, state.msg_sender(), token_in, amount_in)?;
 
     Ok(amount_out)
 }

--- a/crates/tycho-execution/model/src/model/tycho_router.rs
+++ b/crates/tycho-execution/model/src/model/tycho_router.rs
@@ -324,7 +324,7 @@ fn _split_swap_checked(
     if expected_amount_out == 0 {
         return Err(Error::revert("_split_swap_checked: expected_amount_out == 0"));
     }
-    if max_slippage_bps > MAX_SLIPPAGE_BPS {
+    if max_slippage_bps >= MAX_SLIPPAGE_BPS {
         return Err(Error::revert("_split_swap_checked: max_slippage_bps too high"));
     }
     let min_amount_out =
@@ -415,7 +415,7 @@ fn _single_swap(
     if expected_amount_out == 0 {
         return Err(Error::revert("_single_swap: expected_amount_out == 0"));
     }
-    if max_slippage_bps > MAX_SLIPPAGE_BPS {
+    if max_slippage_bps >= MAX_SLIPPAGE_BPS {
         return Err(Error::revert("_single_swap: max_slippage_bps too high"));
     }
     let min_amount_out =
@@ -511,7 +511,7 @@ fn _sequential_swap_checked(
     if expected_amount_out == 0 {
         return Err(Error::revert("_sequential_swap_checked: expected_amount_out == 0"));
     }
-    if max_slippage_bps > MAX_SLIPPAGE_BPS {
+    if max_slippage_bps >= MAX_SLIPPAGE_BPS {
         return Err(Error::revert("_sequential_swap_checked: max_slippage_bps too high"));
     }
     let min_amount_out =

--- a/crates/tycho-execution/model/src/model/tycho_router.rs
+++ b/crates/tycho-execution/model/src/model/tycho_router.rs
@@ -6,7 +6,7 @@ use crate::{
     log::{Event, Log},
     math::checked_subtract,
     model::{
-        dispatcher::{_call_get_effective_router_fee_on_output, _call_swap_on_executor},
+        dispatcher::{_call_must_intercept_output, _call_swap_on_executor},
         executors::Executor,
         fee_calculator::calculate_fee,
         transfer_manager::{_transfer_out, _tstore_transfer_from_info},
@@ -15,6 +15,8 @@ use crate::{
     params::{ParamKey, Params},
     state::State,
 };
+
+const MAX_SLIPPAGE_BPS: i64 = 10_000;
 
 /// <https://github.com/propeller-heads/tycho-execution/blob/d27e2a6f4d9ea6f4cba53b2fc1f54cd6676b60d2/foundry/src/TychoRouter.sol#L184>
 pub fn split_swap(
@@ -25,7 +27,8 @@ pub fn split_swap(
     amount_in: i64,
     token_in: Address,
     token_out: Address,
-    min_amount_out: i64,
+    expected_amount_out: i64,
+    max_slippage_bps: i64,
     n_tokens: i64,
     receiver: Address,
 ) -> Result<(), Error> {
@@ -40,7 +43,8 @@ pub fn split_swap(
         amount_in,
         token_in,
         token_out,
-        min_amount_out,
+        expected_amount_out,
+        max_slippage_bps,
         n_tokens,
         receiver,
     )
@@ -55,7 +59,8 @@ pub fn split_swap_using_vault(
     amount_in: i64,
     token_in: Address,
     token_out: Address,
-    min_amount_out: i64,
+    expected_amount_out: i64,
+    max_slippage_bps: i64,
     n_tokens: i64,
     receiver: Address,
 ) -> Result<(), Error> {
@@ -69,7 +74,8 @@ pub fn split_swap_using_vault(
         amount_in,
         token_in,
         token_out,
-        min_amount_out,
+        expected_amount_out,
+        max_slippage_bps,
         n_tokens,
         receiver,
     )
@@ -84,7 +90,8 @@ pub fn split_swap_permit2(
     amount_in: i64,
     token_in: Address,
     token_out: Address,
-    min_amount_out: i64,
+    expected_amount_out: i64,
+    max_slippage_bps: i64,
     n_tokens: i64,
     receiver: Address,
 ) -> Result<(), Error> {
@@ -101,7 +108,8 @@ pub fn split_swap_permit2(
         amount_in,
         token_in,
         token_out,
-        min_amount_out,
+        expected_amount_out,
+        max_slippage_bps,
         n_tokens,
         receiver,
     )
@@ -116,7 +124,8 @@ pub fn sequential_swap(
     amount_in: i64,
     token_in: Address,
     token_out: Address,
-    min_amount_out: i64,
+    expected_amount_out: i64,
+    max_slippage_bps: i64,
     receiver: Address,
 ) -> Result<(), Error> {
     _update_native_delta_accounting(params, state, vault, log, amount_in)?;
@@ -130,7 +139,8 @@ pub fn sequential_swap(
         amount_in,
         token_in,
         token_out,
-        min_amount_out,
+        expected_amount_out,
+        max_slippage_bps,
         receiver,
     )
 }
@@ -144,7 +154,8 @@ pub fn sequential_swap_using_vault(
     amount_in: i64,
     token_in: Address,
     token_out: Address,
-    min_amount_out: i64,
+    expected_amount_out: i64,
+    max_slippage_bps: i64,
     receiver: Address,
 ) -> Result<(), Error> {
     _tstore_transfer_from_info(state, token_in, amount_in, false, true);
@@ -157,7 +168,8 @@ pub fn sequential_swap_using_vault(
         amount_in,
         token_in,
         token_out,
-        min_amount_out,
+        expected_amount_out,
+        max_slippage_bps,
         receiver,
     )
 }
@@ -171,7 +183,8 @@ pub fn sequential_swap_permit2(
     amount_in: i64,
     token_in: Address,
     token_out: Address,
-    min_amount_out: i64,
+    expected_amount_out: i64,
+    max_slippage_bps: i64,
     receiver: Address,
 ) -> Result<(), Error> {
     if token_in != Address::NativeETH {
@@ -187,7 +200,8 @@ pub fn sequential_swap_permit2(
         amount_in,
         token_in,
         token_out,
-        min_amount_out,
+        expected_amount_out,
+        max_slippage_bps,
         receiver,
     )
 }
@@ -201,7 +215,8 @@ pub fn single_swap(
     amount_in: i64,
     token_in: Address,
     token_out: Address,
-    min_amount_out: i64,
+    expected_amount_out: i64,
+    max_slippage_bps: i64,
     receiver: Address,
 ) -> Result<(), Error> {
     _update_native_delta_accounting(params, state, vault, log, amount_in)?;
@@ -219,7 +234,8 @@ pub fn single_swap(
         amount_in,
         token_in,
         token_out,
-        min_amount_out,
+        expected_amount_out,
+        max_slippage_bps,
         receiver,
     )
 }
@@ -233,7 +249,8 @@ pub fn single_swap_using_vault(
     amount_in: i64,
     token_in: Address,
     token_out: Address,
-    min_amount_out: i64,
+    expected_amount_out: i64,
+    max_slippage_bps: i64,
     receiver: Address,
 ) -> Result<(), Error> {
     _tstore_transfer_from_info(state, token_in, amount_in, false, true);
@@ -246,7 +263,8 @@ pub fn single_swap_using_vault(
         amount_in,
         token_in,
         token_out,
-        min_amount_out,
+        expected_amount_out,
+        max_slippage_bps,
         receiver,
     )
 }
@@ -260,7 +278,8 @@ pub fn single_swap_permit2(
     amount_in: i64,
     token_in: Address,
     token_out: Address,
-    min_amount_out: i64,
+    expected_amount_out: i64,
+    max_slippage_bps: i64,
     receiver: Address,
 ) -> Result<(), Error> {
     if token_in != Address::NativeETH {
@@ -276,7 +295,8 @@ pub fn single_swap_permit2(
         amount_in,
         token_in,
         token_out,
-        min_amount_out,
+        expected_amount_out,
+        max_slippage_bps,
         receiver,
     )
 }
@@ -290,7 +310,8 @@ fn _split_swap_checked(
     amount_in: i64,
     token_in: Address,
     token_out: Address,
-    min_amount_out: i64,
+    expected_amount_out: i64,
+    max_slippage_bps: i64,
     n_tokens: i64,
     receiver: Address,
 ) -> Result<(), Error> {
@@ -300,25 +321,28 @@ fn _split_swap_checked(
     if receiver == Address::Zero {
         return Err(Error::revert("_split_swap_checked: receiver == address(0)"));
     }
-    if min_amount_out == 0 {
-        return Err(Error::revert("_split_swap_checked: min_amount_out == 0"));
+    if expected_amount_out == 0 {
+        return Err(Error::revert("_split_swap_checked: expected_amount_out == 0"));
     }
-
-    let router_fee_on_output_bps = _call_get_effective_router_fee_on_output(params, state)?;
+    if max_slippage_bps > MAX_SLIPPAGE_BPS {
+        return Err(Error::revert("_split_swap_checked: max_slippage_bps too high"));
+    }
+    let min_amount_out = expected_amount_out * (MAX_SLIPPAGE_BPS - max_slippage_bps) / MAX_SLIPPAGE_BPS;
 
     let client_fee_bps = if crate::config::ENABLE_NONZERO_FEE_BPS {
         params.request(
             ParamKey::String("client_fee_bps"),
-            [0, crate::model::fee_calculator::MAX_FEE_BPS],
+            [0, crate::model::fee_calculator::MAX_BPS],
         )?
     } else {
         0
     };
 
-    let final_receiver =
-        determine_final_receiver(receiver, client_fee_bps, router_fee_on_output_bps)?;
+    let must_intercept = _call_must_intercept_output(params, client_fee_bps)?;
 
-    let amount_out_before_fees = _split_swap(
+    let final_receiver = determine_final_receiver(must_intercept, receiver);
+
+    let actual_amount_out = _split_swap(
         params,
         state,
         vault,
@@ -329,10 +353,18 @@ fn _split_swap_checked(
         token_in == token_out,
     )?;
 
-    let amount_out = if client_fee_bps == 0 && router_fee_on_output_bps == 0 {
-        amount_out_before_fees
+    let amount_out = if !must_intercept {
+        actual_amount_out
     } else {
-        _take_fees(params, vault, log, token_out, amount_out_before_fees, client_fee_bps)?
+        _take_fees(
+            params,
+            vault,
+            log,
+            token_out,
+            actual_amount_out,
+            expected_amount_out,
+            client_fee_bps,
+        )?
     };
 
     let amount_out = _maybe_add_client_contribution(
@@ -346,7 +378,9 @@ fn _split_swap_checked(
         receiver,
     )?;
 
-    _settle_output(state, vault, log, amount_out, amount_in, token_in, token_out, receiver)?;
+    _settle_output(
+        state, vault, log, amount_out, min_amount_out, amount_in, token_in, token_out, receiver,
+    )?;
     Ok(())
 }
 
@@ -359,7 +393,8 @@ fn _single_swap(
     amount_in: i64,
     token_in: Address,
     token_out: Address,
-    min_amount_out: i64,
+    expected_amount_out: i64,
+    max_slippage_bps: i64,
     receiver: Address,
 ) -> Result<(), Error> {
     if amount_in == 0 {
@@ -368,28 +403,31 @@ fn _single_swap(
     if receiver == Address::Zero {
         return Err(Error::revert("_single_swap: receiver == address(0)"));
     }
-    if min_amount_out == 0 {
-        return Err(Error::revert("_single_swap: min_amount_out == 0"));
+    if expected_amount_out == 0 {
+        return Err(Error::revert("_single_swap: expected_amount_out == 0"));
     }
-
-    let router_fee_on_output_bps = _call_get_effective_router_fee_on_output(params, state)?;
+    if max_slippage_bps > MAX_SLIPPAGE_BPS {
+        return Err(Error::revert("_single_swap: max_slippage_bps too high"));
+    }
+    let min_amount_out = expected_amount_out * (MAX_SLIPPAGE_BPS - max_slippage_bps) / MAX_SLIPPAGE_BPS;
 
     let client_fee_bps = if crate::config::ENABLE_NONZERO_FEE_BPS {
         params.request(
             ParamKey::String("client_fee_bps"),
-            [0, crate::model::fee_calculator::MAX_FEE_BPS],
+            [0, crate::model::fee_calculator::MAX_BPS],
         )?
     } else {
         0
     };
 
-    let final_receiver =
-        determine_final_receiver(receiver, client_fee_bps, router_fee_on_output_bps)?;
+    let must_intercept = _call_must_intercept_output(params, client_fee_bps)?;
+
+    let final_receiver = determine_final_receiver(must_intercept, receiver);
 
     let swap_index = 0;
     let executor = params.request(ParamKey::Executor { swap_index }, Executor::VARIANTS)?;
 
-    let amount_out_before_fees = _call_swap_on_executor(
+    let actual_amount_out = _call_swap_on_executor(
         params,
         state,
         vault,
@@ -402,10 +440,18 @@ fn _single_swap(
         swap_index,
     )?;
 
-    let amount_out = if client_fee_bps == 0 && router_fee_on_output_bps == 0 {
-        amount_out_before_fees
+    let amount_out = if !must_intercept {
+        actual_amount_out
     } else {
-        _take_fees(params, vault, log, token_out, amount_out_before_fees, client_fee_bps)?
+        _take_fees(
+            params,
+            vault,
+            log,
+            token_out,
+            actual_amount_out,
+            expected_amount_out,
+            client_fee_bps,
+        )?
     };
 
     let amount_out = _maybe_add_client_contribution(
@@ -419,7 +465,9 @@ fn _single_swap(
         receiver,
     )?;
 
-    _settle_output(state, vault, log, amount_out, amount_in, token_in, token_out, receiver)?;
+    _settle_output(
+        state, vault, log, amount_out, min_amount_out, amount_in, token_in, token_out, receiver,
+    )?;
     Ok(())
 }
 
@@ -432,7 +480,8 @@ fn _sequential_swap_checked(
     amount_in: i64,
     token_in: Address,
     token_out: Address,
-    min_amount_out: i64,
+    expected_amount_out: i64,
+    max_slippage_bps: i64,
     receiver: Address,
 ) -> Result<(), Error> {
     if amount_in == 0 {
@@ -441,31 +490,41 @@ fn _sequential_swap_checked(
     if receiver == Address::Zero {
         return Err(Error::revert("_sequential_swap_checked: receiver == address(0)"));
     }
-    if min_amount_out == 0 {
-        return Err(Error::revert("_sequential_swap_checked: min_amount_out == 0"));
+    if expected_amount_out == 0 {
+        return Err(Error::revert("_sequential_swap_checked: expected_amount_out == 0"));
     }
-
-    let router_fee_on_output_bps = _call_get_effective_router_fee_on_output(params, state)?;
+    if max_slippage_bps > MAX_SLIPPAGE_BPS {
+        return Err(Error::revert("_sequential_swap_checked: max_slippage_bps too high"));
+    }
+    let min_amount_out = expected_amount_out * (MAX_SLIPPAGE_BPS - max_slippage_bps) / MAX_SLIPPAGE_BPS;
 
     let client_fee_bps = if crate::config::ENABLE_NONZERO_FEE_BPS {
         params.request(
             ParamKey::String("client_fee_bps"),
-            [0, crate::model::fee_calculator::MAX_FEE_BPS],
+            [0, crate::model::fee_calculator::MAX_BPS],
         )?
     } else {
         0
     };
 
-    let final_receiver =
-        determine_final_receiver(receiver, client_fee_bps, router_fee_on_output_bps)?;
+    let must_intercept = _call_must_intercept_output(params, client_fee_bps)?;
 
-    let amount_out_before_fees =
-        _sequential_swap(params, state, vault, log, amount_in, final_receiver)?;
+    let final_receiver = determine_final_receiver(must_intercept, receiver);
 
-    let amount_out = if client_fee_bps == 0 && router_fee_on_output_bps == 0 {
-        amount_out_before_fees
+    let actual_amount_out = _sequential_swap(params, state, vault, log, amount_in, final_receiver)?;
+
+    let amount_out = if !must_intercept {
+        actual_amount_out
     } else {
-        _take_fees(params, vault, log, token_out, amount_out_before_fees, client_fee_bps)?
+        _take_fees(
+            params,
+            vault,
+            log,
+            token_out,
+            actual_amount_out,
+            expected_amount_out,
+            client_fee_bps,
+        )?
     };
 
     let amount_out = _maybe_add_client_contribution(
@@ -479,7 +538,9 @@ fn _sequential_swap_checked(
         receiver,
     )?;
 
-    _settle_output(state, vault, log, amount_out, amount_in, token_in, token_out, receiver)?;
+    _settle_output(
+        state, vault, log, amount_out, min_amount_out, amount_in, token_in, token_out, receiver,
+    )?;
     Ok(())
 }
 
@@ -489,6 +550,7 @@ fn _settle_output(
     vault: &mut Vault,
     log: &mut impl Log,
     mut amount_out: i64,
+    min_amount_out: i64,
     amount_in: i64,
     token_in: Address,
     token_out: Address,
@@ -520,6 +582,10 @@ fn _settle_output(
                 context_hint: "_settle_output: output_delta > 0 && receiver != Address::Router",
             });
         }
+    }
+
+    if amount_out < min_amount_out {
+        return Err(Error::revert("_settle_output: slippage exceeded"));
     }
 
     vault._finalize_balances(state, state.msg_sender(), token_in, amount_in)?;
@@ -655,12 +721,14 @@ fn _take_fees(
     vault: &mut Vault,
     log: &mut impl Log,
     token: Address,
-    amount_in: i64,
+    actual_amount_out: i64,
+    expected_amount_out: i64,
     client_fee_bps: i64,
 ) -> Result<i64, Error> {
-    let (amount_out, fees) = calculate_fee(params, amount_in, client_fee_bps)?;
+    let fees = calculate_fee(params, actual_amount_out, expected_amount_out, client_fee_bps)?;
 
-    for fee in fees {
+    let mut total_fees = 0i64;
+    for fee in &fees {
         if fee.fee_amount > 0 {
             vault._update_delta_accounting(token, -fee.fee_amount);
             log.append(Event::UpdateDeltaAccounting {
@@ -677,10 +745,12 @@ fn _take_fees(
                 amount: fee.fee_amount,
                 context_hint: "_take_fees: fee_amount > 0",
             });
+
+            total_fees += fee.fee_amount;
         }
     }
 
-    Ok(amount_out)
+    checked_subtract(actual_amount_out, total_fees)
 }
 
 /// <https://github.com/propeller-heads/tycho-execution/blob/0454514f4f6ccff55dcaa8e3abbb4ac494d89eba/foundry/src/TychoRouter.sol#L1063>
@@ -791,14 +861,6 @@ fn _maybe_add_client_contribution(
 }
 
 /// <https://github.com/propeller-heads/tycho-execution/blob/0454514f4f6ccff55dcaa8e3abbb4ac494d89eba/foundry/src/TychoRouter.sol#L1125>
-fn determine_final_receiver(
-    receiver: Address,
-    client_fee_bps: i64,
-    router_fee_on_output_bps: i64,
-) -> Result<Address, Error> {
-    Ok(if client_fee_bps == 0 && router_fee_on_output_bps == 0 {
-        receiver
-    } else {
-        Address::Router
-    })
+fn determine_final_receiver(must_intercept: bool, receiver: Address) -> Address {
+    if must_intercept { Address::Router } else { receiver }
 }

--- a/crates/tycho-execution/model/src/model/tycho_router.rs
+++ b/crates/tycho-execution/model/src/model/tycho_router.rs
@@ -886,4 +886,3 @@ fn _maybe_add_client_contribution(
         Ok(amount_out)
     }
 }
-

--- a/crates/tycho-execution/model/src/model/tycho_router.rs
+++ b/crates/tycho-execution/model/src/model/tycho_router.rs
@@ -327,7 +327,8 @@ fn _split_swap_checked(
     if max_slippage_bps > MAX_SLIPPAGE_BPS {
         return Err(Error::revert("_split_swap_checked: max_slippage_bps too high"));
     }
-    let min_amount_out = expected_amount_out * (MAX_SLIPPAGE_BPS - max_slippage_bps) / MAX_SLIPPAGE_BPS;
+    let min_amount_out =
+        expected_amount_out * (MAX_SLIPPAGE_BPS - max_slippage_bps) / MAX_SLIPPAGE_BPS;
 
     let client_fee_bps = if crate::config::ENABLE_NONZERO_FEE_BPS {
         params.request(
@@ -379,7 +380,15 @@ fn _split_swap_checked(
     )?;
 
     _settle_output(
-        state, vault, log, amount_out, min_amount_out, amount_in, token_in, token_out, receiver,
+        state,
+        vault,
+        log,
+        amount_out,
+        min_amount_out,
+        amount_in,
+        token_in,
+        token_out,
+        receiver,
     )?;
     Ok(())
 }
@@ -409,7 +418,8 @@ fn _single_swap(
     if max_slippage_bps > MAX_SLIPPAGE_BPS {
         return Err(Error::revert("_single_swap: max_slippage_bps too high"));
     }
-    let min_amount_out = expected_amount_out * (MAX_SLIPPAGE_BPS - max_slippage_bps) / MAX_SLIPPAGE_BPS;
+    let min_amount_out =
+        expected_amount_out * (MAX_SLIPPAGE_BPS - max_slippage_bps) / MAX_SLIPPAGE_BPS;
 
     let client_fee_bps = if crate::config::ENABLE_NONZERO_FEE_BPS {
         params.request(
@@ -466,7 +476,15 @@ fn _single_swap(
     )?;
 
     _settle_output(
-        state, vault, log, amount_out, min_amount_out, amount_in, token_in, token_out, receiver,
+        state,
+        vault,
+        log,
+        amount_out,
+        min_amount_out,
+        amount_in,
+        token_in,
+        token_out,
+        receiver,
     )?;
     Ok(())
 }
@@ -496,7 +514,8 @@ fn _sequential_swap_checked(
     if max_slippage_bps > MAX_SLIPPAGE_BPS {
         return Err(Error::revert("_sequential_swap_checked: max_slippage_bps too high"));
     }
-    let min_amount_out = expected_amount_out * (MAX_SLIPPAGE_BPS - max_slippage_bps) / MAX_SLIPPAGE_BPS;
+    let min_amount_out =
+        expected_amount_out * (MAX_SLIPPAGE_BPS - max_slippage_bps) / MAX_SLIPPAGE_BPS;
 
     let client_fee_bps = if crate::config::ENABLE_NONZERO_FEE_BPS {
         params.request(
@@ -539,7 +558,15 @@ fn _sequential_swap_checked(
     )?;
 
     _settle_output(
-        state, vault, log, amount_out, min_amount_out, amount_in, token_in, token_out, receiver,
+        state,
+        vault,
+        log,
+        amount_out,
+        min_amount_out,
+        amount_in,
+        token_in,
+        token_out,
+        receiver,
     )?;
     Ok(())
 }

--- a/crates/tycho-execution/model/src/model/tycho_router.rs
+++ b/crates/tycho-execution/model/src/model/tycho_router.rs
@@ -6,9 +6,9 @@ use crate::{
     log::{Event, Log},
     math::checked_subtract,
     model::{
-        dispatcher::{_call_must_intercept_output, _call_swap_on_executor},
+        dispatcher::_call_swap_on_executor,
         executors::Executor,
-        fee_calculator::calculate_fee,
+        fee_calculator::{calculate_fee, must_intercept_output},
         transfer_manager::{_transfer_out, _tstore_transfer_from_info},
         vault::Vault,
     },
@@ -339,7 +339,7 @@ fn _split_swap_checked(
         0
     };
 
-    let must_intercept = _call_must_intercept_output(params, client_fee_bps)?;
+    let must_intercept = must_intercept_output(params, client_fee_bps)?;
 
     let final_receiver = determine_final_receiver(must_intercept, receiver);
 
@@ -430,7 +430,7 @@ fn _single_swap(
         0
     };
 
-    let must_intercept = _call_must_intercept_output(params, client_fee_bps)?;
+    let must_intercept = must_intercept_output(params, client_fee_bps)?;
 
     let final_receiver = determine_final_receiver(must_intercept, receiver);
 
@@ -526,7 +526,7 @@ fn _sequential_swap_checked(
         0
     };
 
-    let must_intercept = _call_must_intercept_output(params, client_fee_bps)?;
+    let must_intercept = must_intercept_output(params, client_fee_bps)?;
 
     let final_receiver = determine_final_receiver(must_intercept, receiver);
 

--- a/crates/tycho-execution/model/src/simulate.rs
+++ b/crates/tycho-execution/model/src/simulate.rs
@@ -36,9 +36,10 @@ pub fn simulate(params: &Params) -> Result<(State, Vault, impl Log + use<> + Ser
     let token_in = params.request("token_in", Address::VARIANTS_EXCEPT_ZERO)?;
     let token_out = params.request("token_out", Address::VARIANTS_EXCEPT_ZERO)?;
 
-    // assumption: all swap methods revert if `min_amount_out = 0`.
+    // assumption: all swap methods revert if `expected_amount_out = 0`.
     // no need to simulate it.
-    let min_amount_out = params.request("min_amount_out", [1, 10000])?;
+    let expected_amount_out = params.request("expected_amount_out", [1, 10000])?;
+    let max_slippage_bps = params.request("max_slippage_bps", [0, 500, 10000])?;
     // assumption: all swap methods revert if `receiver = address(0)`.
     // no need to simulate it.
     let receiver = params.request("receiver", Address::VARIANTS_EXCEPT_ZERO)?;
@@ -89,7 +90,8 @@ pub fn simulate(params: &Params) -> Result<(State, Vault, impl Log + use<> + Ser
                 amount_in,
                 token_in,
                 token_out,
-                min_amount_out,
+                expected_amount_out,
+                max_slippage_bps,
                 receiver,
             )?;
         }
@@ -102,7 +104,8 @@ pub fn simulate(params: &Params) -> Result<(State, Vault, impl Log + use<> + Ser
                 amount_in,
                 token_in,
                 token_out,
-                min_amount_out,
+                expected_amount_out,
+                max_slippage_bps,
                 receiver,
             )?;
         }
@@ -115,7 +118,8 @@ pub fn simulate(params: &Params) -> Result<(State, Vault, impl Log + use<> + Ser
                 amount_in,
                 token_in,
                 token_out,
-                min_amount_out,
+                expected_amount_out,
+                max_slippage_bps,
                 receiver,
             )?;
         }
@@ -128,7 +132,8 @@ pub fn simulate(params: &Params) -> Result<(State, Vault, impl Log + use<> + Ser
                 amount_in,
                 token_in,
                 token_out,
-                min_amount_out,
+                expected_amount_out,
+                max_slippage_bps,
                 receiver,
             )?;
         }
@@ -141,7 +146,8 @@ pub fn simulate(params: &Params) -> Result<(State, Vault, impl Log + use<> + Ser
                 amount_in,
                 token_in,
                 token_out,
-                min_amount_out,
+                expected_amount_out,
+                max_slippage_bps,
                 receiver,
             )?;
         }
@@ -154,7 +160,8 @@ pub fn simulate(params: &Params) -> Result<(State, Vault, impl Log + use<> + Ser
                 amount_in,
                 token_in,
                 token_out,
-                min_amount_out,
+                expected_amount_out,
+                max_slippage_bps,
                 receiver,
             )?;
         }
@@ -167,7 +174,8 @@ pub fn simulate(params: &Params) -> Result<(State, Vault, impl Log + use<> + Ser
                 amount_in,
                 token_in,
                 token_out,
-                min_amount_out,
+                expected_amount_out,
+                max_slippage_bps,
                 params.request("n_tokens", [1, 2])?,
                 receiver,
             )?;
@@ -181,7 +189,8 @@ pub fn simulate(params: &Params) -> Result<(State, Vault, impl Log + use<> + Ser
                 amount_in,
                 token_in,
                 token_out,
-                min_amount_out,
+                expected_amount_out,
+                max_slippage_bps,
                 params.request("n_tokens", [1, 2])?,
                 receiver,
             )?;
@@ -195,7 +204,8 @@ pub fn simulate(params: &Params) -> Result<(State, Vault, impl Log + use<> + Ser
                 amount_in,
                 token_in,
                 token_out,
-                min_amount_out,
+                expected_amount_out,
+                max_slippage_bps,
                 params.request("n_tokens", [1, 2])?,
                 receiver,
             )?;

--- a/crates/tycho-execution/model/src/simulate.rs
+++ b/crates/tycho-execution/model/src/simulate.rs
@@ -39,7 +39,7 @@ pub fn simulate(params: &Params) -> Result<(State, Vault, impl Log + use<> + Ser
     // assumption: all swap methods revert if `expected_amount_out = 0`.
     // no need to simulate it.
     let expected_amount_out = params.request("expected_amount_out", [1, 10000])?;
-    let max_slippage_bps = params.request("max_slippage_bps", [0, 500, 10000])?;
+    let max_slippage_bps = params.request("max_slippage_bps", [0, 500, 9999])?;
     // assumption: all swap methods revert if `receiver = address(0)`.
     // no need to simulate it.
     let receiver = params.request("receiver", Address::VARIANTS_EXCEPT_ZERO)?;

--- a/protocols/adapter-integration/evm/test/EtherfiAdapter.t.sol
+++ b/protocols/adapter-integration/evm/test/EtherfiAdapter.t.sol
@@ -74,18 +74,20 @@ contract EtherfiAdapterTest is Test, ISwapAdapterTypes {
             // bound was too loose.
             vm.assume(specifiedAmount < limits[1] && specifiedAmount > 100);
             uint256 requiredEeth = weEth.getEETHByWeETH(specifiedAmount);
-            vm.assume(requiredEeth < limits[0]);
+            /// Request extra eETH to cover share-based rounding
+            /// losses during transfer.
+            uint256 fundingAmount = requiredEeth + 10;
+            vm.assume(fundingAmount < limits[0]);
 
             /// @dev workaround for eETH "deal", as standard ERC20 does not
-            /// work(balance is shares). Request extra eETH to cover
-            /// share-based rounding losses during transfer.
+            /// work(balance is shares).
             deal(address(adapter), type(uint256).max);
             adapter.swap(
                 pair,
                 address(address(0)),
                 address(eEth_),
                 OrderSide.Buy,
-                requiredEeth + 10
+                fundingAmount
             );
 
             eEth_.approve(address(adapter), type(uint256).max);

--- a/protocols/adapter-integration/evm/test/EtherfiAdapter.t.sol
+++ b/protocols/adapter-integration/evm/test/EtherfiAdapter.t.sol
@@ -77,14 +77,15 @@ contract EtherfiAdapterTest is Test, ISwapAdapterTypes {
             vm.assume(requiredEeth < limits[0]);
 
             /// @dev workaround for eETH "deal", as standard ERC20 does not
-            /// work(balance is shares)
+            /// work(balance is shares). Request extra eETH to cover
+            /// share-based rounding losses during transfer.
             deal(address(adapter), type(uint256).max);
             adapter.swap(
                 pair,
                 address(address(0)),
                 address(eEth_),
                 OrderSide.Buy,
-                requiredEeth
+                requiredEeth + 10
             );
 
             eEth_.approve(address(adapter), type(uint256).max);


### PR DESCRIPTION
Original [task](https://propeller-heads.atlassian.net/browse/ENG-6119)

  - Replace `minAmountOut` with `expectedAmountOut` + `maxSlippageBps` in all swap entry points                                                         
  - Add positive slippage splitting: when enabled, surplus above expected output is split between router and client via configurable share
  - Replace `_callGetEffectiveRouterFeeOnOutput` with `_callMustInterceptOutput` to match Solidity refactor                                             
  - Bump fee BPS precision from 10_000 to 100_000_000 (uint16->uint32)