### PR TITLE
feat: add tokens to fee taking signature

### DIFF
--- a/crates/tycho-execution/contracts/interfaces/IFeeCalculator.sol
+++ b/crates/tycho-execution/contracts/interfaces/IFeeCalculator.sol
@@ -30,6 +30,9 @@ interface IFeeCalculator {
      * @param actualAmountOut The actual amount received from the swap
      * @param expectedAmountOut Caller-supplied quoted amount out.
      *        Base for fee calculation and slippage surplus
+     * @param amountIn The input amount of the swap
+     * @param tokenIn The input token address
+     * @param tokenOut The output token address
      * @param clientFeeBps Client fee in fee units (100_000_000 = 100%)
      * @param client The client address to look up custom router fees
      *        and slippage share for, and to receive the client fee
@@ -40,6 +43,9 @@ interface IFeeCalculator {
     function calculateFee(
         uint256 actualAmountOut,
         uint256 expectedAmountOut,
+        uint256 amountIn,
+        address tokenIn,
+        address tokenOut,
         uint32 clientFeeBps,
         address client
     ) external view returns (FeeRecipient[] memory feeRecipients);

--- a/crates/tycho-execution/contracts/interfaces/IFeeCalculator.sol
+++ b/crates/tycho-execution/contracts/interfaces/IFeeCalculator.sol
@@ -28,11 +28,10 @@ interface IFeeCalculator {
      *      client address; client fee parameters are passed as
      *      function arguments.
      * @param actualAmountOut The actual amount received from the swap
-     * @param expectedAmountOut Caller-supplied quoted amount out.
-     *        Base for fee calculation and slippage surplus
+     * @param expectedAmountOut Caller-supplied quoted amount out
      * @param amountIn The input amount of the swap
-     * @param tokenIn The input token address
-     * @param tokenOut The output token address
+     * @param tokenIn The swap's input token address
+     * @param tokenOut The swap's output token address
      * @param clientFeeBps Client fee in fee units (100_000_000 = 100%)
      * @param client The client address to look up custom router fees
      *        and slippage share for, and to receive the client fee

--- a/crates/tycho-execution/contracts/lib/FeeStructs.sol
+++ b/crates/tycho-execution/contracts/lib/FeeStructs.sol
@@ -10,3 +10,13 @@ struct FeeRecipient {
     address recipient;
     uint256 feeAmount;
 }
+
+struct FeeInput {
+    uint256 actualAmountOut;
+    uint256 expectedAmountOut;
+    uint256 amountIn;
+    address tokenIn;
+    address tokenOut;
+    uint32 clientFeeBps;
+    address client;
+}

--- a/crates/tycho-execution/contracts/src/Dispatcher.sol
+++ b/crates/tycho-execution/contracts/src/Dispatcher.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.26;
 import {IExecutor} from "@interfaces/IExecutor.sol";
 import {ICallback} from "@interfaces/ICallback.sol";
 import {IFeeCalculator} from "@interfaces/IFeeCalculator.sol";
-import {FeeRecipient} from "../lib/FeeStructs.sol";
+import {FeeRecipient, FeeInput} from "../lib/FeeStructs.sol";
 import {TransferManager} from "./TransferManager.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {
@@ -286,26 +286,21 @@ contract Dispatcher is TransferManager {
         }
     }
 
-    function _callCalculateFee(
-        address feeCalculator,
-        uint256 actualAmountOut,
-        uint256 expectedAmountOut,
-        uint256 amountIn,
-        address tokenIn,
-        address tokenOut,
-        uint32 clientFeeBps,
-        address client
-    ) internal view returns (FeeRecipient[] memory feeRecipients) {
+    function _callCalculateFee(address feeCalculator, FeeInput memory f)
+        internal
+        view
+        returns (FeeRecipient[] memory feeRecipients)
+    {
         // slither-disable-next-line calls-loop
         feeRecipients = IFeeCalculator(feeCalculator)
             .calculateFee(
-                actualAmountOut,
-                expectedAmountOut,
-                amountIn,
-                tokenIn,
-                tokenOut,
-                clientFeeBps,
-                client
+                f.actualAmountOut,
+                f.expectedAmountOut,
+                f.amountIn,
+                f.tokenIn,
+                f.tokenOut,
+                f.clientFeeBps,
+                f.client
             );
     }
 

--- a/crates/tycho-execution/contracts/src/Dispatcher.sol
+++ b/crates/tycho-execution/contracts/src/Dispatcher.sol
@@ -286,7 +286,7 @@ contract Dispatcher is TransferManager {
         }
     }
 
-    function _callCalculateFee(address feeCalculator, FeeInput memory f)
+    function _callCalculateFee(address feeCalculator, FeeInput memory feeInput)
         internal
         view
         returns (FeeRecipient[] memory feeRecipients)
@@ -294,13 +294,13 @@ contract Dispatcher is TransferManager {
         // slither-disable-next-line calls-loop
         feeRecipients = IFeeCalculator(feeCalculator)
             .calculateFee(
-                f.actualAmountOut,
-                f.expectedAmountOut,
-                f.amountIn,
-                f.tokenIn,
-                f.tokenOut,
-                f.clientFeeBps,
-                f.client
+                feeInput.actualAmountOut,
+                feeInput.expectedAmountOut,
+                feeInput.amountIn,
+                feeInput.tokenIn,
+                feeInput.tokenOut,
+                feeInput.clientFeeBps,
+                feeInput.client
             );
     }
 

--- a/crates/tycho-execution/contracts/src/Dispatcher.sol
+++ b/crates/tycho-execution/contracts/src/Dispatcher.sol
@@ -290,13 +290,22 @@ contract Dispatcher is TransferManager {
         address feeCalculator,
         uint256 actualAmountOut,
         uint256 expectedAmountOut,
+        uint256 amountIn,
+        address tokenIn,
+        address tokenOut,
         uint32 clientFeeBps,
         address client
     ) internal view returns (FeeRecipient[] memory feeRecipients) {
         // slither-disable-next-line calls-loop
         feeRecipients = IFeeCalculator(feeCalculator)
             .calculateFee(
-                actualAmountOut, expectedAmountOut, clientFeeBps, client
+                actualAmountOut,
+                expectedAmountOut,
+                amountIn,
+                tokenIn,
+                tokenOut,
+                clientFeeBps,
+                client
             );
     }
 

--- a/crates/tycho-execution/contracts/src/FeeCalculator.sol
+++ b/crates/tycho-execution/contracts/src/FeeCalculator.sol
@@ -91,6 +91,9 @@ contract FeeCalculator is AccessControl, IFeeCalculator {
      *        (used for slippage surplus calculation)
      * @param expectedAmountOut Caller-supplied quoted amount out.
      *        Fees are calculated on this amount.
+     * @param amountIn The input amount of the swap
+     * @param tokenIn The input token address
+     * @param tokenOut The output token address
      * @param clientFeeBps Client fee in fee units (100_000_000 = 100%)
      * @param client The client address to look up custom router fees
      *        and slippage share for and to receive fees.
@@ -101,6 +104,9 @@ contract FeeCalculator is AccessControl, IFeeCalculator {
     function calculateFee(
         uint256 actualAmountOut,
         uint256 expectedAmountOut,
+        uint256 amountIn,
+        address tokenIn,
+        address tokenOut,
         uint32 clientFeeBps,
         address client
     ) external view returns (FeeRecipient[] memory feeRecipients) {

--- a/crates/tycho-execution/contracts/src/FeeCalculator.sol
+++ b/crates/tycho-execution/contracts/src/FeeCalculator.sol
@@ -90,8 +90,8 @@ contract FeeCalculator is AccessControl, IFeeCalculator {
      * @param actualAmountOut The actual amount received from the swap
      * @param expectedAmountOut Caller-supplied quoted amount out
      * @param amountIn The input amount of the swap
-     * @param tokenIn The input token address
-     * @param tokenOut The output token address
+     * @param tokenIn The swap's input token address
+     * @param tokenOut The swap's output token address
      * @param clientFeeBps Client fee in fee units (100_000_000 = 100%)
      * @param client The client address to look up custom router fees
      *        and slippage share for and to receive fees.

--- a/crates/tycho-execution/contracts/src/FeeCalculator.sol
+++ b/crates/tycho-execution/contracts/src/FeeCalculator.sol
@@ -88,9 +88,7 @@ contract FeeCalculator is AccessControl, IFeeCalculator {
      *      Router fee parameters are retrieved from contract storage based on the client address.
      *      Client fee parameters are passed as function arguments.
      * @param actualAmountOut The actual amount received from the swap
-     *        (used for slippage surplus calculation)
-     * @param expectedAmountOut Caller-supplied quoted amount out.
-     *        Fees are calculated on this amount.
+     * @param expectedAmountOut Caller-supplied quoted amount out
      * @param amountIn The input amount of the swap
      * @param tokenIn The input token address
      * @param tokenOut The output token address

--- a/crates/tycho-execution/contracts/src/TychoRouter.sol
+++ b/crates/tycho-execution/contracts/src/TychoRouter.sol
@@ -1260,7 +1260,7 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
 
     /**
      * @notice Calculates and takes fees using the FeeCalculator
-     * @param f Fee calculation inputs (amounts, tokens, client)
+     * @param feeInput Fee calculation inputs (amounts, tokens, client)
      * @return amountOutAfterFees Amount remaining after fee deductions
      */
     function _takeFees(FeeInput memory feeInput)

--- a/crates/tycho-execution/contracts/src/TychoRouter.sol
+++ b/crates/tycho-execution/contracts/src/TychoRouter.sol
@@ -1263,12 +1263,12 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
      * @param f Fee calculation inputs (amounts, tokens, client)
      * @return amountOutAfterFees Amount remaining after fee deductions
      */
-    function _takeFees(FeeInput memory f)
+    function _takeFees(FeeInput memory feeInput)
         internal
         returns (uint256 amountOutAfterFees)
     {
-        FeeRecipient[] memory fees = _callCalculateFee(_feeCalculator, f);
-        amountOutAfterFees = f.actualAmountOut;
+        FeeRecipient[] memory fees = _callCalculateFee(_feeCalculator, feeInput);
+        amountOutAfterFees = feeInput.actualAmountOut;
 
         for (uint256 i = 0; i < fees.length; i++) {
             if (fees[i].feeAmount > 0) {
@@ -1277,15 +1277,17 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
                 // due to incorrect or malicious encoding. Updating the delta
                 // accounting without funds will result in an additional negative
                 // delta, and cause the _finalizeBalances method to revert.
-                _updateDeltaAccounting(f.tokenOut, -int256(fees[i].feeAmount));
+                _updateDeltaAccounting(
+                    feeInput.tokenOut, -int256(fees[i].feeAmount)
+                );
                 _creditVaultForFees(
-                    fees[i].recipient, f.tokenOut, fees[i].feeAmount
+                    fees[i].recipient, feeInput.tokenOut, fees[i].feeAmount
                 );
                 amountOutAfterFees -= fees[i].feeAmount;
             }
         }
         if (fees.length > 0) {
-            emit FeesTaken(f.tokenOut, fees);
+            emit FeesTaken(feeInput.tokenOut, fees);
         }
     }
 

--- a/crates/tycho-execution/contracts/src/TychoRouter.sol
+++ b/crates/tycho-execution/contracts/src/TychoRouter.sol
@@ -759,6 +759,9 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
                 tokenOut,
                 actualAmountOut,
                 expectedAmountOut,
+                amountIn,
+                tokenIn,
+                tokenOut,
                 clientFeeParams.clientFeeBps,
                 client
             );
@@ -846,6 +849,9 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
                 tokenOut,
                 actualAmountOut,
                 expectedAmountOut,
+                amountIn,
+                tokenIn,
+                tokenOut,
                 clientFeeParams.clientFeeBps,
                 client
             );
@@ -928,6 +934,9 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
                 tokenOut,
                 actualAmountOut,
                 expectedAmountOut,
+                amountIn,
+                tokenIn,
+                tokenOut,
                 clientFeeParams.clientFeeBps,
                 client
             );
@@ -1249,6 +1258,9 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
      * @param token The token address for which fees are being taken
      * @param actualAmountOut The actual amount received from the swap
      * @param expectedAmountOut The off-chain quoted amount
+     * @param amountIn The input amount for the swap
+     * @param tokenIn The input token address
+     * @param tokenOut The output token address
      * @param clientFeeBps Client fee in basis points
      * @param client Address to receive client fees
      * @return amountOutAfterFees The amount remaining after all fee deductions
@@ -1257,6 +1269,9 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
         address token,
         uint256 actualAmountOut,
         uint256 expectedAmountOut,
+        uint256 amountIn,
+        address tokenIn,
+        address tokenOut,
         uint32 clientFeeBps,
         address client
     ) internal returns (uint256 amountOutAfterFees) {
@@ -1264,9 +1279,9 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
             _feeCalculator,
             actualAmountOut,
             expectedAmountOut,
-            0,
-            address(0),
-            address(0),
+            amountIn,
+            tokenIn,
+            tokenOut,
             clientFeeBps,
             client
         );

--- a/crates/tycho-execution/contracts/src/TychoRouter.sol
+++ b/crates/tycho-execution/contracts/src/TychoRouter.sol
@@ -1264,6 +1264,9 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
             _feeCalculator,
             actualAmountOut,
             expectedAmountOut,
+            0,
+            address(0),
+            address(0),
             clientFeeBps,
             client
         );

--- a/crates/tycho-execution/contracts/src/TychoRouter.sol
+++ b/crates/tycho-execution/contracts/src/TychoRouter.sol
@@ -24,7 +24,7 @@ import {Dispatcher} from "./Dispatcher.sol";
 import {LibSwap} from "../lib/LibSwap.sol";
 import {TransferManager} from "./TransferManager.sol";
 import {ETH_ADDRESS} from "../lib/NativeETH.sol";
-import {FeeRecipient} from "../lib/FeeStructs.sol";
+import {FeeRecipient, FeeInput} from "../lib/FeeStructs.sol";
 
 //                                         ✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷
 //                                   ✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷✷
@@ -756,14 +756,15 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
 
         if (intercepting) {
             amountOutAfterFees = _takeFees(
-                tokenOut,
-                actualAmountOut,
-                expectedAmountOut,
-                amountIn,
-                tokenIn,
-                tokenOut,
-                clientFeeParams.clientFeeBps,
-                client
+                FeeInput({
+                    actualAmountOut: actualAmountOut,
+                    expectedAmountOut: expectedAmountOut,
+                    amountIn: amountIn,
+                    tokenIn: tokenIn,
+                    tokenOut: tokenOut,
+                    clientFeeBps: clientFeeParams.clientFeeBps,
+                    client: client
+                })
             );
         } else {
             amountOutAfterFees = actualAmountOut;
@@ -827,33 +828,36 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
             (expectedAmountOut * (MAX_SLIPPAGE_BPS - maxSlippageBps))
                 / MAX_SLIPPAGE_BPS;
 
-        (address executor, bytes calldata protocolData) =
-            swap_.decodeSingleSwap();
-
         address client = clientFeeParams.clientFeeReceiver;
         bool intercepting = _callMustInterceptOutput(
             _feeCalculator, clientFeeParams.clientFeeBps, client
         );
 
-        uint256 actualAmountOut = _callSwapOnExecutor(
-            executor,
-            amountIn,
-            protocolData,
-            true,
-            false,
-            intercepting ? address(this) : receiver
-        );
+        uint256 actualAmountOut;
+        {
+            (address executor, bytes calldata protocolData) =
+                swap_.decodeSingleSwap();
+            actualAmountOut = _callSwapOnExecutor(
+                executor,
+                amountIn,
+                protocolData,
+                true,
+                false,
+                intercepting ? address(this) : receiver
+            );
+        }
 
         if (intercepting) {
             amountOutAfterFees = _takeFees(
-                tokenOut,
-                actualAmountOut,
-                expectedAmountOut,
-                amountIn,
-                tokenIn,
-                tokenOut,
-                clientFeeParams.clientFeeBps,
-                client
+                FeeInput({
+                    actualAmountOut: actualAmountOut,
+                    expectedAmountOut: expectedAmountOut,
+                    amountIn: amountIn,
+                    tokenIn: tokenIn,
+                    tokenOut: tokenOut,
+                    clientFeeBps: clientFeeParams.clientFeeBps,
+                    client: client
+                })
             );
         } else {
             amountOutAfterFees = actualAmountOut;
@@ -931,14 +935,15 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
 
         if (intercepting) {
             amountOutAfterFees = _takeFees(
-                tokenOut,
-                actualAmountOut,
-                expectedAmountOut,
-                amountIn,
-                tokenIn,
-                tokenOut,
-                clientFeeParams.clientFeeBps,
-                client
+                FeeInput({
+                    actualAmountOut: actualAmountOut,
+                    expectedAmountOut: expectedAmountOut,
+                    amountIn: amountIn,
+                    tokenIn: tokenIn,
+                    tokenOut: tokenOut,
+                    clientFeeBps: clientFeeParams.clientFeeBps,
+                    client: client
+                })
             );
         } else {
             amountOutAfterFees = actualAmountOut;
@@ -1254,38 +1259,16 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
     }
 
     /**
-     * @notice Calculates and takes fees using the FeeCalculator contract
-     * @param token The token address for which fees are being taken
-     * @param actualAmountOut The actual amount received from the swap
-     * @param expectedAmountOut The off-chain quoted amount
-     * @param amountIn The input amount for the swap
-     * @param tokenIn The input token address
-     * @param tokenOut The output token address
-     * @param clientFeeBps Client fee in basis points
-     * @param client Address to receive client fees
-     * @return amountOutAfterFees The amount remaining after all fee deductions
+     * @notice Calculates and takes fees using the FeeCalculator
+     * @param f Fee calculation inputs (amounts, tokens, client)
+     * @return amountOutAfterFees Amount remaining after fee deductions
      */
-    function _takeFees(
-        address token,
-        uint256 actualAmountOut,
-        uint256 expectedAmountOut,
-        uint256 amountIn,
-        address tokenIn,
-        address tokenOut,
-        uint32 clientFeeBps,
-        address client
-    ) internal returns (uint256 amountOutAfterFees) {
-        FeeRecipient[] memory fees = _callCalculateFee(
-            _feeCalculator,
-            actualAmountOut,
-            expectedAmountOut,
-            amountIn,
-            tokenIn,
-            tokenOut,
-            clientFeeBps,
-            client
-        );
-        amountOutAfterFees = actualAmountOut;
+    function _takeFees(FeeInput memory f)
+        internal
+        returns (uint256 amountOutAfterFees)
+    {
+        FeeRecipient[] memory fees = _callCalculateFee(_feeCalculator, f);
+        amountOutAfterFees = f.actualAmountOut;
 
         for (uint256 i = 0; i < fees.length; i++) {
             if (fees[i].feeAmount > 0) {
@@ -1294,13 +1277,15 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
                 // due to incorrect or malicious encoding. Updating the delta
                 // accounting without funds will result in an additional negative
                 // delta, and cause the _finalizeBalances method to revert.
-                _updateDeltaAccounting(token, -int256(fees[i].feeAmount));
-                _creditVaultForFees(fees[i].recipient, token, fees[i].feeAmount);
+                _updateDeltaAccounting(f.tokenOut, -int256(fees[i].feeAmount));
+                _creditVaultForFees(
+                    fees[i].recipient, f.tokenOut, fees[i].feeAmount
+                );
                 amountOutAfterFees -= fees[i].feeAmount;
             }
         }
         if (fees.length > 0) {
-            emit FeesTaken(token, fees);
+            emit FeesTaken(f.tokenOut, fees);
         }
     }
 

--- a/crates/tycho-execution/contracts/src/TychoRouter.sol
+++ b/crates/tycho-execution/contracts/src/TychoRouter.sol
@@ -1342,6 +1342,7 @@ contract TychoRouter is AccessControl, Dispatcher, EIP712 {
                 // output transfer has been performed yet, or the user has specified the
                 // receiver to be the router in order to rebalance their vault.
                 _updateDeltaAccounting(tokenOut, int256(requiredContribution));
+                // slither-disable-next-line incorrect-equality
             } else if (outputDelta == 0) {
                 if (receiver == address(this)) {
                     _creditVault(msg.sender, tokenOut, requiredContribution);

--- a/crates/tycho-execution/contracts/src/Vault.sol
+++ b/crates/tycho-execution/contracts/src/Vault.sol
@@ -271,6 +271,7 @@ abstract contract Vault is ERC6909, ReentrancyGuard, Pausable {
         if (oldDelta != 0 && newDelta == 0) {
             // Was non zero, now zero: decrement counter
             _setNonZeroDeltaCount(_getNonZeroDeltaCount() - 1);
+            // slither-disable-next-line incorrect-equality
         } else if (oldDelta == 0 && newDelta != 0) {
             // Was zero, now non zero: increment counter
             _setNonZeroDeltaCount(_getNonZeroDeltaCount() + 1);
@@ -357,6 +358,7 @@ abstract contract Vault is ERC6909, ReentrancyGuard, Pausable {
                 revert Vault__UnexpectedNonZeroCount(nonZeroCount);
             } else if (nonZeroCount == 1) {
                 int256 inputDelta = _getDelta(inputToken);
+                // slither-disable-next-line incorrect-equality
                 if (inputDelta == 0 || inputDelta != -int256(inputAmount)) {
                     revert Vault__UnexpectedInputDelta(inputDelta);
                 }

--- a/crates/tycho-execution/contracts/test/FeeCalculator.t.sol
+++ b/crates/tycho-execution/contracts/test/FeeCalculator.t.sol
@@ -39,8 +39,9 @@ contract FeeCalculatorTest is Constants {
         uint256 amountIn = 1 ether;
 
         // The client is BOB - he doesn't get any router fee discounts.
-        FeeRecipient[] memory feeRecipients =
-            feeCalculator.calculateFee(amountIn, amountIn, 0, BOB);
+        FeeRecipient[] memory feeRecipients = feeCalculator.calculateFee(
+            amountIn, amountIn, 0, address(0), address(0), 0, BOB
+        );
         uint256 amountOut = amountIn - _sumFees(feeRecipients);
 
         // routerFeeOnOutput = 1 ether * 1_000_000 / 100_000_000 = 0.01 ether
@@ -63,8 +64,9 @@ contract FeeCalculatorTest is Constants {
         uint256 amountIn = 1 ether;
         uint32 clientFeeBps = 2_000_000; // 2%
 
-        FeeRecipient[] memory feeRecipients =
-            feeCalculator.calculateFee(amountIn, amountIn, clientFeeBps, BOB);
+        FeeRecipient[] memory feeRecipients = feeCalculator.calculateFee(
+            amountIn, amountIn, 0, address(0), address(0), clientFeeBps, BOB
+        );
         uint256 amountOut = amountIn - _sumFees(feeRecipients);
 
         // clientFee = 1 ether * 2_000_000 / 100_000_000 = 0.02 ether
@@ -91,16 +93,18 @@ contract FeeCalculatorTest is Constants {
         uint256 amountIn = 1 ether;
 
         // ALICE should get default fee
-        FeeRecipient[] memory feeRecipientsAlice =
-            feeCalculator.calculateFee(amountIn, amountIn, 0, ALICE);
+        FeeRecipient[] memory feeRecipientsAlice = feeCalculator.calculateFee(
+            amountIn, amountIn, 0, address(0), address(0), 0, ALICE
+        );
         uint256 amountOutAlice = amountIn - _sumFees(feeRecipientsAlice);
         assertEq(amountOutAlice, 0.99 ether);
         // Router fee
         assertEq(feeRecipientsAlice[0].feeAmount, 0.01 ether);
 
         // BOB should get custom fee
-        FeeRecipient[] memory feeRecipientsBob =
-            feeCalculator.calculateFee(amountIn, amountIn, 0, BOB);
+        FeeRecipient[] memory feeRecipientsBob = feeCalculator.calculateFee(
+            amountIn, amountIn, 0, address(0), address(0), 0, BOB
+        );
         uint256 amountOutBob = amountIn - _sumFees(feeRecipientsBob);
         assertEq(amountOutBob, 0.995 ether); // 0.5% fee
         // Router fee
@@ -111,8 +115,9 @@ contract FeeCalculatorTest is Constants {
         // No fees set, should return full amount
         uint256 amountIn = 1 ether;
 
-        FeeRecipient[] memory feeRecipients =
-            feeCalculator.calculateFee(amountIn, amountIn, 0, ALICE);
+        FeeRecipient[] memory feeRecipients = feeCalculator.calculateFee(
+            amountIn, amountIn, 0, address(0), address(0), 0, ALICE
+        );
         uint256 amountOut = amountIn - _sumFees(feeRecipients);
 
         assertEq(amountOut, 1 ether);
@@ -130,8 +135,9 @@ contract FeeCalculatorTest is Constants {
         uint32 clientFeeBps = 1_500_000; // 1.5%
 
         // BOB is the client - but there are no router fees to overwrite with custom client fees
-        FeeRecipient[] memory feeRecipients =
-            feeCalculator.calculateFee(amountIn, amountIn, clientFeeBps, BOB);
+        FeeRecipient[] memory feeRecipients = feeCalculator.calculateFee(
+            amountIn, amountIn, 0, address(0), address(0), clientFeeBps, BOB
+        );
         uint256 amountOut = amountIn - _sumFees(feeRecipients);
 
         // clientFee = 1 ether * 1_500_000 / 100_000_000 = 0.015 ether
@@ -154,8 +160,9 @@ contract FeeCalculatorTest is Constants {
         uint256 amountIn = 1 ether;
         uint32 clientFeeBps = 2_000_000; // 2%
 
-        FeeRecipient[] memory feeRecipients =
-            feeCalculator.calculateFee(amountIn, amountIn, clientFeeBps, BOB);
+        FeeRecipient[] memory feeRecipients = feeCalculator.calculateFee(
+            amountIn, amountIn, 0, address(0), address(0), clientFeeBps, BOB
+        );
         uint256 amountOut = amountIn - _sumFees(feeRecipients);
 
         // 1. clientFee = 1 ether * 2_000_000 / 100_000_000 = 0.02 ether
@@ -184,7 +191,9 @@ contract FeeCalculatorTest is Constants {
         vm.expectRevert(
             abi.encodeWithSelector(FeeCalculator__FeeTooHigh.selector)
         );
-        feeCalculator.calculateFee(amountIn, amountIn, clientFeeBps, BOB);
+        feeCalculator.calculateFee(
+            amountIn, amountIn, 0, address(0), address(0), clientFeeBps, BOB
+        );
     }
 
     function testCalculateRouterFeeOnClientFeeTooHigh() public {
@@ -205,8 +214,9 @@ contract FeeCalculatorTest is Constants {
 
         uint256 amountIn = 1 ether;
 
-        FeeRecipient[] memory feeRecipients =
-            feeCalculator.calculateFee(amountIn, amountIn, 0, ALICE);
+        FeeRecipient[] memory feeRecipients = feeCalculator.calculateFee(
+            amountIn, amountIn, 0, address(0), address(0), 0, ALICE
+        );
 
         // Router fee
         assertEq(feeRecipients[0].recipient, BOB);
@@ -224,8 +234,9 @@ contract FeeCalculatorTest is Constants {
         uint32 clientFeeBps = 2_000_000; // 2%
 
         // ALICE should get custom router fee on client fee (5%)
-        FeeRecipient[] memory feeRecipientsAlice =
-            feeCalculator.calculateFee(amountIn, amountIn, clientFeeBps, ALICE);
+        FeeRecipient[] memory feeRecipientsAlice = feeCalculator.calculateFee(
+            amountIn, amountIn, 0, address(0), address(0), clientFeeBps, ALICE
+        );
         uint256 amountOutAlice = amountIn - _sumFees(feeRecipientsAlice);
 
         // routerFeeOnClientFee = 0.02 * 5% = 0.001 ether
@@ -241,8 +252,9 @@ contract FeeCalculatorTest is Constants {
         );
 
         // BOB should get default router fee on client fee (10%)
-        FeeRecipient[] memory feeRecipientsBob =
-            feeCalculator.calculateFee(amountIn, amountIn, clientFeeBps, BOB);
+        FeeRecipient[] memory feeRecipientsBob = feeCalculator.calculateFee(
+            amountIn, amountIn, 0, address(0), address(0), clientFeeBps, BOB
+        );
         uint256 amountOutBob = amountIn - _sumFees(feeRecipientsBob);
 
         // routerFeeOnClientFee = 0.02 * 10% = 0.002 ether
@@ -270,8 +282,9 @@ contract FeeCalculatorTest is Constants {
         uint256 amountIn = 1 ether;
         uint32 clientFeeBps = 2_000_000; // 2%
 
-        FeeRecipient[] memory feeRecipients =
-            feeCalculator.calculateFee(amountIn, amountIn, clientFeeBps, ALICE);
+        FeeRecipient[] memory feeRecipients = feeCalculator.calculateFee(
+            amountIn, amountIn, 0, address(0), address(0), clientFeeBps, ALICE
+        );
         uint256 amountOut = amountIn - _sumFees(feeRecipients);
 
         // 1. clientFee = 1 ether * 2_000_000 / 100_000_000 = 0.02 ether
@@ -296,8 +309,9 @@ contract FeeCalculatorTest is Constants {
 
         uint256 amountIn = 1 ether;
 
-        FeeRecipient[] memory feeRecipients =
-            feeCalculator.calculateFee(amountIn, amountIn, 0, BOB);
+        FeeRecipient[] memory feeRecipients = feeCalculator.calculateFee(
+            amountIn, amountIn, 0, address(0), address(0), 0, BOB
+        );
         uint256 amountOut = amountIn - _sumFees(feeRecipients);
 
         // routerFeeOnOutput = 1 ether * 15_000 / 100_000_000 = 0.00015 ether
@@ -314,8 +328,9 @@ contract FeeCalculatorTest is Constants {
 
         // Call with client=address(0) and tx.origin=ALICE
         vm.prank(address(this), ALICE);
-        FeeRecipient[] memory fees =
-            feeCalculator.calculateFee(amountIn, amountIn, 0, address(0));
+        FeeRecipient[] memory fees = feeCalculator.calculateFee(
+            amountIn, amountIn, 0, address(0), address(0), 0, address(0)
+        );
         uint256 amountOut = amountIn - _sumFees(fees);
 
         // ALICE's 1% custom fee should be applied
@@ -335,8 +350,9 @@ contract FeeCalculatorTest is Constants {
 
         // Call with client=BOB (no custom fee), tx.origin=ALICE
         vm.prank(address(this), ALICE);
-        FeeRecipient[] memory fees =
-            feeCalculator.calculateFee(amountIn, amountIn, 0, BOB);
+        FeeRecipient[] memory fees = feeCalculator.calculateFee(
+            amountIn, amountIn, 0, address(0), address(0), 0, BOB
+        );
         uint256 amountOut = amountIn - _sumFees(fees);
 
         // Default 5% fee is applied for BOB — ALICE's 1% custom fee is ignored
@@ -813,7 +829,13 @@ contract FeeCalculatorSlippageTest is Constants {
         uint256 expectedAmountOut = 1 ether;
 
         FeeRecipient[] memory fees = feeCalculator.calculateFee(
-            actualAmountOut, expectedAmountOut, 0, BOB
+            actualAmountOut,
+            expectedAmountOut,
+            0,
+            address(0),
+            address(0),
+            0,
+            BOB
         );
 
         // surplus = 0.1 ether, all to router
@@ -831,7 +853,13 @@ contract FeeCalculatorSlippageTest is Constants {
         uint256 expectedAmountOut = 1 ether;
 
         FeeRecipient[] memory fees = feeCalculator.calculateFee(
-            actualAmountOut, expectedAmountOut, 0, BOB
+            actualAmountOut,
+            expectedAmountOut,
+            0,
+            address(0),
+            address(0),
+            0,
+            BOB
         );
 
         // surplus = 0.1 ether, 50% each
@@ -851,7 +879,13 @@ contract FeeCalculatorSlippageTest is Constants {
         uint256 expectedAmountOut = 1 ether;
 
         FeeRecipient[] memory fees = feeCalculator.calculateFee(
-            actualAmountOut, expectedAmountOut, 0, BOB
+            actualAmountOut,
+            expectedAmountOut,
+            0,
+            address(0),
+            address(0),
+            0,
+            BOB
         );
 
         // surplus = 0.1 ether, BOB gets 80% custom share
@@ -872,7 +906,13 @@ contract FeeCalculatorSlippageTest is Constants {
         uint256 expectedAmountOut = 1 ether;
 
         FeeRecipient[] memory fees = feeCalculator.calculateFee(
-            actualAmountOut, expectedAmountOut, 0, BOB
+            actualAmountOut,
+            expectedAmountOut,
+            0,
+            address(0),
+            address(0),
+            0,
+            BOB
         );
 
         // After removal, falls back to default 20%
@@ -904,7 +944,13 @@ contract FeeCalculatorSlippageTest is Constants {
         uint256 expectedAmountOut = 1 ether;
 
         FeeRecipient[] memory fees = feeCalculator.calculateFee(
-            actualAmountOut, expectedAmountOut, 0, BOB
+            actualAmountOut,
+            expectedAmountOut,
+            0,
+            address(0),
+            address(0),
+            0,
+            BOB
         );
 
         // No surplus, but router fee on output still applies
@@ -923,7 +969,13 @@ contract FeeCalculatorSlippageTest is Constants {
         uint256 expectedAmountOut = 1 ether;
 
         FeeRecipient[] memory fees = feeCalculator.calculateFee(
-            actualAmountOut, expectedAmountOut, 0, BOB
+            actualAmountOut,
+            expectedAmountOut,
+            0,
+            address(0),
+            address(0),
+            0,
+            BOB
         );
 
         // surplus = 0.1 ether, split 50/50 → router 0.05, BOB 0.05
@@ -942,8 +994,9 @@ contract FeeCalculatorSlippageTest is Constants {
 
         uint256 amount = 1 ether;
 
-        FeeRecipient[] memory fees =
-            feeCalculator.calculateFee(amount, amount, 0, BOB);
+        FeeRecipient[] memory fees = feeCalculator.calculateFee(
+            amount, amount, 0, address(0), address(0), 0, BOB
+        );
 
         // No surplus, but router fee on output still applies
         assertEq(fees[0].feeAmount, 0.01 ether);

--- a/crates/tycho-execution/contracts/test/FeeCalculator.t.sol
+++ b/crates/tycho-execution/contracts/test/FeeCalculator.t.sol
@@ -36,13 +36,21 @@ contract FeeCalculatorTest is Constants {
         feeCalculator.setRouterFeeOnOutput(_1_PCT); // 1%
         vm.stopPrank();
 
-        uint256 amountIn = 1 ether;
+        uint256 amountIn = 0.5 ether;
+        uint256 actualAmountOut = 1 ether;
+        uint256 expectedAmountOut = 1 ether;
 
         // The client is BOB - he doesn't get any router fee discounts.
         FeeRecipient[] memory feeRecipients = feeCalculator.calculateFee(
-            amountIn, amountIn, 0, address(0), address(0), 0, BOB
+            actualAmountOut,
+            expectedAmountOut,
+            amountIn,
+            address(0),
+            address(0),
+            0,
+            BOB
         );
-        uint256 amountOut = amountIn - _sumFees(feeRecipients);
+        uint256 amountOut = actualAmountOut - _sumFees(feeRecipients);
 
         // routerFeeOnOutput = 1 ether * 1_000_000 / 100_000_000 = 0.01 ether
         // amountOut = 1 ether - 0.01 ether = 0.99 ether
@@ -61,13 +69,21 @@ contract FeeCalculatorTest is Constants {
         vm.prank(FEE_SETTER);
         feeCalculator.setRouterFeeOnClientFee(_10_PCT); // 10% of client fee
 
-        uint256 amountIn = 1 ether;
+        uint256 amountIn = 0.5 ether;
+        uint256 actualAmountOut = 1 ether;
+        uint256 expectedAmountOut = 1 ether;
         uint32 clientFeeBps = 2_000_000; // 2%
 
         FeeRecipient[] memory feeRecipients = feeCalculator.calculateFee(
-            amountIn, amountIn, 0, address(0), address(0), clientFeeBps, BOB
+            actualAmountOut,
+            expectedAmountOut,
+            amountIn,
+            address(0),
+            address(0),
+            clientFeeBps,
+            BOB
         );
-        uint256 amountOut = amountIn - _sumFees(feeRecipients);
+        uint256 amountOut = actualAmountOut - _sumFees(feeRecipients);
 
         // clientFee = 1 ether * 2_000_000 / 100_000_000 = 0.02 ether
         // routerFeeOnClientFee = 0.02 ether * 10% = 0.002 ether
@@ -90,22 +106,36 @@ contract FeeCalculatorTest is Constants {
         feeCalculator.setCustomRouterFeeOnOutput(BOB, _HALF_PCT); // 0.5%
         vm.stopPrank();
 
-        uint256 amountIn = 1 ether;
+        uint256 amountIn = 0.5 ether;
+        uint256 actualAmountOut = 1 ether;
+        uint256 expectedAmountOut = 1 ether;
 
         // ALICE should get default fee
         FeeRecipient[] memory feeRecipientsAlice = feeCalculator.calculateFee(
-            amountIn, amountIn, 0, address(0), address(0), 0, ALICE
+            actualAmountOut,
+            expectedAmountOut,
+            amountIn,
+            address(0),
+            address(0),
+            0,
+            ALICE
         );
-        uint256 amountOutAlice = amountIn - _sumFees(feeRecipientsAlice);
+        uint256 amountOutAlice = actualAmountOut - _sumFees(feeRecipientsAlice);
         assertEq(amountOutAlice, 0.99 ether);
         // Router fee
         assertEq(feeRecipientsAlice[0].feeAmount, 0.01 ether);
 
         // BOB should get custom fee
         FeeRecipient[] memory feeRecipientsBob = feeCalculator.calculateFee(
-            amountIn, amountIn, 0, address(0), address(0), 0, BOB
+            actualAmountOut,
+            expectedAmountOut,
+            amountIn,
+            address(0),
+            address(0),
+            0,
+            BOB
         );
-        uint256 amountOutBob = amountIn - _sumFees(feeRecipientsBob);
+        uint256 amountOutBob = actualAmountOut - _sumFees(feeRecipientsBob);
         assertEq(amountOutBob, 0.995 ether); // 0.5% fee
         // Router fee
         assertEq(feeRecipientsBob[0].feeAmount, 0.005 ether);
@@ -113,12 +143,20 @@ contract FeeCalculatorTest is Constants {
 
     function testCalculateNoFeesSet() public view {
         // No fees set, should return full amount
-        uint256 amountIn = 1 ether;
+        uint256 amountIn = 0.5 ether;
+        uint256 actualAmountOut = 1 ether;
+        uint256 expectedAmountOut = 1 ether;
 
         FeeRecipient[] memory feeRecipients = feeCalculator.calculateFee(
-            amountIn, amountIn, 0, address(0), address(0), 0, ALICE
+            actualAmountOut,
+            expectedAmountOut,
+            amountIn,
+            address(0),
+            address(0),
+            0,
+            ALICE
         );
-        uint256 amountOut = amountIn - _sumFees(feeRecipients);
+        uint256 amountOut = actualAmountOut - _sumFees(feeRecipients);
 
         assertEq(amountOut, 1 ether);
         // Router fee
@@ -131,14 +169,22 @@ contract FeeCalculatorTest is Constants {
 
     function testCalculateOnlyClientFee() public view {
         // Test with only client fee set, no router fees
-        uint256 amountIn = 1 ether;
+        uint256 amountIn = 0.5 ether;
+        uint256 actualAmountOut = 1 ether;
+        uint256 expectedAmountOut = 1 ether;
         uint32 clientFeeBps = 1_500_000; // 1.5%
 
         // BOB is the client - but there are no router fees to overwrite with custom client fees
         FeeRecipient[] memory feeRecipients = feeCalculator.calculateFee(
-            amountIn, amountIn, 0, address(0), address(0), clientFeeBps, BOB
+            actualAmountOut,
+            expectedAmountOut,
+            amountIn,
+            address(0),
+            address(0),
+            clientFeeBps,
+            BOB
         );
-        uint256 amountOut = amountIn - _sumFees(feeRecipients);
+        uint256 amountOut = actualAmountOut - _sumFees(feeRecipients);
 
         // clientFee = 1 ether * 1_500_000 / 100_000_000 = 0.015 ether
         // amountOut = 1 ether - 0.015 ether = 0.985 ether
@@ -157,13 +203,21 @@ contract FeeCalculatorTest is Constants {
         feeCalculator.setRouterFeeOnClientFee(_5_PCT); // 5% of client fee
         vm.stopPrank();
 
-        uint256 amountIn = 1 ether;
+        uint256 amountIn = 0.5 ether;
+        uint256 actualAmountOut = 1 ether;
+        uint256 expectedAmountOut = 1 ether;
         uint32 clientFeeBps = 2_000_000; // 2%
 
         FeeRecipient[] memory feeRecipients = feeCalculator.calculateFee(
-            amountIn, amountIn, 0, address(0), address(0), clientFeeBps, BOB
+            actualAmountOut,
+            expectedAmountOut,
+            amountIn,
+            address(0),
+            address(0),
+            clientFeeBps,
+            BOB
         );
-        uint256 amountOut = amountIn - _sumFees(feeRecipients);
+        uint256 amountOut = actualAmountOut - _sumFees(feeRecipients);
 
         // 1. clientFee = 1 ether * 2_000_000 / 100_000_000 = 0.02 ether
         //    routerFeeOnClientFee = 0.02 ether * 5% = 0.001 ether
@@ -185,14 +239,22 @@ contract FeeCalculatorTest is Constants {
         vm.prank(FEE_SETTER);
         feeCalculator.setRouterFeeOnOutput(_50_PCT); // 50%
 
-        uint256 amountIn = 1 ether;
+        uint256 amountIn = 0.5 ether;
+        uint256 actualAmountOut = 1 ether;
+        uint256 expectedAmountOut = 1 ether;
         uint32 clientFeeBps = 50_010_000; // 50.01% — combined makes 100.01%
 
         vm.expectRevert(
             abi.encodeWithSelector(FeeCalculator__FeeTooHigh.selector)
         );
         feeCalculator.calculateFee(
-            amountIn, amountIn, 0, address(0), address(0), clientFeeBps, BOB
+            actualAmountOut,
+            expectedAmountOut,
+            amountIn,
+            address(0),
+            address(0),
+            clientFeeBps,
+            BOB
         );
     }
 
@@ -212,10 +274,18 @@ contract FeeCalculatorTest is Constants {
         feeCalculator.setRouterFeeOnOutput(_1_PCT); // 1%
         vm.stopPrank();
 
-        uint256 amountIn = 1 ether;
+        uint256 amountIn = 0.5 ether;
+        uint256 actualAmountOut = 1 ether;
+        uint256 expectedAmountOut = 1 ether;
 
         FeeRecipient[] memory feeRecipients = feeCalculator.calculateFee(
-            amountIn, amountIn, 0, address(0), address(0), 0, ALICE
+            actualAmountOut,
+            expectedAmountOut,
+            amountIn,
+            address(0),
+            address(0),
+            0,
+            ALICE
         );
 
         // Router fee
@@ -230,14 +300,22 @@ contract FeeCalculatorTest is Constants {
         feeCalculator.setCustomRouterFeeOnClientFee(ALICE, _5_PCT); // 5% custom for ALICE
         vm.stopPrank();
 
-        uint256 amountIn = 1 ether;
+        uint256 amountIn = 0.5 ether;
+        uint256 actualAmountOut = 1 ether;
+        uint256 expectedAmountOut = 1 ether;
         uint32 clientFeeBps = 2_000_000; // 2%
 
         // ALICE should get custom router fee on client fee (5%)
         FeeRecipient[] memory feeRecipientsAlice = feeCalculator.calculateFee(
-            amountIn, amountIn, 0, address(0), address(0), clientFeeBps, ALICE
+            actualAmountOut,
+            expectedAmountOut,
+            amountIn,
+            address(0),
+            address(0),
+            clientFeeBps,
+            ALICE
         );
-        uint256 amountOutAlice = amountIn - _sumFees(feeRecipientsAlice);
+        uint256 amountOutAlice = actualAmountOut - _sumFees(feeRecipientsAlice);
 
         // routerFeeOnClientFee = 0.02 * 5% = 0.001 ether
         assertEq(amountOutAlice, 0.98 ether); // 1 - 0.02 client fee
@@ -253,9 +331,15 @@ contract FeeCalculatorTest is Constants {
 
         // BOB should get default router fee on client fee (10%)
         FeeRecipient[] memory feeRecipientsBob = feeCalculator.calculateFee(
-            amountIn, amountIn, 0, address(0), address(0), clientFeeBps, BOB
+            actualAmountOut,
+            expectedAmountOut,
+            amountIn,
+            address(0),
+            address(0),
+            clientFeeBps,
+            BOB
         );
-        uint256 amountOutBob = amountIn - _sumFees(feeRecipientsBob);
+        uint256 amountOutBob = actualAmountOut - _sumFees(feeRecipientsBob);
 
         // routerFeeOnClientFee = 0.02 * 10% = 0.002 ether
         assertEq(amountOutBob, 0.98 ether); // 1 - 0.02 client fee
@@ -279,13 +363,21 @@ contract FeeCalculatorTest is Constants {
         feeCalculator.setCustomRouterFeeOnClientFee(ALICE, _5_PCT); // 5% custom
         vm.stopPrank();
 
-        uint256 amountIn = 1 ether;
+        uint256 amountIn = 0.5 ether;
+        uint256 actualAmountOut = 1 ether;
+        uint256 expectedAmountOut = 1 ether;
         uint32 clientFeeBps = 2_000_000; // 2%
 
         FeeRecipient[] memory feeRecipients = feeCalculator.calculateFee(
-            amountIn, amountIn, 0, address(0), address(0), clientFeeBps, ALICE
+            actualAmountOut,
+            expectedAmountOut,
+            amountIn,
+            address(0),
+            address(0),
+            clientFeeBps,
+            ALICE
         );
-        uint256 amountOut = amountIn - _sumFees(feeRecipients);
+        uint256 amountOut = actualAmountOut - _sumFees(feeRecipients);
 
         // 1. clientFee = 1 ether * 2_000_000 / 100_000_000 = 0.02 ether
         //    routerFeeOnClientFee = 0.02 * 5% (custom) = 0.001 ether
@@ -307,12 +399,20 @@ contract FeeCalculatorTest is Constants {
         vm.prank(FEE_SETTER);
         feeCalculator.setRouterFeeOnOutput(15_000); // 1.5 BPS = 0.015%
 
-        uint256 amountIn = 1 ether;
+        uint256 amountIn = 0.5 ether;
+        uint256 actualAmountOut = 1 ether;
+        uint256 expectedAmountOut = 1 ether;
 
         FeeRecipient[] memory feeRecipients = feeCalculator.calculateFee(
-            amountIn, amountIn, 0, address(0), address(0), 0, BOB
+            actualAmountOut,
+            expectedAmountOut,
+            amountIn,
+            address(0),
+            address(0),
+            0,
+            BOB
         );
-        uint256 amountOut = amountIn - _sumFees(feeRecipients);
+        uint256 amountOut = actualAmountOut - _sumFees(feeRecipients);
 
         // routerFeeOnOutput = 1 ether * 15_000 / 100_000_000 = 0.00015 ether
         assertEq(amountOut, 1 ether - 0.00015 ether);
@@ -324,14 +424,22 @@ contract FeeCalculatorTest is Constants {
         vm.prank(FEE_SETTER);
         feeCalculator.setCustomRouterFeeOnOutput(ALICE, _1_PCT);
 
-        uint256 amountIn = 1 ether;
+        uint256 amountIn = 0.5 ether;
+        uint256 actualAmountOut = 1 ether;
+        uint256 expectedAmountOut = 1 ether;
 
         // Call with client=address(0) and tx.origin=ALICE
         vm.prank(address(this), ALICE);
         FeeRecipient[] memory fees = feeCalculator.calculateFee(
-            amountIn, amountIn, 0, address(0), address(0), 0, address(0)
+            actualAmountOut,
+            expectedAmountOut,
+            amountIn,
+            address(0),
+            address(0),
+            0,
+            address(0)
         );
-        uint256 amountOut = amountIn - _sumFees(fees);
+        uint256 amountOut = actualAmountOut - _sumFees(fees);
 
         // ALICE's 1% custom fee should be applied
         assertEq(fees[0].feeAmount, 0.01 ether);
@@ -346,14 +454,22 @@ contract FeeCalculatorTest is Constants {
         feeCalculator.setCustomRouterFeeOnOutput(ALICE, _1_PCT);
         vm.stopPrank();
 
-        uint256 amountIn = 1 ether;
+        uint256 amountIn = 0.5 ether;
+        uint256 actualAmountOut = 1 ether;
+        uint256 expectedAmountOut = 1 ether;
 
         // Call with client=BOB (no custom fee), tx.origin=ALICE
         vm.prank(address(this), ALICE);
         FeeRecipient[] memory fees = feeCalculator.calculateFee(
-            amountIn, amountIn, 0, address(0), address(0), 0, BOB
+            actualAmountOut,
+            expectedAmountOut,
+            amountIn,
+            address(0),
+            address(0),
+            0,
+            BOB
         );
-        uint256 amountOut = amountIn - _sumFees(fees);
+        uint256 amountOut = actualAmountOut - _sumFees(fees);
 
         // Default 5% fee is applied for BOB — ALICE's 1% custom fee is ignored
         // fee = 1 ether * 5_000_000 / 100_000_000 = 0.05 ether

--- a/crates/tycho-execution/model/src/model/fee_calculator.rs
+++ b/crates/tycho-execution/model/src/model/fee_calculator.rs
@@ -74,6 +74,9 @@ pub fn calculate_fee(
     actual_amount_out: i64,
     expected_amount_out: i64,
     client_fee_bps: i64,
+    _token_in: Address,
+    _token_out: Address,
+    _amount_in: i64,
 ) -> Result<Vec<FeeRecipient>, Error> {
     let fee_info = _get_fee_info(params)?;
 

--- a/crates/tycho-execution/model/src/model/tycho_router.rs
+++ b/crates/tycho-execution/model/src/model/tycho_router.rs
@@ -752,7 +752,15 @@ fn _take_fees(
     expected_amount_out: i64,
     client_fee_bps: i64,
 ) -> Result<i64, Error> {
-    let fees = calculate_fee(params, actual_amount_out, expected_amount_out, client_fee_bps)?;
+    let fees = calculate_fee(
+        params,
+        actual_amount_out,
+        expected_amount_out,
+        client_fee_bps,
+        Address::Zero,
+        Address::Zero,
+        0,
+    )?;
 
     let mut total_fees = 0i64;
     for fee in &fees {


### PR DESCRIPTION
[Task](https://propeller-heads.atlassian.net/browse/ENG-6171)

This PR updates the fee calculation interfaces to accept `amountIn`, `tokenIn`, and `tokenOut`.

Implemented:
* Updated `IFeeCalculator.calculateFee` signature.
* Updated `FeeCalculator.sol` implementation.
* Updated `Dispatcher._callCalculateFee` to accept and forward the new parameters.
* Updated the Rust fee calculator model signature with unused stub parameters.
* Updated `FeeCalculator.t.sol` call sites.
* Updated `_takeFees` to accept and forward the new parameters
