### PR TITLE
fix: retry on lagging RPC in integration test validation

### DIFF
--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -46,6 +46,7 @@ use tycho_test::{
         models::{TychoExecutionInput, TychoExecutionResult},
         simulate_swap_transaction, tenderly,
     },
+    is_block_not_found,
     token_prices::{cap_amount_to_eth_value, load_token_prices},
     validation::{batch_validate_components, get_validator, Validator},
 };
@@ -900,6 +901,17 @@ async fn process_update(
                     }
                 }
                 Err(e) => {
+                    if is_block_not_found(&e.to_string()) {
+                        // The RPC node still lags behind Tycho after the batch-validation retries
+                        // exhausted: the block genuinely isn't available yet. This is infra
+                        // latency, not a state mismatch, so skip it rather than polluting the
+                        // validation-failure metric.
+                        warn!(
+                            component_id = %component_id,
+                            "Skipping validation: RPC block not yet available after retries"
+                        );
+                        continue;
+                    }
                     error!(
                         component_id = %component_id,
                         error = %e,

--- a/crates/tycho-test/src/lib.rs
+++ b/crates/tycho-test/src/lib.rs
@@ -4,6 +4,40 @@ pub mod token_prices;
 pub mod validation;
 pub use rpc_tools::RPCTools;
 
-pub(crate) fn is_block_not_found(msg: &str) -> bool {
-    msg.contains("header not found") || (msg.contains("block #") && msg.contains("not found"))
+/// Returns true if an RPC error indicates the queried block is not yet available on the node,
+/// i.e. the node lags behind Tycho. Providers phrase this differently: geth returns
+/// "header not found", others return "block not found" (optionally suffixed with the block, e.g.
+/// Base's `error code -32001: block not found: 0x...`) or "block #<n> not found".
+pub fn is_block_not_found(msg: &str) -> bool {
+    let msg = msg.to_lowercase();
+    msg.contains("header not found") ||
+        msg.contains("block not found") ||
+        (msg.contains("block #") && msg.contains("not found"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_block_not_found;
+
+    #[test]
+    fn detects_block_not_found_variants() {
+        // Base / load-balanced endpoints (JSON-RPC error code -32001)
+        assert!(is_block_not_found(
+            "getReserves call reverted: Call reverted: server returned an error response: \
+             error code -32001: block not found: 0x2dd647d"
+        ));
+        // geth
+        assert!(is_block_not_found("header not found"));
+        // block-number phrasing
+        assert!(is_block_not_found("block #12345 not found"));
+        // case-insensitive
+        assert!(is_block_not_found("Block Not Found"));
+    }
+
+    #[test]
+    fn ignores_genuine_reverts() {
+        assert!(!is_block_not_found("execution reverted"));
+        assert!(!is_block_not_found("TychoRouter__NegativeSlippage(1000, 990)"));
+        assert!(!is_block_not_found("UniswapV2: K"));
+    }
 }

--- a/crates/tycho-test/src/validation.rs
+++ b/crates/tycho-test/src/validation.rs
@@ -207,10 +207,12 @@ pub async fn batch_validate_components(
         // All calls in the batch share one block_id against one backend, so a lagging node fails
         // them all with "block not found". Retry the whole batch — a fresh client each attempt may
         // hit an already-synced backend — rather than recording spurious validation failures.
-        let block_lagging = results.iter().any(|result| match result {
-            Err(e) => crate::is_block_not_found(&e.to_string()),
-            Ok(_) => false,
-        });
+        let block_lagging = results
+            .iter()
+            .any(|result| match result {
+                Err(e) => crate::is_block_not_found(&e.to_string()),
+                Ok(_) => false,
+            });
 
         if !block_lagging || attempt >= BLOCK_NOT_FOUND_MAX_RETRIES {
             return results;

--- a/crates/tycho-test/src/validation.rs
+++ b/crates/tycho-test/src/validation.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
 use alloy::{
     hex,
@@ -170,9 +170,18 @@ pub trait Validator: ProtocolSim {
     ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>>;
 }
 
-/// Batch validation for multiple components across any protocol types
+/// Maximum number of times the whole validation batch is retried when the RPC reports the queried
+/// block is not yet available. The node can lag behind Tycho (especially on fast chains like Base),
+/// and load-balanced endpoints may route a retry to a backend that has already synced the block.
+/// Matches the swap-simulation retry budget (~100s worst case).
+const BLOCK_NOT_FOUND_MAX_RETRIES: u32 = 20;
+
+/// Batch validation for multiple components across any protocol types.
 ///
-/// This function validates multiple components in a single batched RPC request.
+/// Validates multiple components in a single batched RPC request. When the RPC reports the queried
+/// block is not yet available (the node lags behind Tycho), the whole batch is retried with
+/// exponential backoff up to [`BLOCK_NOT_FOUND_MAX_RETRIES`] times rather than surfacing spurious
+/// validation failures.
 ///
 /// # Arguments
 ///
@@ -186,6 +195,34 @@ pub trait Validator: ProtocolSim {
 /// Each result is `Ok(true)` if validation passed, `Ok(false)` if it failed,
 /// or `Err` if there was an error.
 pub async fn batch_validate_components(
+    rpc_url: &str,
+    components: &[(&dyn Validator, ComponentId)],
+    block_id: BlockId,
+) -> Vec<Result<bool, Box<dyn std::error::Error + Send + Sync>>> {
+    let mut backoff = Duration::from_millis(1000);
+    let mut attempt = 0;
+    loop {
+        let results = validate_batch_once(rpc_url, components, block_id).await;
+
+        // All calls in the batch share one block_id against one backend, so a lagging node fails
+        // them all with "block not found". Retry the whole batch — a fresh client each attempt may
+        // hit an already-synced backend — rather than recording spurious validation failures.
+        let block_lagging = results.iter().any(|result| match result {
+            Err(e) => crate::is_block_not_found(&e.to_string()),
+            Ok(_) => false,
+        });
+
+        if !block_lagging || attempt >= BLOCK_NOT_FOUND_MAX_RETRIES {
+            return results;
+        }
+
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(Duration::from_secs(5));
+        attempt += 1;
+    }
+}
+
+async fn validate_batch_once(
     rpc_url: &str,
     components: &[(&dyn Validator, ComponentId)],
     block_id: BlockId,


### PR DESCRIPTION
On fast chains like Base, Tycho often delivers a block before the RPC node has caught up. The node then rejects calls for that block as "block not found". Our integration test was treating these lagging-node errors as real problems, which tanked the execution-success and validation-success rates across all protocols and set off the alerts (both dev and prod).

## What already existed

A `block-not-found` retry was added a while back for the swap-simulation path (originally for Arbitrum). It recognizes the lagging-node error, converts it into a retry, and backs off exponentially (1s doubling to a 5s cap, ~20 attempts). That machinery was working — for the error formats it knew about.

## Why it still failed on Base

The detection only matched the phrasings seen on other chains ("header not found", "block #N not found"). Base returns a different string ("block not found: 0x..."), which the check didn't recognize. So on Base the existing swap-sim retry silently never fired, and every lagging-node call fell through to a revert metric.

Separately, the state-validation path had no retry at all — it went straight to recording a validation failure.

## What this PR adds

- Broadens the lagging-node detection to also match Base's error format (this is what actually re-arms the existing swap-sim retry on Base).
- Adds a retry with the same backoff budget to the state-validation path, which previously had none.
- Skips (rather than counts as a failure) any validation call that still can't find the block after retries — that's node lag, not a state mismatch.

The metrics now reflect actual simulation and validation accuracy rather than transient node lag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)