### PR TITLE
fix(token-analysis): honor min_balance in TokenOwnerStore::find_owner

### DIFF
--- a/crates/tycho-common/src/models/token.rs
+++ b/crates/tycho-common/src/models/token.rs
@@ -166,9 +166,16 @@ impl TokenOwnerFinding for TokenOwnerStore {
     async fn find_owner(
         &self,
         token: Address,
-        _min_balance: Balance,
+        min_balance: Balance,
     ) -> Result<Option<(Address, Balance)>, String> {
-        Ok(self.values.get(&token).cloned())
+        Ok(self
+            .values
+            .get(&token)
+            .filter(|(_, balance)| {
+                BigUint::from_bytes_be(balance.as_ref()) >=
+                    BigUint::from_bytes_be(min_balance.as_ref())
+            })
+            .cloned())
     }
 }
 
@@ -245,5 +252,50 @@ mod tests {
         );
 
         assert_eq!(usdc.one(), BigUint::from(1000000u64));
+    }
+
+    #[tokio::test]
+    async fn test_find_owner_respects_min_balance() {
+        let token = Bytes::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap();
+        let owner = Bytes::from_str("0x1111111111111111111111111111111111111111").unwrap();
+        // Owner holds 1000 (unsigned big-endian).
+        let store = TokenOwnerStore::new(HashMap::from([(
+            token.clone(),
+            (owner.clone(), Bytes::from(1_000u64)),
+        )]));
+
+        // Below the requested minimum -> no adequate owner.
+        assert_eq!(
+            store
+                .find_owner(token.clone(), Bytes::from(2_000u64))
+                .await
+                .unwrap(),
+            None
+        );
+        // Exactly at the minimum -> returned.
+        assert_eq!(
+            store
+                .find_owner(token.clone(), Bytes::from(1_000u64))
+                .await
+                .unwrap(),
+            Some((owner.clone(), Bytes::from(1_000u64)))
+        );
+        // Above the minimum -> returned.
+        assert_eq!(
+            store
+                .find_owner(token.clone(), Bytes::from(500u64))
+                .await
+                .unwrap(),
+            Some((owner, Bytes::from(1_000u64)))
+        );
+        // Unknown token -> None.
+        let other = Bytes::from_str("0x2222222222222222222222222222222222222222").unwrap();
+        assert_eq!(
+            store
+                .find_owner(other, Bytes::from(1u64))
+                .await
+                .unwrap(),
+            None
+        );
     }
 }


### PR DESCRIPTION
## What

`TokenOwnerStore::find_owner` now honors `min_balance`: it returns the cached owner only when that owner holds at least `min_balance` (numeric, unsigned big-endian comparison), and `None` otherwise. Previously it ignored the parameter and returned any cached owner.

## Why

The token quality analyzer calls `find_owner(token, MIN_AMOUNT)` and then simulates transferring `max(balance/2, MIN_AMOUNT)` of the token from that owner. If the cached owner holds less than `MIN_AMOUNT`, the transfer reverts with `ERC20: transfer amount exceeds balance`, and the token is flagged `BadToken` with a misleading `"Transfer of token ... into settlement contract failed"` reason — even for perfectly good tokens. Returning `None` when no cached owner meets the threshold yields the accurate `"Could not find on chain source of the token with at least N balance"` result instead.

## How it was found

While syncing the Ramses V3 (Polygon) integration locally, this warning appeared for WBTC:

```
tycho-indexer-1  | 2026-07-03T13:45:30.558110Z  WARN extractor:process_block_data:handle_tick_scoped_data:construct_currency_tokens:get_tokens: BadToken address=Bytes(0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6) reason="Transfer of token from on-chain source 0x92e5106d91ce2b08b2ee01a65718934b549b716d into settlement contract failed" extractor_id=polygon:ramses_v3 block_number=83294171 is_partial=false block_number=83294171  final_block_height=83294171 new_tokens_count=1 n_addresses=1 block=Number(83294171)
```

WBTC transfers fine; at that block the only indexed source was a pool holding ~1466 units (far below the 100,000 probe amount), so `find_owner` returned it instead of `None`, producing the misleading transfer-failure flag.

## Testing

- Added `test_find_owner_respects_min_balance` (below / at / above threshold + unknown token).
- `cargo +nightly fmt --all`, `cargo clippy --workspace --all-targets --all-features`, and `cargo nextest run -p tycho-common` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)