### PR TITLE
chore(docker): make indexer endpoint, chain, and auth key env-overridable for local runs

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -57,6 +57,7 @@ services:
     env_file:
       - .env
     environment:
+      AUTH_API_KEY: ${AUTH_API_KEY:-dummy}
       SUBSTREAMS_API_TOKEN: ${SUBSTREAMS_API_TOKEN:-readme}
       RPC_URL: ${RPC_URL:-readme}
       TRACE_RPC_URL: ${TRACE_RPC_URL:-readme}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -81,7 +81,7 @@ services:
       - "service=tycho-indexer"
       - "version=0.76.0"
     entrypoint: [ "/usr/wait-for-postgres.sh", "db" ]
-    command: [ "/opt/tycho-indexer/tycho-indexer", "--endpoint", "https://mainnet.eth.streamingfast.io:443", "index", "--retention-horizon", "2099-07-23T00:00:00"]
+    command: [ "/opt/tycho-indexer/tycho-indexer", "--endpoint", "${SUBSTREAMS_ENDPOINT:-https://mainnet.eth.streamingfast.io:443}", "index", "--chains", "${CHAINS:-ethereum}", "--retention-horizon", "2099-07-23T00:00:00"]
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## What

Makes the local `docker/docker-compose.yaml` `tycho-indexer` service configurable via environment, with defaults that preserve the current Ethereum behavior:

- `--endpoint` → `${SUBSTREAMS_ENDPOINT:-https://mainnet.eth.streamingfast.io:443}`
- `--chains` → `${CHAINS:-ethereum}`
- `AUTH_API_KEY` → `${AUTH_API_KEY:-dummy}` (added to the `environment:` block)

## Why

Running the indexer locally against a non-Ethereum chain previously required editing this file (the Substreams endpoint was hardcoded to Ethereum and `--chains` was never set, defaulting to `ethereum`), and the indexer panics at startup when `AUTH_API_KEY` is unset. Now a non-Ethereum local sync is just a `docker/.env` change (`CHAINS`, `SUBSTREAMS_ENDPOINT`), and `AUTH_API_KEY` defaults so startup works out of the box.

Defaults reproduce the previous behavior exactly, so existing Ethereum users are unaffected. This compose file is local-only (dev/prod deploy on EKS/ECS via `cd-deploy-dev.yaml`, not this file), so the dummy auth default is safe — production still requires a real `AUTH_API_KEY` from its own secret store, and the binary keeps failing closed when the key is genuinely absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)