### PR TITLE
fix(substreams): pause and drain superseded BopAMM books

### DIFF
--- a/.github/workflows/cd-deploy-dev.yaml
+++ b/.github/workflows/cd-deploy-dev.yaml
@@ -31,7 +31,6 @@ on:
           - ethereum-tycho-indexer
           - ethereum-tycho-indexer-new-protocol
           - base-tycho-indexer
-          - bsc-tycho-indexer
           - unichain-tycho-indexer
       cargo_profile:
         description: >

--- a/.github/workflows/cd-deploy-dev.yaml
+++ b/.github/workflows/cd-deploy-dev.yaml
@@ -31,6 +31,7 @@ on:
           - ethereum-tycho-indexer
           - ethereum-tycho-indexer-new-protocol
           - base-tycho-indexer
+          - bsc-tycho-indexer
           - unichain-tycho-indexer
       cargo_profile:
         description: >

--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-bopamm"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-bopamm"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-bopamm"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/protocols/substreams/ethereum-bopamm/Cargo.toml
+++ b/protocols/substreams/ethereum-bopamm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-bopamm"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-bopamm/Cargo.toml
+++ b/protocols/substreams/ethereum-bopamm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-bopamm"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-bopamm/Cargo.toml
+++ b/protocols/substreams/ethereum-bopamm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-bopamm"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-bopamm/ethereum-substreams.yaml
+++ b/protocols/substreams/ethereum-bopamm/ethereum-substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_bopamm"
-  version: v0.1.1
+  version: v0.1.2
   url: "https://github.com/propeller-heads/tycho/tree/main/protocols/substreams/ethereum-bopamm"
 
 protobuf:
@@ -40,7 +40,7 @@ modules:
   - name: store_components
     kind: store
     initialBlock: 25099176
-    updatePolicy: set_if_not_exists
+    updatePolicy: set
     valueType: proto:tycho.evm.v1.ProtocolComponent
     inputs:
       - map: map_components

--- a/protocols/substreams/ethereum-bopamm/ethereum-substreams.yaml
+++ b/protocols/substreams/ethereum-bopamm/ethereum-substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_bopamm"
-  version: v0.1.2
+  version: v0.1.3
   url: "https://github.com/propeller-heads/tycho/tree/main/protocols/substreams/ethereum-bopamm"
 
 protobuf:

--- a/protocols/substreams/ethereum-bopamm/ethereum-substreams.yaml
+++ b/protocols/substreams/ethereum-bopamm/ethereum-substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_bopamm"
-  version: v0.1.3
+  version: v0.1.4
   url: "https://github.com/propeller-heads/tycho/tree/main/protocols/substreams/ethereum-bopamm"
 
 protobuf:

--- a/protocols/substreams/ethereum-bopamm/src/common.rs
+++ b/protocols/substreams/ethereum-bopamm/src/common.rs
@@ -178,6 +178,37 @@ fn superseded_books_from(
         .collect()
 }
 
+/// Component id of the book that currently holds a token's inventory before a newer book replaces
+/// it: the highest asset id below `new_asset_id` that backs `asset_token`, or `None` if this is the
+/// token's first book.
+///
+/// Only this book carries a non-zero accumulated balance. Every book below it was already drained
+/// to zero when its own replacement was created, so draining the whole superseded set (rather than
+/// just this one) would push those already-emptied books negative.
+pub fn previous_live_book_for_token(
+    asset_token: &[u8],
+    new_asset_id: u64,
+    store: &StoreGetProto<ProtocolComponent>,
+) -> Option<String> {
+    previous_live_book_from(asset_token, new_asset_id, |i| store.get_last(format!("book:{i}")))
+}
+
+/// Testable core of [`previous_live_book_for_token`] over a probe of asset id -> component.
+fn previous_live_book_from(
+    asset_token: &[u8],
+    new_asset_id: u64,
+    probe: impl Fn(u64) -> Option<ProtocolComponent>,
+) -> Option<String> {
+    (0..new_asset_id).rev().find_map(|i| {
+        let component = probe(i)?;
+        component
+            .tokens
+            .iter()
+            .any(|t| t.as_slice() == asset_token)
+            .then_some(component.id)
+    })
+}
+
 /// Component ids of every book a higher-id book has superseded across the venue.
 ///
 /// A token is backed by exactly one live book — the highest asset id, since BopAMM re-lists an
@@ -471,6 +502,30 @@ mod tests {
         assert_eq!(superseded_books_from(&weth, 2, probe), vec![component_id(&SETTLEMENT, 0)]);
         // The WBTC book is the first for its token: it supersedes nothing.
         assert!(superseded_books_from(&wbtc, 1, probe).is_empty());
+    }
+
+    #[test]
+    fn previous_live_book_returns_only_the_most_recent_superseded_book() {
+        let usdc = hex::decode("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap();
+        let weth = hex::decode("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap();
+        let wbtc = hex::decode("2260fac5e5542a773aa44fbcfedf7c193bc2c599").unwrap();
+        // WETH re-listed twice: book 0 -> book 2 -> book 5. book 1 = WBTC.
+        let probe = |i: u64| match i {
+            0 => Some(book_component(0, &weth, &usdc)),
+            1 => Some(book_component(1, &wbtc, &usdc)),
+            2 => Some(book_component(2, &weth, &usdc)),
+            5 => Some(book_component(5, &weth, &usdc)),
+            _ => None,
+        };
+        // Creating book 5 must drain only book 2 (the live book holding the balance), never book 0
+        // which was already drained to zero when book 2 replaced it.
+        assert_eq!(previous_live_book_from(&weth, 5, probe), Some(component_id(&SETTLEMENT, 2)));
+        // Creating book 2 drains book 0.
+        assert_eq!(previous_live_book_from(&weth, 2, probe), Some(component_id(&SETTLEMENT, 0)));
+        // The token's first book supersedes nothing.
+        assert_eq!(previous_live_book_from(&weth, 0, probe), None);
+        // WBTC's only book has no predecessor.
+        assert_eq!(previous_live_book_from(&wbtc, 1, probe), None);
     }
 
     #[test]

--- a/protocols/substreams/ethereum-bopamm/src/common.rs
+++ b/protocols/substreams/ethereum-bopamm/src/common.rs
@@ -132,6 +132,50 @@ pub fn books_for_token(
     }
 }
 
+/// The book's asset (non-hub) token — the token that is not USDC.
+///
+/// Returns `None` for a malformed component with no non-USDC token.
+pub fn asset_token(component: &ProtocolComponent, usdc: &[u8]) -> Option<Vec<u8>> {
+    component
+        .tokens
+        .iter()
+        .find(|t| t.as_slice() != usdc)
+        .cloned()
+}
+
+/// Component ids of books a token used to back before a newer book superseded them.
+///
+/// BopAMM re-lists an asset under a fresh, higher asset id rather than delisting the old book, so
+/// a token is backed by exactly one live book: the newest. Any already-created book for
+/// `asset_token` with an asset id below `new_asset_id` has been re-listed and is stale. Callers
+/// use this to pause and drain the superseded book when its replacement is created.
+pub fn superseded_books_for_token(
+    asset_token: &[u8],
+    new_asset_id: u64,
+    store: &StoreGetProto<ProtocolComponent>,
+) -> Vec<String> {
+    superseded_books_from(asset_token, new_asset_id, |i| store.get_last(format!("book:{i}")))
+}
+
+/// Testable core of [`superseded_books_for_token`] over a probe of asset id -> component, so the
+/// selection logic can be exercised without the WASM store.
+fn superseded_books_from(
+    asset_token: &[u8],
+    new_asset_id: u64,
+    probe: impl Fn(u64) -> Option<ProtocolComponent>,
+) -> Vec<String> {
+    (0..new_asset_id)
+        .filter_map(|i| {
+            let component = probe(i)?;
+            component
+                .tokens
+                .iter()
+                .any(|t| t.as_slice() == asset_token)
+                .then_some(component.id)
+        })
+        .collect()
+}
+
 /// Reads a big-endian `u64` from a left-padded attribute value.
 pub fn u64_from_word_padded(value: &[u8]) -> Option<u64> {
     if value.len() > 8 {
@@ -356,6 +400,39 @@ mod tests {
     fn enumerate_books_from_empty_store_yields_nothing() {
         let books = enumerate_books_from(|_| None);
         assert!(books.is_empty());
+    }
+
+    fn book_component(asset_id: u64, asset: &[u8], usdc: &[u8]) -> ProtocolComponent {
+        let mut tokens = vec![asset.to_vec(), usdc.to_vec()];
+        tokens.sort_unstable();
+        ProtocolComponent::new(&component_id(&SETTLEMENT, asset_id)).with_tokens(&tokens)
+    }
+
+    #[test]
+    fn superseded_books_from_returns_older_books_for_the_same_token() {
+        let usdc = hex::decode("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap();
+        let weth = hex::decode("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap();
+        let wbtc = hex::decode("2260fac5e5542a773aa44fbcfedf7c193bc2c599").unwrap();
+        // book 0 = WETH (old), book 1 = WBTC, book 2 = WETH (re-listing).
+        let probe = |i: u64| match i {
+            0 => Some(book_component(0, &weth, &usdc)),
+            1 => Some(book_component(1, &wbtc, &usdc)),
+            2 => Some(book_component(2, &weth, &usdc)),
+            _ => None,
+        };
+        // The new WETH book (asset id 2) supersedes only the older WETH book (asset id 0), never
+        // the WBTC book that merely shares USDC.
+        assert_eq!(superseded_books_from(&weth, 2, probe), vec![component_id(&SETTLEMENT, 0)]);
+        // The WBTC book is the first for its token: it supersedes nothing.
+        assert!(superseded_books_from(&wbtc, 1, probe).is_empty());
+    }
+
+    #[test]
+    fn asset_token_returns_the_non_usdc_side() {
+        let usdc = hex::decode("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap();
+        let weth = hex::decode("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap();
+        let component = book_component(0, &weth, &usdc);
+        assert_eq!(asset_token(&component, &usdc), Some(weth));
     }
 
     #[test]

--- a/protocols/substreams/ethereum-bopamm/src/common.rs
+++ b/protocols/substreams/ethereum-bopamm/src/common.rs
@@ -3,6 +3,8 @@
 //! Deployment-specific values (addresses, storage-layout slots) come from
 //! [`crate::config::DeploymentConfig`]; the constants here are ABI-level (function selectors,
 //! event topics) that are fixed by the contract code itself.
+use std::collections::{HashMap, HashSet};
+
 use ethabi::{ParamType, Token};
 use keccak_hash::keccak;
 use substreams::{
@@ -173,6 +175,50 @@ fn superseded_books_from(
                 .any(|t| t.as_slice() == asset_token)
                 .then_some(component.id)
         })
+        .collect()
+}
+
+/// Component ids of every book a higher-id book has superseded across the venue.
+///
+/// A token is backed by exactly one live book — the highest asset id, since BopAMM re-lists an
+/// asset under a fresh higher id rather than delisting. Every lower-id book for the same asset
+/// token is superseded and must stay paused, even across a global settlement unpause (which would
+/// otherwise resurrect a dead book whose stale quote reverts `StaleUpdate`).
+pub fn superseded_book_ids(
+    store: &StoreGetProto<ProtocolComponent>,
+    usdc: &[u8],
+) -> HashSet<String> {
+    superseded_book_ids_from(usdc, |i| store.get_last(format!("book:{i}")))
+}
+
+/// Testable core of [`superseded_book_ids`] over a probe of asset id -> component.
+fn superseded_book_ids_from(
+    usdc: &[u8],
+    probe: impl Fn(u64) -> Option<ProtocolComponent>,
+) -> HashSet<String> {
+    let mut books: Vec<(u64, String, Vec<u8>)> = Vec::new();
+    let mut i = 0u64;
+    while let Some(component) = probe(i) {
+        if let Some(token) = asset_token(&component, usdc) {
+            books.push((i, component.id, token));
+        }
+        i += 1;
+    }
+    let mut live_id: HashMap<Vec<u8>, u64> = HashMap::new();
+    for (asset_id, _, token) in &books {
+        let entry = live_id
+            .entry(token.clone())
+            .or_insert(*asset_id);
+        *entry = (*entry).max(*asset_id);
+    }
+    books
+        .into_iter()
+        .filter(|(asset_id, _, token)| {
+            live_id
+                .get(token)
+                .is_some_and(|live| asset_id < live)
+        })
+        .map(|(_, id, _)| id)
         .collect()
 }
 
@@ -433,6 +479,27 @@ mod tests {
         let weth = hex::decode("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap();
         let component = book_component(0, &weth, &usdc);
         assert_eq!(asset_token(&component, &usdc), Some(weth));
+    }
+
+    #[test]
+    fn superseded_book_ids_flags_all_but_the_newest_per_token() {
+        let usdc = hex::decode("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap();
+        let weth = hex::decode("c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap();
+        let wbtc = hex::decode("2260fac5e5542a773aa44fbcfedf7c193bc2c599").unwrap();
+        // book 0 = WETH (old), 1 = WBTC, 2 = WETH (re-listing).
+        let probe = |i: u64| match i {
+            0 => Some(book_component(0, &weth, &usdc)),
+            1 => Some(book_component(1, &wbtc, &usdc)),
+            2 => Some(book_component(2, &weth, &usdc)),
+            _ => None,
+        };
+        let superseded = superseded_book_ids_from(&usdc, probe);
+        // Only the older WETH book (id 0) is superseded; the live WETH (2) and the sole WBTC (1)
+        // remain live.
+        assert_eq!(superseded.len(), 1);
+        assert!(superseded.contains(&component_id(&SETTLEMENT, 0)));
+        assert!(!superseded.contains(&component_id(&SETTLEMENT, 2)));
+        assert!(!superseded.contains(&component_id(&SETTLEMENT, 1)));
     }
 
     #[test]

--- a/protocols/substreams/ethereum-bopamm/src/modules/map_protocol_changes.rs
+++ b/protocols/substreams/ethereum-bopamm/src/modules/map_protocol_changes.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
 use itertools::Itertools;
@@ -14,7 +14,8 @@ use tycho_substreams::{
 use crate::{
     common::{
         asset_token, committed_updates, component_id, enumerate_books, is_zero,
-        superseded_books_for_token, u64_from_word_padded, PAUSED_TOPIC, UNPAUSED_TOPIC,
+        superseded_book_ids, superseded_books_for_token, u64_from_word_padded, PAUSED_TOPIC,
+        UNPAUSED_TOPIC,
     },
     config::DeploymentConfig,
 };
@@ -135,7 +136,7 @@ fn pause_superseded_books(
     transaction_changes: &mut HashMap<u64, TransactionChangesBuilder>,
 ) {
     for tx_component in &grouped_components.tx_components {
-        let tx = tx_component.tx.as_ref().unwrap();
+        let Some(tx) = tx_component.tx.as_ref() else { continue };
         for component in &tx_component.components {
             let Some(asset_id) = component
                 .get_attribute_value("asset_id")
@@ -277,6 +278,9 @@ fn extract_maker_changes(
 
 /// Reflects settlement `Paused`/`Unpaused` events onto every book (the venue is paused as a
 /// whole). Paused books should not be routed through until unpaused.
+///
+/// A global `Unpaused` never resurrects a superseded book: those are dead markets that revert
+/// `StaleUpdate` and must stay paused regardless of the venue-wide pause state.
 fn extract_pause_state(
     block: &eth::v2::Block,
     config: &DeploymentConfig,
@@ -285,6 +289,7 @@ fn extract_pause_state(
 ) {
     // Computed lazily on the first pause/unpause log so blocks without one do nothing.
     let mut books: Option<Vec<String>> = None;
+    let mut superseded: Option<HashSet<String>> = None;
     for log in block.logs() {
         if log.address() != config.settlement.as_slice() {
             continue;
@@ -301,11 +306,17 @@ fn extract_pause_state(
         if books.is_empty() {
             continue;
         }
+        let superseded =
+            superseded.get_or_insert_with(|| superseded_book_ids(components_store, &config.usdc));
         let tx: Transaction = log.receipt.transaction.into();
         let builder = transaction_changes
             .entry(tx.index)
             .or_insert_with(|| TransactionChangesBuilder::new(&tx));
         for book in books.iter() {
+            // Keep superseded (dead) books paused across a global unpause.
+            if !paused && superseded.contains(book) {
+                continue;
+            }
             builder.change_component_pause_state(book, paused);
         }
     }

--- a/protocols/substreams/ethereum-bopamm/src/modules/map_protocol_changes.rs
+++ b/protocols/substreams/ethereum-bopamm/src/modules/map_protocol_changes.rs
@@ -13,7 +13,8 @@ use tycho_substreams::{
 
 use crate::{
     common::{
-        committed_updates, component_id, enumerate_books, is_zero, PAUSED_TOPIC, UNPAUSED_TOPIC,
+        asset_token, committed_updates, component_id, enumerate_books, is_zero,
+        superseded_books_for_token, u64_from_word_padded, PAUSED_TOPIC, UNPAUSED_TOPIC,
     },
     config::DeploymentConfig,
 };
@@ -38,6 +39,12 @@ pub fn map_protocol_changes(
         .and_then(|m| hex::decode(m).ok());
 
     add_new_components(&grouped_components, maker.as_deref(), &mut transaction_changes);
+    pause_superseded_books(
+        &grouped_components,
+        &config,
+        &components_store,
+        &mut transaction_changes,
+    );
 
     aggregate_balances_changes(balance_store, deltas)
         .into_iter()
@@ -110,6 +117,43 @@ fn add_new_components(
                 component_id: component.id.clone(),
                 attributes,
             });
+        }
+    }
+}
+
+/// Pauses books that a newly created book has superseded.
+///
+/// BopAMM re-lists an asset under a fresh asset id rather than delisting the old book, so a
+/// token's previous book keeps its last committed (now stale) quote. Left active it would surface
+/// a dead market — and revert `StaleUpdate()` once its registry lane is cleared. When a
+/// replacement book is created, mark the older book(s) for the same token paused so consumers
+/// stop routing through them. Runs only on the block a replacement is created (rare).
+fn pause_superseded_books(
+    grouped_components: &BlockTransactionProtocolComponents,
+    config: &DeploymentConfig,
+    components_store: &StoreGetProto<ProtocolComponent>,
+    transaction_changes: &mut HashMap<u64, TransactionChangesBuilder>,
+) {
+    for tx_component in &grouped_components.tx_components {
+        let tx = tx_component.tx.as_ref().unwrap();
+        for component in &tx_component.components {
+            let Some(asset_id) = component
+                .get_attribute_value("asset_id")
+                .and_then(|b| u64_from_word_padded(&b))
+            else {
+                continue;
+            };
+            let Some(asset) = asset_token(component, &config.usdc) else { continue };
+            let superseded = superseded_books_for_token(&asset, asset_id, components_store);
+            if superseded.is_empty() {
+                continue;
+            }
+            let builder = transaction_changes
+                .entry(tx.index)
+                .or_insert_with(|| TransactionChangesBuilder::new(tx));
+            for old_id in superseded {
+                builder.change_component_pause_state(&old_id, true);
+            }
         }
     }
 }

--- a/protocols/substreams/ethereum-bopamm/src/modules/map_relative_balances.rs
+++ b/protocols/substreams/ethereum-bopamm/src/modules/map_relative_balances.rs
@@ -12,7 +12,10 @@ use tycho_substreams::{
 };
 
 use crate::{
-    common::{address_from_word, books_for_token, weth_event_delta},
+    common::{
+        address_from_word, books_for_token, superseded_books_for_token, u64_from_word_padded,
+        weth_event_delta,
+    },
     config::DeploymentConfig,
 };
 
@@ -91,6 +94,9 @@ fn seed_new_books(
     for tx_components in &new_components.tx_components {
         let Some(tx) = &tx_components.tx else { continue };
         for component in &tx_components.components {
+            let new_asset_id = component
+                .get_attribute_value("asset_id")
+                .and_then(|b| u64_from_word_padded(&b));
             for token in &component.tokens {
                 if token.as_slice() == config.usdc.as_slice() {
                     continue;
@@ -105,6 +111,23 @@ fn seed_new_books(
                         token: token.clone(),
                         delta: balance.to_signed_bytes_be(),
                         component_id: comp_id.into_bytes(),
+                    });
+                }
+                // Re-listing: this token's live book (seeded with `balanceOf(maker)` above) has
+                // replaced an older book. Drain the superseded book's asset balance by the same
+                // amount so the maker's inventory is not double-counted across both books. USDC
+                // is intentionally excluded (it is shared across every book by design).
+                let Some(new_asset_id) = new_asset_id else { continue };
+                for old_id in superseded_books_for_token(token, new_asset_id, components_store) {
+                    balance_deltas.push(BalanceDelta {
+                        ord: tx.index,
+                        tx: Some(tx.clone()),
+                        token: token.clone(),
+                        delta: balance
+                            .clone()
+                            .neg()
+                            .to_signed_bytes_be(),
+                        component_id: old_id.into_bytes(),
                     });
                 }
             }

--- a/protocols/substreams/ethereum-bopamm/src/modules/map_relative_balances.rs
+++ b/protocols/substreams/ethereum-bopamm/src/modules/map_relative_balances.rs
@@ -114,9 +114,18 @@ fn seed_new_books(
                     });
                 }
                 // Re-listing: this token's live book (seeded with `balanceOf(maker)` above) has
-                // replaced an older book. Drain the superseded book's asset balance by the same
-                // amount so the maker's inventory is not double-counted across both books. USDC
-                // is intentionally excluded (it is shared across every book by design).
+                // replaced an older book. Drain the superseded book by the same amount so the
+                // maker's inventory is not double-counted across both books. USDC is excluded (it
+                // is shared across every book by design).
+                //
+                // Invariant: the superseded book's accumulated asset balance equals
+                // `balanceOf(maker)` at this block — it was the token's live book and tracked the
+                // maker's holdings until now, so `-balanceOf(maker)` nets it to zero. The balance
+                // store is additive and cannot be read back here (module graph cycle), so an exact
+                // drain isn't possible. The invariant only breaks if the maker's balance moves in
+                // this very block (its own Transfer is skipped via `seeded_tokens`) or the maker is
+                // rotated in the same block; both leave a small residual on the now-paused,
+                // unrouted book. Neither has occurred for this venue.
                 let Some(new_asset_id) = new_asset_id else { continue };
                 for old_id in superseded_books_for_token(token, new_asset_id, components_store) {
                     balance_deltas.push(BalanceDelta {

--- a/protocols/substreams/ethereum-bopamm/src/modules/map_relative_balances.rs
+++ b/protocols/substreams/ethereum-bopamm/src/modules/map_relative_balances.rs
@@ -13,7 +13,7 @@ use tycho_substreams::{
 
 use crate::{
     common::{
-        address_from_word, books_for_token, superseded_books_for_token, u64_from_word_padded,
+        address_from_word, books_for_token, previous_live_book_for_token, u64_from_word_padded,
         weth_event_delta,
     },
     config::DeploymentConfig,
@@ -114,20 +114,27 @@ fn seed_new_books(
                     });
                 }
                 // Re-listing: this token's live book (seeded with `balanceOf(maker)` above) has
-                // replaced an older book. Drain the superseded book by the same amount so the
-                // maker's inventory is not double-counted across both books. USDC is excluded (it
-                // is shared across every book by design).
+                // replaced an older book. Drain only the previous live book by the same amount so
+                // the maker's inventory is not double-counted across both books. USDC is excluded
+                // (it is shared across every book by design).
                 //
-                // Invariant: the superseded book's accumulated asset balance equals
-                // `balanceOf(maker)` at this block — it was the token's live book and tracked the
-                // maker's holdings until now, so `-balanceOf(maker)` nets it to zero. The balance
-                // store is additive and cannot be read back here (module graph cycle), so an exact
-                // drain isn't possible. The invariant only breaks if the maker's balance moves in
-                // this very block (its own Transfer is skipped via `seeded_tokens`) or the maker is
-                // rotated in the same block; both leave a small residual on the now-paused,
+                // Only the immediately preceding book is drained, never the whole superseded set:
+                // each older book was already drained to zero when its own replacement was created,
+                // so draining them again would push them negative.
+                //
+                // Invariant: the previous book's accumulated asset balance equals
+                // `balanceOf(maker)` at this block — it was the token's live book
+                // and tracked the maker's holdings until now, so
+                // `-balanceOf(maker)` nets it to zero. The balance store is additive
+                // and cannot be read back here (module graph cycle), so an exact drain isn't
+                // possible. The invariant only breaks if the maker's balance moves in this very
+                // block (its own Transfer is skipped via `seeded_tokens`) or the maker is rotated
+                // in the same block; both leave a small residual on the now-paused,
                 // unrouted book. Neither has occurred for this venue.
                 let Some(new_asset_id) = new_asset_id else { continue };
-                for old_id in superseded_books_for_token(token, new_asset_id, components_store) {
+                if let Some(old_id) =
+                    previous_live_book_for_token(token, new_asset_id, components_store)
+                {
                     balance_deltas.push(BalanceDelta {
                         ord: tx.index,
                         tx: Some(tx.clone()),

--- a/protocols/substreams/ethereum-bopamm/src/modules/store_components.rs
+++ b/protocols/substreams/ethereum-bopamm/src/modules/store_components.rs
@@ -1,14 +1,19 @@
-use substreams::store::{StoreNew, StoreSetIfNotExists, StoreSetIfNotExistsProto};
+use substreams::store::{StoreNew, StoreSet, StoreSetProto};
 use tycho_substreams::prelude::*;
 
 use crate::common::{token_index_keys, u64_from_word_padded};
 
 /// Indexes discovered books both by `book:{assetId}` and by their asset token, so balance
 /// and update logic can resolve a token or a book id back to its component.
+///
+/// The token index is newest-wins (`set`, not `set_if_not_exists`): when an asset is re-listed
+/// under a new book, `token:{asset}` must resolve to the new (live) book so inventory routes there
+/// rather than to the superseded one. The `book:{assetId}` keys are keyed by a unique asset id, so
+/// their writes are effectively write-once regardless.
 #[substreams::handlers::store]
 pub fn store_components(
     map: BlockTransactionProtocolComponents,
-    store: StoreSetIfNotExistsProto<ProtocolComponent>,
+    store: StoreSetProto<ProtocolComponent>,
 ) {
     for tx_pc in map.tx_components {
         for pc in tx_pc.components {
@@ -16,10 +21,10 @@ pub fn store_components(
                 .get_attribute_value("asset_id")
                 .and_then(|b| u64_from_word_padded(&b))
             {
-                store.set_if_not_exists(0, format!("book:{asset_id}"), &pc);
+                store.set(0, format!("book:{asset_id}"), &pc);
             }
             for key in token_index_keys(&pc.tokens) {
-                store.set_if_not_exists(0, key, &pc);
+                store.set(0, key, &pc);
             }
         }
     }


### PR DESCRIPTION
BopAMM re-lists an asset under a new asset id instead of delisting the old book, so a token's superseded book kept its stale committed quote and its share of the maker's inventory. The old book stayed active — a dead market that reverts `StaleUpdate` — and held the token balance that belongs to the live book.

## Change
- When a new book is created for a token that already has one, pause the older book and move its asset balance onto the new book.
- The token index is now newest-wins (`set` instead of `set_if_not_exists`) so inventory routing and simulation resolve to the live book.
- Shared USDC stays duplicated across books (unchanged).

## Validation
Local re-sync (block 25,099,176 → chain tip) on a Docker indexer, crossing the re-list at block 25,286,302:
- superseded book `…0000`: `paused=true`, WETH drained to 0
- live book `…0002`: holds the maker's WETH = 6.098230, an exact match to on-chain `balanceOf(maker)` at the same block
- WBTC book returns no quote (maker holds 0 WBTC)
- live WETH price ≈ 1699 USDC/WETH vs Bebop's live 1700.65 / 1701.34 (~0.1%)

Unit tests, `wasm32` release build, clippy, and `cargo +nightly fmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
