### PR TITLE
fix: replace transaction cleanup with lock-safe incremental procedure

### DIFF
--- a/.github/workflows/cd-deploy-dev.yaml
+++ b/.github/workflows/cd-deploy-dev.yaml
@@ -31,6 +31,7 @@ on:
           - ethereum-tycho-indexer
           - ethereum-tycho-indexer-new-protocol
           - base-tycho-indexer
+          - bsc-tycho-indexer
           - unichain-tycho-indexer
       cargo_profile:
         description: >

--- a/.github/workflows/cd-deploy-dev.yaml
+++ b/.github/workflows/cd-deploy-dev.yaml
@@ -33,6 +33,7 @@ on:
           - base-tycho-indexer
           - bsc-tycho-indexer
           - unichain-tycho-indexer
+          - polygon-tycho-indexer
       cargo_profile:
         description: >
           Cargo build profile. "profiling" includes debug symbols for

--- a/crates/tycho-storage/migrations/2026-07-03_incremental_transaction_cleanup/down.sql
+++ b/crates/tycho-storage/migrations/2026-07-03_incremental_transaction_cleanup/down.sql
@@ -1,0 +1,136 @@
+-- Revert to the previous cleanup: restore clean_transaction_table() as defined by
+-- 2024-09-19_transaction_cleanup and its cron schedule from
+-- 2025-10-24-reschedule-transaction-cleanup.
+
+SELECT cron.unschedule(jobid)
+FROM cron.job
+WHERE command LIKE '%cleanup_orphaned_transactions%';
+
+DROP PROCEDURE IF EXISTS cleanup_orphaned_transactions(bigint, interval, interval, text);
+
+DROP TABLE IF EXISTS transaction_cleanup_progress;
+
+CREATE OR REPLACE FUNCTION clean_transaction_table() RETURNS void AS $$
+DECLARE
+    batch_size INT := 1000;
+    rows_deleted INT;
+    offset_val INT := 0;
+    orphaned_count INT;  -- Variable to store count of orphaned transactions
+BEGIN
+    -- Create the outer temporary table to hold all transaction IDs that are safe to delete
+    CREATE TEMP TABLE temp_transaction_ids (
+        id BIGINT PRIMARY KEY
+    );
+
+    RAISE NOTICE 'Searching for orphaned transactions';
+
+    INSERT INTO temp_transaction_ids (id)
+    SELECT t2.id
+    FROM "transaction" t2;
+
+    DELETE FROM temp_transaction_ids
+    WHERE id IN (
+        SELECT t2.id
+        FROM temp_transaction_ids t2
+        JOIN contract_code cc ON cc.modify_tx = t2.id
+    );
+
+	RAISE NOTICE 'Scanned contract_code';
+
+    DELETE FROM temp_transaction_ids
+    WHERE id IN (
+        SELECT t2.id
+        FROM temp_transaction_ids t2
+        JOIN protocol_component pc ON pc.creation_tx = t2.id OR pc.deletion_tx = t2.id
+    );
+
+	RAISE NOTICE 'Scanned protocol_component';
+
+    DELETE FROM temp_transaction_ids
+    WHERE id IN (
+        SELECT t2.id
+        FROM temp_transaction_ids t2
+        JOIN account a ON a.creation_tx = t2.id OR a.deletion_tx = t2.id
+    );
+
+	RAISE NOTICE 'Scanned account';
+
+    DELETE FROM temp_transaction_ids
+    WHERE id IN (
+        SELECT t2.id
+        FROM temp_transaction_ids t2
+        JOIN account_balance ab ON ab.modify_tx = t2.id
+    );
+
+	RAISE NOTICE 'Scanned account_balance';
+
+    DELETE FROM temp_transaction_ids
+    WHERE id IN (
+        SELECT t2.id
+        FROM temp_transaction_ids t2
+        JOIN component_balance cb ON cb.modify_tx = t2.id
+    );
+
+	RAISE NOTICE 'Scanned component_balance';
+
+    DELETE FROM temp_transaction_ids
+    WHERE id IN (
+        SELECT t2.id
+        FROM temp_transaction_ids t2
+        JOIN protocol_state ps ON ps.modify_tx = t2.id
+    );
+
+	RAISE NOTICE 'Scanned protocol_state';
+
+    DELETE FROM temp_transaction_ids
+    WHERE id IN (
+        SELECT t2.id
+        FROM temp_transaction_ids t2
+        JOIN contract_storage cs ON cs.modify_tx = t2.id
+    );
+
+	RAISE NOTICE 'Scanned contract_storage';
+
+    SELECT COUNT(*) INTO orphaned_count FROM temp_transaction_ids;
+    RAISE NOTICE 'Found % orphaned transactions', orphaned_count;
+
+
+    -- Phase 2: Delete the collected transaction IDs in batches
+    LOOP
+        RAISE NOTICE 'Deleting next transaction batch. [batch_size = %]', batch_size;
+        RAISE NOTICE 'Remaining transactions: %', orphaned_count;
+
+        -- Delete the rows in batches from the transaction table
+        DELETE FROM "transaction"
+        WHERE id IN (
+            SELECT id FROM temp_transaction_ids
+            LIMIT batch_size
+        );
+
+        DELETE FROM temp_transaction_ids
+        WHERE id IN (
+            SELECT id FROM temp_transaction_ids
+            LIMIT batch_size
+        );
+
+        GET DIAGNOSTICS rows_deleted = ROW_COUNT;
+
+        orphaned_count := orphaned_count - rows_deleted;
+
+        -- Exit the loop if no more transactions are left to delete
+        IF rows_deleted < batch_size THEN
+            RAISE NOTICE 'Transaction table cleanup complete.';
+            EXIT;
+        END IF;
+
+        -- Pause between delete batches to reduce load
+        PERFORM pg_sleep(1);
+    END LOOP;
+
+    -- Drop the temporary tables when done
+    DROP TABLE IF EXISTS temp_transaction_ids;
+
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT cron.schedule('clean_transaction_table', '0 12 * * *', 'SELECT clean_transaction_table();');

--- a/crates/tycho-storage/migrations/2026-07-03_incremental_transaction_cleanup/up.sql
+++ b/crates/tycho-storage/migrations/2026-07-03_incremental_transaction_cleanup/up.sql
@@ -1,0 +1,179 @@
+-- Incremental transaction cleanup
+--
+-- Replaces clean_transaction_table() with cleanup_orphaned_transactions().
+--
+-- The old function ran as a single transaction that anti-joined the whole transaction table
+-- against every referencing table (O(all data), 10-28h on BSC volume). Its long-held
+-- AccessShare locks on component_balance starved pg_partman's midnight partition maintenance
+-- of the AccessExclusive lock it needs, which in turn queued the entire indexer behind
+-- partman and repeatedly gridlocked (and once deadlocked) the database.
+--
+-- The new procedure deletes orphaned transaction rows in small id-range batches and COMMITs
+-- after every batch, so no lock is held longer than a few seconds. A short lock_timeout makes
+-- it yield to partman instead of queueing behind it. A persistent cursor makes runs resumable
+-- after interruption, and a time budget bounds every invocation.
+--
+-- WARNING: the NOT EXISTS probes below are the correctness gate. On databases built purely
+-- from migrations the referencing FKs are ON DELETE CASCADE, so deleting a referenced
+-- transaction would silently cascade-delete protocol data; on environments where the legacy
+-- rebuild script re-created the FKs they are plain NO ACTION, so the delete would error the
+-- batch instead. If a new table ever adds a foreign key to "transaction", its column MUST be
+-- added to the probe list (and indexed).
+
+DROP FUNCTION IF EXISTS clean_transaction_table();
+
+-- Single-row cursor so each run resumes where the previous one stopped.
+CREATE TABLE IF NOT EXISTS transaction_cleanup_progress(
+    id boolean PRIMARY KEY DEFAULT TRUE CHECK (id),
+    last_processed_id bigint NOT NULL DEFAULT 0,
+    updated_at timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO transaction_cleanup_progress DEFAULT VALUES
+ON CONFLICT DO NOTHING;
+
+-- p_min_age: rows younger than this (by inserted_ts) are skipped. 35 days = partman's 1-month
+-- retention plus margin for month-length variance and late partition drops. NOTE: inserted_ts
+-- is DB insertion time, so during a backfill freshly-inserted-but-already-orphaned rows are
+-- skipped for 35 days; drain those with manual runs using a lower p_min_age (see
+-- scripts/prune_transaction_table.md). inserted_ts is used (rather than chain time) because
+-- the horizon binary search requires a timestamp monotone in id order, which chain time is not
+-- when a newly added extractor backfills alongside live ones.
+CREATE OR REPLACE PROCEDURE cleanup_orphaned_transactions(
+    p_batch_size bigint DEFAULT 50000,
+    p_time_budget interval DEFAULT '45 minutes',
+    p_min_age interval DEFAULT '35 days',
+    p_lock_timeout text DEFAULT '2s'
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_started timestamptz := clock_timestamp();
+    v_horizon_ts timestamptz := clock_timestamp() - p_min_age;
+    v_lo bigint;
+    v_hi bigint;
+    v_mid bigint;
+    v_mid_ts timestamptz;
+    v_horizon_id bigint;
+    v_cursor bigint;
+    v_batch_end bigint;
+    v_batch_deleted bigint := 0;
+    v_deleted bigint := 0;
+    v_lock_failed boolean := false;
+BEGIN
+    SELECT min(id), max(id) INTO v_lo, v_hi FROM "transaction";
+    IF v_lo IS NULL THEN
+        RAISE NOTICE 'cleanup_orphaned_transactions: transaction table is empty';
+        RETURN;
+    END IF;
+
+    -- Binary-search the largest id older than the horizon (~40 single-row PK lookups).
+    -- Rows younger than the partman retention window cannot be orphans yet, so probing them
+    -- would be wasted IO. The NOT EXISTS checks below are the correctness gate; this is only
+    -- an optimization.
+    WHILE v_lo < v_hi LOOP
+        v_mid := (v_lo + v_hi + 1) / 2;
+        SELECT inserted_ts INTO v_mid_ts
+        FROM "transaction"
+        WHERE id >= v_mid
+        ORDER BY id
+        LIMIT 1;
+        IF v_mid_ts IS NOT NULL AND v_mid_ts < v_horizon_ts THEN
+            v_lo := v_mid;
+        ELSE
+            v_hi := v_mid - 1;
+        END IF;
+    END LOOP;
+    v_horizon_id := v_lo;
+
+    -- The search only verifies ids it moved v_lo onto; the initial v_lo = min(id) is never
+    -- checked. If every row is younger than the horizon the loop converges there unverified,
+    -- so re-probe the boundary and bail out rather than sweep a too-young row.
+    SELECT inserted_ts INTO v_mid_ts
+    FROM "transaction"
+    WHERE id >= v_horizon_id
+    ORDER BY id
+    LIMIT 1;
+    IF v_mid_ts IS NULL OR v_mid_ts >= v_horizon_ts THEN
+        RAISE NOTICE 'cleanup_orphaned_transactions: no rows older than %, nothing to do',
+            p_min_age;
+        RETURN;
+    END IF;
+
+    SELECT last_processed_id INTO v_cursor FROM transaction_cleanup_progress;
+    IF v_cursor IS NULL THEN
+        -- Self-heal if the progress row is missing (e.g. wiped by test teardown).
+        INSERT INTO transaction_cleanup_progress DEFAULT VALUES
+        ON CONFLICT DO NOTHING;
+        v_cursor := 0;
+    END IF;
+    IF v_cursor >= v_horizon_id THEN
+        -- Previous sweep reached the horizon: wrap around. Orphans appear anywhere below the
+        -- horizon, not just in the newest band: versioned rows move to a dated partition when
+        -- their valid_to is set, and that partition is dropped a month later, orphaning
+        -- transactions of any age.
+        v_cursor := 0;
+    END IF;
+    -- Skip id space below the smallest existing row (earlier sweeps already emptied it).
+    SELECT min(id) - 1 INTO v_lo FROM "transaction";
+    v_cursor := greatest(v_cursor, v_lo);
+
+    WHILE v_cursor < v_horizon_id AND clock_timestamp() - v_started < p_time_budget LOOP
+        v_batch_end := least(v_cursor + p_batch_size, v_horizon_id);
+        BEGIN
+            -- Applies to the current batch transaction only. If partman or anything else
+            -- holds a conflicting lock, the batch aborts and the procedure yields instead of
+            -- queueing behind it (a queued AccessExclusive would freeze the indexer).
+            PERFORM set_config('lock_timeout', p_lock_timeout, true);
+
+            DELETE FROM "transaction" t
+            WHERE t.id > v_cursor
+              AND t.id <= v_batch_end
+              AND NOT EXISTS (SELECT 1 FROM contract_code cc WHERE cc.modify_tx = t.id)
+              AND NOT EXISTS (SELECT 1 FROM protocol_component pc WHERE pc.creation_tx = t.id)
+              AND NOT EXISTS (SELECT 1 FROM protocol_component pc WHERE pc.deletion_tx = t.id)
+              AND NOT EXISTS (SELECT 1 FROM account a WHERE a.creation_tx = t.id)
+              AND NOT EXISTS (SELECT 1 FROM account a WHERE a.deletion_tx = t.id)
+              AND NOT EXISTS (SELECT 1 FROM account_balance ab WHERE ab.modify_tx = t.id)
+              AND NOT EXISTS (SELECT 1 FROM component_balance cb WHERE cb.modify_tx = t.id)
+              AND NOT EXISTS (SELECT 1 FROM protocol_state ps WHERE ps.modify_tx = t.id)
+              AND NOT EXISTS (SELECT 1 FROM contract_storage cs WHERE cs.modify_tx = t.id);
+            GET DIAGNOSTICS v_batch_deleted = ROW_COUNT;
+        EXCEPTION
+            WHEN lock_not_available OR deadlock_detected THEN
+                v_lock_failed := true;
+        END;
+
+        IF v_lock_failed THEN
+            RAISE NOTICE 'cleanup_orphaned_transactions: lock not available, yielding at id %',
+                v_cursor;
+            EXIT;
+        END IF;
+
+        v_deleted := v_deleted + v_batch_deleted;
+        v_cursor := v_batch_end;
+        UPDATE transaction_cleanup_progress
+        SET last_processed_id = v_cursor,
+            updated_at = clock_timestamp();
+        -- Releases every lock taken by this batch and persists cursor progress. Interrupting
+        -- the procedure at any point loses at most the current (uncommitted) batch.
+        COMMIT;
+    END LOOP;
+
+    RAISE NOTICE 'cleanup_orphaned_transactions: deleted % rows, cursor at % (horizon %)',
+        v_deleted, v_cursor, v_horizon_id;
+END;
+$$;
+
+-- Replace the old cron entry. Match by command rather than jobid: ids differ per environment.
+SELECT cron.unschedule(jobid)
+FROM cron.job
+WHERE command LIKE '%clean_transaction_table%';
+
+-- 02:00 UTC keeps the run clear of partman's midnight maintenance; with the per-batch
+-- lock_timeout even an overlap is harmless.
+SELECT cron.schedule(
+    'cleanup_orphaned_transactions',
+    '0 2 * * *',
+    'CALL cleanup_orphaned_transactions();'
+);

--- a/crates/tycho-storage/migrations/2026-07-03_incremental_transaction_cleanup/up.sql
+++ b/crates/tycho-storage/migrations/2026-07-03_incremental_transaction_cleanup/up.sql
@@ -32,24 +32,28 @@ CREATE TABLE IF NOT EXISTS transaction_cleanup_progress(
 INSERT INTO transaction_cleanup_progress DEFAULT VALUES
 ON CONFLICT DO NOTHING;
 
--- p_min_age: rows younger than this (by inserted_ts) are skipped. 35 days = partman's 1-month
--- retention plus margin for month-length variance and late partition drops. NOTE: inserted_ts
--- is DB insertion time, so during a backfill freshly-inserted-but-already-orphaned rows are
--- skipped for 35 days; drain those with manual runs using a lower p_min_age (see
--- scripts/prune_transaction_table.md). inserted_ts is used (rather than chain time) because
--- the horizon binary search requires a timestamp monotone in id order, which chain time is not
--- when a newly added extractor backfills alongside live ones.
+-- p_min_age: rows younger than this (by inserted_ts) are skipped. NULL (the default) resolves
+-- to the largest pg_partman retention plus a 4-day margin for month-length variance and late
+-- partition drops (35 days under the current 1-month retention), so the horizon tracks
+-- retention changes automatically; 31+4 days is the fallback when partman has no retention
+-- configured. NOTE: inserted_ts is DB insertion time, so during a backfill
+-- freshly-inserted-but-already-orphaned rows are skipped until they age past the horizon;
+-- drain those with manual runs using a lower p_min_age (see scripts/prune_transaction_table.md).
+-- inserted_ts is used (rather than chain time) because the horizon binary search requires a
+-- timestamp monotone in id order, which chain time is not when a newly added extractor
+-- backfills alongside live ones.
 CREATE OR REPLACE PROCEDURE cleanup_orphaned_transactions(
     p_batch_size bigint DEFAULT 50000,
     p_time_budget interval DEFAULT '45 minutes',
-    p_min_age interval DEFAULT '35 days',
+    p_min_age interval DEFAULT NULL,
     p_lock_timeout text DEFAULT '2s'
 )
 LANGUAGE plpgsql
 AS $$
 DECLARE
     v_started timestamptz := clock_timestamp();
-    v_horizon_ts timestamptz := clock_timestamp() - p_min_age;
+    v_min_age interval;
+    v_horizon_ts timestamptz;
     v_lo bigint;
     v_hi bigint;
     v_mid bigint;
@@ -60,7 +64,51 @@ DECLARE
     v_batch_deleted bigint := 0;
     v_deleted bigint := 0;
     v_lock_failed boolean := false;
+    v_lock_retries integer := 0;
+    -- Every (table.column) referencing "transaction". Must stay in sync with the NOT EXISTS
+    -- probes below; sorted in COLLATE "C" order for the safeguard comparison.
+    v_expected_refs text[] := ARRAY[
+        'account.creation_tx',
+        'account.deletion_tx',
+        'account_balance.modify_tx',
+        'component_balance.modify_tx',
+        'contract_code.modify_tx',
+        'contract_storage.modify_tx',
+        'protocol_component.creation_tx',
+        'protocol_component.deletion_tx',
+        'protocol_state.modify_tx'];
+    v_actual_refs text[];
 BEGIN
+    IF p_min_age IS NOT NULL THEN
+        v_min_age := p_min_age;
+    ELSE
+        SELECT coalesce(max(retention::interval), interval '31 days') + interval '4 days'
+        INTO v_min_age
+        FROM partman.part_config
+        WHERE retention IS NOT NULL;
+    END IF;
+    v_horizon_ts := clock_timestamp() - v_min_age;
+
+    -- Safeguard: refuse to run if the set of foreign keys referencing "transaction" no longer
+    -- matches the probe list. Without this, a reference added by a future migration would let
+    -- the sweep cascade-delete (or error on) rows the new table still needs.
+    SELECT coalesce(array_agg(ref ORDER BY ref COLLATE "C"), '{}') INTO v_actual_refs
+    FROM (
+        SELECT DISTINCT r.relname || '.' || a.attname AS ref
+        FROM pg_constraint c
+        JOIN pg_class r ON r.oid = c.conrelid
+        CROSS JOIN LATERAL unnest(c.conkey) AS k(attnum)
+        JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum
+        WHERE c.contype = 'f'
+          AND c.confrelid = '"transaction"'::regclass
+          AND c.conparentid = 0
+    ) refs;
+    IF v_actual_refs <> v_expected_refs THEN
+        RAISE EXCEPTION
+            'foreign keys referencing "transaction" (%) do not match the probe list (%); update cleanup_orphaned_transactions before running',
+            v_actual_refs, v_expected_refs;
+    END IF;
+
     SELECT min(id), max(id) INTO v_lo, v_hi FROM "transaction";
     IF v_lo IS NULL THEN
         RAISE NOTICE 'cleanup_orphaned_transactions: transaction table is empty';
@@ -68,9 +116,11 @@ BEGIN
     END IF;
 
     -- Binary-search the largest id older than the horizon (~40 single-row PK lookups).
-    -- Rows younger than the partman retention window cannot be orphans yet, so probing them
-    -- would be wasted IO. The NOT EXISTS checks below are the correctness gate; this is only
-    -- an optimization.
+    -- Under live indexing, rows younger than the retention window cannot be orphans yet (their
+    -- references cannot have been partition-dropped). During backfills young rows CAN already
+    -- be orphans; they are deliberately deferred until they age past the horizon (see the
+    -- p_min_age note above and the runbook). The NOT EXISTS checks below are the correctness
+    -- gate; this is only an optimization.
     WHILE v_lo < v_hi LOOP
         v_mid := (v_lo + v_hi + 1) / 2;
         SELECT inserted_ts INTO v_mid_ts
@@ -96,7 +146,7 @@ BEGIN
     LIMIT 1;
     IF v_mid_ts IS NULL OR v_mid_ts >= v_horizon_ts THEN
         RAISE NOTICE 'cleanup_orphaned_transactions: no rows older than %, nothing to do',
-            p_min_age;
+            v_min_age;
         RETURN;
     END IF;
 
@@ -145,10 +195,20 @@ BEGIN
         END;
 
         IF v_lock_failed THEN
-            RAISE NOTICE 'cleanup_orphaned_transactions: lock not available, yielding at id %',
-                v_cursor;
-            EXIT;
+            v_lock_failed := false;
+            v_lock_retries := v_lock_retries + 1;
+            IF v_lock_retries >= 3 THEN
+                RAISE NOTICE 'cleanup_orphaned_transactions: lock not available after % attempts, yielding at id %',
+                    v_lock_retries, v_cursor;
+                EXIT;
+            END IF;
+            -- The failed batch's subtransaction already rolled back; end the enclosing
+            -- transaction too so nothing (not even a snapshot) is held while backing off.
+            COMMIT;
+            PERFORM pg_sleep(30);
+            CONTINUE;
         END IF;
+        v_lock_retries := 0;
 
         v_deleted := v_deleted + v_batch_deleted;
         v_cursor := v_batch_end;
@@ -170,10 +230,11 @@ SELECT cron.unschedule(jobid)
 FROM cron.job
 WHERE command LIKE '%clean_transaction_table%';
 
--- 02:00 UTC keeps the run clear of partman's midnight maintenance; with the per-batch
--- lock_timeout even an overlap is harmless.
+-- Twice daily, clear of partman's midnight maintenance (with the per-batch lock_timeout even
+-- an overlap is harmless). Two 45-minute runs give roughly 3-10M deletions/day of capacity,
+-- comfortable margin over the ~2M/day steady-state orphan rate.
 SELECT cron.schedule(
     'cleanup_orphaned_transactions',
-    '0 2 * * *',
+    '0 2,14 * * *',
     'CALL cleanup_orphaned_transactions();'
 );

--- a/crates/tycho-storage/scripts/prune_transaction_table.md
+++ b/crates/tycho-storage/scripts/prune_transaction_table.md
@@ -1,0 +1,151 @@
+# Reclaiming `transaction` table disk space
+
+This runbook replaces the old `prune_transaction_table.sql` rebuild-and-swap script (previously
+kept only in the `dev-tycho/prune-tx-script` configmap). That script held `ACCESS EXCLUSIVE`
+locks on `transaction` and all 7 referencing tables for its entire ~day-long run, freezing the
+indexer fleet. It cannot be fixed incrementally on PostgreSQL 15: re-adding foreign keys on the
+partitioned referencers (`component_balance`, `protocol_state`, `contract_storage`) does not
+support `NOT VALID`, so their validation scans are forced inside the exclusive window.
+
+## Division of labor
+
+```
+cleanup_orphaned_transactions()  daily pg_cron job: DELETEs orphan rows (logical cleanup)
+autovacuum                       marks deleted space reusable (file stops growing)
+this runbook                     physically compacts the file (disk returned to the OS)
+```
+
+Row deletion is NOT this runbook's job. Steady state needs no compaction at all: the daily
+cleanup keeps the table at its floor and the file size plateaus. Run this only after something
+structural changed — e.g. partman retention was shortened, or a large historic orphan backlog
+was just deleted for the first time.
+
+## Special case: after an initial sync / large backfill
+
+Backfills orphan transactions immediately and in bulk: referencing rows carry historic
+`valid_to` timestamps, fall outside the partman retention window, and vanish while the
+transactions stay behind. The daily cron will NOT clean these up promptly — its horizon is
+based on `inserted_ts` (DB insertion time), so backfilled rows look young for 35 days even
+though they are already orphaned, and the 45-minute daily budget is sized for the steady-state
+trickle, not a backlog of tens of millions of rows.
+
+After (or during) a large sync, drain the backlog with aggressive manual passes instead.
+`p_min_age` can be lowered safely: correctness comes from the `NOT EXISTS` probes, and block
+flushes are atomic, so a committed transaction is never momentarily reference-less. Repeat
+until a run reports `deleted 0 rows` twice in a row (one full cursor wrap):
+
+```sql
+CALL cleanup_orphaned_transactions(
+    p_min_age     => interval '1 day',
+    p_time_budget => interval '6 hours'
+);
+```
+
+This is safe to run while the sync continues — every batch commits in seconds and yields via
+`lock_timeout` — but it competes for IO with the sync. Once drained, continue below to reclaim
+the disk.
+
+## Before either path
+
+1. Drain orphans to the floor first, otherwise the compaction preserves rows that are about to
+   be deleted anyway. Repeat until a run reports `deleted 0 rows`:
+
+   ```sql
+   CALL cleanup_orphaned_transactions(p_time_budget => interval '6 hours');
+   ```
+
+2. Check whether compaction is even worth it:
+
+   ```sql
+   SELECT pg_size_pretty(pg_total_relation_size('"transaction"')) AS on_disk,
+          (SELECT count(*) FROM "transaction") AS live_rows,
+          n_dead_tup
+   FROM pg_stat_user_tables
+   WHERE relname = 'transaction';
+   ```
+
+   Rough guide: `transaction` averages ~250 bytes/row including indexes. If `on_disk` is within
+   ~30% of `live_rows x 250B`, there is little to reclaim — stop here.
+
+3. Confirm free disk >= 2x the table's total size (both paths build a full copy before dropping
+   the old file):
+
+   ```sql
+   SELECT pg_size_pretty(pg_total_relation_size('"transaction"'));
+   -- compare against FreeStorageSpace in the RDS console/CloudWatch
+   ```
+
+## Path A — pg_repack (recommended: online, indexer keeps running)
+
+pg_repack rewrites the table into a compact file while writes continue (a trigger logs
+concurrent changes, a replay loop applies them), then swaps the physical file under the SAME
+table OID. Foreign keys, indexes, and triggers keep pointing at the table untouched — no FK
+drop/re-add, no PG 15 partitioned-FK limitation. Blocking: milliseconds at trigger install,
+seconds at the final swap.
+
+### Preconditions
+
+- `CREATE EXTENSION pg_repack;` (RDS supports it on PG 15; needs rds_superuser).
+- Client binary version MUST match the extension version:
+
+  ```sql
+  SELECT extversion FROM pg_extension WHERE extname = 'pg_repack';
+  ```
+
+  ```bash
+  pg_repack --version
+  ```
+
+- The table has a primary key (`transaction_pkey` — satisfied).
+- IO note: the copy phase competes with the indexer for the instance's IOPS budget. It holds
+  no locks, but on the current undersized instances (db.m5.large dev / db.m5.xlarge prod are
+  IOPS-burst-starved) expect elevated write latency for the duration. Prefer running after the
+  planned instance resize.
+- Lock note: the two brief `ACCESS EXCLUSIVE` acquisitions (trigger install and final swap)
+  queue arriving queries behind them for up to `--wait-timeout` seconds per attempt.
+
+### Run
+
+From a pod with a version-matched client (run as a k8s Job, credentials from the usual secret):
+
+```bash
+pg_repack \
+    --host "$DB_HOST" --dbname tycho_postgres --username tycho \
+    --table transaction \
+    --no-kill-backend \
+    --wait-timeout 10 \
+    --elevel INFO
+```
+
+- `--no-kill-backend` is MANDATORY. Without it, if the final swap cannot get its lock within
+  `--wait-timeout`, pg_repack CANCELS the conflicting queries — i.e. it would kill indexer
+  writes to win the lock. With it, pg_repack gives up instead; the indexer always has priority.
+- If the swap times out (busy lock traffic), pg_repack aborts cleanly — just rerun the command.
+- If a run is interrupted, rerunning cleans up its temporary objects. Leftovers live in the
+  `repack` schema and are safe to drop manually if needed.
+
+### After
+
+```sql
+ANALYZE "transaction";
+SELECT pg_size_pretty(pg_total_relation_size('"transaction"'));
+```
+
+## Path B — VACUUM FULL (maintenance window, zero moving parts)
+
+Takes `ACCESS EXCLUSIVE` on `transaction` for the whole rewrite (hours at this size on current
+hardware). Only acceptable with the indexer fleet scaled to 0 — which is fine for dev.
+
+```bash
+kubectl -n <namespace> scale deploy <indexer-deployments> --replicas=0
+```
+
+```sql
+VACUUM (FULL, ANALYZE) "transaction";
+```
+
+```bash
+kubectl -n <namespace> scale deploy <indexer-deployments> --replicas=1
+```
+
+Interrupting it at any point is safe: the rewrite is transactional and rolls back atomically.

--- a/crates/tycho-storage/scripts/prune_transaction_table.md
+++ b/crates/tycho-storage/scripts/prune_transaction_table.md
@@ -41,9 +41,22 @@ CALL cleanup_orphaned_transactions(
 );
 ```
 
-This is safe to run while the sync continues — every batch commits in seconds and yields via
-`lock_timeout` — but it competes for IO with the sync. Once drained, continue below to reclaim
-the disk.
+The same procedure serves both the daily cron and these manual drains — only the parameters
+differ.
+
+Timing trade-off: every batch commits in seconds and yields via `lock_timeout`, so running
+during the sync is safe and keeps the backlog from accumulating (100M+ dangling rows), but it
+competes with the sync for IO and slows it down. Running after lets the sync finish sooner but
+allows the backlog to build. Default to draining after the sync; switch to during if table
+growth or disk pressure becomes a concern.
+
+For an extreme backlog (orphans well beyond the retained row count) during a scheduled
+full-downtime window, a rebuild — copy referenced rows to a new table and drop the old one,
+the retired configmap script's approach — does O(retained) work instead of O(orphans) deletes.
+On PG 15 it needs the fleet at 0 anyway (partitioned referencers force FK revalidation inside
+the exclusive window), so treat it as a last resort for maintenance windows only.
+
+Once drained, continue below to reclaim the disk.
 
 ## Before either path
 

--- a/crates/tycho-storage/src/postgres/mod.rs
+++ b/crates/tycho-storage/src/postgres/mod.rs
@@ -762,6 +762,7 @@ pub mod testing {
         let tables = vec![
             // put block early so most FKs cascade, it would
             // be better to find the correct order tough.
+            "transaction_cleanup_progress",
             "extraction_state",
             "block",
             "contract_storage",
@@ -1507,5 +1508,98 @@ mod tests_ensure_chain {
             .unwrap();
         let result = ensure_chain(Chain::Base, &mut conn).await;
         assert!(result.is_err(), "expected error when inserting a different chain");
+    }
+}
+
+#[cfg(test)]
+mod tests_transaction_cleanup {
+    use std::str::FromStr;
+
+    use diesel::prelude::*;
+    use diesel_async::{RunQueryDsl, SimpleAsyncConnection};
+    use tycho_common::Bytes;
+
+    use super::{db_fixtures, schema, testing::run_against_db};
+
+    #[tokio::test]
+    async fn test_cleanup_orphaned_transactions_serial_db() {
+        run_against_db(|connection_pool| async move {
+            let mut conn = connection_pool
+                .get()
+                .await
+                .expect("Failed to get a connection from the pool");
+            let chain_id = db_fixtures::insert_chain(&mut conn, "ethereum").await;
+            let block_ids = db_fixtures::insert_blocks(&mut conn, chain_id).await;
+            let tx_ids = db_fixtures::insert_txns(
+                &mut conn,
+                &[
+                    (
+                        block_ids[0],
+                        1,
+                        "0xbb7e16d797a9e2fbc537e30f91ed3d9a656b25c8d720c28866fbb242b1b0824d",
+                    ),
+                    (
+                        block_ids[0],
+                        2,
+                        "0x794f7df7a3fe973f1583fbb92536f9a8def3a89902439289315326c04068de54",
+                    ),
+                    (
+                        block_ids[1],
+                        1,
+                        "0x3108322284d0a89a7accb288d1a94384d499504fe7e04441b0706c7628dee7b7",
+                    ),
+                    (
+                        block_ids[1],
+                        2,
+                        "0x50449de1973d86f21bfafa7c72011854a7e33a226709dc3e2e4edcca34188388",
+                    ),
+                ],
+            )
+            .await;
+            // tx0 is referenced via account.creation_tx, tx1 via contract_code.modify_tx;
+            // tx2 and tx3 are orphans.
+            let account_id = db_fixtures::insert_account(
+                &mut conn,
+                "6B175474E89094C44Da98b954EedeAC495271d0F",
+                "cleanup_test_account",
+                chain_id,
+                Some(tx_ids[0]),
+            )
+            .await;
+            db_fixtures::insert_contract_code(
+                &mut conn,
+                account_id,
+                tx_ids[1],
+                Bytes::from_str("C0C0").unwrap(),
+            )
+            .await;
+
+            // The procedure commits internally, so it must run as a single autocommit
+            // statement rather than inside a transaction. p_min_age is zeroed because the
+            // fixtures were inserted just now, far inside the production horizon.
+            conn.batch_execute(
+                "CALL cleanup_orphaned_transactions(
+                    p_batch_size => 1000,
+                    p_time_budget => interval '1 minute',
+                    p_min_age => interval '0 seconds'
+                );",
+            )
+            .await
+            .expect("cleanup procedure should run");
+
+            let mut remaining: Vec<i64> = schema::transaction::table
+                .select(schema::transaction::id)
+                .load(&mut conn)
+                .await
+                .expect("querying remaining transactions failed");
+            remaining.sort();
+            let mut expected = vec![tx_ids[0], tx_ids[1]];
+            expected.sort();
+            assert_eq!(
+                remaining, expected,
+                "referenced transactions must survive, orphans must be deleted"
+            );
+        })
+        .await;
     }
 }


### PR DESCRIPTION
## What

Replaces the `clean_transaction_table()` pg_cron job and retires the rebuild-and-swap prune script.

**Migration `2026-07-03_incremental_transaction_cleanup`:**
- Drops `clean_transaction_table()` — it ran as a single 10–28h transaction whose `AccessShare` locks on `component_balance` starved pg_partman's midnight `AccessExclusive` partition maintenance, queueing the whole indexer behind it (repeated gridlocks on dev BSC; one partman deadlock abort).
- Adds `cleanup_orphaned_transactions()`, a procedure that:
  - deletes orphaned `transaction` rows in 50k-id batches, one `COMMIT` per batch — locks are held for seconds, never hours
  - sets a 2s `lock_timeout` per batch and yields (exits gracefully) on `lock_not_available` / `deadlock_detected` instead of queueing behind partman
  - resumes from a persistent cursor (`transaction_cleanup_progress`, single-row table) — interrupting a run loses at most one uncommitted batch
  - bounds each invocation with a time budget (default 45 min)
  - skips rows younger than `p_min_age` (default 35 days — partman's 1-month retention plus margin) via a binary-searched id horizon; the `NOT EXISTS` probes remain the correctness gate
- Re-points the cron entry (matched by command, so differing jobids across environments work) to 02:00 UTC, clear of partman's midnight window.
- `down.sql` restores the previous function and its 12:00 schedule byte-for-byte.

**`scripts/prune_transaction_table.md`:** runbook replacing the configmap-only rebuild-and-swap script. On PG 15, partitioned tables (`component_balance`, `protocol_state`, `contract_storage`) cannot take `NOT VALID` foreign keys, so any drop-and-re-add FK swap forces multi-hour validation inside the exclusive window. Physical disk reclaim now uses pg_repack (same-OID file swap; FKs untouched; `--no-kill-backend` so the indexer always wins lock races) or `VACUUM FULL` with the fleet scaled down. Includes a backfill section: freshly-synced orphans look young to the horizon for 35 days and are drained with manual low-`p_min_age` runs.

**Test:** `test_cleanup_orphaned_transactions_serial_db` seeds referenced (via `account.creation_tx` and `contract_code.modify_tx`) and orphaned transactions, `CALL`s the procedure, and asserts orphans are deleted while referenced rows survive.

## Deployment note

Applying this migration re-enables the (currently manually disabled) cleanup on dev, under the new procedure, at 02:00 UTC.

## Testing

- Full migration chain applied from scratch on the CI Postgres image (pg_cron + partman); `diesel migration redo` round-trips.
- tycho-storage suite CI-style against that DB: 103 parallel + 4 serial, all pass.
- An adversarial review verified empirically on a live DB: the 9 `NOT EXISTS` probes match `pg_constraint` exactly (a missing probe silently cascade-deletes protocol data — demonstrated); `lock_timeout` is re-applied after every in-loop `COMMIT` (an `ACCESS EXCLUSIVE` grabbed mid-run made batch 5 yield at exactly 2s); interrupt/resume drained the exact remainder; cursor wrap-around, self-heal, and clamp behave as written; pg_cron executes the procedure's internal commits; the test fails if a probe is removed (mutation-tested); the horizon boundary case (all rows younger than `p_min_age`) is guarded.
- `cargo +nightly fmt --check`, `clippy --all-targets --all-features`: clean.
- Not run: the full multi-crate workspace suite — the only Rust change is a `#[cfg(test)]` module in tycho-storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)