### PR TITLE
fix(simulation): Titan override timestamps, venue aliases and indexed-state fallback

### DIFF
--- a/crates/tycho-simulation/CLAUDE.md
+++ b/crates/tycho-simulation/CLAUDE.md
@@ -10,6 +10,10 @@ for any protocol indexed by Tycho.
 - **`evm/engine_db/`**: Database backends (`SimulationDB` in-memory, `TychoDB` RPC-backed)
 - **`evm/stream.rs`**: Tycho feed integration — decodes live `FeedMessage` state into protocol
   instances ready for simulation
+- **`evm/override_stream/`**: live per-block VM state overrides for pAMMs — generic
+  `StateOverrideProvider`/`OverrideSnapshot` core plus the Titan quote-stream provider; pools
+  resolve the latest snapshot on every simulation and can fall back to indexed state per the
+  snapshot's `FailurePolicy`
 - **`evm/protocol/`**: Protocol implementations
   - **Native** (`uniswap_v2/`, `uniswap_v3/`, `uniswap_v4/`, `ekubo/`, `cowamm/`, `fluid/`,
     `aerodrome_v1/`, `aerodrome_slipstreams/`, `pancakeswap_v2/`, `etherfi/`, `erc4626/`,

--- a/crates/tycho-simulation/examples/titan_override_monitor/Readme.md
+++ b/crates/tycho-simulation/examples/titan_override_monitor/Readme.md
@@ -1,0 +1,55 @@
+# Titan Override Monitor
+
+Manual monitor proving that Titan pAMM live state overrides reprice pools **mid-block**.
+
+It subscribes to a Tycho stream for pAMM protocols (FermiSwap and bopAMM by default), shares the
+production
+Titan override provider between the pools and the monitor (one WebSocket connection), and re-quotes
+every pool each time a Titan frame arrives. Because `EVMPoolState` resolves the latest override
+snapshot on every `get_amount_out`, quotes change *between* Tycho block updates — which is exactly
+what the output makes visible.
+
+## Run
+
+```bash
+TYCHO_API_KEY=<key> cargo run -p tycho-simulation --example titan_override_monitor -- \
+    --tycho-url tycho-dev.propellerheads.xyz
+```
+
+Optional flags: `--protocols vm:fermiswap` (comma-separated), `--tvl-threshold 1`,
+`--sell-units 0.01` (sell amount in whole units of each pool's first token), `--vm-traces`
+(print full EVM call traces; extremely verbose). The Titan endpoint can be overridden with the
+`TITAN_PAMM_STREAM_URL` env var (same as production).
+
+## What to look for
+
+```
+═══ tycho block 25450948 (3 pool(s)) ═══
+08:59:38.290    vm:fermiswap titan_block=25450949 | 0.01 WETH = 17.179149 USDC
+08:59:40.164    vm:fermiswap titan_block=25450949 | 0.01 WETH = 17.179549 USDC (Δ +0.0023%)
+08:59:41.463    vm:fermiswap titan_block=25450949 | 0.01 WETH = 17.180548 USDC (Δ +0.0058%)
+    block 25450948 recap: WETH->USDC 31 quote(s), 3 distinct  <-- repriced mid-block
+    block 25450948 recap: WBTC->USDC 31 quote(s), 4 distinct  <-- repriced mid-block
+═══ tycho block 25450949 (3 pool(s)) ═══
+```
+
+- Multiple quote lines with different values between two `═══ tycho block ═══` headers — and a
+  recap with more than one distinct value — prove pools are repriced mid-block from the live
+  stream.
+- `titan_block` is the *pending* block the streamed overrides target (one ahead of the Tycho
+  block); `(expired)` means the last snapshot outlived its 12 s TTL and the pool fell back to
+  indexed state.
+- Occasional `revert: ... 0x666a2814` (`StaleUpdate`) lines in the first ~2 s of a block are
+  expected: Titan re-stamps oracle lanes gradually at block transitions, and a pair whose lane
+  still carries the previous block's timestamp reverts exactly as it would on-chain.
+
+## Baseline (overrides disabled)
+
+Point the provider at an unreachable endpoint to see the contrast — quotes then stay constant
+within each block:
+
+```bash
+TITAN_PAMM_STREAM_URL=ws://127.0.0.1:1 TYCHO_API_KEY=<key> \
+    cargo run -p tycho-simulation --example titan_override_monitor -- \
+    --tycho-url tycho-dev.propellerheads.xyz
+```

--- a/crates/tycho-simulation/examples/titan_override_monitor/main.rs
+++ b/crates/tycho-simulation/examples/titan_override_monitor/main.rs
@@ -1,0 +1,377 @@
+//! Manual monitor proving that Titan pAMM live overrides reprice pools *mid-block*.
+//!
+//! Subscribes to a Tycho stream for pAMM protocols (FermiSwap and bopAMM by default), shares the
+//! production
+//! Titan override provider between the pools and this monitor, and re-quotes every pool each time
+//! a Titan frame arrives. Quotes that change between two Tycho block updates demonstrate that
+//! [`EVMPoolState`](tycho_simulation::evm::protocol::vm::state::EVMPoolState) resolves live
+//! overrides at simulation time rather than once per block.
+//!
+//! Run with:
+//!
+//! ```bash
+//! TYCHO_API_KEY=... cargo run -p tycho-simulation --example titan_override_monitor -- \
+//!     --tycho-url tycho-dev.propellerheads.xyz
+//! ```
+//!
+//! See `Readme.md` for expected output.
+
+use std::{
+    collections::{HashMap, HashSet},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use clap::Parser;
+use futures::StreamExt;
+use num_bigint::BigUint;
+use num_traits::ToPrimitive;
+use tokio::sync::mpsc;
+use tracing_subscriber::EnvFilter;
+use tycho_common::{models::Chain, simulation::protocol_sim::ProtocolSim};
+use tycho_simulation::{
+    evm::{
+        engine_db::tycho_db::PreCachedDB,
+        override_stream::{titan, OverrideSnapshot, StateOverrideProvider},
+        protocol::vm::state::EVMPoolState,
+        stream::ProtocolStreamBuilder,
+    },
+    protocol::models::{DecoderContext, ProtocolComponent},
+    tycho_client::feed::component_tracker::ComponentFilter,
+    utils::load_all_tokens,
+};
+
+#[derive(Parser)]
+struct Cli {
+    /// Tycho server URL.
+    #[arg(long, env = "TYCHO_URL")]
+    tycho_url: String,
+
+    /// Tycho API key.
+    #[arg(long, env = "TYCHO_API_KEY", hide_env_values = true)]
+    api_key: String,
+
+    /// pAMM protocol systems to monitor.
+    #[arg(long, value_delimiter = ',', default_value = "vm:fermiswap,vm:bopamm")]
+    protocols: Vec<String>,
+
+    /// TVL threshold (in native token units) for component tracking.
+    #[arg(long, default_value_t = 1.0)]
+    tvl_threshold: f64,
+
+    /// Sell amount in whole units of each pool's first token (e.g. 0.01 WETH). Kept small so
+    /// pools with expensive base tokens (WBTC) are not quoted beyond their inventory.
+    #[arg(long, default_value_t = 0.01)]
+    sell_units: f64,
+
+    /// Print full EVM call traces for every simulation (decode-time and quotes). Extremely
+    /// verbose — redirect to a file.
+    #[arg(long, default_value_t = false)]
+    vm_traces: bool,
+}
+
+/// A monitored pool: its simulation state plus static component metadata.
+struct Pool {
+    state: Box<dyn ProtocolSim>,
+    component: ProtocolComponent,
+}
+
+/// The last quote printed for a pool: display string plus the numeric output (if it succeeded)
+/// used to compute relative deltas.
+struct LastQuote {
+    display: String,
+    value: Option<f64>,
+}
+
+/// Per-pool quote bookkeeping for the current Tycho block.
+#[derive(Default)]
+struct BlockStats {
+    quotes: u32,
+    distinct: HashSet<String>,
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
+        )
+        .init();
+    let cli = Cli::parse();
+    let chain = Chain::Ethereum;
+
+    println!("Loading tokens from {} ...", cli.tycho_url);
+    let all_tokens =
+        load_all_tokens(&cli.tycho_url, false, Some(&cli.api_key), true, chain, None, None)
+            .await
+            .expect("failed loading tokens");
+    println!("Loaded {} tokens", all_tokens.len());
+
+    // Obtain the production default Titan provider (one shared WS connection, including the
+    // TITAN_PAMM_STREAM_URL env override), but keep a handle so this monitor can subscribe to the
+    // same frames the pools consume. Registering it explicitly below prevents the builder from
+    // spawning a second default provider.
+    let providers = titan::default_providers(cli.protocols.iter().cloned());
+    if providers.is_empty() {
+        eprintln!(
+            "None of {:?} is served by the Titan provider; nothing to monitor",
+            cli.protocols
+        );
+        return;
+    }
+
+    // Forward every frame of every subscribed protocol into one channel for the select loop.
+    // Values are read from the receiver at quote time; the channel only signals "new frame".
+    let (frame_tx, mut frame_rx) = mpsc::channel::<String>(64);
+    for (protocol, provider) in &providers {
+        let mut rx = provider
+            .subscribe(protocol)
+            .expect("provider serves the protocol it was registered for");
+        let protocol = protocol.clone();
+        let frame_tx = frame_tx.clone();
+        tokio::spawn(async move {
+            while rx.changed().await.is_ok() {
+                if frame_tx
+                    .send(protocol.clone())
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+            }
+        });
+    }
+
+    let tvl_filter = ComponentFilter::with_tvl_range(cli.tvl_threshold, cli.tvl_threshold);
+    let mut builder = ProtocolStreamBuilder::new(&cli.tycho_url, chain);
+    for protocol in &cli.protocols {
+        builder = builder.exchange_with_decoder_context::<EVMPoolState<PreCachedDB>>(
+            protocol,
+            tvl_filter.clone(),
+            None,
+            DecoderContext::new().vm_traces(cli.vm_traces),
+        );
+    }
+    for (protocol, provider) in &providers {
+        builder = builder.with_override_provider(protocol, provider.clone());
+    }
+    let stream = builder
+        .auth_key(Some(cli.api_key.clone()))
+        .skip_state_decode_failures(true)
+        .set_tokens(all_tokens)
+        .await
+        .build()
+        .await
+        .expect("failed building the protocol stream");
+    tokio::pin!(stream);
+    println!("Waiting for the first Tycho block update (snapshot decoding may take a while) ...\n");
+
+    let mut pools: HashMap<String, Pool> = HashMap::new();
+    let mut last_printed: HashMap<String, LastQuote> = HashMap::new();
+    let mut block_stats: HashMap<String, BlockStats> = HashMap::new();
+    let mut current_block: Option<u64> = None;
+    let mut last_probe = Instant::now() - Duration::from_secs(1);
+
+    loop {
+        tokio::select! {
+            update = stream.next() => {
+                let Some(update) = update else {
+                    println!("Tycho stream closed, exiting");
+                    return;
+                };
+                let update = match update {
+                    Ok(update) => update,
+                    Err(e) => {
+                        eprintln!("stream error: {e}");
+                        continue;
+                    }
+                };
+                print_block_recap(current_block, &pools, &block_stats);
+                block_stats.clear();
+                current_block = Some(update.block_number_or_timestamp);
+
+                for (id, component) in update.new_pairs {
+                    // The stream also carries synthetic components (e.g. the native ETH/WETH
+                    // wrapper); only monitor the pAMM protocols that were asked for.
+                    if !cli.protocols.contains(&component.protocol_system) {
+                        continue;
+                    }
+                    let Some(state) = update.states.get(&id) else { continue };
+                    pools.insert(id.clone(), Pool { state: state.clone(), component });
+                }
+                for (id, state) in update.states {
+                    if let Some(pool) = pools.get_mut(&id) {
+                        pool.state = state;
+                    }
+                }
+                for (id, _) in update.removed_pairs {
+                    pools.remove(&id);
+                }
+
+                println!(
+                    "\n═══ tycho block {} ({} pool(s)) ═══",
+                    update.block_number_or_timestamp,
+                    pools.len()
+                );
+                quote_all(&pools, &providers, cli.sell_units, &mut last_printed, &mut block_stats, true);
+            }
+            Some(_protocol) = frame_rx.recv() => {
+                // Titan pushes several frames per second; a handful of probes per second is
+                // enough to show mid-block movement without hammering the simulator.
+                if last_probe.elapsed() < Duration::from_millis(250) || pools.is_empty() {
+                    continue;
+                }
+                last_probe = Instant::now();
+                quote_all(&pools, &providers, cli.sell_units, &mut last_printed, &mut block_stats, false);
+            }
+            _ = tokio::signal::ctrl_c() => {
+                print_block_recap(current_block, &pools, &block_stats);
+                println!("\nbye");
+                return;
+            }
+        }
+    }
+}
+
+/// Quotes `sell_units` of `token0` on every pool and prints each quote that differs from the last
+/// one printed for that pool. With `force`, prints unconditionally (block-boundary baseline).
+fn quote_all(
+    pools: &HashMap<String, Pool>,
+    providers: &HashMap<String, std::sync::Arc<dyn StateOverrideProvider>>,
+    sell_units: f64,
+    last_printed: &mut HashMap<String, LastQuote>,
+    block_stats: &mut HashMap<String, BlockStats>,
+    force: bool,
+) {
+    for (id, pool) in pools {
+        let [token_in, token_out, ..] = pool.component.tokens.as_slice() else { continue };
+        let amount_in = BigUint::from((10f64.powi(token_in.decimals as i32) * sell_units) as u128);
+        let result = pool
+            .state
+            .get_amount_out(amount_in, token_in, token_out);
+        // `raw` keys the distinct-quote counter on the exact integer output, so movement below
+        // the display precision is still counted as a reprice.
+        let (display, value, raw) = match &result {
+            Ok(res) => {
+                let human =
+                    res.amount.to_f64().unwrap_or(f64::NAN) / 10f64.powi(token_out.decimals as i32);
+                (
+                    format!(
+                        "{sell_units} {} = {} {}",
+                        token_in.symbol,
+                        format_amount(human),
+                        token_out.symbol
+                    ),
+                    Some(human),
+                    res.amount.to_string(),
+                )
+            }
+            Err(e) => {
+                let display = format!("{}->{} revert: {e}", token_in.symbol, token_out.symbol);
+                (display.clone(), None, display)
+            }
+        };
+
+        let stats = block_stats
+            .entry(id.clone())
+            .or_default();
+        stats.quotes += 1;
+        stats.distinct.insert(raw);
+
+        if force ||
+            last_printed
+                .get(id)
+                .is_none_or(|last| last.display != display)
+        {
+            let snapshot = providers
+                .get(&pool.component.protocol_system)
+                .and_then(|provider| provider.subscribe(&pool.component.protocol_system))
+                .map(|rx| rx.borrow().clone())
+                .unwrap_or_default();
+            println!(
+                "{}  {:>14} {} | {}{}",
+                wall_clock(),
+                pool.component.protocol_system,
+                describe_snapshot(&snapshot),
+                display,
+                delta_suffix(
+                    last_printed
+                        .get(id)
+                        .and_then(|last| last.value),
+                    value
+                ),
+            );
+            last_printed.insert(id.clone(), LastQuote { display, value });
+        }
+    }
+}
+
+/// One line per pool: how many quotes were computed in the finished block and how many distinct
+/// values they produced. More than one distinct value proves mid-block repricing.
+fn print_block_recap(
+    block: Option<u64>,
+    pools: &HashMap<String, Pool>,
+    stats: &HashMap<String, BlockStats>,
+) {
+    let Some(block) = block else { return };
+    for (id, stat) in stats {
+        let Some(pool) = pools.get(id) else { continue };
+        let [token_in, token_out, ..] = pool.component.tokens.as_slice() else { continue };
+        println!(
+            "    block {block} recap: {}->{} {} quote(s), {} distinct{}",
+            token_in.symbol,
+            token_out.symbol,
+            stat.quotes,
+            stat.distinct.len(),
+            if stat.distinct.len() > 1 { "  <-- repriced mid-block" } else { "" },
+        );
+    }
+}
+
+/// The live snapshot's block context, e.g. `titan_block=25445671` or `no override`.
+fn describe_snapshot(snapshot: &OverrideSnapshot) -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_secs();
+    match snapshot.block_number {
+        Some(block) if snapshot.is_expired(now) => format!("titan_block={block} (expired)"),
+        Some(block) => format!("titan_block={block}"),
+        None => "no override".to_string(),
+    }
+}
+
+/// Formats an output amount with enough precision that small quotes (e.g. USDC->WETH) still show
+/// movement instead of rounding to a constant.
+fn format_amount(value: f64) -> String {
+    if value == 0.0 || value.abs() >= 0.001 {
+        format!("{value:.6}")
+    } else {
+        format!("{value:.10}")
+    }
+}
+
+/// Relative change vs the previously printed quote, e.g. ` (Δ -0.0021%)`.
+fn delta_suffix(previous: Option<f64>, current: Option<f64>) -> String {
+    let (Some(previous), Some(current)) = (previous, current) else {
+        return String::new();
+    };
+    if previous == 0.0 {
+        return String::new();
+    }
+    format!(" (Δ {:+.4}%)", (current - previous) / previous * 100.0)
+}
+
+/// Current wall-clock time as `HH:MM:SS.mmm` (UTC).
+fn wall_clock() -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock");
+    let secs = now.as_secs();
+    format!(
+        "{:02}:{:02}:{:02}.{:03}",
+        secs / 3600 % 24,
+        secs / 60 % 60,
+        secs % 60,
+        now.subsec_millis()
+    )
+}

--- a/crates/tycho-simulation/src/evm/override_stream/mod.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/mod.rs
@@ -12,6 +12,8 @@
 //! - [`StateOverrideProvider`](crate::evm::override_stream::StateOverrideProvider) — a source that
 //!   maintains a *live* [`watch`](tokio::sync::watch) channel of snapshots per protocol (kept fresh
 //!   in the background, e.g. from a WebSocket).
+//! - [`FailurePolicy`](crate::evm::override_stream::FailurePolicy) — the provider-set reaction of a
+//!   pool to a simulation that fails while a snapshot's overrides are applied.
 //!
 //! Providers are registered per `protocol_system` (see
 //! [`ProtocolStreamBuilder::with_override_provider`](crate::evm::stream::ProtocolStreamBuilder::with_override_provider)).
@@ -28,12 +30,34 @@ use std::{collections::HashMap, sync::Arc};
 use alloy::primitives::{Address, U256};
 use tokio::sync::watch;
 
+/// What a pool should do when a simulation fails while a snapshot's overrides are applied.
+///
+/// Set by the provider, which knows whether its overrides are authoritative or an advisory
+/// enhancement of the indexed state.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FailurePolicy {
+    /// Propagate the failure to the caller.
+    #[default]
+    Error,
+    /// Retry the failed simulation without any overrides, on the plain indexed state.
+    ///
+    /// Suits providers whose overrides are only intermittently applicable — e.g. Titan pAMM
+    /// snapshots, which target the pending block and can make a pair transiently unquotable
+    /// (oracle lane not yet re-stamped for that block) even though the indexed state simulates
+    /// fine.
+    FallbackToIndexedState,
+}
+
 /// Resolved per-block VM overrides for a single protocol at a point in time.
 ///
 /// `block_number` and `block_timestamp` are already resolved by the provider (e.g. Titan derives
 /// `block_timestamp` from the frame's beacon slot) so this core stays protocol-agnostic. Either
 /// field may be `None`, in which case the pool's existing block environment is left intact.
+///
+/// The struct is `#[non_exhaustive]` so fields can be added without breaking downstream
+/// providers; construct it outside this crate by mutating a [`Default::default`] value.
 #[derive(Clone, Default, Debug)]
+#[non_exhaustive]
 pub struct OverrideSnapshot {
     /// The L1 block number these overrides apply to, if known.
     pub block_number: Option<u64>,
@@ -47,6 +71,8 @@ pub struct OverrideSnapshot {
     /// provider from its own freshness rules (e.g. Titan uses the quote timestamp plus one block
     /// time). `None` means the snapshot never expires — e.g. the empty initial snapshot.
     pub expires_at: Option<u64>,
+    /// How a pool should react when a simulation fails with these overrides applied.
+    pub failure_policy: FailurePolicy,
 }
 
 impl OverrideSnapshot {

--- a/crates/tycho-simulation/src/evm/override_stream/mod.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/mod.rs
@@ -30,9 +30,9 @@ use tokio::sync::watch;
 
 /// Resolved per-block VM overrides for a single protocol at a point in time.
 ///
-/// `block_number` and `block_timestamp` are already resolved by the provider (e.g. Titan computes
-/// `block_timestamp` from lane timestamps) so this core stays protocol-agnostic. Either field may
-/// be `None`, in which case the pool's existing block environment is left intact.
+/// `block_number` and `block_timestamp` are already resolved by the provider (e.g. Titan derives
+/// `block_timestamp` from the frame's beacon slot) so this core stays protocol-agnostic. Either
+/// field may be `None`, in which case the pool's existing block environment is left intact.
 #[derive(Clone, Default, Debug)]
 pub struct OverrideSnapshot {
     /// The L1 block number these overrides apply to, if known.

--- a/crates/tycho-simulation/src/evm/override_stream/titan.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/titan.rs
@@ -6,8 +6,45 @@
 //! `EVMPoolState` instances before simulation. See
 //! <https://docs.titanbuilder.xyz/propamms/takers>.
 //!
-//! All Titan/Fermi-specific knowledge (venue addresses, lane-timestamp resolution, endpoint URL)
-//! lives only in this module; the rest of the override machinery is protocol-agnostic.
+//! # Why the block timestamp must be overridden too
+//!
+//! Titan quotes target the *pending* L1 block. Registry-backed venues (FermiSwap, Kipseli)
+//! receive their oracle prices through Flashbots'
+//! [priority-update-registry](https://github.com/flashbots/priority-update-registry), whose lanes
+//! are stamped with the pending block's timestamp and whose reads revert with `StaleUpdate()` when
+//! the stored timestamp falls outside a freshness window derived from `block.timestamp`.
+//! Simulating against the latest indexed block therefore reverts even with the storage overrides
+//! applied; the simulated block timestamp must be bumped to the pending block's.
+//!
+//! The pending block timestamp is derived from the frame's beacon `slot` field as
+//! `BEACON_GENESIS_TIMESTAMP + slot * SECONDS_PER_SLOT`. This mirrors Titan's reference taker
+//! implementation ([gattaca-com/propamm](https://github.com/gattaca-com/propamm), `quoter.py`) and
+//! the [LambdaClass propAMM SDK](https://github.com/lambdaclass/propamm-router-contracts), both of
+//! which pass exactly this value as a block override alongside the state overrides. Should `slot`
+//! ever be absent, the timestamp is recovered from the registry lanes themselves, then from the
+//! frame's wall clock; see [`TitanProvider::pending_block_timestamp`].
+//!
+//! # Observed stream anatomy (2026-07)
+//!
+//! Facts established against the live stream and the deployed contracts, on which this module
+//! relies:
+//!
+//! - Each WebSocket message carries `slot` / `blockNumber` / `timestamp` plus a single top-level
+//!   venue key (one message per venue per update), unlike the docs' merged multi-venue sample. Both
+//!   shapes are handled.
+//! - FermiSwap and Kipseli store their oracle prices in the shared priority-update-registry
+//!   instance at `0xda7afeed01fe625cf15d187a19f94b45f00b8c5f`. A lane's base slot is
+//!   `keccak256(abi.encode(venue, laneIndex))`; the base slot value packs the lane's
+//!   `updateTimestamp` (uint32, top 4 bytes), the slot count (uint8, next byte) and the first
+//!   27-byte value, with continuation slots stored verbatim at `base + 1..`. The deployed
+//!   registry's `MAX_UPDATE_AGE`/`MAX_UPDATE_LEAD_TIME` are both zero, so on-chain writes require
+//!   `updateTimestamp == block.timestamp` — which is why Titan stamps lanes with the pending
+//!   block's timestamp and why simulations must run under that timestamp.
+//! - bopAMM (Bebop) does not use the registry: its frames override the venue's own storage with the
+//!   maker's signed quote, so no lane timestamps appear there.
+//!
+//! All Titan-specific knowledge (venue addresses, timestamp resolution, endpoint URL) lives only
+//! in this module; the rest of the override machinery is protocol-agnostic.
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
@@ -28,13 +65,15 @@ type VenueOverrides = HashMap<Address, HashMap<U256, U256>>;
 
 /// A parsed Titan quote-stream frame.
 ///
-/// `blockNumber` and `timestamp` (the nanosecond wall-clock instant Titan built the quote) are
-/// consumed at this level; every other top-level key (venue addresses, `slot`, and any future
-/// fields) lands in `overrides` as raw JSON. Only the venue keys we look up are then deserialized
-/// into [`AddressEntry`], so an upstream schema change that adds top-level fields never breaks
-/// parsing.
+/// `slot` (the beacon slot the quote targets), `blockNumber` and `timestamp` (the nanosecond
+/// wall-clock instant Titan built the quote) are consumed at this level; every other top-level key
+/// (venue addresses and any future fields) lands in `overrides` as raw JSON. Only the venue keys
+/// we look up are then deserialized into [`AddressEntry`], so an upstream schema change that adds
+/// top-level fields never breaks parsing.
 #[derive(Debug, Deserialize)]
 struct TitanMessage {
+    #[serde(default)]
+    slot: Option<u64>,
     #[serde(rename = "blockNumber", default)]
     block_number: Option<u64>,
     #[serde(default)]
@@ -76,8 +115,11 @@ const BOPAMM_PROTOCOL_SYSTEM: &str = "vm:bopamm";
 const FERMISWAP_VENUE: &str = "0xb1076fe3ab5e28005c7c323bac5ac06a680d452e";
 /// Kipseli pAMM venue address on Titan's quote stream.
 const KIPSELI_VENUE: &str = "0x5cdbe59400cc2efdcc2b54acca4a99fe00dd588c";
-/// bopAMM pAMM venue address on Titan's quote stream.
-const BOPAMM_VENUE: &str = "0x160141a205f5ddcf096ba3f48b7ed21eb52c62ea";
+/// bopAMM (Bebop) pAMM venue address on Titan's quote stream. Unlike the registry-backed venues,
+/// its frames override the venue's own storage with the maker's signed quote. Supersedes
+/// `0x160141a205f5ddcf096ba3f48b7ed21eb52c62ea`, which stopped trading on 2026-05-21 and no longer
+/// appears on the stream.
+const BOPAMM_VENUE: &str = "0x28d9ccedf1b7ac9b3f090f4f0292837de87c1d39";
 
 /// Longest gap between Titan messages tolerated before the socket is treated as dead and
 /// re-established. Titan pushes several updates per second, so a multi-second silence means a
@@ -96,6 +138,20 @@ const MAX_BACKOFF_EXP: u32 = 5;
 /// it the snapshot is stale and the pool reverts to Tycho's indexed state. Used to derive each
 /// snapshot's [`OverrideSnapshot::expires_at`] from the frame's wall-clock `timestamp`.
 const TITAN_QUOTE_TTL_SECS: u64 = 12;
+
+/// Unix timestamp of the Ethereum beacon chain genesis (2020-12-01 12:00:23 UTC). A beacon slot's
+/// timestamp is `BEACON_GENESIS_TIMESTAMP + slot * SECONDS_PER_SLOT`.
+const BEACON_GENESIS_TIMESTAMP: u64 = 1_606_824_023;
+
+/// Post-merge Ethereum slot duration in seconds.
+const SECONDS_PER_SLOT: u64 = 12;
+
+/// Longest a registry lane timestamp may lie ahead of the frame's wall-clock `timestamp` and still
+/// be accepted by the lane-extraction fallback. A genuine lane timestamp is the pending block's
+/// timestamp, i.e. at most one slot ahead of the instant the quote was built; two slots leaves
+/// margin for clock skew. Anything further out is packed venue data that merely looks like a
+/// timestamp.
+const MAX_LANE_TIMESTAMP_LEAD_SECS: u64 = 2 * SECONDS_PER_SLOT;
 
 /// Returns the pAMM `protocol_system`s this provider knows how to serve.
 fn known_pamm_protocols() -> &'static [&'static str] {
@@ -321,10 +377,11 @@ impl TitanProvider {
     /// venue).
     ///
     /// Returns `Ok(None)` if the venue is absent from the frame. The block timestamp is resolved
-    /// from the freshest lane update timestamp (see
-    /// [`max_lane_timestamp`](Self::max_lane_timestamp)) so the pool's oracle-staleness guard
-    /// sees the overridden prices as current, and `expires_at` is set to the frame's wall-clock
-    /// `timestamp` plus [`TITAN_QUOTE_TTL_SECS`] so the pool stops using it once it goes stale.
+    /// to the pending block's timestamp (see
+    /// [`pending_block_timestamp`](Self::pending_block_timestamp)) so the registry's
+    /// oracle-staleness guard sees the overridden prices as current, and `expires_at` is set to the
+    /// frame's wall-clock `timestamp` plus [`TITAN_QUOTE_TTL_SECS`] so the pool stops using it once
+    /// it goes stale.
     fn extract_venue(
         message: &TitanMessage,
         venue: &Address,
@@ -348,10 +405,7 @@ impl TitanProvider {
             }
         }
 
-        // Resolve the block timestamp from the freshest lane update, not the wall-clock
-        // `timestamp` field, so the registry's oracle-staleness guard treats the streamed prices
-        // as current.
-        let block_timestamp = Self::max_lane_timestamp(&storage);
+        let block_timestamp = Self::pending_block_timestamp(message, &storage);
 
         // Expire the snapshot one block time after Titan built it, using the frame's nanosecond
         // wall-clock `timestamp`. Once past this the pool drops the override and reverts to Tycho's
@@ -368,17 +422,79 @@ impl TitanProvider {
         }))
     }
 
-    /// Returns the newest lane update timestamp (in seconds) across all overridden slots.
+    /// Returns the unix-seconds timestamp of the pending block the frame's quote targets, or
+    /// `None` if the frame carries no timestamp signal at all.
     ///
-    /// FermiSwap registry lanes pack a uint32 update timestamp in the first 4 bytes of the slot
-    /// value. This extracts that prefix from every overridden slot and returns the maximum value
-    /// that looks like a plausible unix timestamp, or `None` if there are none. The result is used
-    /// as the resolved `block_timestamp` so the registry's staleness guard treats the streamed
-    /// oracle prices as current.
+    /// Resolution order:
+    /// 1. The frame's beacon `slot` field (`BEACON_GENESIS_TIMESTAMP + slot * 12`) — the
+    ///    authoritative source, and the one used by Titan's reference taker
+    ///    (<https://github.com/gattaca-com/propamm>, `quoter.py`) and the LambdaClass propAMM SDK
+    ///    (<https://github.com/lambdaclass/propamm-router-contracts>). Rejected (falling through
+    ///    to the next sources) if the multiplication overflows or the derived value is implausible
+    ///    against the frame's wall clock — see [`slot_timestamp`](Self::slot_timestamp).
+    /// 2. The registry lane timestamps embedded in the storage overrides (see
+    ///    [`max_lane_timestamp`](Self::max_lane_timestamp)): Titan stamps lanes with the pending
+    ///    block's timestamp, so a genuine lane timestamp equals the slot-derived value. Only
+    ///    accepted when it lies within [`MAX_LANE_TIMESTAMP_LEAD_SECS`] ahead of the frame's wall
+    ///    clock, so packed venue data that merely looks like a timestamp (e.g. bopAMM's signed
+    ///    quote encoding) can never be injected as the block timestamp. Without a wall clock to
+    ///    validate against, a lane timestamp is never trusted.
+    /// 3. The frame's nanosecond wall-clock `timestamp`. Up to one slot earlier than the pending
+    ///    block, so registry-backed venues may still reject it as stale, but it is the best
+    ///    remaining approximation.
+    fn pending_block_timestamp(message: &TitanMessage, storage: &VenueOverrides) -> Option<u64> {
+        let wall_clock = message
+            .timestamp
+            .map(|ns| ns / 1_000_000_000);
+        if let Some(slot_ts) = Self::slot_timestamp(message.slot, wall_clock) {
+            return Some(slot_ts);
+        }
+        match (Self::max_lane_timestamp(storage), wall_clock) {
+            (Some(lane), Some(now))
+                if (now..=now + MAX_LANE_TIMESTAMP_LEAD_SECS).contains(&lane) =>
+            {
+                Some(lane)
+            }
+            (Some(_), wall_clock) | (None, wall_clock) => wall_clock,
+        }
+    }
+
+    /// Derives the timestamp of the beacon `slot`
+    /// (`BEACON_GENESIS_TIMESTAMP + slot * SECONDS_PER_SLOT`).
+    ///
+    /// The slot comes verbatim from the stream, so it is not trusted blindly: returns `None` when
+    /// `slot` is absent, when the arithmetic overflows, or when a wall clock is available and the
+    /// derived value falls outside `wall_clock - SECONDS_PER_SLOT ..=
+    /// wall_clock + MAX_LANE_TIMESTAMP_LEAD_SECS` (a genuine pending-block timestamp is at most
+    /// one slot ahead of the instant the quote was built; the slack behind covers clock skew and
+    /// late frames). Without a wall clock the arithmetic-checked value is accepted as is.
+    fn slot_timestamp(slot: Option<u64>, wall_clock: Option<u64>) -> Option<u64> {
+        let derived = slot?
+            .checked_mul(SECONDS_PER_SLOT)
+            .and_then(|offset| BEACON_GENESIS_TIMESTAMP.checked_add(offset))?;
+        match wall_clock {
+            Some(now)
+                if !(now.saturating_sub(SECONDS_PER_SLOT)..=
+                    now.saturating_add(MAX_LANE_TIMESTAMP_LEAD_SECS))
+                    .contains(&derived) =>
+            {
+                None
+            }
+            Some(_) | None => Some(derived),
+        }
+    }
+
+    /// Returns the newest lane update timestamp (in seconds) across all overridden slots, or
+    /// `None` if no plausible one is present.
+    ///
+    /// Registry lane base slots pack a uint32 unix-seconds `updateTimestamp` in the top 4 bytes of
+    /// the slot value (see the module docs and
+    /// <https://github.com/flashbots/priority-update-registry>). This extracts that prefix from
+    /// every overridden slot and keeps the maximum value inside a plausible unix-timestamp window.
+    /// Heuristic by nature — continuation slots and non-registry venues store raw data whose top
+    /// bytes can collide with the window — so callers must cross-check the result against the
+    /// frame's wall clock before trusting it.
     fn max_lane_timestamp(overrides: &VenueOverrides) -> Option<u64> {
-        // Lane slots pack a uint32 unix-seconds timestamp in the top 4 bytes (`value >> 224`).
-        // Non-lane slots have other (usually zero) top bytes, so we keep only values inside a
-        // plausible window to discard them.
         const MIN_PLAUSIBLE: u64 = 1_000_000_000; // ~2001-09
         const MAX_PLAUSIBLE: u64 = u32::MAX as u64; // uint32 ceiling (~2106)
         overrides
@@ -463,6 +579,8 @@ mod tests {
             .expect("venue is present");
 
         assert_eq!(snapshot.block_number, Some(25051224));
+        // Pending block timestamp derived from the beacon slot: 1606824023 + 14285824 * 12.
+        assert_eq!(snapshot.block_timestamp, Some(1778253911));
         // 1778253913749564761 ns -> 1778253913 s, plus the 12s quote TTL.
         assert_eq!(snapshot.expires_at, Some(1778253913 + TITAN_QUOTE_TTL_SECS));
 
@@ -495,34 +613,98 @@ mod tests {
             .is_none());
     }
 
-    #[test]
-    fn max_lane_timestamp_picks_newest_plausible_top_word() {
-        let addr = FERMISWAP_VENUE
+    fn message(slot: Option<u64>, timestamp: Option<u64>) -> TitanMessage {
+        TitanMessage { slot, block_number: Some(25445022), timestamp, overrides: HashMap::new() }
+    }
+
+    fn lane_overrides(lane_ts: u64) -> VenueOverrides {
+        let account = "0xda7afeed01fe625cf15d187a19f94b45f00b8c5f"
             .parse::<Address>()
             .unwrap();
-        // Two lane slots with the timestamp packed in the top 4 bytes, plus a non-lane slot
-        // whose top bytes are zero (must be ignored).
-        let older = U256::from(1_700_000_000u64) << 224;
-        let newer = U256::from(1_800_000_000u64) << 224;
-        let non_lane = U256::from(42u64);
-        let overrides = HashMap::from([(
-            addr,
-            HashMap::from([
-                (U256::from(0u64), older),
-                (U256::from(1u64), newer),
-                (U256::from(2u64), non_lane),
-            ]),
-        )]);
-        assert_eq!(TitanProvider::max_lane_timestamp(&overrides), Some(1_800_000_000));
+        HashMap::from([(account, HashMap::from([(U256::from(1u64), U256::from(lane_ts) << 224)]))])
+    }
+
+    /// Wall clock 1782997641s, one slot before the pending block's timestamp 1782997643 (both
+    /// observed live for block 25445022 / slot 14681135).
+    const WALL_CLOCK_NS: u64 = 1782997641189454379;
+    const PENDING_BLOCK_TS: u64 = 1782997643;
+
+    #[test]
+    fn pending_block_timestamp_derives_from_beacon_slot() {
+        // The slot field wins even when lane timestamps are present.
+        let message = message(Some(14681135), Some(WALL_CLOCK_NS));
+        assert_eq!(
+            TitanProvider::pending_block_timestamp(&message, &lane_overrides(1_800_000_000)),
+            Some(PENDING_BLOCK_TS)
+        );
     }
 
     #[test]
-    fn max_lane_timestamp_none_when_no_plausible_values() {
-        let addr = FERMISWAP_VENUE
-            .parse::<Address>()
-            .unwrap();
-        let overrides =
-            HashMap::from([(addr, HashMap::from([(U256::from(0u64), U256::from(7u64))]))]);
-        assert!(TitanProvider::max_lane_timestamp(&overrides).is_none());
+    fn pending_block_timestamp_rejects_implausible_slot() {
+        // A slot decoding to a timestamp far from the frame's wall clock is corrupt stream data;
+        // resolution must fall through to the remaining sources (here: the wall clock).
+        let message = message(Some(1), Some(WALL_CLOCK_NS));
+        assert_eq!(
+            TitanProvider::pending_block_timestamp(&message, &HashMap::new()),
+            Some(1782997641)
+        );
+    }
+
+    #[test]
+    fn pending_block_timestamp_survives_overflowing_slot() {
+        // `u64::MAX * SECONDS_PER_SLOT` must not panic or wrap; it falls through to the wall
+        // clock.
+        let message = message(Some(u64::MAX), Some(WALL_CLOCK_NS));
+        assert_eq!(
+            TitanProvider::pending_block_timestamp(&message, &HashMap::new()),
+            Some(1782997641)
+        );
+    }
+
+    #[test]
+    fn pending_block_timestamp_ignores_lane_without_wall_clock() {
+        // Without a wall clock there is nothing to validate a lane timestamp against, so even a
+        // plausible-looking one must not be trusted.
+        let message = message(None, None);
+        assert!(TitanProvider::pending_block_timestamp(
+            &message,
+            &lane_overrides(PENDING_BLOCK_TS)
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn pending_block_timestamp_backs_up_to_lane_timestamps() {
+        let message = message(None, Some(WALL_CLOCK_NS));
+        assert_eq!(
+            TitanProvider::pending_block_timestamp(&message, &lane_overrides(PENDING_BLOCK_TS)),
+            Some(PENDING_BLOCK_TS)
+        );
+    }
+
+    #[test]
+    fn pending_block_timestamp_rejects_implausible_lane_timestamps() {
+        // Top bytes of bopAMM's packed quote data decode to 1557751927 (2019) — far outside the
+        // wall-clock window, so the fallback must skip it and use the wall clock.
+        let message = message(None, Some(WALL_CLOCK_NS));
+        assert_eq!(
+            TitanProvider::pending_block_timestamp(&message, &lane_overrides(1_557_751_927)),
+            Some(1782997641)
+        );
+    }
+
+    #[test]
+    fn pending_block_timestamp_falls_back_to_wall_clock() {
+        let message = message(None, Some(WALL_CLOCK_NS));
+        assert_eq!(
+            TitanProvider::pending_block_timestamp(&message, &HashMap::new()),
+            Some(1782997641)
+        );
+    }
+
+    #[test]
+    fn pending_block_timestamp_none_without_any_signal() {
+        let message = message(None, None);
+        assert!(TitanProvider::pending_block_timestamp(&message, &HashMap::new()).is_none());
     }
 }

--- a/crates/tycho-simulation/src/evm/override_stream/titan.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/titan.rs
@@ -60,7 +60,7 @@ use tokio::{
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{info, warn};
 
-use super::{OverrideSnapshot, StateOverrideProvider};
+use super::{FailurePolicy, OverrideSnapshot, StateOverrideProvider};
 
 /// Storage overrides keyed by contract address, then by storage slot.
 type VenueOverrides = HashMap<Address, HashMap<U256, U256>>;
@@ -449,6 +449,12 @@ impl TitanProvider {
             block_timestamp,
             storage: Arc::new(storage),
             expires_at,
+            // Titan snapshots target the pending block and a pair is only quotable under them
+            // once its oracle lane is re-stamped for that block — briefly false for every pair
+            // at block transitions, and for longer stretches for pairs the maker is not actively
+            // quoting. The indexed state remains simulatable throughout, so pools should fall
+            // back to it instead of surfacing the transient revert.
+            failure_policy: FailurePolicy::FallbackToIndexedState,
         }))
     }
 
@@ -615,6 +621,8 @@ mod tests {
         assert_eq!(snapshot.block_timestamp, Some(1778253911));
         // 1778253913749564761 ns -> 1778253913 s, plus the 12s quote TTL.
         assert_eq!(snapshot.expires_at, Some(1778253913 + TITAN_QUOTE_TTL_SECS));
+        // Titan overrides are only intermittently applicable, so pools must fall back.
+        assert_eq!(snapshot.failure_policy, FailurePolicy::FallbackToIndexedState);
 
         let account = "0x1038c87766e36d1925889e6f26d10e0012d50fed"
             .parse::<Address>()

--- a/crates/tycho-simulation/src/evm/override_stream/titan.rs
+++ b/crates/tycho-simulation/src/evm/override_stream/titan.rs
@@ -40,8 +40,10 @@
 //!   registry's `MAX_UPDATE_AGE`/`MAX_UPDATE_LEAD_TIME` are both zero, so on-chain writes require
 //!   `updateTimestamp == block.timestamp` — which is why Titan stamps lanes with the pending
 //!   block's timestamp and why simulations must run under that timestamp.
-//! - bopAMM (Bebop) does not use the registry: its frames override the venue's own storage with the
-//!   maker's signed quote, so no lane timestamps appear there.
+//! - Venue keys are unstable: makers stream under several alias addresses (oracle and router keys
+//!   carry identical payloads) and deployments change every few weeks. Each protocol therefore
+//!   subscribes to all of its known aliases, and an empty snapshot channel is the first sign that
+//!   every alias left the stream (`scripts/titan-venue-census.py` shows the live venue set).
 //!
 //! All Titan-specific knowledge (venue addresses, timestamp resolution, endpoint URL) lives only
 //! in this module; the rest of the override machinery is protocol-agnostic.
@@ -111,15 +113,17 @@ const KIPSELI_PROTOCOL_SYSTEM: &str = "vm:kipseli";
 /// bopAMM protocol system identifier as indexed by Tycho.
 const BOPAMM_PROTOCOL_SYSTEM: &str = "vm:bopamm";
 
-/// FermiSwap pAMM venue address on Titan's quote stream.
-const FERMISWAP_VENUE: &str = "0xb1076fe3ab5e28005c7c323bac5ac06a680d452e";
-/// Kipseli pAMM venue address on Titan's quote stream.
-const KIPSELI_VENUE: &str = "0x5cdbe59400cc2efdcc2b54acca4a99fe00dd588c";
-/// bopAMM (Bebop) pAMM venue address on Titan's quote stream. Unlike the registry-backed venues,
-/// its frames override the venue's own storage with the maker's signed quote. Supersedes
-/// `0x160141a205f5ddcf096ba3f48b7ed21eb52c62ea`, which stopped trading on 2026-05-21 and no longer
-/// appears on the stream.
-const BOPAMM_VENUE: &str = "0x28d9ccedf1b7ac9b3f090f4f0292837de87c1d39";
+/// FermiSwap venue aliases on Titan's quote stream: the FermiSwap oracle and the FermiSwapper
+/// router. Both keys carry the same registry diffs; either serves the protocol.
+const FERMISWAP_VENUES: &[&str] =
+    &["0xb1076fe3ab5e28005c7c323bac5ac06a680d452e", "0x5979458912f80b96d30d4220af8e2e4925a33320"];
+/// Kipseli venue aliases on Titan's quote stream: the Kipseli oracle and the KipseliPropAMMWrapper
+/// router, both carrying the same registry diffs.
+const KIPSELI_VENUES: &[&str] =
+    &["0x5cdbe59400cc2efdcc2b54acca4a99fe00dd588c", "0x71e790dd841c8a9061487cb3e78c288e75ce0b3d"];
+/// bopAMM (Bebop) venue on Titan's quote stream: a self-storage pAMM whose frames write the
+/// maker's signed quote into the venue's own storage.
+const BOPAMM_VENUES: &[&str] = &["0x160141a205f5ddcf096ba3f48b7ed21eb52c62ea"];
 
 /// Longest gap between Titan messages tolerated before the socket is treated as dead and
 /// re-established. Titan pushes several updates per second, so a multi-second silence means a
@@ -215,13 +219,13 @@ impl TitanProvider {
         let mut receivers = HashMap::new();
         let mut senders = Vec::new();
         for &protocol in protocols {
-            let Some(venue) = Self::venue_for_protocol(protocol) else {
+            let Some(venues) = Self::venues_for_protocol(protocol) else {
                 warn!("Unknown protocol: {protocol}");
                 continue;
             };
             let (tx, rx) = watch::channel(OverrideSnapshot::default());
             receivers.insert(protocol.to_string(), rx);
-            senders.push((venue, tx));
+            senders.push((venues, tx));
         }
         tokio::spawn(Self::run(url, senders));
         Self { receivers }
@@ -230,12 +234,13 @@ impl TitanProvider {
     /// Maintains the Titan WebSocket connection for the lifetime of the process.
     ///
     /// Connects, reads messages, and publishes each parsed [`OverrideSnapshot`] on the matching
-    /// venue channel. Any disconnect, read error, server-side close, or idle timeout drops back to
-    /// the reconnect loop, which retries forever with capped exponential backoff. The backoff is
-    /// reset only after a message is actually received, so a socket that connects and immediately
-    /// drops still backs off instead of busy-looping. This task never returns and never panics:
-    /// every failure mode is logged and retried.
-    async fn run(url: String, senders: Vec<(Address, watch::Sender<OverrideSnapshot>)>) {
+    /// protocol channel (a frame keyed by any of the protocol's venue aliases publishes). Any
+    /// disconnect, read error, server-side close, or idle timeout drops back to the reconnect
+    /// loop, which retries forever with capped exponential backoff. The backoff is reset only
+    /// after a message is actually received, so a socket that connects and immediately drops
+    /// still backs off instead of busy-looping. This task never returns and never panics: every
+    /// failure mode is logged and retried.
+    async fn run(url: String, senders: Vec<(Vec<Address>, watch::Sender<OverrideSnapshot>)>) {
         let mut attempt: u32 = 0;
         loop {
             // Every receiver (the provider handle plus all pool clones) has been dropped, so
@@ -282,21 +287,21 @@ impl TitanProvider {
                                 attempt = 0;
                                 match serde_json::from_str::<TitanMessage>(text.as_str()) {
                                     Ok(message) => {
-                                        for (venue, sender) in &senders {
-                                            match Self::extract_venue(&message, venue) {
+                                        for (venues, sender) in &senders {
+                                            match Self::extract_any_venue(&message, venues) {
                                                 // A send error means every receiver has been
                                                 // dropped; the check after this loop stops the
                                                 // task, so ignoring it here is safe.
                                                 Ok(Some(snapshot)) => {
                                                     let _ = sender.send(snapshot);
                                                 }
-                                                // Venue not present in this frame — nothing to do.
+                                                // No alias present in this frame — nothing to do.
                                                 Ok(None) => {}
                                                 // Malformed payload for this venue: keep the
                                                 // connection and last good snapshot, but surface
                                                 // it.
                                                 Err(e) => {
-                                                    warn!(%venue, error = %e, "Failed to extract Titan venue snapshot");
+                                                    warn!(?venues, error = %e, "Failed to extract Titan venue snapshot");
                                                 }
                                             }
                                         }
@@ -359,17 +364,42 @@ impl TitanProvider {
         }
     }
 
-    /// Maps a known pAMM `protocol_system` to its Titan venue address, or `None` if unknown.
+    /// Maps a known pAMM `protocol_system` to its Titan venue aliases, or `None` if unknown.
     ///
-    /// Titan/Fermi specifics (the venue address mapping) live only here.
-    fn venue_for_protocol(protocol_system: &str) -> Option<Address> {
+    /// Every alias of a protocol streams the same maker feed (e.g. its oracle and router
+    /// addresses); subscribing to all of them keeps the protocol served when one key disappears
+    /// from the stream, which venue deployments have been observed doing within hours.
+    /// Titan/venue specifics (the address mapping) live only here.
+    fn venues_for_protocol(protocol_system: &str) -> Option<Vec<Address>> {
         let raw = match protocol_system {
-            FERMISWAP_PROTOCOL_SYSTEM => FERMISWAP_VENUE,
-            KIPSELI_PROTOCOL_SYSTEM => KIPSELI_VENUE,
-            BOPAMM_PROTOCOL_SYSTEM => BOPAMM_VENUE,
+            FERMISWAP_PROTOCOL_SYSTEM => FERMISWAP_VENUES,
+            KIPSELI_PROTOCOL_SYSTEM => KIPSELI_VENUES,
+            BOPAMM_PROTOCOL_SYSTEM => BOPAMM_VENUES,
             _ => return None,
         };
-        raw.parse().ok()
+        let venues = raw
+            .iter()
+            .map(|venue| {
+                venue
+                    .parse()
+                    .unwrap_or_else(|e| panic!("hardcoded venue address {venue} must parse: {e}"))
+            })
+            .collect();
+        Some(venues)
+    }
+
+    /// Extracts the snapshot of the first alias in `venues` present in the frame, or `Ok(None)`
+    /// if none is. A frame carries a single top-level venue key, so at most one alias matches.
+    fn extract_any_venue(
+        message: &TitanMessage,
+        venues: &[Address],
+    ) -> Result<Option<OverrideSnapshot>, String> {
+        for venue in venues {
+            if let Some(snapshot) = Self::extract_venue(message, venue)? {
+                return Ok(Some(snapshot));
+            }
+        }
+        Ok(None)
     }
 
     /// Extracts a single venue's snapshot (`stateDiff` overrides + resolved block environment)
@@ -530,24 +560,26 @@ mod tests {
     }
 
     #[test]
-    fn venue_for_protocol_resolves_all_known_venues() {
+    fn venues_for_protocol_resolves_all_known_aliases() {
         let cases = [
-            (FERMISWAP_PROTOCOL_SYSTEM, FERMISWAP_VENUE),
-            (KIPSELI_PROTOCOL_SYSTEM, KIPSELI_VENUE),
-            (BOPAMM_PROTOCOL_SYSTEM, BOPAMM_VENUE),
+            (FERMISWAP_PROTOCOL_SYSTEM, FERMISWAP_VENUES),
+            (KIPSELI_PROTOCOL_SYSTEM, KIPSELI_VENUES),
+            (BOPAMM_PROTOCOL_SYSTEM, BOPAMM_VENUES),
         ];
         for (protocol, expected) in cases {
-            assert_eq!(
-                TitanProvider::venue_for_protocol(protocol).expect("venue must resolve"),
-                expected.parse::<Address>().unwrap(),
-                "venue mismatch for {protocol}",
-            );
+            let venues = TitanProvider::venues_for_protocol(protocol).expect("venues must resolve");
+            let expected: Vec<Address> = expected
+                .iter()
+                .map(|raw| raw.parse().unwrap())
+                .collect();
+            assert_eq!(venues, expected, "venue mismatch for {protocol}");
+            assert!(!venues.is_empty(), "every protocol needs at least one venue");
         }
     }
 
     #[test]
-    fn venue_for_protocol_returns_none_for_unknown() {
-        assert!(TitanProvider::venue_for_protocol("vm:unknown").is_none());
+    fn venues_for_protocol_returns_none_for_unknown() {
+        assert!(TitanProvider::venues_for_protocol("vm:unknown").is_none());
     }
 
     /// Sample message from the Titan docs (<https://docs.titanbuilder.xyz/propamms/takers>).
@@ -570,7 +602,7 @@ mod tests {
 
     #[test]
     fn extract_venue_reads_state_diff() {
-        let venue = FERMISWAP_VENUE
+        let venue = FERMISWAP_VENUES[0]
             .parse::<Address>()
             .unwrap();
         let message = serde_json::from_str::<TitanMessage>(SAMPLE_MESSAGE).expect("valid JSON");
@@ -604,11 +636,42 @@ mod tests {
 
     #[test]
     fn extract_venue_returns_none_for_absent_venue() {
-        let venue = KIPSELI_VENUE
+        let venue = KIPSELI_VENUES[0]
             .parse::<Address>()
             .unwrap();
         let message = serde_json::from_str::<TitanMessage>(SAMPLE_MESSAGE).expect("valid JSON");
         assert!(TitanProvider::extract_venue(&message, &venue)
+            .unwrap()
+            .is_none());
+    }
+
+    /// The sample message is keyed by the FermiSwap oracle (`FERMISWAP_VENUES[0]`), so listing the
+    /// router alias first must fall through to the oracle rather than give up.
+    #[test]
+    fn extract_any_venue_falls_back_to_a_later_alias() {
+        let message = serde_json::from_str::<TitanMessage>(SAMPLE_MESSAGE).expect("valid JSON");
+        let aliases = [
+            FERMISWAP_VENUES[1]
+                .parse::<Address>()
+                .unwrap(),
+            FERMISWAP_VENUES[0]
+                .parse::<Address>()
+                .unwrap(),
+        ];
+        let snapshot = TitanProvider::extract_any_venue(&message, &aliases)
+            .expect("extract must succeed")
+            .expect("oracle alias is present in the frame");
+        assert_eq!(snapshot.block_number, Some(25051224));
+    }
+
+    #[test]
+    fn extract_any_venue_returns_none_when_no_alias_matches() {
+        let message = serde_json::from_str::<TitanMessage>(SAMPLE_MESSAGE).expect("valid JSON");
+        let aliases: Vec<Address> = KIPSELI_VENUES
+            .iter()
+            .map(|raw| raw.parse().unwrap())
+            .collect();
+        assert!(TitanProvider::extract_any_venue(&message, &aliases)
             .unwrap()
             .is_none());
     }

--- a/crates/tycho-simulation/src/evm/protocol/vm/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/vm/state.rs
@@ -13,6 +13,7 @@ use num_bigint::BigUint;
 use revm::DatabaseRef;
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
+use tracing::{debug, warn};
 use tycho_common::{
     dto::ProtocolStateDelta,
     models::token::Token,
@@ -31,7 +32,7 @@ use super::{
 };
 use crate::evm::{
     engine_db::{engine_db_interface::EngineDatabaseInterface, tycho_db::PreCachedDB},
-    override_stream::OverrideSnapshot,
+    override_stream::{FailurePolicy, OverrideSnapshot},
     protocol::{
         u256_num::{u256_to_biguint, u256_to_f64},
         utils::bytes_to_address,
@@ -188,6 +189,46 @@ where
         Some(snapshot)
     }
 
+    /// Runs `simulate` against `live_snapshot` and, when the snapshot's provider opted into
+    /// [`FailurePolicy::FallbackToIndexedState`], retries a failure once on the plain indexed
+    /// state.
+    ///
+    /// `InvalidInput` failures are never retried: the simulation itself succeeded and the input
+    /// was merely clamped to the pool's limit. Note that under overrides the limit is itself
+    /// override-derived (it reflects the size the live maker quote covers), and that clamp is
+    /// treated as authoritative rather than retried against the indexed pool's larger limit.
+    fn run_with_indexed_fallback<T>(
+        pool_id: &str,
+        operation: &str,
+        live_snapshot: Option<&OverrideSnapshot>,
+        mut simulate: impl FnMut(Option<&OverrideSnapshot>) -> Result<T, SimulationError>,
+    ) -> Result<T, SimulationError> {
+        let attempt = simulate(live_snapshot);
+        let Err(error) = &attempt else { return attempt };
+        if matches!(error, SimulationError::InvalidInput(..)) {
+            return attempt;
+        }
+        let Some(snapshot) = live_snapshot
+            .filter(|snapshot| snapshot.failure_policy == FailurePolicy::FallbackToIndexedState)
+        else {
+            return attempt;
+        };
+        debug!(
+            pool = %pool_id,
+            %error,
+            snapshot_block = ?snapshot.block_number,
+            snapshot_ts = ?snapshot.block_timestamp,
+            expires_at = ?snapshot.expires_at,
+            override_accounts = snapshot.storage.len(),
+            "{operation} failed with live overrides; retrying on indexed state"
+        );
+        let retry = simulate(None);
+        if let Err(retry_error) = &retry {
+            warn!(pool = %pool_id, %retry_error, "{operation} retry on indexed state also failed");
+        }
+        retry
+    }
+
     /// The block environment to apply to adapter simulations, resolved from a single pre-read
     /// `live` snapshot: its block number/timestamp take precedence over the statically configured
     /// [`Self::block_overrides`].
@@ -267,11 +308,26 @@ where
         &mut self,
         tokens: &HashMap<Bytes, Token>,
     ) -> Result<(), SimulationError> {
-        // Read the live snapshot once and resolve the block environment from it, so every pair
-        // (and both sub-swaps in the no-capability branch) simulates against one consistent
-        // snapshot.
+        // Read the live snapshot once, so every pair (and both sub-swaps in the no-capability
+        // branch) simulates against one consistent snapshot.
         let live_snapshot = self.get_live_snapshot();
-        let block_overrides = self.block_env(live_snapshot.as_ref());
+        let pool_id = self.id.clone();
+        Self::run_with_indexed_fallback(
+            &pool_id,
+            "Spot prices",
+            live_snapshot.as_ref(),
+            |snapshot| self.set_spot_prices_with(tokens, snapshot),
+        )
+    }
+
+    /// Computes and stores spot prices against `live_snapshot`'s overrides (or the plain indexed
+    /// state when `None`).
+    fn set_spot_prices_with(
+        &mut self,
+        tokens: &HashMap<Bytes, Token>,
+        live_snapshot: Option<&OverrideSnapshot>,
+    ) -> Result<(), SimulationError> {
+        let block_overrides = self.block_env(live_snapshot);
         match self.ensure_capability(Capability::PriceFunction) {
             Ok(_) => {
                 for [sell_token_address, buy_token_address] in self
@@ -286,7 +342,7 @@ where
                     let overwrites = Some(self.get_overwrites(
                         vec![sell_token_address, buy_token_address],
                         *MAX_BALANCE / U256::from(100),
-                        live_snapshot.as_ref(),
+                        live_snapshot,
                     )?);
 
                     let (sell_amount_limit, _) = self.get_amount_limits(
@@ -339,7 +395,7 @@ where
                     let overwrites = Some(self.get_overwrites(
                         vec![t0, t1],
                         *MAX_BALANCE / U256::from(100),
-                        live_snapshot.as_ref(),
+                        live_snapshot,
                     )?);
 
                     // Calculate the first sell amount (x1) as 1% of the maximum limit.
@@ -689,6 +745,126 @@ where
         self.manual_updates
     }
 
+    /// Simulates a sell of `amount_in` against `live_snapshot`'s overrides (or the plain indexed
+    /// state when `None`); see [`ProtocolSim::get_amount_out`] for the caller-facing contract.
+    fn get_amount_out_with(
+        &self,
+        amount_in: &BigUint,
+        token_in: &Token,
+        token_out: &Token,
+        live_snapshot: Option<&OverrideSnapshot>,
+    ) -> Result<GetAmountOutResult, SimulationError> {
+        let sell_token_address = bytes_to_address(&token_in.address)?;
+        let buy_token_address = bytes_to_address(&token_out.address)?;
+        let sell_amount = U256::from_be_slice(&amount_in.to_bytes_be());
+        let block_overrides = self.block_env(live_snapshot);
+        let overwrites = self.get_overwrites(
+            vec![sell_token_address, buy_token_address],
+            *MAX_BALANCE / U256::from(100),
+            live_snapshot,
+        )?;
+        let (sell_amount_limit, _) = self.get_amount_limits(
+            vec![sell_token_address, buy_token_address],
+            Some(overwrites.clone()),
+            block_overrides.clone(),
+        )?;
+        let (sell_amount_respecting_limit, sell_amount_exceeds_limit) = if self
+            .capabilities
+            .contains(&Capability::HardLimits) &&
+            sell_amount_limit < sell_amount
+        {
+            (sell_amount_limit, true)
+        } else {
+            (sell_amount, false)
+        };
+
+        let overwrites_with_sell_limit = self.get_overwrites(
+            vec![sell_token_address, buy_token_address],
+            sell_amount_limit,
+            live_snapshot,
+        )?;
+        let complete_overwrites = self.merge(overwrites, overwrites_with_sell_limit);
+
+        let (trade, state_changes) = self.adapter_contract.swap(
+            &self.id,
+            sell_token_address,
+            buy_token_address,
+            false,
+            sell_amount_respecting_limit,
+            Some(complete_overwrites),
+            block_overrides,
+        )?;
+
+        let mut new_state = self.clone();
+
+        // Apply state changes to the new state
+        for (address, state_update) in state_changes {
+            if let Some(storage) = state_update.storage {
+                let block_overwrites = new_state
+                    .block_lasting_overwrites
+                    .entry(address)
+                    .or_default();
+                for (slot, value) in storage {
+                    let slot = U256::from_str(&slot.to_string()).map_err(|_| {
+                        SimulationError::FatalError("Failed to decode slot index".to_string())
+                    })?;
+                    let value = U256::from_str(&value.to_string()).map_err(|_| {
+                        SimulationError::FatalError("Failed to decode slot overwrite".to_string())
+                    })?;
+                    block_overwrites.insert(slot, value);
+                }
+            }
+        }
+
+        // Update spot prices
+        let tokens = HashMap::from([
+            (token_in.address.clone(), token_in.clone()),
+            (token_out.address.clone(), token_out.clone()),
+        ]);
+        let _ = new_state.set_spot_prices(&tokens);
+
+        let buy_amount = trade.received_amount;
+
+        if sell_amount_exceeds_limit {
+            return Err(SimulationError::InvalidInput(
+                format!("Sell amount exceeds limit {sell_amount_limit}"),
+                Some(GetAmountOutResult::new(
+                    u256_to_biguint(buy_amount),
+                    u256_to_biguint(trade.gas_used),
+                    Box::new(new_state.clone()),
+                )),
+            ));
+        }
+        Ok(GetAmountOutResult::new(
+            u256_to_biguint(buy_amount),
+            u256_to_biguint(trade.gas_used),
+            Box::new(new_state.clone()),
+        ))
+    }
+
+    /// Computes trade limits against `live_snapshot`'s overrides (or the plain indexed state when
+    /// `None`); see [`ProtocolSim::get_limits`] for the caller-facing contract.
+    fn get_limits_with(
+        &self,
+        sell_token: &Bytes,
+        buy_token: &Bytes,
+        live_snapshot: Option<&OverrideSnapshot>,
+    ) -> Result<(BigUint, BigUint), SimulationError> {
+        let sell_token = bytes_to_address(sell_token)?;
+        let buy_token = bytes_to_address(buy_token)?;
+        let overwrites = self.get_overwrites(
+            vec![sell_token, buy_token],
+            *MAX_BALANCE / U256::from(100),
+            live_snapshot,
+        )?;
+        let limits = self.get_amount_limits(
+            vec![sell_token, buy_token],
+            Some(overwrites),
+            self.block_env(live_snapshot),
+        )?;
+        Ok((u256_to_biguint(limits.0), u256_to_biguint(limits.1)))
+    }
+
     #[cfg(test)]
     pub fn get_balance_owner(&self) -> Option<Address> {
         self.balance_owner
@@ -762,94 +938,11 @@ where
         token_in: &Token,
         token_out: &Token,
     ) -> Result<GetAmountOutResult, SimulationError> {
-        let sell_token_address = bytes_to_address(&token_in.address)?;
-        let buy_token_address = bytes_to_address(&token_out.address)?;
-        let sell_amount = U256::from_be_slice(&amount_in.to_bytes_be());
         // Read the live snapshot once so overwrites, limits and the swap use one snapshot.
         let live_snapshot = self.get_live_snapshot();
-        let block_overrides = self.block_env(live_snapshot.as_ref());
-        let overwrites = self.get_overwrites(
-            vec![sell_token_address, buy_token_address],
-            *MAX_BALANCE / U256::from(100),
-            live_snapshot.as_ref(),
-        )?;
-        let (sell_amount_limit, _) = self.get_amount_limits(
-            vec![sell_token_address, buy_token_address],
-            Some(overwrites.clone()),
-            block_overrides.clone(),
-        )?;
-        let (sell_amount_respecting_limit, sell_amount_exceeds_limit) = if self
-            .capabilities
-            .contains(&Capability::HardLimits) &&
-            sell_amount_limit < sell_amount
-        {
-            (sell_amount_limit, true)
-        } else {
-            (sell_amount, false)
-        };
-
-        let overwrites_with_sell_limit = self.get_overwrites(
-            vec![sell_token_address, buy_token_address],
-            sell_amount_limit,
-            live_snapshot.as_ref(),
-        )?;
-        let complete_overwrites = self.merge(overwrites, overwrites_with_sell_limit);
-
-        let (trade, state_changes) = self.adapter_contract.swap(
-            &self.id,
-            sell_token_address,
-            buy_token_address,
-            false,
-            sell_amount_respecting_limit,
-            Some(complete_overwrites),
-            block_overrides,
-        )?;
-
-        let mut new_state = self.clone();
-
-        // Apply state changes to the new state
-        for (address, state_update) in state_changes {
-            if let Some(storage) = state_update.storage {
-                let block_overwrites = new_state
-                    .block_lasting_overwrites
-                    .entry(address)
-                    .or_default();
-                for (slot, value) in storage {
-                    let slot = U256::from_str(&slot.to_string()).map_err(|_| {
-                        SimulationError::FatalError("Failed to decode slot index".to_string())
-                    })?;
-                    let value = U256::from_str(&value.to_string()).map_err(|_| {
-                        SimulationError::FatalError("Failed to decode slot overwrite".to_string())
-                    })?;
-                    block_overwrites.insert(slot, value);
-                }
-            }
-        }
-
-        // Update spot prices
-        let tokens = HashMap::from([
-            (token_in.address.clone(), token_in.clone()),
-            (token_out.address.clone(), token_out.clone()),
-        ]);
-        let _ = new_state.set_spot_prices(&tokens);
-
-        let buy_amount = trade.received_amount;
-
-        if sell_amount_exceeds_limit {
-            return Err(SimulationError::InvalidInput(
-                format!("Sell amount exceeds limit {sell_amount_limit}"),
-                Some(GetAmountOutResult::new(
-                    u256_to_biguint(buy_amount),
-                    u256_to_biguint(trade.gas_used),
-                    Box::new(new_state.clone()),
-                )),
-            ));
-        }
-        Ok(GetAmountOutResult::new(
-            u256_to_biguint(buy_amount),
-            u256_to_biguint(trade.gas_used),
-            Box::new(new_state.clone()),
-        ))
+        Self::run_with_indexed_fallback(&self.id, "Swap", live_snapshot.as_ref(), |snapshot| {
+            self.get_amount_out_with(&amount_in, token_in, token_out, snapshot)
+        })
     }
 
     fn get_limits(
@@ -857,20 +950,10 @@ where
         sell_token: Bytes,
         buy_token: Bytes,
     ) -> Result<(BigUint, BigUint), SimulationError> {
-        let sell_token = bytes_to_address(&sell_token)?;
-        let buy_token = bytes_to_address(&buy_token)?;
         let live_snapshot = self.get_live_snapshot();
-        let overwrites = self.get_overwrites(
-            vec![sell_token, buy_token],
-            *MAX_BALANCE / U256::from(100),
-            live_snapshot.as_ref(),
-        )?;
-        let limits = self.get_amount_limits(
-            vec![sell_token, buy_token],
-            Some(overwrites),
-            self.block_env(live_snapshot.as_ref()),
-        )?;
-        Ok((u256_to_biguint(limits.0), u256_to_biguint(limits.1)))
+        Self::run_with_indexed_fallback(&self.id, "Limits", live_snapshot.as_ref(), |snapshot| {
+            self.get_limits_with(&sell_token, &buy_token, snapshot)
+        })
     }
 
     fn delta_transition(
@@ -1739,5 +1822,70 @@ mod tests {
         let (_expired_tx, expired_rx) = watch::channel(expired);
         pool_state.set_live_overrides(expired_rx);
         assert!(pool_state.get_live_snapshot().is_none());
+    }
+
+    /// A live snapshot that corrupts the Balancer Vault's low storage slots (pause / reentrancy
+    /// state), guaranteeing that any simulation run with it applied reverts.
+    fn poison_snapshot(failure_policy: FailurePolicy) -> OverrideSnapshot {
+        let vault: Address = "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
+            .parse()
+            .unwrap();
+        let poisoned_slots = (0u64..10)
+            .map(|slot| (U256::from(slot), U256::MAX))
+            .collect();
+        OverrideSnapshot {
+            storage: std::sync::Arc::new(HashMap::from([(vault, poisoned_slots)])),
+            failure_policy,
+            ..Default::default()
+        }
+    }
+
+    /// With the default [`FailurePolicy::Error`], a snapshot that breaks the simulation surfaces
+    /// the failure to the caller.
+    #[tokio::test]
+    async fn test_failing_overrides_error_by_default() {
+        let mut pool_state = setup_pool_state().await;
+        let poison = poison_snapshot(FailurePolicy::Error);
+        let (_tx, rx) = watch::channel(poison);
+        pool_state.set_live_overrides(rx);
+
+        assert!(pool_state
+            .get_amount_out(BigUint::from_str("1000000000000000000").unwrap(), &dai(), &bal())
+            .is_err());
+    }
+
+    /// With [`FailurePolicy::FallbackToIndexedState`], a snapshot that breaks the simulation is
+    /// dropped and the operation is retried on the plain indexed state, matching the result the
+    /// pool produces without any live overrides.
+    #[tokio::test]
+    async fn test_failing_overrides_fall_back_to_indexed_state() {
+        let pool_state = setup_pool_state().await;
+        let expected = pool_state
+            .get_amount_out(BigUint::from_str("1000000000000000000").unwrap(), &dai(), &bal())
+            .unwrap();
+        let expected_limits = pool_state
+            .get_limits(dai().address.clone(), bal().address.clone())
+            .unwrap();
+
+        let mut pool_state = pool_state;
+        let poison = poison_snapshot(FailurePolicy::FallbackToIndexedState);
+        let (_tx, rx) = watch::channel(poison);
+        pool_state.set_live_overrides(rx);
+
+        let result = pool_state
+            .get_amount_out(BigUint::from_str("1000000000000000000").unwrap(), &dai(), &bal())
+            .expect("must fall back to indexed state");
+        assert_eq!(result.amount, expected.amount);
+
+        let limits = pool_state
+            .get_limits(dai().address.clone(), bal().address.clone())
+            .expect("limits must fall back to indexed state");
+        assert_eq!(limits, expected_limits);
+
+        let tokens =
+            HashMap::from([(dai().address.clone(), dai()), (bal().address.clone(), bal())]);
+        pool_state
+            .set_spot_prices(&tokens)
+            .expect("spot prices must fall back to indexed state");
     }
 }

--- a/scripts/titan-venue-census.py
+++ b/scripts/titan-venue-census.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Count top-level venue addresses on the Titan pAMM quote stream.
+
+Subscribes to the pamm_quote_stream WebSocket for a fixed duration and prints, per top-level
+venue address: frame count and which accounts received storage overrides (stateDiff). Useful to
+detect venue deployments appearing/disappearing (they historically change every few weeks) and to
+check whether a venue is registry-backed (overrides 0xda7afeed...) or self-storage.
+
+Usage:
+    python3 scripts/titan-venue-census.py [--seconds 60] [--url wss://...]
+
+Requires the `websockets` package (pip install websockets).
+"""
+
+import argparse
+import asyncio
+import hashlib
+import itertools
+import json
+from collections import Counter, defaultdict
+
+DEFAULT_URL = "wss://eu.rpc.titanbuilder.xyz/ws/pamm_quote_stream"
+META_KEYS = {"slot", "blockNumber", "timestamp"}
+
+
+def payload_hash(state_override: dict) -> str:
+    """Canonical hash of a venue's override payload, used to detect duplicate venue keys."""
+    return hashlib.sha256(
+        json.dumps(state_override, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+async def census(url: str, seconds: float) -> None:
+    import websockets
+
+    venues: Counter = Counter()
+    diff_accounts: dict = defaultdict(Counter)
+    payloads: dict = defaultdict(set)
+    frames = 0
+    blocks = set()
+
+    async with websockets.connect(url, max_size=2**24) as ws:
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + seconds
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                break
+            try:
+                raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+            except asyncio.TimeoutError:
+                break
+            frame = json.loads(raw)
+            frames += 1
+            if "blockNumber" in frame:
+                blocks.add(frame["blockNumber"])
+            for key, value in frame.items():
+                if key in META_KEYS:
+                    continue
+                venues[key] += 1
+                payloads[key].add(payload_hash(value.get("stateOverride", {})))
+                for account, override in value.get("stateOverride", {}).items():
+                    if override.get("stateDiff"):
+                        diff_accounts[key][account] += 1
+
+    print(f"{frames} frames over {seconds:.0f}s, {len(blocks)} blocks, {len(venues)} venues\n")
+    for venue, count in venues.most_common():
+        print(f"{venue}  {count} frames  ({len(payloads[venue])} unique payloads)")
+        for account, n in diff_accounts[venue].most_common():
+            print(f"    stateDiff -> {account}  ({n} frames)")
+    if not venues:
+        print("No venue frames received.")
+        return
+
+    # Venues whose payload streams overlap are aliases of the same maker feed (e.g. a maker's
+    # oracle and router addresses both carrying the identical registry diff).
+    print("\nDuplicate analysis (payload overlap between venue pairs):")
+    duplicates_found = False
+    for a, b in itertools.combinations(sorted(payloads), 2):
+        intersection = len(payloads[a] & payloads[b])
+        union = len(payloads[a] | payloads[b])
+        if union == 0 or intersection == 0:
+            continue
+        duplicates_found = True
+        print(
+            f"  {a} == {b}: {intersection}/{union} shared payloads"
+            f" ({100 * intersection / union:.0f}% overlap)"
+        )
+    if not duplicates_found:
+        print("  none — every venue streams distinct payloads")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--seconds", type=float, default=60, help="capture duration (default 60)")
+    parser.add_argument("--url", default=DEFAULT_URL, help=f"stream endpoint (default {DEFAULT_URL})")
+    args = parser.parse_args()
+    asyncio.run(census(args.url, args.seconds))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Hardens the Titan pAMM live-override pipeline (follow-up to #1106) based on live-stream and on-chain investigation:

- **Beacon-slot block timestamp** (`9b6fe290`): the override block timestamp is derived from the frame's beacon `slot` (`genesis + slot * 12`), matching Titan's reference taker ([gattaca-com/propamm](https://github.com/gattaca-com/propamm)) and the [LambdaClass propAMM SDK](https://github.com/lambdaclass/propamm-router-contracts), with plausibility validation against the frame's wall clock. The registry-lane extraction stays as a guarded fallback. Required because the [priority-update-registry](https://github.com/flashbots/priority-update-registry) enforces `updateTimestamp == block.timestamp` (verified on-chain: plain eth_call reverts `StaleUpdate()`, bumped timestamp succeeds).
- **Venue aliases** (`4e128a8b`): each pAMM subscribes to all known Titan venue alias addresses (oracle and router keys carry identical payloads, and deployments rotate). bopAMM's venue is the self-storage pAMM `0x28d9ccedf1`. `scripts/titan-venue-census.py` inspects the live venue set.
- **Indexed-state fallback** (`94f72385`): provider-set `FailurePolicy` on `OverrideSnapshot`; Titan snapshots opt into retrying failed simulations without overrides. Fixes pools being unquotable (and undecodable) whenever a pair's oracle lane is not re-stamped for the pending block — briefly true for every pair at block transitions (lanes re-stamp gradually over ~2s), and for minutes at a time during maker quoting droughts.
- **`titan_override_monitor` example** (`d46c3a26`): manual proof that quotes reprice mid-block, with per-block distinct-quote recaps and optional VM traces (`--vm-traces`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)