### PR TITLE
fix: log instead of failing when Metric RFQ is unsupported on chain

### DIFF
--- a/crates/tycho-integration-test/src/stream_processor/rfq_stream_processor.rs
+++ b/crates/tycho-integration-test/src/stream_processor/rfq_stream_processor.rs
@@ -136,9 +136,8 @@ impl RFQStreamProcessor {
                     true
                 }
                 Err(e) => {
-                    return Err(miette!(
-                        "No PAMM RFQ client could be added with --run-pamm-protocols: {e}"
-                    ));
+                    warn!("Metric RFQ not supported on chain {:?}, skipping: {e}", self.chain);
+                    false
                 }
             }
         } else {


### PR DESCRIPTION
## Problem

The Unichain integration test aborted with:

> No PAMM RFQ client could be added with --run-pamm-protocols: RFQ fatal error: Metric does not support chain in this integration: Unichain

The test runs with `--run-pamm-protocols`, but Metric is the only PAMM RFQ protocol and it does not support Unichain. The Metric client build error was turned into a fatal error, aborting the run.

## Change

When the Metric client fails to build (e.g. unsupported chain), log a warning and skip it instead of returning an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)