### PR TITLE
fix(simulation): exclude Angstrom pools when ANGSTROM_API_KEY is unset

### DIFF
--- a/crates/tycho-simulation/examples/quickstart/main.rs
+++ b/crates/tycho-simulation/examples/quickstart/main.rs
@@ -201,10 +201,9 @@ async fn main() {
                     Some(balancer_v2_pool_filter),
                 )
                 .exchange::<UniswapV4State>("uniswap_v4", tvl_filter.clone(), None)
+                // Angstrom pools are included only when ANGSTROM_API_KEY is set: encoding
+                // their swaps requires per-block attestations from the Angstrom API.
                 .exchange::<UniswapV4State>("uniswap_v4_hooks", tvl_filter.clone(), None)
-                // Only uncomment if you have ANGSTROM_API_KEY set
-                // .exchange::<UniswapV4State>("uniswap_v4_hooks", tvl_filter.clone(),
-                // Some(uniswap_v4_angstrom_hook_pool_filter))
                 .exchange::<EkuboState>("ekubo_v2", tvl_filter.clone(), None)
                 .exchange::<EkuboV3State>(
                     "ekubo_v3",

--- a/crates/tycho-simulation/src/evm/protocol/filters.rs
+++ b/crates/tycho-simulation/src/evm/protocol/filters.rs
@@ -54,6 +54,17 @@ pub fn uniswap_v4_angstrom_hook_pool_filter(component: &ComponentWithState) -> b
         .is_some_and(|s| s == "angstrom_v1")
 }
 
+/// Filters out uniswap v4 pools with Angstrom hooks.
+///
+/// Encoding an Angstrom swap requires per-block attestations fetched from the Angstrom API,
+/// authenticated with `ANGSTROM_API_KEY`. Without the key the swap fails at encoding time —
+/// after route selection — so consumers without the key should exclude these pools up front.
+/// [`ProtocolStreamBuilder`](crate::evm::stream::ProtocolStreamBuilder) applies this filter to
+/// `uniswap_v4_hooks` automatically when no filter function is provided and the key is unset.
+pub fn uniswap_v4_non_angstrom_hook_pool_filter(component: &ComponentWithState) -> bool {
+    !uniswap_v4_angstrom_hook_pool_filter(component)
+}
+
 /// Filters out pools that rely on ERC4626 in Balancer V3
 pub fn balancer_v3_pool_filter(component: &ComponentWithState) -> bool {
     if let Some(erc4626) = component
@@ -167,6 +178,8 @@ pub fn erc4626_filter(component: &ComponentWithState) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use tycho_common::models::protocol::{ProtocolComponent, ProtocolComponentState};
+
     use super::*;
 
     fn attrs(pairs: &[(&str, &str)]) -> HashMap<String, Bytes> {
@@ -174,6 +187,26 @@ mod tests {
             .iter()
             .map(|(k, v)| (k.to_string(), Bytes::from(v.as_bytes().to_vec())))
             .collect()
+    }
+
+    fn hooks_component(hook_identifier: Option<&str>) -> ComponentWithState {
+        let static_attributes = match hook_identifier {
+            Some(id) => attrs(&[("hook_identifier", id)]),
+            None => HashMap::new(),
+        };
+        ComponentWithState {
+            state: ProtocolComponentState::new("test_pool", HashMap::new(), HashMap::new()),
+            component: ProtocolComponent { static_attributes, ..Default::default() },
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn non_angstrom_filter_excludes_angstrom_pools() {
+        assert!(!uniswap_v4_non_angstrom_hook_pool_filter(&hooks_component(Some("angstrom_v1"))));
+        assert!(uniswap_v4_non_angstrom_hook_pool_filter(&hooks_component(Some("euler_v1"))));
+        assert!(uniswap_v4_non_angstrom_hook_pool_filter(&hooks_component(None)));
     }
 
     #[test]

--- a/crates/tycho-simulation/src/evm/stream.rs
+++ b/crates/tycho-simulation/src/evm/stream.rs
@@ -130,6 +130,7 @@ use crate::{
         override_stream::{self, StateOverrideProvider},
         pending::PendingBlockProcessor,
         protocol::{
+            filters::uniswap_v4_non_angstrom_hook_pool_filter,
             native_wrapper::state::NativeWrapperState,
             uniswap_v4::hooks::hook_handler_creator::initialize_hook_handlers,
         },
@@ -142,6 +143,22 @@ use crate::{
 };
 
 const EXCHANGES_REQUIRING_FILTER: [&str; 4] = ["vm:balancer_v2", "fluid_v1", "erc4626", "ekubo_v3"];
+
+/// The client-side filter applied to exchange `name` when the caller provides none.
+///
+/// `uniswap_v4_hooks`: without `ANGSTROM_API_KEY`, Angstrom swaps cannot be encoded (encoding
+/// fetches per-block attestations from the Angstrom API), so Angstrom pools are excluded up
+/// front rather than failing every route that selects them at encoding time.
+fn default_filter_fn(name: &str) -> Option<fn(&ComponentWithState) -> bool> {
+    if name == "uniswap_v4_hooks" && std::env::var("ANGSTROM_API_KEY").is_err() {
+        warn!(
+            "ANGSTROM_API_KEY is not set: excluding Angstrom pools from '{name}'. \
+             Set the key to include them."
+        );
+        return Some(uniswap_v4_non_angstrom_hook_pool_filter);
+    }
+    None
+}
 
 #[derive(Default, Debug, Clone, Copy)]
 pub enum StreamEndPolicy {
@@ -308,6 +325,9 @@ impl ProtocolStreamBuilder {
         if let Some(predicate) = filter_fn {
             self.decoder
                 .register_filter(name, predicate);
+        } else if let Some(predicate) = default_filter_fn(name) {
+            self.decoder
+                .register_filter(name, predicate);
         }
 
         if EXCHANGES_REQUIRING_FILTER.contains(&name) && filter_fn.is_none() {
@@ -363,6 +383,9 @@ impl ProtocolStreamBuilder {
         self.decoder
             .register_decoder_with_context::<T>(name, decoder_context);
         if let Some(predicate) = filter_fn {
+            self.decoder
+                .register_filter(name, predicate);
+        } else if let Some(predicate) = default_filter_fn(name) {
             self.decoder
                 .register_filter(name, predicate);
         }

--- a/docs/for-solvers/supported-protocols.md
+++ b/docs/for-solvers/supported-protocols.md
@@ -106,3 +106,5 @@ Angstrom requires querying their <a href="https://docs.angstrom.xyz/l1/core-mech
 
 * Set the `ANGSTROM_API_KEY` environment variable (request one from the Angstrom team directly)
 * Set `ANGSTROM_BLOCKS_IN_FUTURE` environment variable (if you want to override the <a href="https://github.com/propeller-heads/tycho-indexer/blob/main/crates/tycho-execution/src/encoding/evm/constants.rs" target="_blank" rel="noopener noreferrer">default value</a> of 5 blocks). **Important trade-off**: The more blocks you fetch, the more calldata will be sent to the Tycho Router, making execution more gas expensive.
+
+If `ANGSTROM_API_KEY` is not set, `ProtocolStreamBuilder` excludes Angstrom pools from `uniswap_v4_hooks` by default (unless you pass your own filter function), since routes over these pools would fail at encoding without attestations.


### PR DESCRIPTION
Angstrom swaps need per-block attestations from the Angstrom API, so without the key every route over an Angstrom pool fails at encoding, after route selection.

ProtocolStreamBuilder now filters Angstrom pools out of uniswap_v4_hooks when the key is unset and no custom filter function is given.