### PR TITLE
fix(metric): params-encode oracle update args, default Ethereum to RetryOnRevert

### DIFF
--- a/crates/tycho-simulation/src/rfq/protocols/metric/client.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/metric/client.rs
@@ -528,7 +528,7 @@ fn encode_oracle_update_args(
         biguint_decimal_to_u256(&slot.new_slot_value)?,
         AlloyBytes::from(slot.signature.to_vec()),
     )
-        .abi_encode()
+        .abi_encode_params()
         .into())
 }
 
@@ -813,7 +813,7 @@ mod tests {
         );
         assert_eq!(
             component.component.static_attributes[ORACLE_UPDATE_POLICY_ATTR],
-            MetricOracleUpdatePolicy::Always.as_attribute_value()
+            MetricOracleUpdatePolicy::RetryOnRevert.as_attribute_value()
         );
         assert_eq!(component.component.id, metadata.pool_address.to_string());
         assert!(component
@@ -917,5 +917,15 @@ mod tests {
 
         assert!(!args.starts_with(&[0x78, 0xce, 0x3a, 0xe1]));
         assert!(!args.is_empty());
+
+        // Must be params-encoded (no leading tuple offset word), matching Solidity's
+        // `abi.decode(oracleArgs, (address, uint256, uint256, bytes))`. Params encoding is
+        // 256 bytes (address, deadline, new_slot_value, bytes offset, bytes len, 65-byte sig
+        // padded to 96); the wrapped `abi_encode` form prepends a 0x20 offset word (288 bytes)
+        // and shifts every field, which reverts on-chain.
+        assert_eq!(args.len(), 256);
+        // First word is the feed creator address (left-padded), not an ABI offset.
+        assert!(args[0..12].iter().all(|b| *b == 0));
+        assert_eq!(&args[12..32], feed_creator.as_ref());
     }
 }

--- a/crates/tycho-simulation/src/rfq/protocols/metric/models.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/metric/models.rs
@@ -24,7 +24,7 @@ pub enum MetricOracleUpdatePolicy {
 impl MetricOracleUpdatePolicy {
     pub fn default_for_chain(chain: Chain) -> Self {
         match chain {
-            Chain::Ethereum => Self::Always,
+            Chain::Ethereum => Self::RetryOnRevert,
             _ => Self::Never,
         }
     }


### PR DESCRIPTION
## Problem

Metric swaps on Ethereum reverted during on-chain execution. Two issues:

1. **Oracle args encoding mismatch.** `MetricExecutor._updateOracle` decodes the oracle update payload with `abi.decode(oracleArgs, (address, uint256, uint256, bytes))` — the params form. The client encoded it with alloy's `abi_encode()`, which wraps the dynamic tuple in a leading `0x20` offset word and shifts every field by one slot. The `bytes` offset then read a garbage (out-of-bounds) value, so `abi.decode` reverted with empty returndata, surfaced on-chain as `Dispatcher__SwapReverted(executor)`.

2. **Oracle update policy on Ethereum was `Always`**, which submitted a signed oracle update on every swap. Metric's per-block heartbeat already keeps the on-chain oracle fresh for most swaps.

## Change

- `encode_oracle_update_args`: `abi_encode()` → `abi_encode_params()`, matching the executor's `abi.decode`.
- `MetricOracleUpdatePolicy::default_for_chain(Ethereum)`: `Always` → `RetryOnRevert` — try the pool swap against the heartbeat-maintained oracle first, only submit a signed update if it reverts.

## Tests

- Updated the round-trip test's expected Ethereum default to `RetryOnRevert`.
- Strengthened `test_encode_oracle_update_args` to assert the params layout (256 bytes; first word is the feed-creator address, not an ABI offset), so a regression back to `abi_encode()` fails.

`cargo test` metric suite: 22 passed (2 network-ignored). `cargo clippy --all-features` clean.

## Scope

This fixes the current (v1) Metric integration only. The v2 migration (6-arg pool swap, `api.metric.xyz`, per-chain oracle) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)