### PR TITLE
feat: add Flaunch Uniswap V4 hook integration on Base

### DIFF
--- a/crates/tycho-indexer/extractors.yaml
+++ b/crates/tycho-indexer/extractors.yaml
@@ -95,6 +95,24 @@ extractors:
     spkg: "substreams/ethereum-uniswap-v4/ethereum-uniswap-v4-v0.2.1.spkg"
     module_name: "map_protocol_changes"
 
+  # Base Uniswap V4 hooks: indexes all swap-hooked pools on Base; the Flaunch
+  # enrichment tags Flaunch pools with hook_identifier=flaunch_v1 so the hooks DCI
+  # and GenericVMHookHandler can simulate them.
+  uniswap_v4_hooks_base:
+    name: "uniswap_v4_hooks"
+    chain: "base"
+    implementation_type: "Custom"
+    sync_batch_size: 1000
+    start_block: 25350988
+    protocol_types:
+      - name: "uniswap_v4_pool"
+        financial_type: "Swap"
+    spkg: "substreams/ethereum-uniswap-v4/with-hooks/base-uniswap-v4-with-hooks-v0.8.0.spkg"
+    module_name: "map_flaunch_enriched_protocol_changes"
+    dci_plugin:
+      type: "uniswap_v4_hooks"
+      pool_manager_address: "0x498581fF718922c3f8e6a244956aF099B2652b2b"
+
   ekubo_v2:
     name: "ekubo_v2"
     chain: "ethereum"

--- a/protocols/substreams/ethereum-uniswap-v4/Cargo.lock
+++ b/protocols/substreams/ethereum-uniswap-v4/Cargo.lock
@@ -272,21 +272,14 @@ dependencies = [
 name = "ethereum-uniswap-v4-no-hooks"
 version = "0.4.1"
 dependencies = [
- "anyhow",
  "ethabi 18.0.0",
  "ethereum-uniswap-v4-shared",
  "getrandom 0.2.16",
  "hex",
- "hex-literal 0.4.1",
- "itertools 0.13.0",
- "num-bigint",
- "prost 0.11.9",
  "rstest",
  "substreams",
- "substreams-entity-change",
  "substreams-ethereum",
  "substreams-helper",
- "tiny-keccak",
  "tycho-substreams",
 ]
 
@@ -298,22 +291,19 @@ dependencies = [
  "ethabi 18.0.0",
  "getrandom 0.2.16",
  "hex",
- "hex-literal 0.4.1",
  "itertools 0.13.0",
  "num-bigint",
  "prost 0.11.9",
  "rstest",
  "substreams",
- "substreams-entity-change",
  "substreams-ethereum",
  "substreams-helper",
- "tiny-keccak",
  "tycho-substreams",
 ]
 
 [[package]]
 name = "ethereum-uniswap-v4-with-hooks"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -321,17 +311,13 @@ dependencies = [
  "getrandom 0.2.16",
  "hex",
  "hex-literal 0.4.1",
- "itertools 0.13.0",
- "num-bigint",
  "prost 0.11.9",
  "rstest",
  "serde",
  "serde_qs",
  "substreams",
- "substreams-entity-change",
  "substreams-ethereum",
  "substreams-helper",
- "tiny-keccak",
  "tycho-substreams",
 ]
 

--- a/protocols/substreams/ethereum-uniswap-v4/with-hooks/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v4/with-hooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v4-with-hooks"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-uniswap-v4/with-hooks/base-uniswap-v4-with-hooks.yaml
+++ b/protocols/substreams/ethereum-uniswap-v4/with-hooks/base-uniswap-v4-with-hooks.yaml
@@ -1,0 +1,153 @@
+specVersion: v0.1.0
+package:
+  name: "base_uniswap_v4_with_hooks"
+  version: v0.8.0
+  url: "https://github.com/propeller-heads/tycho-indexer/tree/main/protocols/substreams/ethereum-uniswap-v4/with-hooks"
+
+protobuf:
+  files:
+    - tycho/evm/v1/entity.proto
+    - tycho/evm/v1/common.proto
+    - tycho/evm/v1/utils.proto
+    - uniswap.proto
+  importPaths:
+    - ../../../../proto
+    - ../shared/proto
+  excludePaths:
+    - sf/substreams
+    - google
+    - tycho
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v4_with_hooks.wasm
+
+modules:
+  - name: map_pools_created
+    kind: map
+    initialBlock: 25350988
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.evm.v1.BlockEntityChanges
+
+  - name: store_pools
+    kind: store
+    initialBlock: 25350988
+    updatePolicy: set_if_not_exists
+    valueType: proto:uniswap.v4.Pool
+    inputs:
+      - map: map_pools_created
+
+  - name: map_events
+    kind: map
+    initialBlock: 25350988
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - store: store_pools
+    output:
+      type: proto:uniswap.v4.Events
+
+  - name: store_pool_current_tick
+    kind: store
+    initialBlock: 25350988
+    updatePolicy: set
+    valueType: int64
+    inputs:
+      - map: map_events
+
+  - name: store_pool_current_sqrt_price
+    kind: store
+    initialBlock: 25350988
+    updatePolicy: set
+    valueType: bigint
+    inputs:
+      - map: map_events
+
+  - name: map_balance_changes
+    kind: map
+    initialBlock: 25350988
+    inputs:
+      - map: map_events
+      - store: store_pool_current_sqrt_price
+    output:
+      type: proto:tycho.evm.v1.BlockBalanceDeltas
+
+  - name: store_pools_balances
+    kind: store
+    initialBlock: 25350988
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_balance_changes
+
+  - name: map_ticks_changes
+    kind: map
+    initialBlock: 25350988
+    inputs:
+      - map: map_events
+    output:
+      type: proto:uniswap.v4.TickDeltas
+
+  - name: store_ticks_liquidity
+    kind: store
+    initialBlock: 25350988
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_ticks_changes
+
+  - name: map_liquidity_changes
+    kind: map
+    initialBlock: 25350988
+    inputs:
+      - map: map_events
+      - store: store_pool_current_tick
+    output:
+      type: proto:uniswap.v4.LiquidityChanges
+
+  - name: store_liquidity
+    kind: store
+    initialBlock: 25350988
+    updatePolicy: set_sum
+    valueType: bigint
+    inputs:
+      - map: map_liquidity_changes
+
+  - name: map_protocol_changes
+    kind: map
+    initialBlock: 25350988
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - map: map_pools_created
+      - map: map_events
+      - map: map_balance_changes
+      - store: store_pools_balances
+        mode: deltas
+      - map: map_ticks_changes
+      - store: store_ticks_liquidity
+        mode: deltas
+      - map: map_liquidity_changes
+      - store: store_liquidity
+        mode: deltas
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+  - name: map_flaunch_enriched_protocol_changes
+    kind: map
+    initialBlock: 25350988
+    inputs:
+      - params: string
+      - map: map_protocol_changes
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+params:
+  # Base mainnet Uniswap V4 PoolManager (all swap-hooked pools are indexed here;
+  # the enrichment below only tags the Flaunch ones).
+  map_pools_created: "498581ff718922c3f8e6a244956af099b2652b2b"
+  # All deployed Flaunch hooks: PositionManager 23321f.. (v1.3, current), 265b62..,
+  # 51bba1.. (v1.0); AnyPositionManager 83b37a.., 8dc3b8..
+  map_flaunch_enriched_protocol_changes: "23321f11a6d44fd1ab790044fdfde5758c902fdc,265b62141854b3abb183bc1724230fb5d81defdc,51bba15255406cfe7099a42183302640ba7dafdc,83b37a87be8792fb7479d767d80a2032ddb025dc,8dc3b85e1dc1c846ebf3971179a751896842e5dc"

--- a/protocols/substreams/ethereum-uniswap-v4/with-hooks/integration_test_base_flaunch.tycho.yaml
+++ b/protocols/substreams/ethereum-uniswap-v4/with-hooks/integration_test_base_flaunch.tycho.yaml
@@ -1,0 +1,33 @@
+substreams_yaml_path: ./base-uniswap-v4-with-hooks.yaml
+# The balance check does not support vault-like contracts such as the Uniswap V4
+# PoolManager (a single contract holds the reserves of every pool).
+skip_balance_check: true
+protocol_type_names:
+  - "uniswap_v4_pool"
+protocol_system: "uniswap_v4_hooks"
+module_name: "map_flaunch_enriched_protocol_changes"
+initialized_accounts:
+  - "0x498581fF718922c3f8e6a244956aF099B2652b2b" # Uniswap V4 PoolManager (Base)
+  - "0x23321f11a6d44Fd1ab790044FdFDE5758c902FDc" # Flaunch PositionManager v1.3 (hook)
+tests:
+  # Real Base-mainnet Flaunch v1.3 pool (flETH / memecoin), verified against the
+  # PoolManager Initialize log. Created ~2h before selection, so its 1h fair-launch
+  # window has closed (swaps are unrestricted). The component is emitted by the
+  # shared with-hooks pipeline and tagged hook_identifier=flaunch_v1 by the
+  # enrichment module.
+  - name: test_flaunch_pool_creation
+    start_block: 48014462
+    stop_block: 48014500
+    expected_components:
+      - id: "0x662c65f4d37538fd2841aa5e40c6cbed5679c53578367f4961f4ef440cb5e1d7"
+        tokens:
+          - "0x000000000d564d5be76f7f0d28fe52605afc7cf8" # flETH
+          - "0x207c9e2544a782bcfef2f47c0316e297c851a935" # memecoin
+        static_attributes:
+          tick_spacing: "0x3c" # 60
+          hooks: "0x23321f11a6d44fd1ab790044fdfde5758c902fdc"
+          key_lp_fee: "0x00" # static fee 0
+          hook_identifier: "0x666c61756e63685f7631" # flaunch_v1
+        creation_tx: "0x44694eb8419e2ccb944eb874c283f296d56763122f867d3e2e4fe558fa358500"
+        skip_simulation: false
+        skip_execution: true

--- a/protocols/substreams/ethereum-uniswap-v4/with-hooks/src/variant_modules/4_map_flaunch_enriched_protocol_changes.rs
+++ b/protocols/substreams/ethereum-uniswap-v4/with-hooks/src/variant_modules/4_map_flaunch_enriched_protocol_changes.rs
@@ -1,0 +1,122 @@
+use tycho_substreams::prelude::*;
+
+/// Enrich the base Uniswap V4 hooks protocol changes with the Flaunch hook
+/// identifier.
+///
+/// Every pool whose `hooks` static attribute matches one of the configured
+/// Flaunch hook addresses is tagged with `hook_identifier = "flaunch_v1"`, which
+/// the indexer hooks DCI and tycho-simulation use to route the component to the
+/// correct handler (mirrors the `euler_v1` / `angstrom_v1` enrichment).
+///
+/// `params` is a comma-separated list of the Flaunch hook addresses (hex, with or
+/// without a `0x` prefix) — kept in the manifest so a single WASM target serves
+/// every network and every deployed Flaunch hook version.
+#[substreams::handlers::map]
+pub fn map_flaunch_enriched_protocol_changes(
+    params: String,
+    protocol_changes: BlockChanges,
+) -> Result<BlockChanges, substreams::errors::Error> {
+    let flaunch_hooks = parse_hook_addresses(&params);
+    Ok(tag_flaunch_components(protocol_changes, &flaunch_hooks))
+}
+
+fn parse_hook_addresses(params: &str) -> Vec<Vec<u8>> {
+    params
+        .split(',')
+        .map(str::trim)
+        .filter(|hook| !hook.is_empty())
+        .map(|hook| {
+            hex::decode(hook.trim_start_matches("0x")).expect("invalid Flaunch hook address")
+        })
+        .collect()
+}
+
+fn tag_flaunch_components(mut changes: BlockChanges, flaunch_hooks: &[Vec<u8>]) -> BlockChanges {
+    for tx_changes in &mut changes.changes {
+        for component in &mut tx_changes.component_changes {
+            if component.change != i32::from(ChangeType::Creation) {
+                continue;
+            }
+            // Clone the hooks value first so the immutable borrow ends before we
+            // push the new attribute.
+            let hook = component
+                .static_att
+                .iter()
+                .find(|attr| attr.name == "hooks")
+                .map(|attr| attr.value.clone());
+            if let Some(hook) = hook {
+                if flaunch_hooks
+                    .iter()
+                    .any(|flaunch| flaunch == &hook)
+                {
+                    component.static_att.push(Attribute {
+                        name: "hook_identifier".to_string(),
+                        value: b"flaunch_v1".to_vec(),
+                        change: ChangeType::Creation.into(),
+                    });
+                }
+            }
+        }
+    }
+    changes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FLAUNCH_V1_3: &str = "23321f11a6d44fd1ab790044fdfde5758c902fdc";
+    const OTHER_HOOK: &str = "0000000aa232009084bd71a5797d089aa4edfad4";
+
+    fn component_with_hook(hook_hex: &str) -> ProtocolComponent {
+        ProtocolComponent {
+            id: "0xpool".to_string(),
+            change: i32::from(ChangeType::Creation),
+            static_att: vec![Attribute {
+                name: "hooks".to_string(),
+                value: hex::decode(hook_hex).unwrap(),
+                change: ChangeType::Creation.into(),
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn block_with(components: Vec<ProtocolComponent>) -> BlockChanges {
+        BlockChanges {
+            block: None,
+            changes: vec![TransactionChanges {
+                component_changes: components,
+                ..Default::default()
+            }],
+            storage_changes: vec![],
+        }
+    }
+
+    fn hook_identifier(component: &ProtocolComponent) -> Option<Vec<u8>> {
+        component
+            .static_att
+            .iter()
+            .find(|a| a.name == "hook_identifier")
+            .map(|a| a.value.clone())
+    }
+
+    #[test]
+    fn tags_only_flaunch_hooks() {
+        let block =
+            block_with(vec![component_with_hook(FLAUNCH_V1_3), component_with_hook(OTHER_HOOK)]);
+        let filter = parse_hook_addresses(FLAUNCH_V1_3);
+
+        let out = tag_flaunch_components(block, &filter);
+        let comps = &out.changes[0].component_changes;
+
+        assert_eq!(hook_identifier(&comps[0]), Some(b"flaunch_v1".to_vec()));
+        assert_eq!(hook_identifier(&comps[1]), None, "non-Flaunch hook must not be tagged");
+    }
+
+    #[test]
+    fn parses_multiple_hooks_with_and_without_prefix() {
+        let hooks = parse_hook_addresses(" 0x23321f11a6d44fd1ab790044fdfde5758c902fdc, 8dc3b85e1dc1c846ebf3971179a751896842e5dc ");
+        assert_eq!(hooks.len(), 2);
+        assert_eq!(hooks[0], hex::decode(FLAUNCH_V1_3).unwrap());
+    }
+}

--- a/protocols/substreams/ethereum-uniswap-v4/with-hooks/src/variant_modules/mod.rs
+++ b/protocols/substreams/ethereum-uniswap-v4/with-hooks/src/variant_modules/mod.rs
@@ -16,6 +16,9 @@ pub mod map_euler_enriched_protocol_changes;
 #[path = "4_map_angstrom_enriched_block_changes.rs"]
 pub mod map_angstrom_enriched_block_changes;
 
+#[path = "4_map_flaunch_enriched_protocol_changes.rs"]
+pub mod map_flaunch_enriched_protocol_changes;
+
 #[path = "5_map_protocol_changes.rs"]
 pub mod map_protocol_changes;
 

--- a/protocols/testing/src/test_runner.rs
+++ b/protocols/testing/src/test_runner.rs
@@ -74,6 +74,7 @@ static CLONE_TO_BASE_PROTOCOL: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| 
         ("ethereum-pancakeswap-v2", "ethereum-uniswap-v2"),
         ("base-alienbase-v3", "ethereum-uniswap-v3-logs-only"),
         ("unichain-curve", "ethereum-curve"),
+        ("base-flaunch", "ethereum-uniswap-v4/with-hooks"),
     ])
 });
 


### PR DESCRIPTION
## What

Adds indexing support for Flaunch, a Uniswap V4 hook protocol on Base.

- New `base-uniswap-v4-with-hooks.yaml` manifest for the `ethereum-uniswap-v4-with-hooks` package, starting at the Base V4 PoolManager deployment (block 25350988).
- New `map_flaunch_enriched_protocol_changes` module: tags pools whose `hooks` static attribute matches a configured Flaunch hook address with `hook_identifier=flaunch_v1`, following the existing `euler_v1`/`angstrom_v1` enrichment pattern. Hook addresses are passed as manifest params (all five deployed Flaunch PositionManager/AnyPositionManager hooks).
- `extractors.yaml`: new `uniswap_v4_hooks_base` entry (protocol system `uniswap_v4_hooks`, chain `base`) with the `uniswap_v4_hooks` DCI plugin.
- Integration test `integration_test_base_flaunch.tycho.yaml` against a real Base-mainnet Flaunch v1.3 pool, runnable via `protocol-testing` with `--package base-flaunch --chain base`.
- Version bump `0.7.0` → `0.8.0`.

## Notes

- A sibling PR adds an NFTX enrichment to the same package on Ethereum, pre-assigned version `0.9.0`. Whichever merges second needs a trivial `Cargo.toml`/`Cargo.lock` version conflict resolution (keep the higher version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)