### PR TITLE
feat: add NFTX Uniswap V4 hook integration on Ethereum

### DIFF
--- a/crates/tycho-indexer/extractors.yaml
+++ b/crates/tycho-indexer/extractors.yaml
@@ -95,6 +95,25 @@ extractors:
     spkg: "substreams/ethereum-uniswap-v4/ethereum-uniswap-v4-v0.2.1.spkg"
     module_name: "map_protocol_changes"
 
+  # Ethereum Uniswap V4 hooks: indexes all swap-hooked pools on Ethereum; the
+  # terminal module chains the euler, angstrom and NFTX enrichments, tagging NFTX
+  # pools with hook_identifier=nftx_v1 so the hooks DCI and GenericVMHookHandler
+  # can simulate them.
+  uniswap_v4_hooks_ethereum:
+    name: "uniswap_v4_hooks"
+    chain: "ethereum"
+    implementation_type: "Custom"
+    sync_batch_size: 1000
+    start_block: 21688329
+    protocol_types:
+      - name: "uniswap_v4_pool"
+        financial_type: "Swap"
+    spkg: "substreams/ethereum-uniswap-v4/with-hooks/ethereum-uniswap-v4-with-hooks-v0.9.0.spkg"
+    module_name: "map_nftx_enriched_protocol_changes"
+    dci_plugin:
+      type: "uniswap_v4_hooks"
+      pool_manager_address: "0x000000000004444c5dc75cB358380D2e3dE08A90"
+
   ekubo_v2:
     name: "ekubo_v2"
     chain: "ethereum"

--- a/protocols/substreams/ethereum-uniswap-v4/Cargo.lock
+++ b/protocols/substreams/ethereum-uniswap-v4/Cargo.lock
@@ -272,21 +272,14 @@ dependencies = [
 name = "ethereum-uniswap-v4-no-hooks"
 version = "0.4.1"
 dependencies = [
- "anyhow",
  "ethabi 18.0.0",
  "ethereum-uniswap-v4-shared",
  "getrandom 0.2.16",
  "hex",
- "hex-literal 0.4.1",
- "itertools 0.13.0",
- "num-bigint",
- "prost 0.11.9",
  "rstest",
  "substreams",
- "substreams-entity-change",
  "substreams-ethereum",
  "substreams-helper",
- "tiny-keccak",
  "tycho-substreams",
 ]
 
@@ -298,22 +291,19 @@ dependencies = [
  "ethabi 18.0.0",
  "getrandom 0.2.16",
  "hex",
- "hex-literal 0.4.1",
  "itertools 0.13.0",
  "num-bigint",
  "prost 0.11.9",
  "rstest",
  "substreams",
- "substreams-entity-change",
  "substreams-ethereum",
  "substreams-helper",
- "tiny-keccak",
  "tycho-substreams",
 ]
 
 [[package]]
 name = "ethereum-uniswap-v4-with-hooks"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -321,17 +311,13 @@ dependencies = [
  "getrandom 0.2.16",
  "hex",
  "hex-literal 0.4.1",
- "itertools 0.13.0",
- "num-bigint",
  "prost 0.11.9",
  "rstest",
  "serde",
  "serde_qs",
  "substreams",
- "substreams-entity-change",
  "substreams-ethereum",
  "substreams-helper",
- "tiny-keccak",
  "tycho-substreams",
 ]
 

--- a/protocols/substreams/ethereum-uniswap-v4/with-hooks/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v4/with-hooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v4-with-hooks"
-version = "0.7.0"
+version = "0.9.0"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-uniswap-v4/with-hooks/ethereum-uniswap-v4-with-hooks.yaml
+++ b/protocols/substreams/ethereum-uniswap-v4/with-hooks/ethereum-uniswap-v4-with-hooks.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_uniswap_v4_with_hooks"
-  version: v0.7.0
+  version: v0.9.0
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v4/with-hooks"
 
 protobuf:
@@ -192,6 +192,15 @@ modules:
     output:
       type: proto:tycho.evm.v1.BlockChanges
 
+  - name: map_nftx_enriched_protocol_changes
+    kind: map
+    initialBlock: 21688329
+    inputs:
+      - params: string
+      - map: map_angstrom_enriched_block_changes
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
 
 params:
   map_pools_created: "000000000004444c5dc75cB358380D2e3dE08A90"
@@ -199,3 +208,4 @@ params:
   map_euler_enriched_protocol_changes: "0xb013be1D0D380C13B58e889f412895970A2Cf228"
   store_tokens_to_pool_id_angstrom: "0x0000000aa232009084bd71a5797d089aa4edfad4" # angstrom hook address
   map_angstrom_enriched_block_changes: controller_address=0x1746484ea5e11c75e009252c102c8c33e0315fd4&angstrom_address=0x0000000aa232009084bd71a5797d089aa4edfad4
+  map_nftx_enriched_protocol_changes: "d2094b5cdb1a12b6274e4a4d3a252cd94c51efcc" # NFTXV4Hook

--- a/protocols/substreams/ethereum-uniswap-v4/with-hooks/integration_test_ethereum_nftx.tycho.yaml
+++ b/protocols/substreams/ethereum-uniswap-v4/with-hooks/integration_test_ethereum_nftx.tycho.yaml
@@ -1,0 +1,32 @@
+substreams_yaml_path: ./ethereum-uniswap-v4-with-hooks.yaml
+# The balance check does not support vault-like contracts such as the Uniswap V4
+# PoolManager (a single contract holds the reserves of every pool).
+skip_balance_check: true
+protocol_type_names:
+  - "uniswap_v4_pool"
+protocol_system: "uniswap_v4_hooks"
+module_name: "map_nftx_enriched_protocol_changes"
+initialized_accounts:
+  - "0x000000000004444c5dc75cB358380D2e3dE08A90" # Uniswap V4 PoolManager
+  - "0xd2094b5cDB1a12b6274e4A4D3a252cD94C51EFcC" # NFTXV4Hook
+tests:
+  # Real Ethereum-mainnet NFTX pool (flETH / CollectionToken), verified against the
+  # PoolManager Initialize log at block 25438812. The block range also covers swaps
+  # at blocks 25438814-25438838. The component is emitted by the shared with-hooks
+  # pipeline and tagged hook_identifier=nftx_v1 by the enrichment module.
+  - name: test_nftx_pool_creation
+    start_block: 25438812
+    stop_block: 25438840
+    expected_components:
+      - id: "0x709a1cfa2a4b27238c669ce82277c47282f13620171459bbe764d8967e72867c"
+        tokens:
+          - "0x000000000bb1f9944965c64066d10038a84f9af2" # flETH
+          - "0x47e59e2ff346fb686fe42afe75e1f16c81650fe0" # CollectionToken
+        static_attributes:
+          tick_spacing: "0x3c" # 60
+          hooks: "0xd2094b5cdb1a12b6274e4a4d3a252cd94c51efcc"
+          key_lp_fee: "0x00800000" # dynamic-fee flag
+          hook_identifier: "0x6e6674785f7631" # nftx_v1
+        creation_tx: "0x5e510ed23b7623caca7a66a217356e1cca79533d374fe8cd7bc8efe4b262e64e"
+        skip_simulation: false
+        skip_execution: true

--- a/protocols/substreams/ethereum-uniswap-v4/with-hooks/src/variant_modules/4_map_nftx_enriched_protocol_changes.rs
+++ b/protocols/substreams/ethereum-uniswap-v4/with-hooks/src/variant_modules/4_map_nftx_enriched_protocol_changes.rs
@@ -1,0 +1,112 @@
+use tycho_substreams::prelude::*;
+
+/// Enrich the base Uniswap V4 hooks protocol changes with the NFTX hook
+/// identifier.
+///
+/// Every pool whose `hooks` static attribute matches one of the configured NFTX
+/// hook addresses is tagged with `hook_identifier = "nftx_v1"`, which the indexer
+/// hooks DCI and tycho-simulation use to route the component (mirrors the
+/// `euler_v1` / `angstrom_v1` enrichment).
+///
+/// `params` is a comma-separated list of the NFTX hook addresses (hex, with or
+/// without a `0x` prefix).
+#[substreams::handlers::map]
+pub fn map_nftx_enriched_protocol_changes(
+    params: String,
+    protocol_changes: BlockChanges,
+) -> Result<BlockChanges, substreams::errors::Error> {
+    let nftx_hooks = parse_hook_addresses(&params);
+    Ok(tag_nftx_components(protocol_changes, &nftx_hooks))
+}
+
+fn parse_hook_addresses(params: &str) -> Vec<Vec<u8>> {
+    params
+        .split(',')
+        .map(str::trim)
+        .filter(|hook| !hook.is_empty())
+        .map(|hook| hex::decode(hook.trim_start_matches("0x")).expect("invalid NFTX hook address"))
+        .collect()
+}
+
+fn tag_nftx_components(mut changes: BlockChanges, nftx_hooks: &[Vec<u8>]) -> BlockChanges {
+    for tx_changes in &mut changes.changes {
+        for component in &mut tx_changes.component_changes {
+            if component.change != i32::from(ChangeType::Creation) {
+                continue;
+            }
+            // Clone the hooks value first so the immutable borrow ends before we
+            // push the new attribute.
+            let hook = component
+                .static_att
+                .iter()
+                .find(|attr| attr.name == "hooks")
+                .map(|attr| attr.value.clone());
+            if let Some(hook) = hook {
+                if nftx_hooks
+                    .iter()
+                    .any(|nftx| nftx == &hook)
+                {
+                    component.static_att.push(Attribute {
+                        name: "hook_identifier".to_string(),
+                        value: b"nftx_v1".to_vec(),
+                        change: ChangeType::Creation.into(),
+                    });
+                }
+            }
+        }
+    }
+    changes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NFTX_HOOK: &str = "d2094b5cdb1a12b6274e4a4d3a252cd94c51efcc";
+    const OTHER_HOOK: &str = "0000000aa232009084bd71a5797d089aa4edfad4";
+
+    fn component_with_hook(hook_hex: &str) -> ProtocolComponent {
+        ProtocolComponent {
+            id: "0xpool".to_string(),
+            change: i32::from(ChangeType::Creation),
+            static_att: vec![Attribute {
+                name: "hooks".to_string(),
+                value: hex::decode(hook_hex).unwrap(),
+                change: ChangeType::Creation.into(),
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn block_with(components: Vec<ProtocolComponent>) -> BlockChanges {
+        BlockChanges {
+            block: None,
+            changes: vec![TransactionChanges {
+                component_changes: components,
+                ..Default::default()
+            }],
+            storage_changes: vec![],
+        }
+    }
+
+    fn hook_identifier(component: &ProtocolComponent) -> Option<Vec<u8>> {
+        component
+            .static_att
+            .iter()
+            .find(|a| a.name == "hook_identifier")
+            .map(|a| a.value.clone())
+    }
+
+    #[test]
+    fn tags_only_nftx_hooks() {
+        let block =
+            block_with(vec![component_with_hook(NFTX_HOOK), component_with_hook(OTHER_HOOK)]);
+        let filter = parse_hook_addresses(NFTX_HOOK);
+
+        let out = tag_nftx_components(block, &filter);
+        let comps = &out.changes[0].component_changes;
+
+        assert_eq!(hook_identifier(&comps[0]), Some(b"nftx_v1".to_vec()));
+        assert_eq!(hook_identifier(&comps[1]), None, "non-NFTX hook must not be tagged");
+    }
+}

--- a/protocols/substreams/ethereum-uniswap-v4/with-hooks/src/variant_modules/mod.rs
+++ b/protocols/substreams/ethereum-uniswap-v4/with-hooks/src/variant_modules/mod.rs
@@ -16,6 +16,9 @@ pub mod map_euler_enriched_protocol_changes;
 #[path = "4_map_angstrom_enriched_block_changes.rs"]
 pub mod map_angstrom_enriched_block_changes;
 
+#[path = "4_map_nftx_enriched_protocol_changes.rs"]
+pub mod map_nftx_enriched_protocol_changes;
+
 #[path = "5_map_protocol_changes.rs"]
 pub mod map_protocol_changes;
 

--- a/protocols/testing/src/test_runner.rs
+++ b/protocols/testing/src/test_runner.rs
@@ -74,6 +74,7 @@ static CLONE_TO_BASE_PROTOCOL: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| 
         ("ethereum-pancakeswap-v2", "ethereum-uniswap-v2"),
         ("base-alienbase-v3", "ethereum-uniswap-v3-logs-only"),
         ("unichain-curve", "ethereum-curve"),
+        ("ethereum-nftx", "ethereum-uniswap-v4/with-hooks"),
     ])
 });
 


### PR DESCRIPTION
## What

Adds indexing support for NFTX, a Uniswap V4 hook protocol deployed on Ethereum mainnet (NFTXV4Hook `0xd2094b5cDB1a12b6274e4A4D3a252cD94C51EFcC`, deployed at block 25438150).

- New `map_nftx_enriched_protocol_changes` module in the `ethereum-uniswap-v4-with-hooks` package: tags pools whose `hooks` static attribute matches a configured NFTX hook address with `hook_identifier=nftx_v1`, following the existing `euler_v1`/`angstrom_v1` enrichment pattern.
- The module chains after `map_angstrom_enriched_block_changes` as the new terminal module of the ethereum manifest, so its output still includes the euler and angstrom enrichments.
- `extractors.yaml`: new `uniswap_v4_hooks_ethereum` entry (protocol system `uniswap_v4_hooks`, chain `ethereum`) with the `uniswap_v4_hooks` DCI plugin.
- Integration test `integration_test_ethereum_nftx.tycho.yaml` against a real mainnet NFTX pool (flETH/CollectionToken, created at block 25438812), runnable via `protocol-testing` with `--package ethereum-nftx`.
- Version bump `0.7.0` → `0.9.0` (`0.8.0` is pre-assigned to the sibling Flaunch PR #1172).

## Notes

- Deployments currently running `map_angstrom_enriched_block_changes` should switch `module_name` to `map_nftx_enriched_protocol_changes` when adopting the v0.9.0 spkg; the output is a superset.
- Whichever of this and #1172 merges second needs a trivial `Cargo.toml`/`Cargo.lock` version conflict resolution (keep the higher version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)