### PR TITLE
fix(substreams): bump tycho-substreams to 0.8.0 in DCI packages

### DIFF
--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -753,12 +753,12 @@ dependencies = [
  "substreams 0.5.22",
  "substreams-ethereum 0.9.13",
  "tiny-keccak",
- "tycho-substreams 0.2.1 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=52d5021)",
+ "tycho-substreams 0.2.1",
 ]
 
 [[package]]
 name = "ethereum-balancer-v2"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -768,12 +768,12 @@ dependencies = [
  "num-bigint",
  "substreams 0.5.22",
  "substreams-ethereum 0.9.13",
- "tycho-substreams 0.5.1",
+ "tycho-substreams 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ethereum-balancer-v3"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -785,7 +785,7 @@ dependencies = [
  "regex",
  "substreams 0.5.22",
  "substreams-ethereum 0.9.13",
- "tycho-substreams 0.2.1 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=51995f9)",
+ "tycho-substreams 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-curve"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -840,7 +840,7 @@ dependencies = [
  "serde_qs 0.13.0",
  "substreams 0.5.22",
  "substreams-ethereum 0.9.13",
- "tycho-substreams 0.5.0",
+ "tycho-substreams 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-fluid_v1"
-version = "0.2.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -935,7 +935,7 @@ dependencies = [
  "substreams 0.5.22",
  "substreams-ethereum 0.9.13",
  "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=b8aeaa3)",
- "tycho-substreams 0.5.1",
+ "tycho-substreams 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -983,7 +983,7 @@ dependencies = [
  "substreams 0.5.22",
  "substreams-ethereum 0.9.13",
  "substreams-helper 0.0.2 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=52d5021)",
- "tycho-substreams 0.2.1 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=52d5021)",
+ "tycho-substreams 0.2.1",
 ]
 
 [[package]]
@@ -1034,7 +1034,7 @@ dependencies = [
  "regex",
  "substreams 0.5.22",
  "substreams-ethereum 0.9.13",
- "tycho-substreams 0.2.1 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=52d5021)",
+ "tycho-substreams 0.2.1",
 ]
 
 [[package]]
@@ -1052,7 +1052,7 @@ dependencies = [
  "regex",
  "substreams 0.5.22",
  "substreams-ethereum 0.9.13",
- "tycho-substreams 0.2.1 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=52d5021)",
+ "tycho-substreams 0.2.1",
 ]
 
 [[package]]
@@ -1065,7 +1065,7 @@ dependencies = [
  "serde-sibor",
  "substreams 0.5.22",
  "substreams-ethereum 0.9.13",
- "tycho-substreams 0.2.1 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=52d5021)",
+ "tycho-substreams 0.2.1",
 ]
 
 [[package]]
@@ -1079,7 +1079,7 @@ dependencies = [
  "serde_qs 0.13.0",
  "substreams 0.5.22",
  "substreams-ethereum 0.9.13",
- "tycho-substreams 0.2.1 (git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=52d5021)",
+ "tycho-substreams 0.2.1",
 ]
 
 [[package]]
@@ -3088,22 +3088,6 @@ dependencies = [
 [[package]]
 name = "tycho-substreams"
 version = "0.2.1"
-source = "git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=51995f9#51995f9731ecf549a5ae68c281906c90efe9909a"
-dependencies = [
- "ethabi 18.0.0",
- "hex",
- "itertools 0.12.1",
- "num-bigint",
- "prost 0.11.9",
- "serde",
- "serde_json",
- "substreams 0.5.22",
- "substreams-ethereum 0.9.13",
-]
-
-[[package]]
-name = "tycho-substreams"
-version = "0.2.1"
 source = "git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=52d5021#52d502198e9aa964814ef5f139df0886c3eb7bb0"
 dependencies = [
  "ethabi 18.0.0",
@@ -3121,39 +3105,6 @@ dependencies = [
 name = "tycho-substreams"
 version = "0.2.2"
 source = "git+https://github.com/propeller-heads/tycho-protocol-sdk.git?tag=0.4.0#cfbf6812bdc9503ff51debcf5e171cd680b4d694"
-dependencies = [
- "ethabi 18.0.0",
- "hex",
- "itertools 0.12.1",
- "num-bigint",
- "prost 0.11.9",
- "serde",
- "serde_json",
- "substreams 0.5.22",
- "substreams-ethereum 0.9.13",
-]
-
-[[package]]
-name = "tycho-substreams"
-version = "0.5.0"
-source = "git+https://github.com/propeller-heads/tycho-protocol-sdk.git?rev=655fae7#655fae77aba34b84353d923575096bd9c26ee418"
-dependencies = [
- "ethabi 18.0.0",
- "hex",
- "itertools 0.12.1",
- "num-bigint",
- "prost 0.11.9",
- "serde",
- "serde_json",
- "substreams 0.5.22",
- "substreams-ethereum 0.9.13",
-]
-
-[[package]]
-name = "tycho-substreams"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a164ecbc3f2d7515e9447d7c1933a01fba6e54a082bbe1c73eb7b827d2a45b47"
 dependencies = [
  "ethabi 18.0.0",
  "hex",

--- a/protocols/substreams/ethereum-balancer-v2/CHANGELOG.md
+++ b/protocols/substreams/ethereum-balancer-v2/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## v0.4.2
+
+- Update `tycho-substreams` from `0.5.1` to `0.8.0`. `get_block_storage_changes` now
+  emits native balance changes in the block storage output consumed by the DCI.
+  Earlier builds never emitted them, so native balances of DCI-tracked contracts
+  stayed frozen at their initial snapshot.

--- a/protocols/substreams/ethereum-balancer-v2/Cargo.toml
+++ b/protocols/substreams/ethereum-balancer-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-balancer-v2"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 [lib]
@@ -15,7 +15,7 @@ hex = "0.4.3"
 anyhow = "1.0.75"
 num-bigint = "0.4.4"
 itertools = "0.12.0"
-tycho-substreams = "0.5.1"
+tycho-substreams = "0.8.0"
 
 [build-dependencies]
 anyhow = "1"

--- a/protocols/substreams/ethereum-balancer-v2/substreams.yaml
+++ b/protocols/substreams/ethereum-balancer-v2/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_balancer_v2"
-  version: v0.4.1
+  version: v0.4.2
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-balancer-v2"
 
 protobuf:

--- a/protocols/substreams/ethereum-balancer-v3/CHANGELOG.md
+++ b/protocols/substreams/ethereum-balancer-v3/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## v0.4.1
+
+- Update `tycho-substreams` from git rev `51995f9` (2025-06-05, pre-0.6.0) to `0.8.0`.
+  `get_block_storage_changes` now emits native balance changes in the block storage
+  output consumed by the DCI. Earlier builds never emitted them, so native balances
+  of DCI-tracked contracts stayed frozen at their initial snapshot.
+- Picks up the `previous_value` field and its multi-write fix for storage slot
+  changes (tycho-substreams 0.5.0/0.5.1).

--- a/protocols/substreams/ethereum-balancer-v3/Cargo.toml
+++ b/protocols/substreams/ethereum-balancer-v3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-balancer-v3"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [lib]
@@ -14,7 +14,7 @@ ethabi = "18.0.0"
 hex = "0.4.3"
 anyhow = "1.0.75"
 num-bigint = "0.4.4"
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "51995f9" }
+tycho-substreams = "0.8.0"
 itertools = "0.13.0"
 keccak-hash = "0.11.0"
 

--- a/protocols/substreams/ethereum-balancer-v3/src/modules.rs
+++ b/protocols/substreams/ethereum-balancer-v3/src/modules.rs
@@ -63,7 +63,7 @@ pub fn store_components(
             tx_pc
                 .components
                 .into_iter()
-                .for_each(|pc| store.set_if_not_exists(0, format!("pool:{0}", &pc.id), &pc))
+                .for_each(|pc| store.set_if_not_exists(0, format!("pool:{0}", pc.id), &pc))
         });
 }
 
@@ -107,7 +107,7 @@ pub fn map_relative_balances(
                 );
 
                 if store
-                    .get_last(format!("pool:{}", &component_id))
+                    .get_last(format!("pool:{}", component_id))
                     .is_some()
                 {
                     deltas.extend_from_slice(&[
@@ -132,7 +132,7 @@ pub fn map_relative_balances(
                 LiquidityAdded::match_and_decode(vault_log.log)
             {
                 let component_id = format!("0x{}", hex::encode(pool));
-                if let Some(component) = store.get_last(format!("pool:{}", &component_id)) {
+                if let Some(component) = store.get_last(format!("pool:{}", component_id)) {
                     if component.tokens.len() != amounts_added_raw.len() {
                         panic!(
                             "liquidity added to pool with different number of tokens than expected"
@@ -167,7 +167,7 @@ pub fn map_relative_balances(
                     component_id,
                     format!("pool:{}", &component_id)
                 );
-                if let Some(component) = store.get_last(format!("pool:{}", &component_id)) {
+                if let Some(component) = store.get_last(format!("pool:{}", component_id)) {
                     if component.tokens.len() != amounts_removed_raw.len() {
                         panic!(
                             "liquidity removed from pool with different number of tokens than expected"
@@ -232,7 +232,7 @@ pub fn map_protocol_changes(
                 let component_id = format!("0x{}", hex::encode(&pool));
                 let tx: Transaction = log.receipt.transaction.into();
                 if components_store
-                    .get_last(format!("pool:{}", &component_id))
+                    .get_last(format!("pool:{}", component_id))
                     .is_some()
                 {
                     let builder = transaction_changes

--- a/protocols/substreams/ethereum-balancer-v3/substreams.yaml
+++ b/protocols/substreams/ethereum-balancer-v3/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_balancer_v3"
-  version: v0.4.0
+  version: v0.4.1
 
 protobuf:
   files:

--- a/protocols/substreams/ethereum-curve/CHANGELOG.md
+++ b/protocols/substreams/ethereum-curve/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## v0.3.8
+
+- Update `tycho-substreams` from git rev `655fae7` (2025-09-05, pre-0.6.0) to `0.8.0`.
+  `get_block_storage_changes` now emits native balance changes in the block storage
+  output consumed by the DCI. Earlier builds never emitted them, so native balances
+  of DCI-tracked contracts stayed frozen at their initial snapshot.
+- Picks up the `previous_value` fix for storage slots written multiple times in one
+  transaction, and drops intra-transaction no-op slot changes (tycho-substreams 0.5.1).

--- a/protocols/substreams/ethereum-curve/Cargo.toml
+++ b/protocols/substreams/ethereum-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-curve"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 
 [lib]
@@ -14,7 +14,7 @@ ethabi = "18.0.0"
 hex = "0.4.3"
 anyhow = "1.0.75"
 num-bigint = "0.4.4"
-tycho-substreams = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "655fae7" }
+tycho-substreams = "0.8.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_qs = "0.13.0"
 itertools = "0.13.0"

--- a/protocols/substreams/ethereum-curve/ethereum-curve.yaml
+++ b/protocols/substreams/ethereum-curve/ethereum-curve.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_curve"
-  version: v0.3.7
+  version: v0.3.8
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-curve"
 
 protobuf:

--- a/protocols/substreams/ethereum-curve/src/pool_factories.rs
+++ b/protocols/substreams/ethereum-curve/src/pool_factories.rs
@@ -32,8 +32,10 @@ impl SerializableVecBigInt for Vec<BigInt> {
     }
     fn deserialize_bytes(bytes: &[u8]) -> Vec<BigInt> {
         bytes
-            .chunks_exact(32)
-            .map(BigInt::from_signed_bytes_be)
+            .as_chunks::<32>()
+            .0
+            .iter()
+            .map(|chunk| BigInt::from_signed_bytes_be(chunk))
             .collect::<Vec<BigInt>>()
     }
 }

--- a/protocols/substreams/ethereum-curve/unichain-curve.yaml
+++ b/protocols/substreams/ethereum-curve/unichain-curve.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "unichain_curve"
-  version: v0.3.7
+  version: v0.3.8
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-curve"
 
 protobuf:

--- a/protocols/substreams/ethereum-fluid/CHANGELOG.md
+++ b/protocols/substreams/ethereum-fluid/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## v0.3.1
+
+- Update `tycho-substreams` from `0.5.1` to `0.8.0`. `get_block_storage_changes` now
+  emits native balance changes in the block storage output consumed by the DCI.
+  Earlier builds never emitted them, so native balances of DCI-tracked contracts
+  stayed frozen at their initial snapshot.
+- Align `Cargo.toml` version (`0.2.0`) with the manifest version (`v0.3.0`); both are
+  now `0.3.1`.

--- a/protocols/substreams/ethereum-fluid/Cargo.toml
+++ b/protocols/substreams/ethereum-fluid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-fluid_v1"
-version = "0.2.0"
+version = "0.3.1"
 edition = "2021"
 
 [lib]
@@ -12,7 +12,7 @@ substreams = "0.5.22"
 substreams-ethereum = "0.9.9"
 prost = "0.11"
 substreams-helper = { git = "https://github.com/propeller-heads/tycho-protocol-sdk.git", rev = "b8aeaa3" }
-tycho-substreams = "0.5.1"
+tycho-substreams = "0.8.0"
 anyhow = "1.0.95"
 ethabi = "18.0.0"
 num-bigint = "0.4.6"

--- a/protocols/substreams/ethereum-fluid/build.rs
+++ b/protocols/substreams/ethereum-fluid/build.rs
@@ -38,7 +38,7 @@ fn main() -> Result<()> {
         Abigen::new(contract_name, &input_path)?
             .generate()
             .map_err(|e| {
-                println!("Failed to generate contract: {} from {}", e, &input_path);
+                println!("Failed to generate contract: {} from {}", e, input_path);
                 e
             })?
             .write_to_file(&output_path)?;

--- a/protocols/substreams/ethereum-fluid/substreams.yaml
+++ b/protocols/substreams/ethereum-fluid/substreams.yaml
@@ -63,7 +63,7 @@ modules:
 network: mainnet
 package:
   name: ethereum_fluid_v1
-  version: v0.3.0
+  version: v0.3.1
 protobuf:
   files:
     - tycho/evm/v1/vm.proto


### PR DESCRIPTION
## What

Bumps `tycho-substreams` to `0.8.0` in the four DCI-feeding packages that pinned pre-0.6.0 versions, and bumps each package version:

| Package | tycho-substreams before | Package version |
|---|---|---|
| ethereum-curve | git rev `655fae7` (2025-09-05) | v0.3.7 → v0.3.8 |
| ethereum-balancer-v2 | `0.5.1` | v0.4.1 → v0.4.2 |
| ethereum-balancer-v3 | git rev `51995f9` (2025-06-05) | v0.4.0 → v0.4.1 |
| ethereum-fluid | `0.5.1` | v0.3.0 → v0.3.1 (also aligns Cargo.toml, which was at 0.2.0) |

Adds a `CHANGELOG.md` to each package, and fixes clippy lints raised by the latest nightly in files rebuilt by this change (separate commit).

## Why

`get_block_storage_changes` emits native balance changes since `tycho-substreams` 0.6.0 (propeller-heads/tycho-protocol-sdk#292, 2025-10-06). Packages pinned to older versions produce block storage output without balances, so the DCI never receives balance updates for tracked contracts — their ETH balances stay frozen at the initial account snapshot.

Concrete impact: the ynETH/wstETH curve pool `0xb85d5b88…` quotes a rate built from the redemption vault's ETH balance frozen at 43.99 ETH (snapshot 2025-01-08) vs 25.90 on-chain — currently ~9.4% overpriced. Verified by running the deployed `ethereum-curve-v0.3.6.spkg` at block 25486933 (a 25.93 ETH vault outflow): 628 storage-change entries, zero `nativeBalance` fields.

## Notes

- Emitted `native_balance` is the absolute post-tx balance, so tracked accounts self-heal on their first balance change after the new spkgs are deployed. Rarely-touched accounts need a one-time balance backfill.
- New wasm = new module hashes; substreams servers will rebuild module caches from each package's initial block on first sync.
- The 2026-05-29 fix `b67b1bb57` (retain token-balance-only contract changes) exists only in the workspace crate and is not in any published release; publishing 0.9.0 and bumping again could be a follow-up.
- `ethereum-fluid` still pins `substreams-helper` to git rev `b8aeaa3` — untouched here, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
