### PR TITLE
feat: mark Chain enum as non_exhaustive

### DIFF
--- a/crates/tycho-client/src/stream.rs
+++ b/crates/tycho-client/src/stream.rs
@@ -117,7 +117,7 @@ impl TychoStreamBuilder {
             Chain::Bsc => (1, 12, 50),
             Chain::Unichain => (1, 10, 100),
             Chain::Polygon => (2, 12, 50), // ~2s block time
-            Chain::Custom(_) => {
+            _ => {
                 let block_time = chain.block_time_secs();
                 (block_time, block_time * 3, 50)
             }

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -81,6 +81,7 @@ pub type EntryPointId = String;
 /// for the self-host case. Full rationale in the custom-chain decision record.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum Chain {
     #[default]
     Ethereum,


### PR DESCRIPTION
## What

Adds `#[non_exhaustive]` to `tycho_common::models::Chain`.

## Why

Following up on a code-review suggestion. `#[non_exhaustive]` makes adding a
new built-in chain variant a non-breaking change for downstream matchers:
they're required to carry a wildcard arm, so a new variant no longer forces a
compile error (or a semver-major bump) on every consumer that matches on
`Chain`.

## Changes

- `tycho-common`: tag `Chain` with `#[non_exhaustive]`.
- `tycho-client`: broaden `default_timing`'s `Chain::Custom(_)` arm to `_`.
  It already fell through to the generic `block_time_secs()` path, so behavior
  is unchanged — the wildcard now also covers any future variant.

This was the only downstream match that needed updating; everything else either
matches on `dto::Chain` (left exhaustive) or constructs values rather than
matching.

## Notes / follow-up

- `dto::Chain` — the wire type external clients deserialize — was intentionally
  left exhaustive, matching the reviewer's scope. It's arguably the more
  important one for API stability; happy to tag it in a follow-up if we want the
  same guarantee there.
- Trade-off: `#[non_exhaustive]` mandates wildcard arms, which runs against our
  "no wildcard matches" guideline (exhaustive matches catch new variants at
  compile time). Accepted here in exchange for the semver guarantee.

## Testing

- `cargo check --all-features --workspace --all-targets` ✅
- `cargo clippy --all-features` ✅
- `cargo fmt --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
