### PR TITLE
feat: unify chain config env vars as CUSTOM_CHAINS_CONFIG

### DIFF
--- a/crates/tycho-client/src/stream.rs
+++ b/crates/tycho-client/src/stream.rs
@@ -10,7 +10,10 @@ use tokio::{sync::mpsc::Receiver, task::JoinHandle};
 use tracing::{info, warn};
 use tycho_common::{
     dto::{PaginationLimits, ProtocolSystemsRequestBody},
-    models::{Chain, ExtractorIdentity},
+    models::{
+        chain_config::{init_chain_registry, ChainConfigRegistry},
+        Chain, ExtractorIdentity,
+    },
 };
 
 use crate::{
@@ -51,6 +54,19 @@ impl RetryConfiguration {
 pub struct ConstantRetryConfiguration {
     max_attempts: u64,
     cooldown: Duration,
+}
+
+/// Loads and validates the custom-chain config once, before the stream starts. A missing or
+/// malformed `TYCHO_CHAINS_CONFIG` fails here with an actionable error, rather than degrading to
+/// an empty registry and resurfacing later as a confusing unknown-chain error mid-stream. An unset
+/// env var yields an empty registry (Ok), so built-in-only consumers are unaffected. The validated
+/// registry is best-effort installed as the process-wide one; a prior lazy access may already have
+/// initialised it, in which case the install is a no-op.
+fn validate_chain_config() -> Result<(), StreamError> {
+    let registry = ChainConfigRegistry::load_default()
+        .map_err(|e| StreamError::SetUpError(format!("failed to load custom chain config: {e}")))?;
+    let _ = init_chain_registry(registry);
+    Ok(())
 }
 
 pub struct TychoStreamBuilder {
@@ -259,6 +275,9 @@ impl TychoStreamBuilder {
                 "At least one exchange must be registered.".to_string(),
             ));
         }
+
+        // Fail fast on a broken custom-chain config, before any network I/O.
+        validate_chain_config()?;
 
         // Attempt to read the authentication key from the environment variable if not provided
         let auth_key = self
@@ -477,6 +496,31 @@ impl ProtocolSystemsInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_validate_chain_config_errors_on_broken_file() {
+        // Relies on nextest process isolation: this mutates the process-global env var.
+        std::env::set_var("TYCHO_CHAINS_CONFIG", "/nonexistent/does-not-exist.yaml");
+        let result = validate_chain_config();
+        std::env::remove_var("TYCHO_CHAINS_CONFIG");
+
+        let err = result.expect_err("a missing config file must fail validation");
+        assert!(matches!(err, StreamError::SetUpError(_)));
+        assert!(
+            err.to_string()
+                .contains("custom chain config"),
+            "error should name the custom chain config: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_chain_config_ok_when_env_unset() {
+        std::env::remove_var("TYCHO_CHAINS_CONFIG");
+        assert!(
+            validate_chain_config().is_ok(),
+            "an unset env var means no custom chains, which is valid"
+        );
+    }
 
     #[test]
     fn test_retry_configuration_constant() {

--- a/crates/tycho-common/src/models/chain_config.rs
+++ b/crates/tycho-common/src/models/chain_config.rs
@@ -198,11 +198,11 @@ pub enum TvlThresholdTier {
 
 /// Env var holding the path the registry reads custom-chain config from. Unset means "no custom
 /// chains"; there is no default path, so loading never depends on the current working directory.
-const CHAIN_CONFIG_ENV: &str = "TYCHO_CHAIN_CONFIG";
+const TYCHO_CHAINS_CONFIG_ENV: &str = "TYCHO_CHAINS_CONFIG";
 
 /// On-disk shape of the custom-chain config file: a top-level `chains:` list. This is the format of
 /// the indexer's `chains.yaml` (its `--chain-config` file), so a consumer can point
-/// `TYCHO_CHAIN_CONFIG` at the same file the indexer uses.
+/// `TYCHO_CHAINS_CONFIG` at the same file the indexer uses.
 #[derive(Debug, Default, Deserialize)]
 struct ChainConfigFile {
     #[serde(default)]
@@ -245,7 +245,7 @@ impl ChainConfigRegistry {
         Ok(Self { custom })
     }
 
-    /// Reads custom chain configs from the path in `TYCHO_CHAIN_CONFIG`.
+    /// Reads custom chain configs from the path in `TYCHO_CHAINS_CONFIG`.
     ///
     /// Returns an empty registry when the env var is unset, so runs on built-in chains need no
     /// config. When it is set, the file is loaded as-is: a missing, unreadable, or malformed file
@@ -253,22 +253,22 @@ impl ChainConfigRegistry {
     /// chains"), leaving the caller to decide how to react. Install the result with
     /// [`init_chain_registry`] to make it the process-wide registry.
     pub fn load_default() -> Result<Self, ChainConfigError> {
-        let Ok(path) = std::env::var(CHAIN_CONFIG_ENV) else {
+        let Ok(path) = std::env::var(TYCHO_CHAINS_CONFIG_ENV) else {
             return Ok(Self::empty());
         };
         Self::from_yaml_file(&path)
     }
 
-    /// Like [`load_default`](Self::load_default) but never fails: a broken `TYCHO_CHAIN_CONFIG`
+    /// Like [`load_default`](Self::load_default) but never fails: a broken `TYCHO_CHAINS_CONFIG`
     /// (missing, unreadable, or malformed file) is logged and degrades to an empty registry rather
     /// than aborting. Used by [`chain_registry`] to lazily initialise the process-wide registry, so
-    /// a consumer only needs to set `TYCHO_CHAIN_CONFIG` — no explicit init call. Call
+    /// a consumer only needs to set `TYCHO_CHAINS_CONFIG` — no explicit init call. Call
     /// [`load_default`](Self::load_default) directly when you need to react to the error.
     pub fn load_default_or_empty() -> Self {
         Self::load_default().unwrap_or_else(|e| {
             tracing::warn!(
                 error = %e,
-                "failed to load custom chain config from TYCHO_CHAIN_CONFIG; falling back to an \
+                "failed to load custom chain config from TYCHO_CHAINS_CONFIG; falling back to an \
                  empty registry"
             );
             Self::empty()
@@ -304,7 +304,7 @@ static CHAIN_REGISTRY: OnceLock<ChainConfigRegistry> = OnceLock::new();
 
 /// Returns the process-wide chain config registry.
 ///
-/// On first access, lazily initialises itself from `TYCHO_CHAIN_CONFIG` via
+/// On first access, lazily initialises itself from `TYCHO_CHAINS_CONFIG` via
 /// [`ChainConfigRegistry::load_default_or_empty`] — so a consumer that wants custom chains only
 /// needs to set that env var, no explicit init call. A run with the env var unset resolves
 /// built-in chains from an empty registry. Install a registry explicitly with
@@ -394,12 +394,12 @@ chains:
         assert!(!registry.contains("anything"));
     }
 
-    // These tests mutate the process-global `TYCHO_CHAIN_CONFIG` env var; they rely on nextest
+    // These tests mutate the process-global `TYCHO_CHAINS_CONFIG` env var; they rely on nextest
     // running each test in its own process (repo convention). Under plain `cargo test` they would
     // race on the shared env.
     #[test]
     fn load_default_returns_empty_when_env_unset() {
-        std::env::remove_var(CHAIN_CONFIG_ENV);
+        std::env::remove_var(TYCHO_CHAINS_CONFIG_ENV);
         assert!(!ChainConfigRegistry::load_default()
             .unwrap()
             .contains("anything"));
@@ -412,7 +412,7 @@ chains:
             std::env::temp_dir().display(),
             std::process::id()
         );
-        std::env::set_var(CHAIN_CONFIG_ENV, &missing);
+        std::env::set_var(TYCHO_CHAINS_CONFIG_ENV, &missing);
         assert!(matches!(ChainConfigRegistry::load_default(), Err(ChainConfigError::Io(_))));
     }
 
@@ -424,7 +424,7 @@ chains:
             std::process::id()
         );
         std::fs::write(&path, SAMPLE_YAML).unwrap();
-        std::env::set_var(CHAIN_CONFIG_ENV, &path);
+        std::env::set_var(TYCHO_CHAINS_CONFIG_ENV, &path);
         // No explicit init_chain_registry — first access lazily loads from the env path.
         assert!(chain_registry().contains("testchain"));
     }
@@ -436,7 +436,7 @@ chains:
             std::env::temp_dir().display(),
             std::process::id()
         );
-        std::env::set_var(CHAIN_CONFIG_ENV, &missing);
+        std::env::set_var(TYCHO_CHAINS_CONFIG_ENV, &missing);
         // A broken config must not panic here; it degrades to an empty registry.
         assert!(!ChainConfigRegistry::load_default_or_empty().contains("anything"));
     }

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -170,7 +170,7 @@ impl From<dto::Chain> for Chain {
             dto::Chain::Custom(name) => Chain::custom(name.as_str()).unwrap_or_else(|e| {
                 panic!(
                     "received custom chain '{name}' with no registered config: {e}; install it via \
-                     the chain config file (TYCHO_CHAIN_CONFIG, default ./chains.yaml) or \
+                     the chain config file (TYCHO_CHAINS_CONFIG, default ./chains.yaml) or \
                      init_chain_registry before decoding wire data"
                 )
             }),

--- a/crates/tycho-indexer/chains.example.yaml
+++ b/crates/tycho-indexer/chains.example.yaml
@@ -6,7 +6,7 @@
 # (ethereum, base, unichain, …) need no entry here.
 #
 # Consumers (tycho-simulation, tycho-client, tycho-execution) resolve custom chains the same way:
-# set the `TYCHO_CHAIN_CONFIG` env var to this file's path and they load the identical definitions
+# set the `TYCHO_CHAINS_CONFIG` env var to this file's path and they load the identical definitions
 # the indexer uses. Leave it unset and they resolve only built-in chains.
 
 chains:

--- a/crates/tycho-indexer/src/cli.rs
+++ b/crates/tycho-indexer/src/cli.rs
@@ -164,7 +164,7 @@ pub struct IndexArgs {
     pub extractors_config: String,
 
     /// Custom chains configuration file
-    #[clap(long, env, default_value = "./chains.yaml")]
+    #[clap(long, env = "TYCHO_CHAINS_CONFIG", default_value = "./chains.yaml")]
     pub chain_config: String,
 
     /// A comma separated list of blockchains to index on
@@ -190,7 +190,7 @@ pub struct RunSpkgArgs {
     pub chain: String,
 
     /// Custom chains configuration file
-    #[clap(long, env, default_value = "./chains.yaml")]
+    #[clap(long, env = "TYCHO_CHAINS_CONFIG", default_value = "./chains.yaml")]
     pub chain_config: String,
 
     #[clap(flatten)]

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -71,7 +71,7 @@ services:
       # Override to use a chain-specific extractors file, e.g. ./extractors-tempo.yaml
       EXTRACTORS_CONFIG: ${EXTRACTORS_CONFIG:-/opt/tycho-indexer/extractors.yaml}
       # Custom-chain definitions; empty by default so built-in chains need no config.
-      CHAIN_CONFIG: ${CHAIN_CONFIG:-/opt/tycho-indexer/chains.yaml}
+      TYCHO_CHAINS_CONFIG: ${TYCHO_CHAINS_CONFIG:-/opt/tycho-indexer/chains.yaml}
     ports:
       - "4242:4242"
     volumes:

--- a/docs/for-solvers/self-hosted-evm-chain.md
+++ b/docs/for-solvers/self-hosted-evm-chain.md
@@ -43,7 +43,7 @@ Configure the stack through `docker/.env`. The compose file reads it for both th
 <tr><td><code>CHAINS</code></td><td>indexer</td><td>No</td><td><code>ethereum</code></td><td>Active chain to index. The indexer uses only the first value (multichain is not yet supported). Name a built-in chain, or a custom chain you declare in <code>chains.yaml</code> (see below).</td></tr>
 <tr><td><code>RETENTION_HORIZON</code></td><td>indexer</td><td>No</td><td><code>2000-01-01T00:00:00</code></td><td>Earliest version history the indexer keeps. Use a <strong>future</strong> date to keep no historical state (recommended) — see <a href="#retention-horizon">the note below</a>. The <code>2000-01-01</code> default keeps all history and fails a from-scratch historical backfill.</td></tr>
 <tr><td><code>EXTRACTORS_CONFIG</code></td><td>indexer</td><td>No</td><td><code>/opt/tycho-indexer/extractors.yaml</code></td><td>Path to the extractors config inside the container.</td></tr>
-<tr><td><code>CHAIN_CONFIG</code></td><td>indexer</td><td>No</td><td><code>/opt/tycho-indexer/chains.yaml</code></td><td>Path to the custom-chains config inside the container. Only needed to index a non-built-in chain.</td></tr>
+<tr><td><code>TYCHO_CHAINS_CONFIG</code></td><td>indexer + consumers</td><td>No</td><td><code>/opt/tycho-indexer/chains.yaml</code></td><td>Path to the custom-chains config. The indexer and every consumer (tycho-simulation, tycho-client, tycho-execution) read the same variable. Only needed for a non-built-in chain.</td></tr>
 <tr><td><code>SUBSTREAMS_API_TOKEN</code></td><td>indexer</td><td>No</td><td><code>readme</code></td><td>Auth token for a hosted Substreams endpoint; unused self-hosted.</td></tr>
 <tr><td><code>TRACE_RPC_URL</code></td><td>indexer</td><td>For DCI</td><td><code>readme</code> (placeholder)</td><td>Trace-capable RPC for dynamic contract indexing.</td></tr>
 <tr><td><code>OTLP_EXPORTER_ENDPOINT</code></td><td>indexer</td><td>No</td><td>empty (disabled)</td><td>OpenTelemetry collector. Set <code>http://lgtm:4317</code> with the <code>observability</code> profile.</td></tr>
@@ -109,7 +109,7 @@ extractors:
 
 ### Declaring a custom chain
 
-Built-in chains (`ethereum`, `base`, `unichain`, …) need no extra config. To index a chain Tycho does not know, define it in a separate `chains.yaml` file. Copy <a href="https://github.com/propeller-heads/tycho/blob/main/crates/tycho-indexer/chains.example.yaml" target="_blank" rel="noopener noreferrer"><code>crates/tycho-indexer/chains.example.yaml</code></a> to `crates/tycho-indexer/chains.yaml` and edit it — the compose file mounts it into the container at `/opt/tycho-indexer/chains.yaml`, and the indexer reads it via `CHAIN_CONFIG` (the `--chain-config` flag). Each extractor's `chain:` field and `CHAINS` resolve against these entries; the indexer fails fast at startup if an extractor references a chain that is neither built-in nor defined here.
+Built-in chains (`ethereum`, `base`, `unichain`, …) need no extra config. To index a chain Tycho does not know, define it in a separate `chains.yaml` file. Copy <a href="https://github.com/propeller-heads/tycho/blob/main/crates/tycho-indexer/chains.example.yaml" target="_blank" rel="noopener noreferrer"><code>crates/tycho-indexer/chains.example.yaml</code></a> to `crates/tycho-indexer/chains.yaml` and edit it — the compose file mounts it into the container at `/opt/tycho-indexer/chains.yaml`, and the indexer reads it via `TYCHO_CHAINS_CONFIG` (the `--chain-config` flag). Each extractor's `chain:` field and `CHAINS` resolve against these entries; the indexer fails fast at startup if an extractor references a chain that is neither built-in nor defined here.
 
 ```yaml
 chains:
@@ -220,13 +220,13 @@ Without `--profile substreams-endpoint`, the `substreams-endpoint` service never
 
 ## Consuming the custom chain
 
-The indexer serves your custom chain over RPC and WebSocket, but a consumer (tycho-simulation, tycho-client, tycho-execution) resolves a chain name against its own copy of the chain config. Point it at the same `chains.yaml` through the `TYCHO_CHAIN_CONFIG` environment variable:
+The indexer serves your custom chain over RPC and WebSocket, but a consumer (tycho-simulation, tycho-client, tycho-execution) resolves a chain name against its own copy of the chain config. Point it at the same `chains.yaml` through the `TYCHO_CHAINS_CONFIG` environment variable — the same variable the indexer uses:
 
 ```bash
-export TYCHO_CHAIN_CONFIG=crates/tycho-indexer/chains.yaml
+export TYCHO_CHAINS_CONFIG=crates/tycho-indexer/chains.yaml
 ```
 
-With the variable set, a chain name like `tempo` resolves to its full config on first use. Leave it unset and the consumer resolves only built-in chains and rejects the custom name. A `TYCHO_CHAIN_CONFIG` that points at a missing or malformed file fails loudly rather than silently falling back to built-in chains.
+With the variable set, a chain name like `tempo` resolves to its full config on first use. Leave it unset and the consumer resolves only built-in chains and rejects the custom name. When the variable points at a missing or malformed file, the stream builder rejects it at startup and returns a set-up error naming the config — the consumer never starts against a half-configured chain.
 
 ## Monitoring sync progress
 


### PR DESCRIPTION
## What this does

Unifies the two environment variables that point at the custom-chains config
file into a single `CUSTOM_CHAINS_CONFIG`. The indexer previously read the
clap-derived `CHAIN_CONFIG`, while consumers (tycho-simulation, tycho-client,
tycho-execution) read `TYCHO_CHAIN_CONFIG`. Both now read `CUSTOM_CHAINS_CONFIG`,
so one variable applies everywhere and points at the same `chains.yaml`.

## Changes

- **tycho-indexer**: the `--chain-config` flag binds `env = "CUSTOM_CHAINS_CONFIG"`.
- **tycho-common**: the registry's lazy loader reads `CUSTOM_CHAINS_CONFIG`
  (const `CUSTOM_CHAINS_CONFIG_ENV`); doc comments and the load-failure log
  message updated to match.
- **docker-compose**: passes `CUSTOM_CHAINS_CONFIG`.
- **docs / example config**: the runbook env table lists one variable used by the
  indexer and every consumer; `chains.example.yaml` updated.

The `chains.yaml` file name is unchanged.
