### PR TITLE
Bg/fix/custom chain config fail fast

### DIFF
--- a/crates/tycho-client/src/stream.rs
+++ b/crates/tycho-client/src/stream.rs
@@ -10,7 +10,10 @@ use tokio::{sync::mpsc::Receiver, task::JoinHandle};
 use tracing::{info, warn};
 use tycho_common::{
     dto::{PaginationLimits, ProtocolSystemsRequestBody},
-    models::{Chain, ExtractorIdentity},
+    models::{
+        chain_config::{init_chain_registry, ChainConfigRegistry},
+        Chain, ExtractorIdentity,
+    },
 };
 
 use crate::{
@@ -52,6 +55,19 @@ impl RetryConfiguration {
 pub struct ConstantRetryConfiguration {
     max_attempts: u64,
     cooldown: Duration,
+}
+
+/// Loads and validates the custom-chain config once, before the stream starts. A missing or
+/// malformed `CUSTOM_CHAINS_CONFIG` fails here with an actionable error, rather than degrading to
+/// an empty registry and resurfacing later as a confusing unknown-chain error mid-stream. An unset
+/// env var yields an empty registry (Ok), so built-in-only consumers are unaffected. The validated
+/// registry is best-effort installed as the process-wide one; a prior lazy access may already have
+/// initialised it, in which case the install is a no-op.
+fn validate_chain_config() -> Result<(), StreamError> {
+    let registry = ChainConfigRegistry::load_default()
+        .map_err(|e| StreamError::SetUpError(format!("failed to load custom chain config: {e}")))?;
+    let _ = init_chain_registry(registry);
+    Ok(())
 }
 
 pub struct TychoStreamBuilder {
@@ -286,6 +302,9 @@ impl TychoStreamBuilder {
             ));
         }
 
+        // Fail fast on a broken custom-chain config, before any network I/O.
+        validate_chain_config()?;
+
         // Serialize client metadata once, before any network I/O. Metadata is best-effort
         // telemetry, so invalid input is dropped with a warning rather than failing the stream.
         let metadata_header =
@@ -513,6 +532,31 @@ impl ProtocolSystemsInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_validate_chain_config_errors_on_broken_file() {
+        // Relies on nextest process isolation: this mutates the process-global env var.
+        std::env::set_var("CUSTOM_CHAINS_CONFIG", "/nonexistent/does-not-exist.yaml");
+        let result = validate_chain_config();
+        std::env::remove_var("CUSTOM_CHAINS_CONFIG");
+
+        let err = result.expect_err("a missing config file must fail validation");
+        assert!(matches!(err, StreamError::SetUpError(_)));
+        assert!(
+            err.to_string()
+                .contains("custom chain config"),
+            "error should name the custom chain config: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_chain_config_ok_when_env_unset() {
+        std::env::remove_var("CUSTOM_CHAINS_CONFIG");
+        assert!(
+            validate_chain_config().is_ok(),
+            "an unset env var means no custom chains, which is valid"
+        );
+    }
 
     #[test]
     fn test_retry_configuration_constant() {

--- a/docs/for-solvers/self-hosted-evm-chain.md
+++ b/docs/for-solvers/self-hosted-evm-chain.md
@@ -226,7 +226,7 @@ The indexer serves your custom chain over RPC and WebSocket, but a consumer (tyc
 export CUSTOM_CHAINS_CONFIG=crates/tycho-indexer/chains.yaml
 ```
 
-With the variable set, a chain name like `tempo` resolves to its full config on first use. Leave it unset and the consumer resolves only built-in chains and rejects the custom name. A `CUSTOM_CHAINS_CONFIG` that points at a missing or malformed file fails loudly rather than silently falling back to built-in chains.
+With the variable set, a chain name like `tempo` resolves to its full config on first use. Leave it unset and the consumer resolves only built-in chains and rejects the custom name. When the variable points at a missing or malformed file, the stream builder rejects it at startup and returns a set-up error naming the config — the consumer never starts against a half-configured chain.
 
 ## Monitoring sync progress
 


### PR DESCRIPTION
## What this does

A consumer (tycho-simulation, tycho-client, tycho-execution) that points
`CUSTOM_CHAINS_CONFIG` at a missing or malformed file used to log a warning and
fall back to an empty registry, then fail later with a confusing unknown-chain
error mid-stream. Now `TychoStreamBuilder::build()` loads and validates the
config up front and returns a set-up error naming the config, so the consumer
never starts against a half-configured chain.

## Changes

- **tycho-client**: `build()` calls a new `validate_chain_config()` before any
  network I/O. It runs `ChainConfigRegistry::load_default()`, maps a failure to
  `StreamError::SetUpError`, and best-effort installs the validated registry.
- **tycho-simulation**: no change — `ProtocolStreamBuilder::build()` and
  `build_with_pending()` delegate to the client `build()`, so they inherit the check.
- **docs**: the self-hosted chain runbook now describes the startup failure.

An unset `CUSTOM_CHAINS_CONFIG` loads an empty registry (Ok), so consumers on
built-in chains are unaffected.

## Known limitation

This makes stream startup fail loudly with a precise error. It does not cover a
consumer that constructs `Chain::custom("name")` before `build()` — that call
triggers the lazy registry load itself and, on a broken file, already fails at
construction with a less precise unknown-chain error. Surfacing the precise
error at the earliest point would require an explicit init in the consumer's
`main`, which is out of scope here.
