### PR TITLE
feat(simulation): add protocol registry and exchange_by_name builder API

### DIFF
--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -270,6 +270,20 @@ where
             .insert(exchange.to_string(), predicate);
     }
 
+    /// Returns true if a decoder is registered for `exchange`. Test support.
+    #[cfg(test)]
+    pub(crate) fn has_decoder(&self, exchange: &str) -> bool {
+        self.registry.contains_key(exchange)
+    }
+
+    /// Returns the client-side filter registered for `exchange`, if any. Test support.
+    #[cfg(test)]
+    pub(crate) fn registered_filter(&self, exchange: &str) -> Option<FilterFn> {
+        self.inclusion_filters
+            .get(exchange)
+            .copied()
+    }
+
     /// Decodes a `FeedMessage` into a `BlockUpdate` containing the updated states of protocol
     /// components
     pub async fn decode(&self, msg: &FeedMessage<H>) -> Result<Update, StreamDecodeError> {

--- a/crates/tycho-simulation/src/evm/protocol/mod.rs
+++ b/crates/tycho-simulation/src/evm/protocol/mod.rs
@@ -13,6 +13,7 @@ pub mod fluid;
 pub mod lunarbase;
 pub mod native_wrapper;
 pub mod pancakeswap_v2;
+pub mod registry;
 pub mod rocketpool;
 pub mod safe_math;
 pub mod u256_num;

--- a/crates/tycho-simulation/src/evm/protocol/registry.rs
+++ b/crates/tycho-simulation/src/evm/protocol/registry.rs
@@ -1,0 +1,198 @@
+//! Registry mapping protocol names to their canonical decoder state types and
+//! default component filters.
+//!
+//! This is the single source of truth consumed by
+//! [`ProtocolStreamBuilder::exchange_by_name`](crate::evm::stream::ProtocolStreamBuilder::exchange_by_name).
+//! Adding stream support for a new protocol means adding one row to the `PROTOCOLS` table.
+use tycho_client::feed::{
+    component_tracker::ComponentFilter, synchronizer::ComponentWithState, BlockHeader,
+};
+use tycho_common::simulation::protocol_sim::ProtocolSim;
+
+use crate::{
+    evm::{
+        engine_db::tycho_db::PreCachedDB,
+        protocol::{
+            aerodrome_slipstreams::state::AerodromeSlipstreamsState,
+            aerodrome_v1::state::AerodromeV1State,
+            cowamm::state::CowAMMState,
+            curve::CurveState,
+            ekubo::state::EkuboState,
+            ekubo_v3::{self, state::EkuboV3State},
+            erc4626::state::ERC4626State,
+            etherfi::state::EtherfiState,
+            filters::{
+                balancer_v2_pool_filter, balancer_v3_pool_filter, curve_filter, erc4626_filter,
+                fluid_v1_paused_pools_filter,
+            },
+            fluid::FluidV1,
+            lunarbase::LunarBaseState,
+            pancakeswap_v2::state::PancakeswapV2State,
+            rocketpool::state::RocketpoolState,
+            uniswap_v2::state::UniswapV2State,
+            uniswap_v3::state::UniswapV3State,
+            uniswap_v4::state::UniswapV4State,
+            velodrome_slipstreams::state::VelodromeSlipstreamsState,
+            vm::state::EVMPoolState,
+        },
+        stream::ProtocolStreamBuilder,
+    },
+    protocol::{errors::InvalidSnapshotError, models::TryFromWithBlock},
+};
+
+/// Client-side component filter, matching the signature accepted by
+/// [`ProtocolStreamBuilder::exchange`](crate::evm::stream::ProtocolStreamBuilder::exchange).
+pub type ComponentFilterFn = fn(&ComponentWithState) -> bool;
+
+/// Monomorphized registration hook: applies `builder.exchange::<T>(...)` for one
+/// concrete state type `T`.
+type RegisterFn = fn(
+    ProtocolStreamBuilder,
+    &str,
+    ComponentFilter,
+    Option<ComponentFilterFn>,
+) -> ProtocolStreamBuilder;
+
+/// How one protocol is registered: which state type decodes it (via `register`)
+/// and which client-side filter it needs by default.
+pub(crate) struct ProtocolEntry {
+    pub(crate) register: RegisterFn,
+    pub(crate) default_filter: Option<ComponentFilterFn>,
+}
+
+fn entry_for<T>(default_filter: Option<ComponentFilterFn>) -> ProtocolEntry
+where
+    T: ProtocolSim
+        + TryFromWithBlock<ComponentWithState, BlockHeader, Error = InvalidSnapshotError>
+        + Send
+        + 'static,
+{
+    ProtocolEntry { register: ProtocolStreamBuilder::exchange::<T>, default_filter }
+}
+
+/// One row of [`PROTOCOLS`]: a protocol name paired with a thunk that builds its
+/// [`ProtocolEntry`] on demand.
+type ProtocolRow = (&'static str, fn() -> ProtocolEntry);
+
+/// One row per supported protocol name. `entry()` and `supported_protocols()` both
+/// derive from this table, so the two cannot drift apart.
+///
+/// `vm:`-prefixed entries backed by [`EVMPoolState`] require embedded adapter bytecode in
+/// `vm::constants::get_adapter_file` — an `EVMPoolState` registered without one fails at decode
+/// time. `vm:curve` keeps its `vm:` name for extractor compatibility but decodes via the native
+/// [`CurveState`], so it is exempt from that requirement.
+static PROTOCOLS: &[ProtocolRow] = &[
+    ("uniswap_v2", || entry_for::<UniswapV2State>(None)),
+    ("sushiswap_v2", || entry_for::<UniswapV2State>(None)),
+    ("quickswap_v2", || entry_for::<UniswapV2State>(None)),
+    ("pancakeswap_v2", || entry_for::<PancakeswapV2State>(None)),
+    ("uniswap_v3", || entry_for::<UniswapV3State>(None)),
+    ("pancakeswap_v3", || entry_for::<UniswapV3State>(None)),
+    ("uniswap_v4", || entry_for::<UniswapV4State>(None)),
+    ("uniswap_v4_hooks", || entry_for::<UniswapV4State>(None)),
+    ("ekubo_v2", || entry_for::<EkuboState>(None)),
+    ("ekubo_v3", || entry_for::<EkuboV3State>(Some(ekubo_v3::filter_fn))),
+    ("aerodrome_v1", || entry_for::<AerodromeV1State>(None)),
+    ("aerodrome_slipstreams", || entry_for::<AerodromeSlipstreamsState>(None)),
+    ("velodrome_slipstreams", || entry_for::<VelodromeSlipstreamsState>(None)),
+    ("cowamm", || entry_for::<CowAMMState>(None)),
+    ("etherfi", || entry_for::<EtherfiState>(None)),
+    ("rocketpool", || entry_for::<RocketpoolState>(None)),
+    ("erc4626", || entry_for::<ERC4626State>(Some(erc4626_filter))),
+    ("fluid_v1", || entry_for::<FluidV1>(Some(fluid_v1_paused_pools_filter))),
+    ("lunarbase", || entry_for::<LunarBaseState>(None)),
+    ("vm:balancer_v2", || entry_for::<EVMPoolState<PreCachedDB>>(Some(balancer_v2_pool_filter))),
+    ("vm:balancer_v3", || entry_for::<EVMPoolState<PreCachedDB>>(Some(balancer_v3_pool_filter))),
+    ("vm:bopamm", || entry_for::<EVMPoolState<PreCachedDB>>(None)),
+    ("vm:curve", || entry_for::<CurveState>(Some(curve_filter))),
+    ("vm:fermiswap", || entry_for::<EVMPoolState<PreCachedDB>>(None)),
+    ("vm:maverick_v2", || entry_for::<EVMPoolState<PreCachedDB>>(None)),
+    ("vm:liquidityparty", || entry_for::<EVMPoolState<PreCachedDB>>(None)),
+];
+
+/// All protocol names registrable via
+/// [`ProtocolStreamBuilder::exchange_by_name`](crate::evm::stream::ProtocolStreamBuilder::exchange_by_name).
+pub fn supported_protocols() -> Vec<&'static str> {
+    PROTOCOLS
+        .iter()
+        .map(|(name, _)| *name)
+        .collect()
+}
+
+pub(crate) fn entry(name: &str) -> Option<ProtocolEntry> {
+    PROTOCOLS
+        .iter()
+        .find(|(protocol_name, _)| *protocol_name == name)
+        .map(|(_, make_entry)| make_entry())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::evm::protocol::filters::{balancer_v2_pool_filter, curve_filter};
+
+    #[test]
+    fn test_supported_protocols_all_resolve() {
+        for name in supported_protocols() {
+            assert!(entry(name).is_some(), "'{name}' listed but has no registry entry");
+        }
+    }
+
+    #[test]
+    fn test_unknown_protocol_has_no_entry() {
+        assert!(entry("definitely_not_a_protocol").is_none());
+        // Typo of vm:balancer_v2 — must NOT fall into a vm: catch-all.
+        assert!(entry("vm:blancer_v2").is_none());
+    }
+
+    #[test]
+    fn test_entry_maps_name_to_expected_state_type() {
+        for name in ["uniswap_v2", "sushiswap_v2", "quickswap_v2"] {
+            let register = entry(name)
+                .expect("registered")
+                .register;
+            assert!(
+                std::ptr::fn_addr_eq(
+                    register,
+                    ProtocolStreamBuilder::exchange::<UniswapV2State> as RegisterFn
+                ),
+                "'{name}' must register UniswapV2State"
+            );
+        }
+        let curve_register = entry("vm:curve")
+            .expect("registered")
+            .register;
+        assert!(std::ptr::fn_addr_eq(
+            curve_register,
+            ProtocolStreamBuilder::exchange::<CurveState> as RegisterFn
+        ));
+        let bopamm_register = entry("vm:bopamm")
+            .expect("registered")
+            .register;
+        assert!(std::ptr::fn_addr_eq(
+            bopamm_register,
+            ProtocolStreamBuilder::exchange::<EVMPoolState<PreCachedDB>> as RegisterFn
+        ));
+    }
+
+    #[test]
+    fn test_default_filters_wired() {
+        let balancer_filter = entry("vm:balancer_v2")
+            .expect("vm:balancer_v2 registered")
+            .default_filter
+            .expect("vm:balancer_v2 has a default filter");
+        assert!(std::ptr::fn_addr_eq(
+            balancer_filter,
+            balancer_v2_pool_filter as ComponentFilterFn
+        ));
+        let curve_default = entry("vm:curve")
+            .expect("vm:curve registered")
+            .default_filter
+            .expect("vm:curve has a default filter");
+        assert!(std::ptr::fn_addr_eq(curve_default, curve_filter as ComponentFilterFn));
+        assert!(entry("uniswap_v2")
+            .expect("uniswap_v2 registered")
+            .default_filter
+            .is_none());
+    }
+}

--- a/crates/tycho-simulation/src/evm/stream.rs
+++ b/crates/tycho-simulation/src/evm/stream.rs
@@ -132,6 +132,7 @@ use crate::{
         protocol::{
             filters::uniswap_v4_non_angstrom_hook_pool_filter,
             native_wrapper::state::NativeWrapperState,
+            registry::{self, ComponentFilterFn},
             uniswap_v4::hooks::hook_handler_creator::initialize_hook_handlers,
         },
     },
@@ -398,6 +399,51 @@ impl ProtocolStreamBuilder {
         }
 
         self
+    }
+
+    /// Registers `name` using the canonical state type and default filter from the
+    /// [protocol registry](crate::evm::protocol::registry).
+    ///
+    /// Passing `Some(filter_fn)` overrides the registry's default filter for this
+    /// protocol; `None` keeps the default (which may itself be `None`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StreamError::SetUpError`] if `name` is not a known protocol. See
+    /// [`registry::supported_protocols`] for the valid names.
+    pub fn exchange_by_name(
+        self,
+        name: &str,
+        filter: ComponentFilter,
+        filter_fn: Option<ComponentFilterFn>,
+    ) -> Result<Self, StreamError> {
+        let Some(entry) = registry::entry(name) else {
+            return Err(StreamError::SetUpError(format!(
+                "Unknown protocol '{name}'; supported protocols: {}",
+                registry::supported_protocols().join(", ")
+            )));
+        };
+        let filter_fn = filter_fn.or(entry.default_filter);
+        Ok((entry.register)(self, name, filter, filter_fn))
+    }
+
+    /// Registers every protocol in `names` via [`Self::exchange_by_name`] with no
+    /// filter overrides, sharing one [`ComponentFilter`].
+    ///
+    /// Duplicate names overwrite earlier registrations (matching `exchange`'s insert semantics).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StreamError::SetUpError`] on the first unknown name.
+    pub fn exchanges_by_name<S: AsRef<str>>(
+        mut self,
+        names: &[S],
+        filter: ComponentFilter,
+    ) -> Result<Self, StreamError> {
+        for name in names {
+            self = self.exchange_by_name(name.as_ref(), filter.clone(), None)?;
+        }
+        Ok(self)
     }
 
     /// Sets the block time interval for the stream.
@@ -920,7 +966,10 @@ mod tests {
     use tycho_common::models::Chain;
 
     use super::*;
-    use crate::protocol::models::Update;
+    use crate::{
+        evm::protocol::{filters::balancer_v2_pool_filter, registry::ComponentFilterFn},
+        protocol::models::Update,
+    };
 
     fn empty_update(block: u64) -> Update {
         Update::new(block, HashMap::new(), HashMap::new())
@@ -1038,5 +1087,81 @@ mod tests {
             .expect("stream ended unexpectedly");
 
         assert!(update.is_ok(), "decoded update should be Ok, got: {:?}", update);
+    }
+
+    fn test_builder() -> ProtocolStreamBuilder {
+        ProtocolStreamBuilder::new("localhost:4242", Chain::Ethereum)
+    }
+
+    fn tvl_filter() -> ComponentFilter {
+        ComponentFilter::with_tvl_range(5.0, 10.0)
+    }
+
+    #[test]
+    fn test_exchange_by_name_registers_decoder_and_default_filter() {
+        let builder = test_builder()
+            .exchange_by_name("vm:balancer_v2", tvl_filter(), None)
+            .expect("known protocol registers");
+        assert!(builder
+            .get_decoder()
+            .has_decoder("vm:balancer_v2"));
+        let installed = builder
+            .get_decoder()
+            .registered_filter("vm:balancer_v2")
+            .expect("default filter installed");
+        assert!(std::ptr::fn_addr_eq(installed, balancer_v2_pool_filter as ComponentFilterFn));
+    }
+
+    #[test]
+    fn test_exchange_by_name_filter_override_wins() {
+        fn reject_all(_: &ComponentWithState) -> bool {
+            false
+        }
+        let builder = test_builder()
+            .exchange_by_name("vm:balancer_v2", tvl_filter(), Some(reject_all))
+            .expect("known protocol registers");
+        let installed = builder
+            .get_decoder()
+            .registered_filter("vm:balancer_v2")
+            .expect("override filter installed");
+        assert!(std::ptr::fn_addr_eq(installed, reject_all as ComponentFilterFn));
+    }
+
+    #[test]
+    fn test_exchange_by_name_no_default_filter_installs_none() {
+        let builder = test_builder()
+            .exchange_by_name("uniswap_v2", tvl_filter(), None)
+            .expect("known protocol registers");
+        assert!(builder
+            .get_decoder()
+            .has_decoder("uniswap_v2"));
+        assert!(builder
+            .get_decoder()
+            .registered_filter("uniswap_v2")
+            .is_none());
+    }
+
+    #[test]
+    fn test_exchange_by_name_unknown_protocol_errors() {
+        let err = test_builder()
+            .exchange_by_name("vm:blancer_v2", tvl_filter(), None)
+            .err()
+            .expect("unknown protocol must error");
+        let message = err.to_string();
+        assert!(message.contains("vm:blancer_v2"), "error names the protocol: {message}");
+        assert!(message.contains("uniswap_v2"), "error lists supported protocols: {message}");
+    }
+
+    #[test]
+    fn test_exchanges_by_name_registers_all() {
+        let builder = test_builder()
+            .exchanges_by_name(&["uniswap_v2", "ekubo_v3"], tvl_filter())
+            .expect("all known protocols register");
+        assert!(builder
+            .get_decoder()
+            .has_decoder("uniswap_v2"));
+        assert!(builder
+            .get_decoder()
+            .has_decoder("ekubo_v3"));
     }
 }


### PR DESCRIPTION
## What

Adds a centralized protocol registry to `tycho-simulation` so consumers can register protocol decoders by name instead of maintaining their own match blocks.

### New module: `evm/protocol/registry.rs`

A static `PROTOCOLS` table (26 rows) mapping every supported protocol name to:
- Its canonical decoder state type (via monomorphized fn pointer)
- Its default component filter (bundled, so callers can't forget required filters)

Both `entry()` and `supported_protocols()` derive from the same table — they cannot drift.

### New builder methods on `ProtocolStreamBuilder`

- `exchange_by_name(name, filter, filter_fn)` — registers a protocol by name, using the registry's default filter or a caller override. Returns `StreamError::SetUpError` for unknown names (fail-fast, listing valid protocols).
- `exchanges_by_name(names, filter)` — batch registration, errors on first unknown name.

`exchange::<T>()` is unchanged — purely additive API, backwards-compatible for all existing consumers.

### Protocols covered (26)

uniswap_v2, sushiswap_v2, quickswap_v2, pancakeswap_v2, uniswap_v3, pancakeswap_v3, uniswap_v4, uniswap_v4_hooks, ekubo_v2, ekubo_v3, aerodrome_v1, aerodrome_slipstreams, velodrome_slipstreams, cowamm, etherfi, rocketpool, erc4626, fluid_v1, lunarbase, vm:balancer_v2, vm:balancer_v3, vm:bopamm, vm:curve, vm:fermiswap, vm:maverick_v2, vm:liquidityparty

### Key design decisions
- `vm:curve` uses native `CurveState` with `curve_filter` bundled (not `EVMPoolState`)
- `velodrome_slipstreams` uses `VelodromeSlipstreamsState` (canonical, not `AerodromeSlipstreamsState`)
- Default filters bundled per protocol — no more silent missing-filter footgun
- RFQ protocols out of scope (different construction model)

## Why

Fynd's `register_exchanges` had a ~110-line match block duplicating this mapping. Every new protocol required a fynd PR; if it wasn't updated, the protocol was silently dropped. This eliminates the duplication — adding a protocol is now a one-line table entry here, and consumers pick it up automatically.

JIRA: [ENG-6246](https://propeller-heads.atlassian.net/browse/ENG-6246)

[ENG-6246]: https://propeller-heads.atlassian.net/browse/ENG-6246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ