### PR TITLE
feat(tycho-indexer): capture client metadata into Prometheus labels

### DIFF
--- a/crates/tycho-indexer/src/services/client_metadata.rs
+++ b/crates/tycho-indexer/src/services/client_metadata.rs
@@ -11,7 +11,7 @@
 //! This mirrors the client serializer in `tycho-client` but deliberately does not depend on that
 //! crate, so the two can ship independently.
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 use metrics::Label;
 
@@ -32,8 +32,8 @@ const MAX_HEADER_BYTES: usize = 1024;
 /// Parses the raw header into a metadata map, applying defensive caps. Oversized input is dropped
 /// rather than trusted: a header over the total-length cap yields an empty map, and individual
 /// pairs over the key/value caps or beyond the entry cap are skipped.
-pub(in crate::services) fn parse_client_metadata(raw: &str) -> BTreeMap<String, String> {
-    let mut out = BTreeMap::new();
+pub(in crate::services) fn parse_client_metadata(raw: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
     if raw.len() > MAX_HEADER_BYTES {
         return out;
     }
@@ -60,7 +60,7 @@ pub(in crate::services) fn parse_client_metadata(raw: &str) -> BTreeMap<String, 
 /// Builds the Prometheus labels for every allowlisted metadata key, in allowlist order. Missing
 /// keys yield `"none"`; present values are emitted verbatim (already size-capped by the parser).
 /// Non-allowlisted keys are never emitted.
-pub(in crate::services) fn metric_labels(metadata: &BTreeMap<String, String>) -> Vec<Label> {
+pub(in crate::services) fn metric_labels(metadata: &HashMap<String, String>) -> Vec<Label> {
     METADATA_METRIC_KEYS
         .iter()
         .map(|&key| {
@@ -78,14 +78,14 @@ pub(in crate::services) fn metric_labels(metadata: &BTreeMap<String, String>) ->
 mod tests {
     use super::*;
 
-    fn labels_map(metadata: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    fn labels_map(metadata: &HashMap<String, String>) -> HashMap<String, String> {
         metric_labels(metadata)
             .into_iter()
             .map(|l| (l.key().to_string(), l.value().to_string()))
             .collect()
     }
 
-    fn map(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    fn map(pairs: &[(&str, &str)]) -> HashMap<String, String> {
         pairs
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -129,7 +129,7 @@ mod tests {
 
     #[test]
     fn labels_default_to_none_when_absent() {
-        let labels = labels_map(&BTreeMap::new());
+        let labels = labels_map(&HashMap::new());
         assert_eq!(labels, map(&[("fynd_version", "none"), ("fynd_preset", "none")]));
     }
 

--- a/crates/tycho-indexer/src/services/client_metadata.rs
+++ b/crates/tycho-indexer/src/services/client_metadata.rs
@@ -1,0 +1,210 @@
+//! Server-side parsing of the generic `X-Tycho-Client-Metadata` header.
+//!
+//! Clients send an opaque `key=value; key=value` map. The server parses it generically, applies
+//! defensive size caps (never trusting the client to have validated), and projects a small
+//! allowlist of keys into Prometheus labels. Because label *values* are client-controlled, each
+//! allowlisted key has a per-key validator that collapses unexpected input to a bounded token, so
+//! a malicious client cannot inflate metric cardinality.
+//!
+//! This mirrors the client serializer in `tycho-client` but deliberately does not depend on that
+//! crate, so the two can ship independently.
+
+use std::collections::BTreeMap;
+
+use metrics::Label;
+
+/// Header carrying generic client metadata.
+pub(in crate::services) const CLIENT_METADATA_HEADER: &str = "x-tycho-client-metadata";
+
+/// Allowlisted metadata keys promoted to Prometheus labels. Adding a key multiplies series count.
+pub(in crate::services) const METADATA_METRIC_KEYS: &[&str] = &["fynd_version", "preset"];
+
+/// Known Fynd presets; any other `preset` value collapses to `"other"`.
+const KNOWN_PRESETS: &[&str] = &["best", "fast", "deep", "none"];
+
+// Defensive caps mirroring the client serializer (by value, not by crate dependency).
+const MAX_ENTRIES: usize = 16;
+const MAX_KEY_BYTES: usize = 64;
+const MAX_VALUE_BYTES: usize = 128;
+const MAX_HEADER_BYTES: usize = 1024;
+
+/// Parses the raw header into a metadata map, applying defensive caps. Oversized input is dropped
+/// rather than trusted: a header over the total-length cap yields an empty map, and individual
+/// pairs over the key/value caps or beyond the entry cap are skipped.
+pub(in crate::services) fn parse_client_metadata(raw: &str) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    if raw.len() > MAX_HEADER_BYTES {
+        return out;
+    }
+    for pair in raw.split(';') {
+        if out.len() >= MAX_ENTRIES {
+            break;
+        }
+        let Some((key, value)) = pair.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = value.trim();
+        if key.is_empty() || value.is_empty() {
+            continue;
+        }
+        if key.len() > MAX_KEY_BYTES || value.len() > MAX_VALUE_BYTES {
+            continue;
+        }
+        out.insert(key.to_string(), value.to_string());
+    }
+    out
+}
+
+/// Builds the bounded Prometheus labels for every allowlisted metadata key, in allowlist order.
+/// Missing keys yield `"none"`; present values are validated per key and collapsed to
+/// `"other"`/`"invalid"` when they don't match, so client-controlled strings can never inflate
+/// label cardinality. Non-allowlisted keys are never emitted.
+pub(in crate::services) fn metric_labels(metadata: &BTreeMap<String, String>) -> Vec<Label> {
+    METADATA_METRIC_KEYS
+        .iter()
+        .map(|&key| Label::new(key, label_value(key, metadata.get(key).map(String::as_str))))
+        .collect()
+}
+
+fn label_value(key: &str, value: Option<&str>) -> String {
+    let Some(value) = value else {
+        return "none".to_string();
+    };
+    match key {
+        "preset" => {
+            if KNOWN_PRESETS.contains(&value) {
+                value.to_string()
+            } else {
+                "other".to_string()
+            }
+        }
+        "fynd_version" => {
+            if is_version_prefix(value) {
+                value.to_string()
+            } else {
+                "invalid".to_string()
+            }
+        }
+        _ => "invalid".to_string(),
+    }
+}
+
+/// Returns true if `value` starts with `MAJOR.MINOR.PATCH` (each numeric), matching
+/// `^[0-9]+\.[0-9]+\.[0-9]+`.
+fn is_version_prefix(value: &str) -> bool {
+    let mut rest = value;
+    for i in 0..3 {
+        let digits = rest
+            .bytes()
+            .take_while(|b| b.is_ascii_digit())
+            .count();
+        if digits == 0 {
+            return false;
+        }
+        rest = &rest[digits..];
+        if i < 2 {
+            match rest.strip_prefix('.') {
+                Some(r) => rest = r,
+                None => return false,
+            }
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels_map(metadata: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+        metric_labels(metadata)
+            .into_iter()
+            .map(|l| (l.key().to_string(), l.value().to_string()))
+            .collect()
+    }
+
+    fn map(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn parses_and_trims_pairs() {
+        let parsed = parse_client_metadata("fynd_version=1.2.3; preset=fast");
+        assert_eq!(parsed, map(&[("fynd_version", "1.2.3"), ("preset", "fast")]));
+    }
+
+    #[test]
+    fn skips_empty_and_malformed_pairs() {
+        let parsed = parse_client_metadata("a=1;; no_equals ;b=;=novalue;c=2");
+        assert_eq!(parsed, map(&[("a", "1"), ("c", "2")]));
+    }
+
+    #[test]
+    fn drops_header_over_total_length_cap() {
+        let raw = format!("k={}", "v".repeat(MAX_HEADER_BYTES));
+        assert!(parse_client_metadata(&raw).is_empty());
+    }
+
+    #[test]
+    fn skips_oversized_key_or_value() {
+        let long_key = "a".repeat(MAX_KEY_BYTES + 1);
+        let long_value = "b".repeat(MAX_VALUE_BYTES + 1);
+        let raw = format!("{long_key}=ok; k={long_value}; good=1");
+        assert_eq!(parse_client_metadata(&raw), map(&[("good", "1")]));
+    }
+
+    #[test]
+    fn caps_entry_count() {
+        let raw = (0..MAX_ENTRIES + 5)
+            .map(|i| format!("k{i}=v"))
+            .collect::<Vec<_>>()
+            .join(";");
+        assert_eq!(parse_client_metadata(&raw).len(), MAX_ENTRIES);
+    }
+
+    #[test]
+    fn labels_default_to_none_when_absent() {
+        let labels = labels_map(&BTreeMap::new());
+        assert_eq!(labels, map(&[("fynd_version", "none"), ("preset", "none")]));
+    }
+
+    #[test]
+    fn labels_pass_through_valid_values() {
+        let labels = labels_map(&map(&[("fynd_version", "0.57.0"), ("preset", "best")]));
+        assert_eq!(labels, map(&[("fynd_version", "0.57.0"), ("preset", "best")]));
+    }
+
+    #[test]
+    fn labels_collapse_unexpected_values() {
+        let labels = labels_map(&map(&[("fynd_version", "not-a-version"), ("preset", "turbo")]));
+        assert_eq!(labels, map(&[("fynd_version", "invalid"), ("preset", "other")]));
+    }
+
+    #[test]
+    fn labels_omit_non_allowlisted_keys() {
+        let labels = labels_map(&map(&[("secret", "abc"), ("preset", "fast")]));
+        assert_eq!(labels, map(&[("fynd_version", "none"), ("preset", "fast")]));
+        assert!(!labels.contains_key("secret"));
+    }
+
+    #[test]
+    fn version_prefix_accepts_major_minor_patch() {
+        assert!(is_version_prefix("1.2.3"));
+        assert!(is_version_prefix("0.57.0"));
+        assert!(is_version_prefix("1.2.3-rc1"));
+        assert!(is_version_prefix("10.20.30.40"));
+    }
+
+    #[test]
+    fn version_prefix_rejects_non_semver() {
+        assert!(!is_version_prefix("1.2"));
+        assert!(!is_version_prefix("1.2.x"));
+        assert!(!is_version_prefix("v1.2.3"));
+        assert!(!is_version_prefix(""));
+        assert!(!is_version_prefix("abc"));
+    }
+}

--- a/crates/tycho-indexer/src/services/client_metadata.rs
+++ b/crates/tycho-indexer/src/services/client_metadata.rs
@@ -21,7 +21,7 @@ pub(in crate::services) const CLIENT_METADATA_HEADER: &str = "x-tycho-client-met
 /// Metadata keys projected onto Prometheus labels. This is a projection policy, not an
 /// interpretation of the values: the server decides which keys become labels (bounding label
 /// names) but never inspects what they mean. Adding a key multiplies series count.
-pub(in crate::services) const METADATA_METRIC_KEYS: &[&str] = &["fynd_version", "preset"];
+pub(in crate::services) const METADATA_METRIC_KEYS: &[&str] = &["fynd_version", "fynd_preset"];
 
 // Defensive caps mirroring the client serializer (by value, not by crate dependency).
 const MAX_ENTRIES: usize = 16;
@@ -94,8 +94,8 @@ mod tests {
 
     #[test]
     fn parses_and_trims_pairs() {
-        let parsed = parse_client_metadata("fynd_version=1.2.3; preset=fast");
-        assert_eq!(parsed, map(&[("fynd_version", "1.2.3"), ("preset", "fast")]));
+        let parsed = parse_client_metadata("fynd_version=1.2.3; fynd_preset=fast");
+        assert_eq!(parsed, map(&[("fynd_version", "1.2.3"), ("fynd_preset", "fast")]));
     }
 
     #[test]
@@ -130,21 +130,22 @@ mod tests {
     #[test]
     fn labels_default_to_none_when_absent() {
         let labels = labels_map(&BTreeMap::new());
-        assert_eq!(labels, map(&[("fynd_version", "none"), ("preset", "none")]));
+        assert_eq!(labels, map(&[("fynd_version", "none"), ("fynd_preset", "none")]));
     }
 
     #[test]
     fn labels_pass_through_values_verbatim() {
         // The server never interprets values, so any string on an allowlisted key is emitted as-is
         // (after the parser's size caps). Value semantics are the client's concern.
-        let labels = labels_map(&map(&[("fynd_version", "not-a-version"), ("preset", "turbo")]));
-        assert_eq!(labels, map(&[("fynd_version", "not-a-version"), ("preset", "turbo")]));
+        let labels =
+            labels_map(&map(&[("fynd_version", "not-a-version"), ("fynd_preset", "turbo")]));
+        assert_eq!(labels, map(&[("fynd_version", "not-a-version"), ("fynd_preset", "turbo")]));
     }
 
     #[test]
     fn labels_omit_non_allowlisted_keys() {
-        let labels = labels_map(&map(&[("secret", "abc"), ("preset", "fast")]));
-        assert_eq!(labels, map(&[("fynd_version", "none"), ("preset", "fast")]));
+        let labels = labels_map(&map(&[("secret", "abc"), ("fynd_preset", "fast")]));
+        assert_eq!(labels, map(&[("fynd_version", "none"), ("fynd_preset", "fast")]));
         assert!(!labels.contains_key("secret"));
     }
 }

--- a/crates/tycho-indexer/src/services/client_metadata.rs
+++ b/crates/tycho-indexer/src/services/client_metadata.rs
@@ -2,9 +2,11 @@
 //!
 //! Clients send an opaque `key=value; key=value` map. The server parses it generically, applies
 //! defensive size caps (never trusting the client to have validated), and projects a small
-//! allowlist of keys into Prometheus labels. Because label *values* are client-controlled, each
-//! allowlisted key has a per-key validator that collapses unexpected input to a bounded token, so
-//! a malicious client cannot inflate metric cardinality.
+//! allowlist of keys into Prometheus labels. Values are emitted verbatim (after the caps): the
+//! server never interprets them, so it stays free of any client-specific vocabulary. The allowlist
+//! bounds label *names*, which is what protects the in-process metrics registry from being flooded
+//! with arbitrary series; bounding label *value* cardinality, if ever needed, is left to the
+//! Prometheus scrape layer.
 //!
 //! This mirrors the client serializer in `tycho-client` but deliberately does not depend on that
 //! crate, so the two can ship independently.
@@ -16,11 +18,10 @@ use metrics::Label;
 /// Header carrying generic client metadata.
 pub(in crate::services) const CLIENT_METADATA_HEADER: &str = "x-tycho-client-metadata";
 
-/// Allowlisted metadata keys promoted to Prometheus labels. Adding a key multiplies series count.
+/// Metadata keys projected onto Prometheus labels. This is a projection policy, not an
+/// interpretation of the values: the server decides which keys become labels (bounding label
+/// names) but never inspects what they mean. Adding a key multiplies series count.
 pub(in crate::services) const METADATA_METRIC_KEYS: &[&str] = &["fynd_version", "preset"];
-
-/// Known Fynd presets; any other `preset` value collapses to `"other"`.
-const KNOWN_PRESETS: &[&str] = &["best", "fast", "deep", "none"];
 
 // Defensive caps mirroring the client serializer (by value, not by crate dependency).
 const MAX_ENTRIES: usize = 16;
@@ -56,61 +57,21 @@ pub(in crate::services) fn parse_client_metadata(raw: &str) -> BTreeMap<String, 
     out
 }
 
-/// Builds the bounded Prometheus labels for every allowlisted metadata key, in allowlist order.
-/// Missing keys yield `"none"`; present values are validated per key and collapsed to
-/// `"other"`/`"invalid"` when they don't match, so client-controlled strings can never inflate
-/// label cardinality. Non-allowlisted keys are never emitted.
+/// Builds the Prometheus labels for every allowlisted metadata key, in allowlist order. Missing
+/// keys yield `"none"`; present values are emitted verbatim (already size-capped by the parser).
+/// Non-allowlisted keys are never emitted.
 pub(in crate::services) fn metric_labels(metadata: &BTreeMap<String, String>) -> Vec<Label> {
     METADATA_METRIC_KEYS
         .iter()
-        .map(|&key| Label::new(key, label_value(key, metadata.get(key).map(String::as_str))))
+        .map(|&key| {
+            let value = metadata
+                .get(key)
+                .map(String::as_str)
+                .unwrap_or("none")
+                .to_owned();
+            Label::new(key, value)
+        })
         .collect()
-}
-
-fn label_value(key: &str, value: Option<&str>) -> String {
-    let Some(value) = value else {
-        return "none".to_string();
-    };
-    match key {
-        "preset" => {
-            if KNOWN_PRESETS.contains(&value) {
-                value.to_string()
-            } else {
-                "other".to_string()
-            }
-        }
-        "fynd_version" => {
-            if is_version_prefix(value) {
-                value.to_string()
-            } else {
-                "invalid".to_string()
-            }
-        }
-        _ => "invalid".to_string(),
-    }
-}
-
-/// Returns true if `value` starts with `MAJOR.MINOR.PATCH` (each numeric), matching
-/// `^[0-9]+\.[0-9]+\.[0-9]+`.
-fn is_version_prefix(value: &str) -> bool {
-    let mut rest = value;
-    for i in 0..3 {
-        let digits = rest
-            .bytes()
-            .take_while(|b| b.is_ascii_digit())
-            .count();
-        if digits == 0 {
-            return false;
-        }
-        rest = &rest[digits..];
-        if i < 2 {
-            match rest.strip_prefix('.') {
-                Some(r) => rest = r,
-                None => return false,
-            }
-        }
-    }
-    true
 }
 
 #[cfg(test)]
@@ -173,15 +134,11 @@ mod tests {
     }
 
     #[test]
-    fn labels_pass_through_valid_values() {
-        let labels = labels_map(&map(&[("fynd_version", "0.57.0"), ("preset", "best")]));
-        assert_eq!(labels, map(&[("fynd_version", "0.57.0"), ("preset", "best")]));
-    }
-
-    #[test]
-    fn labels_collapse_unexpected_values() {
+    fn labels_pass_through_values_verbatim() {
+        // The server never interprets values, so any string on an allowlisted key is emitted as-is
+        // (after the parser's size caps). Value semantics are the client's concern.
         let labels = labels_map(&map(&[("fynd_version", "not-a-version"), ("preset", "turbo")]));
-        assert_eq!(labels, map(&[("fynd_version", "invalid"), ("preset", "other")]));
+        assert_eq!(labels, map(&[("fynd_version", "not-a-version"), ("preset", "turbo")]));
     }
 
     #[test]
@@ -189,22 +146,5 @@ mod tests {
         let labels = labels_map(&map(&[("secret", "abc"), ("preset", "fast")]));
         assert_eq!(labels, map(&[("fynd_version", "none"), ("preset", "fast")]));
         assert!(!labels.contains_key("secret"));
-    }
-
-    #[test]
-    fn version_prefix_accepts_major_minor_patch() {
-        assert!(is_version_prefix("1.2.3"));
-        assert!(is_version_prefix("0.57.0"));
-        assert!(is_version_prefix("1.2.3-rc1"));
-        assert!(is_version_prefix("10.20.30.40"));
-    }
-
-    #[test]
-    fn version_prefix_rejects_non_semver() {
-        assert!(!is_version_prefix("1.2"));
-        assert!(!is_version_prefix("1.2.x"));
-        assert!(!is_version_prefix("v1.2.3"));
-        assert!(!is_version_prefix(""));
-        assert!(!is_version_prefix("abc"));
     }
 }

--- a/crates/tycho-indexer/src/services/middleware/metrics.rs
+++ b/crates/tycho-indexer/src/services/middleware/metrics.rs
@@ -203,7 +203,7 @@ mod tests {
             ("endpoint", "/v1/health"),
             ("user_identity", "alice"),
             ("fynd_version", "none"),
-            ("preset", "none"),
+            ("fynd_preset", "none"),
         ];
         assert_eq!(
             counter_value(&after, "rpc_requests", &success_labels) -
@@ -216,7 +216,7 @@ mod tests {
             ("status", "400"),
             ("user_identity", "alice"),
             ("fynd_version", "none"),
-            ("preset", "none"),
+            ("fynd_preset", "none"),
         ];
         assert_eq!(
             counter_value(&after, "rpc_requests_failed", &no_failure_labels),
@@ -240,7 +240,7 @@ mod tests {
             .insert_header(("user-identity", "alice"))
             .insert_header((
                 "x-tycho-client-metadata",
-                "fynd_version=1.2.3; preset=fast; secret=xyz",
+                "fynd_version=1.2.3; fynd_preset=fast; secret=xyz",
             ))
             .to_request();
         let response = test::call_service(&app, request).await;
@@ -252,7 +252,7 @@ mod tests {
             ("endpoint", "/v1/health"),
             ("user_identity", "alice"),
             ("fynd_version", "1.2.3"),
-            ("preset", "fast"),
+            ("fynd_preset", "fast"),
         ];
         assert_eq!(
             counter_value(&after, "rpc_requests", &metadata_labels) -
@@ -264,7 +264,7 @@ mod tests {
             ("endpoint", "/v1/health"),
             ("user_identity", "alice"),
             ("fynd_version", "1.2.3"),
-            ("preset", "fast"),
+            ("fynd_preset", "fast"),
             ("secret", "xyz"),
         ];
         assert_eq!(counter_value(&after, "rpc_requests", &with_secret), 0);
@@ -287,7 +287,7 @@ mod tests {
             ("endpoint", "/v1/fail"),
             ("user_identity", "unknown"),
             ("fynd_version", "none"),
-            ("preset", "none"),
+            ("fynd_preset", "none"),
         ];
         assert_eq!(
             counter_value(&after, "rpc_requests", &fail_request_labels) -
@@ -300,7 +300,7 @@ mod tests {
             ("status", expected_status.as_str()),
             ("user_identity", "unknown"),
             ("fynd_version", "none"),
-            ("preset", "none"),
+            ("fynd_preset", "none"),
         ];
         assert_eq!(
             counter_value(&after, "rpc_requests_failed", &fail_labels) -

--- a/crates/tycho-indexer/src/services/middleware/metrics.rs
+++ b/crates/tycho-indexer/src/services/middleware/metrics.rs
@@ -41,6 +41,13 @@ where
         .and_then(|v| v.to_str().ok())
         .unwrap_or("unknown")
         .to_string();
+    // Client plan from the upstream-injected X-User-Plan header (`none` when absent).
+    let user_plan = req
+        .headers()
+        .get("x-user-plan")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("none")
+        .to_string();
 
     let metadata = client_metadata::parse_client_metadata(
         req.headers()
@@ -54,6 +61,7 @@ where
         Label::new("endpoint", endpoint.clone()),
         Label::new("user_identity", user_identity.clone()),
         Label::new("client_version", client_version.clone()),
+        Label::new("user_plan", user_plan.clone()),
     ];
     request_labels.extend(metadata_labels.iter().cloned());
     counter!("rpc_requests", request_labels).increment(1);
@@ -74,6 +82,7 @@ where
                     Label::new("status", srv_res.status().as_u16().to_string()),
                     Label::new("user_identity", user_identity.clone()),
                     Label::new("client_version", client_version.clone()),
+                    Label::new("user_plan", user_plan.clone()),
                 ];
                 fail_labels.extend(metadata_labels.iter().cloned());
                 counter!("rpc_requests_failed", fail_labels).increment(1);
@@ -90,6 +99,7 @@ where
                 Label::new("status", status.to_string()),
                 Label::new("user_identity", user_identity.clone()),
                 Label::new("client_version", client_version.clone()),
+                Label::new("user_plan", user_plan.clone()),
             ];
             fail_labels.extend(metadata_labels.iter().cloned());
             counter!("rpc_requests_failed", fail_labels).increment(1);
@@ -214,6 +224,7 @@ mod tests {
             ("endpoint", "/v1/health"),
             ("user_identity", "alice"),
             ("client_version", "unknown"),
+            ("user_plan", "none"),
             ("fynd_version", "none"),
             ("fynd_preset", "none"),
         ];
@@ -228,6 +239,7 @@ mod tests {
             ("status", "400"),
             ("user_identity", "alice"),
             ("client_version", "unknown"),
+            ("user_plan", "none"),
             ("fynd_version", "none"),
             ("fynd_preset", "none"),
         ];
@@ -252,6 +264,7 @@ mod tests {
             .uri("/v1/health")
             .insert_header(("user-identity", "alice"))
             .insert_header(("user-agent", "tycho-client-1.0"))
+            .insert_header(("x-user-plan", "pro"))
             .insert_header((
                 "x-tycho-client-metadata",
                 "fynd_version=1.2.3; fynd_preset=fast; secret=xyz",
@@ -266,6 +279,7 @@ mod tests {
             ("endpoint", "/v1/health"),
             ("user_identity", "alice"),
             ("client_version", "tycho-client-1.0"),
+            ("user_plan", "pro"),
             ("fynd_version", "1.2.3"),
             ("fynd_preset", "fast"),
         ];
@@ -279,6 +293,7 @@ mod tests {
             ("endpoint", "/v1/health"),
             ("user_identity", "alice"),
             ("client_version", "tycho-client-1.0"),
+            ("user_plan", "pro"),
             ("fynd_version", "1.2.3"),
             ("fynd_preset", "fast"),
             ("secret", "xyz"),
@@ -303,6 +318,7 @@ mod tests {
             ("endpoint", "/v1/fail"),
             ("user_identity", "unknown"),
             ("client_version", "unknown"),
+            ("user_plan", "none"),
             ("fynd_version", "none"),
             ("fynd_preset", "none"),
         ];
@@ -317,6 +333,7 @@ mod tests {
             ("status", expected_status.as_str()),
             ("user_identity", "unknown"),
             ("client_version", "unknown"),
+            ("user_plan", "none"),
             ("fynd_version", "none"),
             ("fynd_preset", "none"),
         ];

--- a/crates/tycho-indexer/src/services/middleware/metrics.rs
+++ b/crates/tycho-indexer/src/services/middleware/metrics.rs
@@ -238,7 +238,10 @@ mod tests {
         let request = test::TestRequest::get()
             .uri("/v1/health")
             .insert_header(("user-identity", "alice"))
-            .insert_header(("x-tycho-client-metadata", "fynd_version=1.2.3; preset=fast; secret=xyz"))
+            .insert_header((
+                "x-tycho-client-metadata",
+                "fynd_version=1.2.3; preset=fast; secret=xyz",
+            ))
             .to_request();
         let response = test::call_service(&app, request).await;
         assert_eq!(response.status(), StatusCode::OK);

--- a/crates/tycho-indexer/src/services/middleware/metrics.rs
+++ b/crates/tycho-indexer/src/services/middleware/metrics.rs
@@ -34,6 +34,14 @@ where
 
     Span::current().record("user_identity", &user_identity);
 
+    // Mirrors the WS `client_version` label (raw User-Agent), defaulting to a bounded sentinel.
+    let client_version = req
+        .headers()
+        .get("user-agent")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown")
+        .to_string();
+
     let metadata = client_metadata::parse_client_metadata(
         req.headers()
             .get(client_metadata::CLIENT_METADATA_HEADER)
@@ -45,6 +53,7 @@ where
     let mut request_labels = vec![
         Label::new("endpoint", endpoint.clone()),
         Label::new("user_identity", user_identity.clone()),
+        Label::new("client_version", client_version.clone()),
     ];
     request_labels.extend(metadata_labels.iter().cloned());
     counter!("rpc_requests", request_labels).increment(1);
@@ -64,6 +73,7 @@ where
                     Label::new("endpoint", endpoint.clone()),
                     Label::new("status", srv_res.status().as_u16().to_string()),
                     Label::new("user_identity", user_identity.clone()),
+                    Label::new("client_version", client_version.clone()),
                 ];
                 fail_labels.extend(metadata_labels.iter().cloned());
                 counter!("rpc_requests_failed", fail_labels).increment(1);
@@ -79,6 +89,7 @@ where
                 Label::new("endpoint", endpoint.clone()),
                 Label::new("status", status.to_string()),
                 Label::new("user_identity", user_identity.clone()),
+                Label::new("client_version", client_version.clone()),
             ];
             fail_labels.extend(metadata_labels.iter().cloned());
             counter!("rpc_requests_failed", fail_labels).increment(1);
@@ -202,6 +213,7 @@ mod tests {
         let success_labels = [
             ("endpoint", "/v1/health"),
             ("user_identity", "alice"),
+            ("client_version", "unknown"),
             ("fynd_version", "none"),
             ("fynd_preset", "none"),
         ];
@@ -215,6 +227,7 @@ mod tests {
             ("endpoint", "/v1/health"),
             ("status", "400"),
             ("user_identity", "alice"),
+            ("client_version", "unknown"),
             ("fynd_version", "none"),
             ("fynd_preset", "none"),
         ];
@@ -238,6 +251,7 @@ mod tests {
         let request = test::TestRequest::get()
             .uri("/v1/health")
             .insert_header(("user-identity", "alice"))
+            .insert_header(("user-agent", "tycho-client-1.0"))
             .insert_header((
                 "x-tycho-client-metadata",
                 "fynd_version=1.2.3; fynd_preset=fast; secret=xyz",
@@ -251,6 +265,7 @@ mod tests {
         let metadata_labels = [
             ("endpoint", "/v1/health"),
             ("user_identity", "alice"),
+            ("client_version", "tycho-client-1.0"),
             ("fynd_version", "1.2.3"),
             ("fynd_preset", "fast"),
         ];
@@ -263,6 +278,7 @@ mod tests {
         let with_secret = [
             ("endpoint", "/v1/health"),
             ("user_identity", "alice"),
+            ("client_version", "tycho-client-1.0"),
             ("fynd_version", "1.2.3"),
             ("fynd_preset", "fast"),
             ("secret", "xyz"),
@@ -286,6 +302,7 @@ mod tests {
         let fail_request_labels = [
             ("endpoint", "/v1/fail"),
             ("user_identity", "unknown"),
+            ("client_version", "unknown"),
             ("fynd_version", "none"),
             ("fynd_preset", "none"),
         ];
@@ -299,6 +316,7 @@ mod tests {
             ("endpoint", "/v1/fail"),
             ("status", expected_status.as_str()),
             ("user_identity", "unknown"),
+            ("client_version", "unknown"),
             ("fynd_version", "none"),
             ("fynd_preset", "none"),
         ];

--- a/crates/tycho-indexer/src/services/middleware/metrics.rs
+++ b/crates/tycho-indexer/src/services/middleware/metrics.rs
@@ -5,8 +5,10 @@ use actix_web::{
     dev::{ServiceRequest, ServiceResponse},
     middleware::Next,
 };
-use metrics::{counter, histogram};
+use metrics::{counter, histogram, Label};
 use tracing::{instrument, Span};
+
+use crate::services::client_metadata;
 
 /// Middleware to record metrics for RPC requests.
 #[instrument(skip_all, fields(user_identity))]
@@ -32,7 +34,20 @@ where
 
     Span::current().record("user_identity", &user_identity);
 
-    counter!("rpc_requests", "endpoint" => endpoint.clone(), "user_identity" => user_identity.clone()).increment(1);
+    let metadata = client_metadata::parse_client_metadata(
+        req.headers()
+            .get(client_metadata::CLIENT_METADATA_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or(""),
+    );
+    let metadata_labels = client_metadata::metric_labels(&metadata);
+
+    let mut request_labels = vec![
+        Label::new("endpoint", endpoint.clone()),
+        Label::new("user_identity", user_identity.clone()),
+    ];
+    request_labels.extend(metadata_labels.iter().cloned());
+    counter!("rpc_requests", request_labels).increment(1);
 
     let res = next.call(req).await;
 
@@ -45,13 +60,13 @@ where
     match res {
         Ok(srv_res) => {
             if srv_res.status().is_client_error() || srv_res.status().is_server_error() {
-                counter!(
-                    "rpc_requests_failed",
-                    "endpoint" => endpoint.clone(),
-                    "status" => srv_res.status().as_u16().to_string(),
-                    "user_identity" => user_identity.clone()
-                )
-                .increment(1);
+                let mut fail_labels = vec![
+                    Label::new("endpoint", endpoint.clone()),
+                    Label::new("status", srv_res.status().as_u16().to_string()),
+                    Label::new("user_identity", user_identity.clone()),
+                ];
+                fail_labels.extend(metadata_labels.iter().cloned());
+                counter!("rpc_requests_failed", fail_labels).increment(1);
             }
 
             Ok(srv_res.map_into_boxed_body())
@@ -60,13 +75,13 @@ where
             let resp_e = e.as_response_error();
             let status = resp_e.status_code().as_u16();
 
-            counter!(
-                "rpc_requests_failed",
-                "endpoint" => endpoint.clone(),
-                "status" => status.to_string(),
-                "user_identity" => user_identity.clone()
-            )
-            .increment(1);
+            let mut fail_labels = vec![
+                Label::new("endpoint", endpoint.clone()),
+                Label::new("status", status.to_string()),
+                Label::new("user_identity", user_identity.clone()),
+            ];
+            fail_labels.extend(metadata_labels.iter().cloned());
+            counter!("rpc_requests_failed", fail_labels).increment(1);
 
             Err(e)
         }
@@ -184,15 +199,25 @@ mod tests {
 
         let after = snapshot_to_map(snapshotter.snapshot());
 
-        let success_labels = [("endpoint", "/v1/health"), ("user_identity", "alice")];
+        let success_labels = [
+            ("endpoint", "/v1/health"),
+            ("user_identity", "alice"),
+            ("fynd_version", "none"),
+            ("preset", "none"),
+        ];
         assert_eq!(
             counter_value(&after, "rpc_requests", &success_labels) -
                 counter_value(&before, "rpc_requests", &success_labels),
             1
         );
 
-        let no_failure_labels =
-            [("endpoint", "/v1/health"), ("status", "400"), ("user_identity", "alice")];
+        let no_failure_labels = [
+            ("endpoint", "/v1/health"),
+            ("status", "400"),
+            ("user_identity", "alice"),
+            ("fynd_version", "none"),
+            ("preset", "none"),
+        ];
         assert_eq!(
             counter_value(&after, "rpc_requests_failed", &no_failure_labels),
             counter_value(&before, "rpc_requests_failed", &no_failure_labels),
@@ -206,6 +231,40 @@ mod tests {
             ),
             1
         );
+
+        // --- Client metadata case: allowlisted keys become labels, others are dropped ---
+        let before = snapshot_to_map(snapshotter.snapshot());
+
+        let request = test::TestRequest::get()
+            .uri("/v1/health")
+            .insert_header(("user-identity", "alice"))
+            .insert_header(("x-tycho-client-metadata", "fynd_version=1.2.3; preset=fast; secret=xyz"))
+            .to_request();
+        let response = test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let after = snapshot_to_map(snapshotter.snapshot());
+
+        let metadata_labels = [
+            ("endpoint", "/v1/health"),
+            ("user_identity", "alice"),
+            ("fynd_version", "1.2.3"),
+            ("preset", "fast"),
+        ];
+        assert_eq!(
+            counter_value(&after, "rpc_requests", &metadata_labels) -
+                counter_value(&before, "rpc_requests", &metadata_labels),
+            1
+        );
+        // The non-allowlisted `secret` key must never appear as a label.
+        let with_secret = [
+            ("endpoint", "/v1/health"),
+            ("user_identity", "alice"),
+            ("fynd_version", "1.2.3"),
+            ("preset", "fast"),
+            ("secret", "xyz"),
+        ];
+        assert_eq!(counter_value(&after, "rpc_requests", &with_secret), 0);
 
         // --- Failure case ---
         let expected_error = RpcError::Pagination(100);
@@ -221,7 +280,12 @@ mod tests {
 
         let after = snapshot_to_map(snapshotter.snapshot());
 
-        let fail_request_labels = [("endpoint", "/v1/fail"), ("user_identity", "unknown")];
+        let fail_request_labels = [
+            ("endpoint", "/v1/fail"),
+            ("user_identity", "unknown"),
+            ("fynd_version", "none"),
+            ("preset", "none"),
+        ];
         assert_eq!(
             counter_value(&after, "rpc_requests", &fail_request_labels) -
                 counter_value(&before, "rpc_requests", &fail_request_labels),
@@ -232,6 +296,8 @@ mod tests {
             ("endpoint", "/v1/fail"),
             ("status", expected_status.as_str()),
             ("user_identity", "unknown"),
+            ("fynd_version", "none"),
+            ("preset", "none"),
         ];
         assert_eq!(
             counter_value(&after, "rpc_requests_failed", &fail_labels) -

--- a/crates/tycho-indexer/src/services/mod.rs
+++ b/crates/tycho-indexer/src/services/mod.rs
@@ -32,6 +32,7 @@ use crate::{
 mod access_control;
 mod api_docs;
 mod cache;
+mod client_metadata;
 #[cfg(feature = "jemalloc")]
 mod debug;
 mod deltas_buffer;

--- a/crates/tycho-indexer/src/services/ws.rs
+++ b/crates/tycho-indexer/src/services/ws.rs
@@ -1,6 +1,6 @@
 //! This module contains Tycho Websocket implementation
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -10,7 +10,7 @@ use actix::{
 };
 use actix_web::{web, Error, HttpRequest, HttpResponse};
 use actix_web_actors::ws;
-use metrics::{counter, gauge};
+use metrics::{counter, gauge, Label};
 use tracing::{debug, error, info, instrument, trace, warn};
 use tycho_common::{
     dto::{BlockAggregatedChanges, Command, Response, WebSocketMessage},
@@ -18,7 +18,7 @@ use tycho_common::{
 };
 use uuid::Uuid;
 
-use crate::extractor::runner::MessageSender;
+use crate::{extractor::runner::MessageSender, services::client_metadata};
 
 /// How often heartbeat pings are sent
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
@@ -63,6 +63,8 @@ pub struct WsActor {
     compression_enabled: HashMap<Uuid, bool>,
     user_identity: Option<String>,
     client_version: String,
+    /// Allowlisted client metadata projected onto connection metrics.
+    client_metadata: BTreeMap<String, String>,
 }
 
 impl WsActor {
@@ -70,6 +72,7 @@ impl WsActor {
         app_state: web::Data<WsData>,
         user_identity: Option<String>,
         client_version: String,
+        client_metadata: BTreeMap<String, String>,
     ) -> Self {
         Self {
             id: Uuid::new_v4(),
@@ -79,7 +82,25 @@ impl WsActor {
             compression_enabled: HashMap::new(),
             user_identity,
             client_version,
+            client_metadata,
         }
+    }
+
+    /// Labels for the `websocket_connections_active` gauge: the existing identity/version labels
+    /// plus the allowlisted client metadata.
+    fn connection_labels(&self) -> Vec<Label> {
+        let mut labels = vec![
+            Label::new(
+                "user_identity",
+                self.user_identity
+                    .as_deref()
+                    .unwrap_or("unknown")
+                    .to_owned(),
+            ),
+            Label::new("client_version", self.client_version.clone()),
+        ];
+        labels.extend(client_metadata::metric_labels(&self.client_metadata));
+        labels
     }
 
     /// Entry point for the WS connection
@@ -105,7 +126,14 @@ impl WsActor {
             .unwrap_or("unknown")
             .to_string();
 
-        let ws_actor = WsActor::new(data, user_identity, client_version);
+        let client_metadata = client_metadata::parse_client_metadata(
+            req.headers()
+                .get(client_metadata::CLIENT_METADATA_HEADER)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or(""),
+        );
+
+        let ws_actor = WsActor::new(data, user_identity, client_version, client_metadata);
 
         ws::start(ws_actor, &req, stream)
     }
@@ -376,12 +404,7 @@ impl Actor for WsActor {
     fn started(&mut self, ctx: &mut Self::Context) {
         info!("Websocket connection established");
 
-        gauge!(
-            "websocket_connections_active",
-            "user_identity" => self.user_identity.as_deref().unwrap_or("unknown").to_owned(),
-            "client_version" => self.client_version.clone(),
-        )
-        .increment(1);
+        gauge!("websocket_connections_active", self.connection_labels()).increment(1);
 
         // Start the heartbeat
         self.heartbeat(ctx);
@@ -391,12 +414,7 @@ impl Actor for WsActor {
     fn stopped(&mut self, ctx: &mut Self::Context) {
         info!("Websocket connection closed");
 
-        gauge!(
-            "websocket_connections_active",
-            "user_identity" => self.user_identity.as_deref().unwrap_or("unknown").to_owned(),
-            "client_version" => self.client_version.clone(),
-        )
-        .decrement(1);
+        gauge!("websocket_connections_active", self.connection_labels()).decrement(1);
 
         // Close all remaining subscriptions
         let user_identity = self

--- a/crates/tycho-indexer/src/services/ws.rs
+++ b/crates/tycho-indexer/src/services/ws.rs
@@ -63,6 +63,8 @@ pub struct WsActor {
     compression_enabled: HashMap<Uuid, bool>,
     user_identity: Option<String>,
     client_version: String,
+    /// Client plan from the X-User-Plan header, projected onto connection metrics.
+    user_plan: String,
     /// Allowlisted client metadata projected onto connection metrics.
     client_metadata: HashMap<String, String>,
 }
@@ -72,6 +74,7 @@ impl WsActor {
         app_state: web::Data<WsData>,
         user_identity: Option<String>,
         client_version: String,
+        user_plan: String,
         client_metadata: HashMap<String, String>,
     ) -> Self {
         Self {
@@ -82,6 +85,7 @@ impl WsActor {
             compression_enabled: HashMap::new(),
             user_identity,
             client_version,
+            user_plan,
             client_metadata,
         }
     }
@@ -98,6 +102,7 @@ impl WsActor {
                     .to_owned(),
             ),
             Label::new("client_version", self.client_version.clone()),
+            Label::new("user_plan", self.user_plan.clone()),
         ];
         labels.extend(client_metadata::metric_labels(&self.client_metadata));
         labels
@@ -126,6 +131,13 @@ impl WsActor {
             .unwrap_or("unknown")
             .to_string();
 
+        let user_plan = req
+            .headers()
+            .get("x-user-plan")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("none")
+            .to_string();
+
         let client_metadata = client_metadata::parse_client_metadata(
             req.headers()
                 .get(client_metadata::CLIENT_METADATA_HEADER)
@@ -133,7 +145,8 @@ impl WsActor {
                 .unwrap_or(""),
         );
 
-        let ws_actor = WsActor::new(data, user_identity, client_version, client_metadata);
+        let ws_actor =
+            WsActor::new(data, user_identity, client_version, user_plan, client_metadata);
 
         ws::start(ws_actor, &req, stream)
     }

--- a/crates/tycho-indexer/src/services/ws.rs
+++ b/crates/tycho-indexer/src/services/ws.rs
@@ -1,6 +1,6 @@
 //! This module contains Tycho Websocket implementation
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -64,7 +64,7 @@ pub struct WsActor {
     user_identity: Option<String>,
     client_version: String,
     /// Allowlisted client metadata projected onto connection metrics.
-    client_metadata: BTreeMap<String, String>,
+    client_metadata: HashMap<String, String>,
 }
 
 impl WsActor {
@@ -72,7 +72,7 @@ impl WsActor {
         app_state: web::Data<WsData>,
         user_identity: Option<String>,
         client_version: String,
-        client_metadata: BTreeMap<String, String>,
+        client_metadata: HashMap<String, String>,
     ) -> Self {
         Self {
             id: Uuid::new_v4(),


### PR DESCRIPTION
Reads the generic X-Tycho-Client-Metadata header on RPC requests and WS upgrades and projects an allowlist of keys (fynd_version, fynd_preset) into Prometheus labels (ENG-6180, subtask ENG-6193). Independent of the client change: the header name is referenced by value, with no dependency on tycho-client, so this can merge before or after the client PR.

- New services/client_metadata module parses the header into a HashMap and applies defensive size caps (<=16 entries, <=64B keys, <=128B values, <=1KiB header; oversized input dropped) — the server never trusts the client to have validated.
- A key allowlist bounds label *names*, which protects the in-process metrics registry from arbitrary series. It is a projection policy (which keys become labels), not an interpretation of values: allowlisted values are emitted verbatim (missing => "none"), with no client-specific value semantics (no version-format or preset-name checks). Non-allowlisted keys are never emitted.
- Alongside the metadata labels, the same series also carry client_version (from the untouched User-Agent) and user_plan (from the upstream-injected X-User-Plan header, "none" when absent), so a connected client is identified by user_identity + client_version + user_plan + fynd_version + fynd_preset.
- Labels are added to rpc_requests, rpc_requests_failed, and websocket_connections_active. The RPC duration histogram stays endpoint-only. Per-protocol data stays on the existing websocket_subscriptions_active series, joinable by user_identity.

Bounding label *value* cardinality (a misbehaving client spamming distinct values on an allowlisted key) is left to the Prometheus scrape layer (metric_relabel_configs / sample+label limits), not tycho code. user_plan/client_version follow the same trust model as the existing user_identity label (upstream-injected headers).

Testing (unit-level, no DB/network):
- [x] `parse_client_metadata`: trims pairs, skips empty/malformed, drops oversized key/value, rejects over-cap header, caps entry count
- [x] `metric_labels`: missing keys => "none", allowlisted values pass through verbatim, non-allowlisted keys omitted
- [x] RPC middleware end-to-end (`test_rpc_metrics`): defaults (`client_version`=unknown, `user_plan`=none, metadata=none), real `client_version`/`user_plan`/metadata values, and a dropped non-allowlisted key
- [x] fmt + clippy via the CI-pinned nightly-2026-06-28
- [x] Tests run on stable
