### PR TITLE
fix: track active CowAMM bindings

### DIFF
--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-cowamm"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/protocols/substreams/ethereum-cowamm/Cargo.toml
+++ b/protocols/substreams/ethereum-cowamm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-cowamm"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-cowamm/ethereum-cowamm.yaml
+++ b/protocols/substreams/ethereum-cowamm/ethereum-cowamm.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_cowamm"
-  version: v0.1.3
+  version: v0.1.4
 
 protobuf:
   files:

--- a/protocols/substreams/ethereum-cowamm/proto/cowamm.proto
+++ b/protocols/substreams/ethereum-cowamm/proto/cowamm.proto
@@ -35,6 +35,13 @@ message CowPoolBind {
   Transaction tx = 5;
   //ordinal of the event the bind was recorded in the block
   uint64 ordinal = 6;
+  BindingChangeType change_type = 7;
+}
+
+enum BindingChangeType {
+  BINDING_CHANGE_TYPE_UNSPECIFIED = 0;
+  BINDING_CHANGE_TYPE_BIND = 1;
+  BINDING_CHANGE_TYPE_UNBIND = 2;
 }
 
 message CowPoolBinds {
@@ -45,6 +52,7 @@ message CowPoolCreation {
   bytes address = 1;
   bytes lp_token = 2;
   bytes created_tx_hash = 3;
+  uint64 ordinal = 4;
 }
 
 message CowPoolCreations {
@@ -125,5 +133,3 @@ message BlockPoolChanges {
   
   BlockBalanceDeltas block_balance_deltas = 2;
 }
-
-

--- a/protocols/substreams/ethereum-cowamm/src/modules/1_map_cowpool_creations.rs
+++ b/protocols/substreams/ethereum-cowamm/src/modules/1_map_cowpool_creations.rs
@@ -34,6 +34,7 @@ pub fn map_cowpool_creations(params: String, block: Block) -> Result<CowPoolCrea
                 address: address.clone(),
                 lp_token: address.clone(), //address of lptoken is same as the pool address
                 created_tx_hash: tx_hash,
+                ordinal: log.ordinal(),
             })
         })
         .collect::<Vec<CowPoolCreation>>();

--- a/protocols/substreams/ethereum-cowamm/src/modules/2_map_cowpool_binds.rs
+++ b/protocols/substreams/ethereum-cowamm/src/modules/2_map_cowpool_binds.rs
@@ -2,7 +2,7 @@ use crate::{
     abi::b_cow_pool::functions::{Bind, Unbind},
     pb::cowamm::{BindingChangeType, CowPoolBind, CowPoolBinds},
 };
-use anyhow::{bail, Context, Ok, Result};
+use anyhow::Result;
 use substreams_ethereum::pb::eth::v2::Block;
 use substreams_helper::hex::Hexable;
 
@@ -13,10 +13,10 @@ const UNBIND_SELECTOR: &str = "cf5e7bd3";
 
 #[substreams::handlers::map]
 pub fn map_cowpool_binds(block: Block) -> Result<CowPoolBinds> {
-    extract_cowpool_bindings(block)
+    Ok(extract_cowpool_bindings(block))
 }
 
-fn extract_cowpool_bindings(block: Block) -> Result<CowPoolBinds> {
+fn extract_cowpool_bindings(block: Block) -> CowPoolBinds {
     let mut binds = Vec::new();
     for tx in block.transactions() {
         for (log, call) in tx.logs_with_calls() {
@@ -31,43 +31,48 @@ fn extract_cowpool_bindings(block: Block) -> Result<CowPoolBinds> {
                 continue;
             }
 
+            // This map scans logs from every contract on chain, and anyone can emit a log
+            // whose first topic collides with the BCoWPool bind/unbind LOG_CALL topics.
+            // Genuine BCoWPool events are always emitted by the bind/unbind call itself, so
+            // a log whose emitting call doesn't carry the matching selector, or whose input
+            // doesn't decode, is a lookalike from an unrelated contract. Skip it: erroring
+            // here would permanently halt the stream at this block.
             let selector = if topic == BIND_TOPIC { BIND_SELECTOR } else { UNBIND_SELECTOR };
             if call.call.input.len() <= 4 || hex::encode(&call.call.input[..4]) != selector {
-                bail!(
-                    "CowAMM {} event at pool {} in tx {} was emitted by a mismatched call",
+                substreams::log::info!(
+                    "skipping {} lookalike log at {} in tx {}: emitting call does not match the selector",
                     selector,
                     log.address.to_hex(),
                     tx.hash.to_hex()
                 );
+                continue;
             }
 
-            let (token, amount, weight, change_type) = if selector == BIND_SELECTOR {
-                let bind = Bind::decode(call.call)
-                    .map_err(anyhow::Error::msg)
-                    .with_context(|| {
-                        format!(
-                            "failed to decode CowAMM bind at pool {} in tx {}",
-                            log.address.to_hex(),
-                            tx.hash.to_hex()
-                        )
-                    })?;
-                (
-                    bind.token,
-                    bind.balance.to_signed_bytes_be(),
-                    bind.denorm.to_signed_bytes_be(),
-                    BindingChangeType::Bind,
-                )
+            let decoded = if selector == BIND_SELECTOR {
+                Bind::decode(call.call).map(|bind| {
+                    (
+                        bind.token,
+                        bind.balance.to_signed_bytes_be(),
+                        bind.denorm.to_signed_bytes_be(),
+                        BindingChangeType::Bind,
+                    )
+                })
             } else {
-                let unbind = Unbind::decode(call.call)
-                    .map_err(anyhow::Error::msg)
-                    .with_context(|| {
-                        format!(
-                            "failed to decode CowAMM unbind at pool {} in tx {}",
-                            log.address.to_hex(),
-                            tx.hash.to_hex()
-                        )
-                    })?;
-                (unbind.token, vec![], vec![], BindingChangeType::Unbind)
+                Unbind::decode(call.call)
+                    .map(|unbind| (unbind.token, vec![], vec![], BindingChangeType::Unbind))
+            };
+            let (token, amount, weight, change_type) = match decoded {
+                Ok(decoded) => decoded,
+                Err(error) => {
+                    substreams::log::info!(
+                        "skipping undecodable {} call at {} in tx {}: {}",
+                        selector,
+                        log.address.to_hex(),
+                        tx.hash.to_hex(),
+                        error
+                    );
+                    continue;
+                }
             };
             binds.push(CowPoolBind {
                 address: log.address.clone(),
@@ -81,7 +86,7 @@ fn extract_cowpool_bindings(block: Block) -> Result<CowPoolBinds> {
         }
     }
 
-    Ok(CowPoolBinds { binds })
+    CowPoolBinds { binds }
 }
 
 #[cfg(test)]
@@ -90,25 +95,38 @@ mod tests {
     use substreams::scalar::BigInt;
     use substreams_ethereum::pb::eth::v2::{Call, Log, TransactionReceipt, TransactionTrace};
 
+    fn bind_log(address: &[u8], ordinal: u64) -> Log {
+        Log {
+            address: address.to_vec(),
+            topics: vec![hex::decode(&BIND_TOPIC[2..]).unwrap()],
+            ordinal,
+            ..Default::default()
+        }
+    }
+
+    fn block_with_calls(calls: Vec<Call>) -> Block {
+        let logs = calls
+            .iter()
+            .flat_map(|call| call.logs.clone())
+            .collect();
+        Block {
+            transaction_traces: vec![TransactionTrace {
+                status: 1,
+                hash: vec![1; 32],
+                calls,
+                receipt: Some(TransactionReceipt { logs, ..Default::default() }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn maps_each_binding_log_to_the_call_that_emitted_it() {
         let pool = hex::decode("9bd702e05b9c97e4a4a3e47df1e0fe7a0c26d2f1").unwrap();
         let token_a = hex::decode("def1ca1fb7fbcdc777520aa7f396b4e015f497ab").unwrap();
         let token_b = hex::decode("7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0").unwrap();
-        let bind_topic = hex::decode(&BIND_TOPIC[2..]).unwrap();
         let unbind_topic = hex::decode(&UNBIND_TOPIC[2..]).unwrap();
-        let log_a = Log {
-            address: pool.clone(),
-            topics: vec![bind_topic.clone()],
-            ordinal: 1,
-            ..Default::default()
-        };
-        let log_b = Log {
-            address: pool.clone(),
-            topics: vec![bind_topic.clone()],
-            ordinal: 2,
-            ..Default::default()
-        };
         let log_unbind = Log {
             address: pool.clone(),
             topics: vec![unbind_topic],
@@ -121,30 +139,18 @@ mod tests {
             logs: vec![log],
             ..Default::default()
         };
-        let block = Block {
-            transaction_traces: vec![TransactionTrace {
-                status: 1,
-                hash: vec![1; 32],
-                calls: vec![
-                    call(token_a.clone(), log_a.clone()),
-                    call(token_b.clone(), log_b.clone()),
-                    Call {
-                        address: pool.clone(),
-                        input: Unbind { token: token_a.clone() }.encode(),
-                        logs: vec![log_unbind.clone()],
-                        ..Default::default()
-                    },
-                ],
-                receipt: Some(TransactionReceipt {
-                    logs: vec![log_a, log_b, log_unbind],
-                    ..Default::default()
-                }),
+        let block = block_with_calls(vec![
+            call(token_a.clone(), bind_log(&pool, 1)),
+            call(token_b.clone(), bind_log(&pool, 2)),
+            Call {
+                address: pool.clone(),
+                input: Unbind { token: token_a.clone() }.encode(),
+                logs: vec![log_unbind],
                 ..Default::default()
-            }],
-            ..Default::default()
-        };
+            },
+        ]);
 
-        let changes = extract_cowpool_bindings(block).expect("binding calls should decode");
+        let changes = extract_cowpool_bindings(block);
 
         assert_eq!(changes.binds.len(), 3);
         assert_eq!(changes.binds[0].token, token_a);
@@ -154,5 +160,54 @@ mod tests {
             BindingChangeType::from_i32(changes.binds[2].change_type),
             Some(BindingChangeType::Unbind)
         );
+    }
+
+    #[test]
+    fn skips_lookalike_logs_not_emitted_by_a_binding_call() {
+        let pool = hex::decode("9bd702e05b9c97e4a4a3e47df1e0fe7a0c26d2f1").unwrap();
+        let lookalike = hex::decode("00000000000000000000000000000000000000ff").unwrap();
+        let token = hex::decode("def1ca1fb7fbcdc777520aa7f396b4e015f497ab").unwrap();
+        let block = block_with_calls(vec![
+            // carries the bind topic but comes from a call with a different selector
+            Call {
+                address: lookalike.clone(),
+                input: hex::decode("deadbeef00").unwrap(),
+                logs: vec![bind_log(&lookalike, 1)],
+                ..Default::default()
+            },
+            Call {
+                address: pool.clone(),
+                input: Bind {
+                    token: token.clone(),
+                    balance: BigInt::from(10),
+                    denorm: BigInt::from(1),
+                }
+                .encode(),
+                logs: vec![bind_log(&pool, 2)],
+                ..Default::default()
+            },
+        ]);
+
+        let changes = extract_cowpool_bindings(block);
+
+        assert_eq!(changes.binds.len(), 1);
+        assert_eq!(changes.binds[0].token, token);
+        assert_eq!(changes.binds[0].address, pool);
+    }
+
+    #[test]
+    fn skips_binding_calls_with_undecodable_input() {
+        let lookalike = hex::decode("00000000000000000000000000000000000000ff").unwrap();
+        // starts with the bind selector but is too short to decode as a bind call
+        let block = block_with_calls(vec![Call {
+            address: lookalike.clone(),
+            input: hex::decode("e4e1e538ff").unwrap(),
+            logs: vec![bind_log(&lookalike, 1)],
+            ..Default::default()
+        }]);
+
+        let changes = extract_cowpool_bindings(block);
+
+        assert!(changes.binds.is_empty());
     }
 }

--- a/protocols/substreams/ethereum-cowamm/src/modules/2_map_cowpool_binds.rs
+++ b/protocols/substreams/ethereum-cowamm/src/modules/2_map_cowpool_binds.rs
@@ -1,60 +1,158 @@
 use crate::{
-    abi::b_cow_pool::functions::Bind,
-    pb::cowamm::{CowPoolBind, CowPoolBinds},
+    abi::b_cow_pool::functions::{Bind, Unbind},
+    pb::cowamm::{BindingChangeType, CowPoolBind, CowPoolBinds},
 };
-use anyhow::{Ok, Result};
+use anyhow::{bail, Context, Ok, Result};
 use substreams_ethereum::pb::eth::v2::Block;
 use substreams_helper::hex::Hexable;
 
+const BIND_TOPIC: &str = "0xe4e1e53800000000000000000000000000000000000000000000000000000000";
+const BIND_SELECTOR: &str = "e4e1e538";
+const UNBIND_TOPIC: &str = "0xcf5e7bd300000000000000000000000000000000000000000000000000000000";
+const UNBIND_SELECTOR: &str = "cf5e7bd3";
+
 #[substreams::handlers::map]
 pub fn map_cowpool_binds(block: Block) -> Result<CowPoolBinds> {
-    const BIND_TOPIC: &str = "0xe4e1e53800000000000000000000000000000000000000000000000000000000";
-    const BIND_SELECTOR: &str = "e4e1e538";
+    extract_cowpool_bindings(block)
+}
 
-    let binds = block
-        .transaction_traces
-        .iter()
-        // extract (tx, receipt) pairs; skip tx without receipts
-        .filter_map(|tx| {
-            tx.receipt
-                .as_ref()
-                .map(|receipt| (tx, receipt))
-        })
-        // for each (tx, receipt) emit all the matching binds
-        .flat_map(|(tx, receipt)| {
-            receipt
-                .logs
-                .iter()
-                // topic match
-                .filter(|log| {
-                    log.topics.first().map(|t| t.to_hex()) == Some(BIND_TOPIC.to_string())
-                })
-                // validate log data and map to CowPoolBind
-                .filter_map(move |log| {
-                    // Find the call that contains this log by matching addresses and checking calls
-                    let call = tx.calls.iter().find(|call| {
-                        call.address == log.address
-                        && !call.state_reverted
-                        && call.input.len() > 4 //checks if theres data after the function selector, if not then theres no data to decode
-                        && hex::encode(&call.input[..4]) == BIND_SELECTOR //check if its the the
-                                                                          // right function
-                                                                          // selection selector
+fn extract_cowpool_bindings(block: Block) -> Result<CowPoolBinds> {
+    let mut binds = Vec::new();
+    for tx in block.transactions() {
+        for (log, call) in tx.logs_with_calls() {
+            let Some(topic) = log
+                .topics
+                .first()
+                .map(|topic| topic.to_hex())
+            else {
+                continue;
+            };
+            if topic != BIND_TOPIC && topic != UNBIND_TOPIC {
+                continue;
+            }
+
+            let selector = if topic == BIND_TOPIC { BIND_SELECTOR } else { UNBIND_SELECTOR };
+            if call.call.input.len() <= 4 || hex::encode(&call.call.input[..4]) != selector {
+                bail!(
+                    "CowAMM {} event at pool {} in tx {} was emitted by a mismatched call",
+                    selector,
+                    log.address.to_hex(),
+                    tx.hash.to_hex()
+                );
+            }
+
+            let (token, amount, weight, change_type) = if selector == BIND_SELECTOR {
+                let bind = Bind::decode(call.call)
+                    .map_err(anyhow::Error::msg)
+                    .with_context(|| {
+                        format!(
+                            "failed to decode CowAMM bind at pool {} in tx {}",
+                            log.address.to_hex(),
+                            tx.hash.to_hex()
+                        )
                     })?;
-                    let bind = Bind::decode(call).expect("failed to decode bind");
-                    let token = bind.token;
-                    let amount = bind.balance.to_signed_bytes_be();
-                    let weight = bind.denorm.to_signed_bytes_be();
-                    Some(CowPoolBind {
-                        address: log.address.clone(),
-                        token,
-                        amount,
-                        weight,
-                        tx: Some(tx.into()), // full TransactionTrace
-                        ordinal: log.ordinal,
-                    })
-                })
-        })
-        .collect::<Vec<_>>();
+                (
+                    bind.token,
+                    bind.balance.to_signed_bytes_be(),
+                    bind.denorm.to_signed_bytes_be(),
+                    BindingChangeType::Bind,
+                )
+            } else {
+                let unbind = Unbind::decode(call.call)
+                    .map_err(anyhow::Error::msg)
+                    .with_context(|| {
+                        format!(
+                            "failed to decode CowAMM unbind at pool {} in tx {}",
+                            log.address.to_hex(),
+                            tx.hash.to_hex()
+                        )
+                    })?;
+                (unbind.token, vec![], vec![], BindingChangeType::Unbind)
+            };
+            binds.push(CowPoolBind {
+                address: log.address.clone(),
+                token,
+                amount,
+                weight,
+                tx: Some(tx.into()),
+                ordinal: log.ordinal,
+                change_type: change_type.into(),
+            });
+        }
+    }
 
     Ok(CowPoolBinds { binds })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use substreams::scalar::BigInt;
+    use substreams_ethereum::pb::eth::v2::{Call, Log, TransactionReceipt, TransactionTrace};
+
+    #[test]
+    fn maps_each_binding_log_to_the_call_that_emitted_it() {
+        let pool = hex::decode("9bd702e05b9c97e4a4a3e47df1e0fe7a0c26d2f1").unwrap();
+        let token_a = hex::decode("def1ca1fb7fbcdc777520aa7f396b4e015f497ab").unwrap();
+        let token_b = hex::decode("7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0").unwrap();
+        let bind_topic = hex::decode(&BIND_TOPIC[2..]).unwrap();
+        let unbind_topic = hex::decode(&UNBIND_TOPIC[2..]).unwrap();
+        let log_a = Log {
+            address: pool.clone(),
+            topics: vec![bind_topic.clone()],
+            ordinal: 1,
+            ..Default::default()
+        };
+        let log_b = Log {
+            address: pool.clone(),
+            topics: vec![bind_topic.clone()],
+            ordinal: 2,
+            ..Default::default()
+        };
+        let log_unbind = Log {
+            address: pool.clone(),
+            topics: vec![unbind_topic],
+            ordinal: 3,
+            ..Default::default()
+        };
+        let call = |token: Vec<u8>, log: Log| Call {
+            address: pool.clone(),
+            input: Bind { token, balance: BigInt::from(10), denorm: BigInt::from(1) }.encode(),
+            logs: vec![log],
+            ..Default::default()
+        };
+        let block = Block {
+            transaction_traces: vec![TransactionTrace {
+                status: 1,
+                hash: vec![1; 32],
+                calls: vec![
+                    call(token_a.clone(), log_a.clone()),
+                    call(token_b.clone(), log_b.clone()),
+                    Call {
+                        address: pool.clone(),
+                        input: Unbind { token: token_a.clone() }.encode(),
+                        logs: vec![log_unbind.clone()],
+                        ..Default::default()
+                    },
+                ],
+                receipt: Some(TransactionReceipt {
+                    logs: vec![log_a, log_b, log_unbind],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let changes = extract_cowpool_bindings(block).expect("binding calls should decode");
+
+        assert_eq!(changes.binds.len(), 3);
+        assert_eq!(changes.binds[0].token, token_a);
+        assert_eq!(changes.binds[1].token, token_b);
+        assert_eq!(changes.binds[2].token, changes.binds[0].token);
+        assert_eq!(
+            BindingChangeType::from_i32(changes.binds[2].change_type),
+            Some(BindingChangeType::Unbind)
+        );
+    }
 }

--- a/protocols/substreams/ethereum-cowamm/src/modules/2_store_cowpool_binds.rs
+++ b/protocols/substreams/ethereum-cowamm/src/modules/2_store_cowpool_binds.rs
@@ -1,5 +1,26 @@
 use crate::pb::cowamm::CowPoolBinds;
+use anyhow::{Context, Result};
 use substreams::store::{Appender, StoreAppend};
+
+pub(crate) fn serialize_binding_change(bind: &crate::pb::cowamm::CowPoolBind) -> Result<String> {
+    let tx = bind
+        .tx
+        .as_ref()
+        .context("CowAMM binding change is missing transaction context")?;
+    Ok(serde_json::json!({
+        "address": hex::encode(&bind.address),
+        "token": hex::encode(&bind.token),
+        "weight": hex::encode(&bind.weight),
+        "amount": hex::encode(&bind.amount),
+        "from": hex::encode(&tx.from),
+        "to": hex::encode(&tx.to),
+        "hash": hex::encode(&tx.hash),
+        "index": hex::encode(tx.index.to_le_bytes()),
+        "ordinal": hex::encode(bind.ordinal.to_le_bytes()),
+        "change_type": bind.change_type,
+    })
+    .to_string())
+}
 
 #[substreams::handlers::store]
 pub fn store_cowpool_binds(binds: CowPoolBinds, store: StoreAppend<String>) {
@@ -8,20 +29,16 @@ pub fn store_cowpool_binds(binds: CowPoolBinds, store: StoreAppend<String>) {
         // Format the bind as a JSON string, we use an AppendString store so that
         // the binds can persist across block state and we can create pools with the binds
         // in map_cowpools
-        let bind_string = serde_json::json!({
-            "address": hex::encode(&bind.address),
-            "token": hex::encode(&bind.token),
-            "weight": hex::encode(&bind.weight),
-            "amount": hex::encode(&bind.amount),
-            //store fields individually, reconstruct tx object in map cowpools
-            //this information is useful for the deltas we want to create
-            "from": hex::encode(&bind.tx.as_ref().unwrap().from),
-            "to": hex::encode(&bind.tx.as_ref().unwrap().to),
-            "hash": hex::encode(&bind.tx.as_ref().unwrap().hash),
-            "index": hex::encode(bind.tx.clone().unwrap().index.to_le_bytes()),
-            "ordinal": hex::encode(bind.ordinal.to_le_bytes()),
-        })
-        .to_string();
-        store.append(0, pool_key, bind_string);
+        let bind_string = match serialize_binding_change(bind) {
+            Ok(bind_string) => bind_string,
+            Err(error) => {
+                substreams::log::info!(
+                    "skipping CowAMM binding change for pool {}: {error:#}",
+                    pool_key
+                );
+                continue;
+            }
+        };
+        store.append(bind.ordinal, pool_key, bind_string);
     }
 }

--- a/protocols/substreams/ethereum-cowamm/src/modules/3_map_cowpools.rs
+++ b/protocols/substreams/ethereum-cowamm/src/modules/3_map_cowpools.rs
@@ -1,5 +1,7 @@
-use crate::pb::cowamm::{CowPool, CowPoolBind, CowPoolCreations, CowPools, Transaction};
-use anyhow::{Ok, Result};
+use crate::pb::cowamm::{
+    BindingChangeType, CowPool, CowPoolBind, CowPoolCreations, CowPools, Transaction,
+};
+use anyhow::{anyhow, Context, Ok, Result};
 use serde::{Deserialize, Serialize};
 use substreams::store::{StoreGet, StoreGetString};
 
@@ -15,11 +17,24 @@ struct CowPoolBindJson {
     hash: String,
     index: String,
     ordinal: String,
+    #[serde(default)]
+    change_type: i32,
 }
 
-pub fn parse_binds(bind_str: &str) -> Option<Vec<CowPoolBind>> {
+fn decode_hex(value: &str, field: &str) -> Result<Vec<u8>> {
+    hex::decode(value).with_context(|| format!("invalid hex in CowAMM binding field {field}"))
+}
+
+fn decode_u64_le(value: &str, field: &str) -> Result<u64> {
+    let bytes: [u8; 8] = decode_hex(value, field)?
+        .try_into()
+        .map_err(|_| anyhow!("CowAMM binding field {field} must be exactly 8 bytes"))?;
+    Ok(u64::from_le_bytes(bytes))
+}
+
+pub fn parse_binds(bind_str: &str) -> Result<Vec<CowPoolBind>> {
     let bind_strs: Vec<&str> = bind_str.split(';').collect();
-    let mut binds = Vec::new();
+    let mut active_binds: Vec<CowPoolBind> = Vec::new();
     for bind in bind_strs {
         let bind = bind.trim();
         // Skip empty strings (which can happen if there are extra semicolons)
@@ -29,42 +44,36 @@ pub fn parse_binds(bind_str: &str) -> Option<Vec<CowPoolBind>> {
         // Wrap the bind in square brackets to create an array of JSON objects
         let formatted_str = format!("[{}]", bind.replace("};", "},"));
 
-        let parsed: Vec<CowPoolBindJson> =
-            serde_json::from_str(&formatted_str).expect("should successfully parse binds string");
+        let parsed: Vec<CowPoolBindJson> = serde_json::from_str(&formatted_str)
+            .context("failed to parse CowAMM binding history")?;
         for bind_json in parsed {
+            let token = decode_hex(&bind_json.token, "token")?;
+            active_binds.retain(|bind| bind.token != token);
+            let change_type = BindingChangeType::from_i32(bind_json.change_type)
+                .context("invalid CowAMM binding change type")?;
+            // Histories written before v0.1.4 have no change_type and contain bind events only.
+            match change_type {
+                BindingChangeType::Unbind => continue,
+                BindingChangeType::Unspecified | BindingChangeType::Bind => {}
+            }
             let cow_bind = CowPoolBind {
-                address: hex::decode(&bind_json.address).expect("Invalid hex for address"),
-                token: hex::decode(&bind_json.token).expect("Invalid hex for token"),
-                weight: hex::decode(&bind_json.weight).expect("Invalid hex for weight"),
-                amount: hex::decode(&bind_json.amount).expect("Invalid hex for amount"),
+                address: decode_hex(&bind_json.address, "address")?,
+                token,
+                weight: decode_hex(&bind_json.weight, "weight")?,
+                amount: decode_hex(&bind_json.amount, "amount")?,
                 tx: Some(Transaction {
-                    from: hex::decode(&bind_json.from).expect("Invalid hex for tx from address"),
-                    to: hex::decode(&bind_json.to).expect("Invalid hex for tx to address"),
-                    hash: hex::decode(&bind_json.hash).expect("Invalid hex for tx to hash"),
-                    index: u64::from_le_bytes(
-                        //verify this
-                        hex::decode(&bind_json.index)
-                            .expect("Invalid hex for tx index")
-                            .try_into()
-                            .expect("tx index must be exactly 8 bytes"),
-                    ),
+                    from: decode_hex(&bind_json.from, "transaction from")?,
+                    to: decode_hex(&bind_json.to, "transaction to")?,
+                    hash: decode_hex(&bind_json.hash, "transaction hash")?,
+                    index: decode_u64_le(&bind_json.index, "transaction index")?,
                 }),
-                ordinal: u64::from_le_bytes(
-                    //verify this
-                    hex::decode(&bind_json.ordinal)
-                        .expect("Invalid hex for tx ordinal")
-                        .try_into()
-                        .expect("ordinal must be exactly 8 bytes"),
-                ),
+                ordinal: decode_u64_le(&bind_json.ordinal, "ordinal")?,
+                change_type: BindingChangeType::Bind.into(),
             };
-            binds.push(cow_bind);
+            active_binds.push(cow_bind);
         }
     }
-    if binds.is_empty() {
-        None
-    } else {
-        Some(binds)
-    }
+    Ok(active_binds)
 }
 
 #[substreams::handlers::map]
@@ -79,15 +88,15 @@ pub fn map_cowpools(
 
     for creation in creations.pools.iter() {
         let base_key = hex::encode(&creation.address);
-        let bind_first = match binds.get_first(&base_key) {
+        let bind_history = match binds.get_at(creation.ordinal, &base_key) {
             Some(data) => data,
             None => continue, // skip if no bind found
         };
 
-        let parsed_binds = match parse_binds(&bind_first) {
-            Some(binds) if binds.len() == 2 => binds,
-            _ => continue, // skip if parsing fails or not enough binds
-        };
+        let parsed_binds = parse_binds(&bind_history)?;
+        if parsed_binds.len() != 2 {
+            continue;
+        }
         let bind1 = &parsed_binds[0];
         let bind2 = &parsed_binds[1];
 
@@ -119,10 +128,7 @@ mod tests {
     #[test]
     fn test_parse_binds_single_entry() {
         let bind_str = r#"{"address":"9bd702e05b9c97e4a4a3e47df1e0fe7a0c26d2f1","token":"def1ca1fb7fbcdc777520aa7f396b4e015f497ab","weight":"0000000000000000000000000000000000000000000000000de0b6b3a7640000","amount":"0000000000000000000000000000000000000000000000000000000000000001","from":"1234567890123456789012345678901234567890","to":"abcdefabcdefabcdefabcdefabcdefabcdefabcd","hash":"fedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcba","index":"0100000000000000","ordinal":"0200000000000000"}"#;
-        let result = parse_binds(bind_str);
-
-        assert!(result.is_some());
-        let binds = result.unwrap();
+        let binds = parse_binds(bind_str).expect("binding history should parse");
         assert_eq!(binds.len(), 1);
 
         assert_eq!(binds[0].address, hex!("9bd702e05b9c97e4a4a3e47df1e0fe7a0c26d2f1"));
@@ -136,9 +142,7 @@ mod tests {
     #[test]
     fn test_parse_binds_multiple_entries() {
         let bind_str = r#"{"address":"9bd702e05b9c97e4a4a3e47df1e0fe7a0c26d2f1","token":"def1ca1fb7fbcdc777520aa7f396b4e015f497ab","weight":"0000000000000000000000000000000000000000000000000de0b6b3a7640000","amount":"0000000000000000000000000000000000000000000000000000000000000001","from":"1234567890123456789012345678901234567890","to":"abcdefabcdefabcdefabcdefabcdefabcdefabcd","hash":"fedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcba","index":"0100000000000000","ordinal":"0200000000000000"};{"address":"9bd702e05b9c97e4a4a3e47df1e0fe7a0c26d2f1","token":"7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0","weight":"0000000000000000000000000000000000000000000000000de0b6b3a7640000","amount":"0000000000000000000000000000000000000000000000000000000000000002","from":"1234567890123456789012345678901234567890","to":"abcdefabcdefabcdefabcdefabcdefabcdefabcd","hash":"fedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcba","index":"0100000000000000","ordinal":"0200000000000000"}"#;
-        let result = parse_binds(bind_str);
-        assert!(result.is_some());
-        let binds = result.unwrap();
+        let binds = parse_binds(bind_str).expect("binding history should parse");
         assert_eq!(binds.len(), 2);
         assert_eq!(binds[0].address, hex!("9bd702e05b9c97e4a4a3e47df1e0fe7a0c26d2f1"));
         assert_eq!(binds[0].token, hex!("def1ca1fb7fbcdc777520aa7f396b4e015f497ab"));
@@ -148,9 +152,82 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "should successfully parse binds string")]
+    fn test_parse_binds_returns_only_active_bindings_after_rebind() {
+        fn binding_change(
+            token: Vec<u8>,
+            weight: Vec<u8>,
+            amount: Vec<u8>,
+            ordinal: u64,
+            change_type: BindingChangeType,
+        ) -> CowPoolBind {
+            CowPoolBind {
+                address: hex!("9bd702e05b9c97e4a4a3e47df1e0fe7a0c26d2f1").to_vec(),
+                token,
+                weight,
+                amount,
+                tx: Some(Transaction {
+                    from: hex!("1234567890123456789012345678901234567890").to_vec(),
+                    to: hex!("abcdefabcdefabcdefabcdefabcdefabcdefabcd").to_vec(),
+                    hash: hex!(
+                        "fedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcbafedcba"
+                    )
+                    .to_vec(),
+                    index: ordinal,
+                }),
+                ordinal,
+                change_type: change_type.into(),
+            }
+        }
+
+        let token_a = hex!("def1ca1fb7fbcdc777520aa7f396b4e015f497ab").to_vec();
+        let token_b = hex!("7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0").to_vec();
+        let changes = [
+            binding_change(
+                token_a.clone(),
+                hex!("01").to_vec(),
+                hex!("0a").to_vec(),
+                1,
+                BindingChangeType::Bind,
+            ),
+            binding_change(token_a.clone(), vec![], vec![], 2, BindingChangeType::Unbind),
+            binding_change(
+                token_b,
+                hex!("02").to_vec(),
+                hex!("14").to_vec(),
+                3,
+                BindingChangeType::Bind,
+            ),
+            binding_change(
+                token_a.clone(),
+                hex!("03").to_vec(),
+                hex!("1e").to_vec(),
+                4,
+                BindingChangeType::Bind,
+            ),
+        ];
+        let bind_str = changes
+            .iter()
+            .map(crate::modules::store_cowpool_binds::serialize_binding_change)
+            .collect::<Result<Vec<_>>>()
+            .expect("binding changes should serialize")
+            .join(";");
+
+        let binds = parse_binds(&bind_str).expect("two bindings should remain active");
+
+        assert_eq!(binds.len(), 2);
+        let rebound = binds
+            .iter()
+            .find(|bind| bind.token == token_a)
+            .expect("rebound token should be active");
+        assert_eq!(rebound.weight, hex!("03"));
+        assert_eq!(rebound.amount, hex!("1e"));
+    }
+
+    #[test]
     fn test_parse_binds_invalid_json() {
-        let bind_str = r#"invalid_json"#;
-        let _result = parse_binds(bind_str);
+        let error = parse_binds("invalid_json").expect_err("invalid JSON should return an error");
+        assert!(error
+            .to_string()
+            .contains("failed to parse CowAMM binding history"));
     }
 }

--- a/protocols/substreams/ethereum-cowamm/src/modules/4_map_components_with_balances.rs
+++ b/protocols/substreams/ethereum-cowamm/src/modules/4_map_components_with_balances.rs
@@ -122,7 +122,11 @@ pub fn map_components_with_balances(
                 };
 
                 let parsed_binds = parse_binds(&bind_data)?;
-                if parsed_binds.is_empty() {
+                // Mirror the map_cowpools guard: pools without exactly two active bindings
+                // are never stored, so any other count must skip here as well — otherwise the
+                // store lookup below reports a legitimately skipped pool as missing and halts
+                // the stream.
+                if parsed_binds.len() != 2 {
                     continue;
                 }
 

--- a/protocols/substreams/ethereum-cowamm/src/modules/4_map_components_with_balances.rs
+++ b/protocols/substreams/ethereum-cowamm/src/modules/4_map_components_with_balances.rs
@@ -10,7 +10,7 @@ use crate::{
         TransactionProtocolComponents,
     },
 };
-use anyhow::{Ok, Result};
+use anyhow::{anyhow, Ok, Result};
 use substreams::{
     prelude::{BigInt, StoreGetString},
     store::{StoreGet, StoreGetProto},
@@ -116,38 +116,47 @@ pub fn map_components_with_balances(
                 let pool_address_hex = hex::encode(&pool_address_topic);
                 let pool_key = format!("Pool:0x{}", pool_address_hex);
 
-                let bind_data = match binds.get_first(&pool_address_hex) {
+                let bind_data = match binds.get_at(log.ordinal, &pool_address_hex) {
                     Some(data) => data,
                     None => continue,
                 };
 
-                let parsed_binds = match parse_binds(&bind_data) {
-                    Some(binds) if !binds.is_empty() => binds,
-                    _ => continue,
+                let parsed_binds = parse_binds(&bind_data)?;
+                if parsed_binds.is_empty() {
+                    continue;
+                }
+
+                let Some(pool) = store.get_at(log.ordinal, &pool_key) else {
+                    return Err(anyhow!(
+                        "CowAMM pool {} is missing from store at block {}, tx {}",
+                        pool_key,
+                        block.number,
+                        tx_hash.to_hex()
+                    ));
                 };
 
                 for bind in parsed_binds.iter() {
-                    //HACK - we'll make the txn hash of the balance delta to be the tx hash of the 
+                    //HACK - we'll make the txn hash of the balance delta to be the tx hash of the
                     //pool creation, also the index too, so that it gets emitted in the same transaction
-                    //and not as txns from previous block (Block N) emitted in Block N + X... the decision 
+                    //and not as txns from previous block (Block N) emitted in Block N + X... the decision
                     // to come to this was deliberated and this was the conclusion:
 
                     //we assign the index and the hash of the current balance delta to make it seem
                     //like the component change actually happened in the same transaction in the same
-                    // block, and not from a previous txn from a previous block, doing this before caused 
-                    //write conflicts during syncing with the tycho indexer 
+                    // block, and not from a previous txn from a previous block, doing this before caused
+                    //write conflicts during syncing with the tycho indexer
 
                     //always emit transaction together with the block that produced them, just emit old
-                    // component balances together with the component creation in the same transaction 
-                    //(it’s not 100% accurate but from a Tycho perspective it doesn’t break anything 
-                    // so it’s acceptable) 
+                    // component balances together with the component creation in the same transaction
+                    //(it’s not 100% accurate but from a Tycho perspective it doesn’t break anything
+                    // so it’s acceptable)
                     let bind_tx = bind.tx.as_ref().unwrap();
                     let delta = BalanceDelta {
                         ord: bind.ordinal,
                         tx: Some(Transaction {
                             from: bind_tx.from.clone(),
                             to: bind_tx.to.clone(),
-                            hash: tx_hash.clone(), //since the binds happen 
+                            hash: tx_hash.clone(), //since the binds happen
                             index: tx_index as u64,
                         }),
                         token: bind.token.clone(),
@@ -161,9 +170,6 @@ pub fn map_components_with_balances(
                     };
                     tx_deltas.push(delta);
                 }
-                let pool = store
-                    .get_last(pool_key)
-                    .expect("failed to get pool from store");
                 // Create the component
                 if let Some(component) = create_component(pool.clone()) {
                     tx_components.push(component);

--- a/protocols/substreams/ethereum-cowamm/src/pb/cowamm.rs
+++ b/protocols/substreams/ethereum-cowamm/src/pb/cowamm.rs
@@ -55,6 +55,8 @@ pub struct CowPoolBind {
     /// ordinal of the event the bind was recorded in the block
     #[prost(uint64, tag="6")]
     pub ordinal: u64,
+    #[prost(enumeration="BindingChangeType", tag="7")]
+    pub change_type: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -71,12 +73,38 @@ pub struct CowPoolCreation {
     pub lp_token: ::prost::alloc::vec::Vec<u8>,
     #[prost(bytes="vec", tag="3")]
     pub created_tx_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint64, tag="4")]
+    pub ordinal: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CowPoolCreations {
     #[prost(message, repeated, tag="1")]
     pub pools: ::prost::alloc::vec::Vec<CowPoolCreation>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum BindingChangeType {
+    Unspecified = 0,
+    Bind = 1,
+    Unbind = 2,
+}
+impl BindingChangeType {
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            BindingChangeType::Unspecified => "BINDING_CHANGE_TYPE_UNSPECIFIED",
+            BindingChangeType::Bind => "BINDING_CHANGE_TYPE_BIND",
+            BindingChangeType::Unbind => "BINDING_CHANGE_TYPE_UNBIND",
+        }
+    }
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "BINDING_CHANGE_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
+            "BINDING_CHANGE_TYPE_BIND" => Some(Self::Bind),
+            "BINDING_CHANGE_TYPE_UNBIND" => Some(Self::Unbind),
+            _ => None,
+        }
+    }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]


### PR DESCRIPTION
## Summary

- decode both CowAMM bind and unbind calls and associate each event with its emitting call
- persist binding changes at their real ordinal and reduce the history to active bindings
- read same-block pool and binding state at the relevant ordinal and replace the missing-pool panic with a contextual error
- bump the CowAMM Substreams package to v0.1.4

## Root cause

The append store retained historical binds but did not record unbinds. After a token was unbound and rebound, pool creation observed more than two bindings, skipped the pool, and the downstream balance mapper panicked when it could not find that pool.

## Validation

- `cargo test -p ethereum-cowamm`
- `cargo test --workspace`
- `cargo clippy -p ethereum-cowamm --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- release wasm build and `substreams pack`
- live replay of bind/unbind/rebind events over blocks 25489102-25489133
- live replay of `map_components_with_balances` at block 25489133; the pool and balances are emitted without the previous panic