### PR TITLE
feat: detect token slots at the latest block

### DIFF
--- a/crates/tycho-common/src/traits.rs
+++ b/crates/tycho-common/src/traits.rs
@@ -233,10 +233,12 @@ pub trait BalanceSlotDetector: Send + Sync {
     /// Detect balance storage slots for multiple tokens from a single holder.
     /// Useful to allow overriding balances.
     ///
+    /// No block parameter is taken: a token's storage layout is fixed, so the slot location does
+    /// not depend on chain state at any particular block.
+    ///
     /// # Arguments
     /// * `tokens` - Slice of ERC20 token addresses.
     /// * `holder` - Address that holds the tokens (e.g., pool manager)
-    /// * `block_hash` - Block at which to detect slots
     ///
     /// # Returns
     /// HashMap mapping Token -> Result containing (contract_address -> storage_slot) or error.
@@ -245,7 +247,6 @@ pub trait BalanceSlotDetector: Send + Sync {
         &self,
         tokens: &[Address],
         holder: Address,
-        block_hash: BlockHash,
     ) -> HashMap<Address, Result<(Address, Bytes), Self::Error>>;
 }
 
@@ -258,11 +259,13 @@ pub trait AllowanceSlotDetector: Send + Sync {
     /// Detect allowance storage slots for multiple tokens for owner-spender pairs.
     /// Useful to allow overriding allowances in simulations.
     ///
+    /// No block parameter is taken: a token's storage layout is fixed, so the slot location does
+    /// not depend on chain state at any particular block.
+    ///
     /// # Arguments
     /// * `tokens` - Slice of ERC20 token addresses.
     /// * `owner` - Address that owns the tokens
     /// * `spender` - Address that is allowed to spend the tokens
-    /// * `block_hash` - Block at which to detect slots
     ///
     /// # Returns
     /// HashMap mapping Token -> Result containing (contract_address -> storage_slot) or error.
@@ -272,7 +275,6 @@ pub trait AllowanceSlotDetector: Send + Sync {
         tokens: &[Address],
         owner: Address,
         spender: Address,
-        block_hash: BlockHash,
     ) -> HashMap<Address, Result<(Address, Bytes), Self::Error>>;
 }
 

--- a/crates/tycho-ethereum/src/rpc/mod.rs
+++ b/crates/tycho-ethereum/src/rpc/mod.rs
@@ -775,10 +775,9 @@ impl EthereumRpcClient {
         &self,
         requests: Vec<SlotDetectorValueRequest>,
         calldata: &Bytes,
-        block_hash: &B256,
     ) -> Result<Vec<(GethTrace, U256)>, RPCError> {
         if let Some(max_batch_size) = self.batching.max_batch_size() {
-            self.batch_slot_detector_trace(requests, calldata, block_hash, max_batch_size)
+            self.batch_slot_detector_trace(requests, calldata, max_batch_size)
                 .await
         } else {
             Err(RPCError::SetupError(
@@ -794,7 +793,6 @@ impl EthereumRpcClient {
         &self,
         requests: Vec<SlotDetectorValueRequest>,
         calldata: &Bytes,
-        block_hash: &B256,
         batch_size: usize,
     ) -> Result<Vec<(GethTrace, U256)>, RPCError> {
         let chunk_size = batch_size / 2; // we make 2 requests in a batch call: trace + eth_call
@@ -822,7 +820,7 @@ impl EthereumRpcClient {
                                 "to": token.to_string(),
                                 "data": calldata.to_string()
                             },
-                            block_hash.to_string()
+                            "latest"
                         ]);
                         let eth_call = batch.add_call::<_, U256>("eth_call", &eth_call_param)?;
 
@@ -851,12 +849,7 @@ impl EthereumRpcClient {
                 .call_with_retry(|| async { batch_call().await })
                 .await
                 .map_err(|e| {
-                    RPCError::from_alloy(
-                        format!(
-                    "Failed to send batch request for slot detector traces for block {block_hash}"
-                ),
-                        e,
-                    )
+                    RPCError::from_alloy("Failed to send batch request for slot detector traces", e)
                 })?;
 
             result.extend(chunk_results);
@@ -872,10 +865,9 @@ impl EthereumRpcClient {
         &self,
         requests: &[SlotDetectorSlotTestRequest],
         calldata: &Bytes,
-        block_hash: &B256,
     ) -> Result<Vec<TransportResult<Value>>, RPCError> {
         if let Some(max_batch_size) = self.batching.max_batch_size() {
-            self.batch_slot_detector_tests(requests, calldata, block_hash, max_batch_size)
+            self.batch_slot_detector_tests(requests, calldata, max_batch_size)
                 .await
         } else {
             Err(RPCError::SetupError(
@@ -891,7 +883,6 @@ impl EthereumRpcClient {
         &self,
         requests: &[SlotDetectorSlotTestRequest],
         calldata: &Bytes,
-        block_hash: &B256,
         batch_size: usize,
     ) -> Result<Vec<TransportResult<Value>>, RPCError> {
         let chunk_size = batch_size; // we make 1 request per test
@@ -919,7 +910,7 @@ impl EthereumRpcClient {
                                     "to": token,
                                     "data": calldata
                                 },
-                                block_hash.to_string(),
+                                "latest",
                                 {
                                     storage_address.to_string(): {
                                         "stateDiff": {
@@ -1004,13 +995,8 @@ impl EthereumRpcClient {
             }
 
             let chunk_results = last_batch_result.map_err(|e| {
-                    RPCError::from_alloy(
-                        format!(
-                            "Failed to send batch request for slot detector tests for block {block_hash}"
-                        ),
-                        e,
-                    )
-                })?;
+                RPCError::from_alloy("Failed to send batch request for slot detector tests", e)
+            })?;
 
             result.extend(chunk_results);
         }
@@ -1614,15 +1600,14 @@ mod tests {
         let usdc = parse_address(USDC_STR);
         let usdt = parse_address(USDT_STR);
 
-        // Holder address that has balances in all three tokens
-        let holder = parse_address(USDC_HOLDER_ADDR);
+        // Use the USDT token contract itself as the holder: tokens mistakenly sent to it are
+        // stuck (it has no rescue path), so its balances of USDT, WETH, and USDC form a permanent
+        // non-zero floor that cannot drain to zero. For USDT this is self-referential (holder ==
+        // token), which is fine for balance-slot detection.
+        let holder = parse_address(USDT_STR);
         let calldata: Bytes = balanceOfCall { _owner: holder }
             .abi_encode()
             .into();
-
-        // Verified block hash where all tokens have non-zero balances
-        let block_hash_str = "0x658814e4cb074359f10dd71237cc57b1ae6791fc9de59fde570e724bd884cbb0";
-        let block_hash = B256::from_str(block_hash_str).expect("Failed to parse block hash");
 
         // Create requests with different tokens to test order preservation
         // The eth_call uses the same calldata, but we call different token contracts
@@ -1635,9 +1620,7 @@ mod tests {
                         "to": token.to_string(),
                         "input": calldata.to_string()
                     },
-                    {
-                        "blockHash": block_hash_str
-                    },
+                    "latest",
                     {
                         "tracer": "prestateTracer",
                         "enableReturnData": true
@@ -1648,31 +1631,23 @@ mod tests {
             .collect();
 
         let results = client
-            .slot_detector_trace(requests.clone(), &calldata, &block_hash)
+            .slot_detector_trace(requests.clone(), &calldata)
             .await
             .expect("Batch slot detector trace failed");
 
         // Verify all results returned and order preserved
         assert_eq!(results.len(), tokens.len(), "Should receive result for each request");
 
-        let expected_balances = [
-            U256::from_str("911262488844363150815").unwrap(), // WETH balance
-            U256::from(69346617579396u64),                    // USDC balance
-            U256::from(52511836228219u64),                    // USDT balance
-        ];
-
-        // Each token should return a result in expected order with the correct balance
+        // Each token should return a result in expected order with a non-zero balance (the USDT
+        // contract permanently holds all three tokens). Balances are queried at the latest block,
+        // so exact values cannot be asserted.
         for (idx, (trace, value)) in results.iter().enumerate() {
             assert!(
                 matches!(trace, GethTrace::PreStateTracer(_)),
                 "Request {} should return PreStateTracer",
                 idx
             );
-            assert_eq!(
-                *value, expected_balances[idx],
-                "Request {} balance mismatch. Expected: {}, Got: {}",
-                idx, expected_balances[idx], *value
-            );
+            assert!(!value.is_zero(), "Request {} should return a non-zero balance", idx);
         }
     }
 
@@ -1707,12 +1682,8 @@ mod tests {
             "Calldata should match verified test case"
         );
 
-        // Verified block hash where all slots contain actual balances
-        let block_hash_str = "0x658814e4cb074359f10dd71237cc57b1ae6791fc9de59fde570e724bd884cbb0";
-        let block_hash = B256::from_str(block_hash_str).expect("Failed to parse block hash");
-
         // Create test requests with verified slot locations and test values
-        // These are real balance storage slots for the holder at this block
+        // These are real balance storage slots for the holder
         let requests = vec![
             // USDT: slot and test_value verified to work
             SlotDetectorSlotTestRequest {
@@ -1747,7 +1718,7 @@ mod tests {
         ];
 
         let results = client
-            .slot_detector_tests(&requests, &calldata, &block_hash)
+            .slot_detector_tests(&requests, &calldata)
             .await
             .expect("Batch slot detector tests failed");
 
@@ -1803,7 +1774,7 @@ mod tests {
         let calldata: Bytes = Bytes::new();
 
         let result = rpc_client
-            .slot_detector_tests(&batch_request, &calldata, &B256::ZERO)
+            .slot_detector_tests(&batch_request, &calldata)
             .await;
 
         result

--- a/crates/tycho-ethereum/src/services/entrypoint_tracer/allowance_slot_detector.rs
+++ b/crates/tycho-ethereum/src/services/entrypoint_tracer/allowance_slot_detector.rs
@@ -2,11 +2,7 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use tracing::{debug, info};
-use tycho_common::{
-    models::{Address, BlockHash},
-    traits::AllowanceSlotDetector,
-    Bytes,
-};
+use tycho_common::{models::Address, traits::AllowanceSlotDetector, Bytes};
 
 use crate::services::entrypoint_tracer::slot_detector::{
     SlotDetectionStrategy, SlotDetector, SlotDetectorError,
@@ -57,7 +53,6 @@ impl AllowanceSlotDetector for EVMAllowanceSlotDetector {
         tokens: &[Address],
         owner: Address,
         spender: Address,
-        block_hash: BlockHash,
     ) -> HashMap<Address, Result<(Address, Bytes), Self::Error>> {
         info!("Starting allowance slot detection for {} tokens", tokens.len());
 
@@ -79,7 +74,7 @@ impl AllowanceSlotDetector for EVMAllowanceSlotDetector {
 
         let params = (owner, spender);
         let results = self
-            .detect_slots_chunked(&filtered_tokens, &params, &block_hash)
+            .detect_slots_chunked(&filtered_tokens, &params)
             .await;
 
         info!("Allowance slot detection completed. Found results for {} tokens", results.len());
@@ -98,8 +93,6 @@ mod tests {
         rpc::EthereumRpcClient,
         test_fixtures::{USDC_STR, USDT_STR, WETH_STR},
     };
-
-    const BLOCK_HASH: &str = "0x658814e4cb074359f10dd71237cc57b1ae6791fc9de59fde570e724bd884cbb0";
 
     #[test]
     fn test_encode_allowance_calldata() {
@@ -136,13 +129,8 @@ mod tests {
         let owner = Address::from_str("0xcd09f75e2bf2a4d11f3ab23f1389fcc1621c0cc2").unwrap();
         let spender = Address::from_str("0xfd0b31d2e955fa55e3fa641fe90e08b677188d35").unwrap();
 
-        let block_hash = BlockHash::from_str(
-            "0x23efd28b949cff1bea0cce77277d4e113793ff029c0c9815a36b6528eaa187ca",
-        )
-        .unwrap();
-
         let results = detector
-            .detect_allowance_slots(std::slice::from_ref(&token), owner, spender, block_hash)
+            .detect_allowance_slots(std::slice::from_ref(&token), owner, spender)
             .await;
 
         match results.get(&token) {
@@ -193,13 +181,9 @@ mod tests {
 
         let tokens = vec![weth.clone(), usdc.clone(), usdt.clone()];
 
-        // Use a recent block
-        let block_hash = BlockHash::from_str(BLOCK_HASH).expect("Invalid block hash");
-        println!("Block hash: {block_hash}");
-
         let detector = EVMAllowanceSlotDetector::new(&rpc).with_max_token_batch_size(5);
         let results = detector
-            .detect_allowance_slots(&tokens, owner_address, spender_address, block_hash)
+            .detect_allowance_slots(&tokens, owner_address, spender_address)
             .await;
 
         // We should get results for the tokens

--- a/crates/tycho-ethereum/src/services/entrypoint_tracer/balance_slot_detector.rs
+++ b/crates/tycho-ethereum/src/services/entrypoint_tracer/balance_slot_detector.rs
@@ -2,11 +2,7 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use tracing::{debug, info};
-use tycho_common::{
-    models::{Address, BlockHash},
-    traits::BalanceSlotDetector,
-    Bytes,
-};
+use tycho_common::{models::Address, traits::BalanceSlotDetector, Bytes};
 
 use crate::services::entrypoint_tracer::slot_detector::{
     SlotDetectionStrategy, SlotDetector, SlotDetectorError,
@@ -50,7 +46,6 @@ impl BalanceSlotDetector for EVMBalanceSlotDetector {
         &self,
         tokens: &[Address],
         holder: Address,
-        block_hash: BlockHash,
     ) -> HashMap<Address, Result<(Address, Bytes), Self::Error>> {
         info!("Starting balance slot detection for {} tokens", tokens.len());
 
@@ -71,7 +66,7 @@ impl BalanceSlotDetector for EVMBalanceSlotDetector {
         }
 
         let results = self
-            .detect_slots_chunked(&filtered_tokens, &holder, &block_hash)
+            .detect_slots_chunked(&filtered_tokens, &holder)
             .await;
 
         info!("Balance slot detection completed. Found results for {} tokens", results.len());
@@ -86,6 +81,7 @@ mod tests {
     use alloy::{primitives::U256, transports::http::reqwest};
     use rstest::rstest;
     use serde_json::json;
+    use tycho_common::models::BlockHash;
 
     use super::{BalanceStrategy, SlotDetectionStrategy, *};
     use crate::test_fixtures::{
@@ -148,13 +144,9 @@ mod tests {
 
         let tokens = vec![weth.clone(), usdc.clone(), usdt.clone()];
 
-        // Use a recent block
-        let block_hash = BlockHash::from_str(BLOCK_HASH).expect("Invalid block hash");
-        println!("Block hash: {block_hash}");
-
         let detector = TestFixture::create_balance_detector();
         let results = detector
-            .detect_balance_slots(&tokens, holder_address, block_hash)
+            .detect_balance_slots(&tokens, holder_address)
             .await;
 
         // We should get results for the tokens
@@ -237,7 +229,7 @@ mod tests {
 
         let detector = TestFixture::create_balance_detector();
         let results = detector
-            .detect_balance_slots(&tokens, balance_owner.clone(), block_hash.clone())
+            .detect_balance_slots(&tokens, balance_owner.clone())
             .await;
 
         // For rebasing tokens like stETH, we expect multiple slots to be accessed
@@ -351,7 +343,7 @@ mod tests {
 
         let detector = TestFixture::create_arb_balance_detector();
         let results = detector
-            .detect_balance_slots(&tokens, holder_address, block_hash)
+            .detect_balance_slots(&tokens, holder_address)
             .await;
 
         assert!(!results.is_empty(), "Expected results for at least one token, but got none");

--- a/crates/tycho-ethereum/src/services/entrypoint_tracer/slot_detector.rs
+++ b/crates/tycho-ethereum/src/services/entrypoint_tracer/slot_detector.rs
@@ -4,15 +4,18 @@ use std::{
 };
 
 use alloy::{
-    primitives::{Address as AlloyAddress, B256, U256},
-    rpc::types::trace::geth::{FourByteFrame, GethTrace, PreStateFrame},
+    primitives::{Address as AlloyAddress, U256},
+    rpc::types::{
+        trace::geth::{FourByteFrame, GethTrace, PreStateFrame},
+        BlockId,
+    },
     transports::TransportResult,
 };
 use serde_json::Value;
 use thiserror::Error;
 use tracing::{debug, error, warn};
 use tycho_common::{
-    models::{blockchain::RPCTracerParams, Address, BlockHash},
+    models::{blockchain::RPCTracerParams, Address},
     Bytes,
 };
 
@@ -123,12 +126,15 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
         self
     }
 
-    /// Detect slots for tokens using batched requests (debug_traceCall + eth_call per token)
+    /// Detect slots for tokens using batched requests (debug_traceCall + eth_call per token).
+    ///
+    /// All requests query the latest block: results are cached across blocks anyway, and pinning
+    /// a fresh block hash makes detection fail on RPC backends that have not made that block
+    /// canonical yet.
     async fn detect_token_slots(
         &self,
         tokens: &[Address],
         params: &S::Params,
-        block_hash: &BlockHash,
     ) -> HashMap<Address, Result<(Address, Bytes), SlotDetectorError>> {
         if tokens.is_empty() {
             return HashMap::new();
@@ -156,12 +162,12 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
 
         // Create batched request: 2 requests per token (debug_traceCall + eth_call)
         let calldata = S::encode_calldata(params);
-        let requests = self.create_value_requests(&request_tokens, &calldata, block_hash);
+        let requests = self.create_value_requests(&request_tokens, &calldata);
 
         // Send the batched request
         let responses = match self
             .rpc
-            .slot_detector_trace(requests, &calldata, &B256::from_bytes(block_hash))
+            .slot_detector_trace(requests, &calldata)
             .await
         {
             Ok(responses) => responses,
@@ -179,7 +185,7 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
 
         // Detect the correct slot by testing candidates with storage overrides
         let detected_results = self
-            .detect_correct_slots(token_slots, &calldata, block_hash)
+            .detect_correct_slots(token_slots, &calldata)
             .await;
 
         // Update cache and prepare final results
@@ -204,12 +210,12 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
         final_results
     }
 
-    /// Detect slots for multiple tokens in chunks
+    /// Detect slots for multiple tokens in chunks. Detection always queries the latest block —
+    /// see [`Self::detect_token_slots`].
     pub async fn detect_slots_chunked(
         &self,
         tokens: &[Address],
         params: &S::Params,
-        block_hash: &BlockHash,
     ) -> HashMap<Address, Result<(Address, Bytes), SlotDetectorError>> {
         let mut all_results = HashMap::new();
 
@@ -220,7 +226,7 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
             debug!("Processing chunk {} with {} tokens", chunk_idx, chunk.len());
 
             let chunk_results = self
-                .detect_token_slots(chunk, params, block_hash)
+                .detect_token_slots(chunk, params)
                 .await;
             all_results.extend(chunk_results);
         }
@@ -236,7 +242,6 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
         &self,
         tokens: &[Address],
         calldata: &Bytes,
-        block_hash: &BlockHash,
     ) -> Vec<SlotDetectorValueRequest> {
         let tracer_params = RPCTracerParams::new(None, calldata.clone());
 
@@ -246,7 +251,7 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
                 let tracer_params = EVMEntrypointService::create_trace_call_params(
                     token,
                     &tracer_params,
-                    block_hash,
+                    BlockId::latest(),
                 );
 
                 SlotDetectorValueRequest { token: AlloyAddress::from_bytes(token), tracer_params }
@@ -287,7 +292,6 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
         &self,
         slots_to_test: Vec<SlotMetadata>,
         calldata: &Bytes,
-        block_hash: &BlockHash,
     ) -> TokenSlotResults {
         let mut detected_results = HashMap::new();
         let mut current_attempts = slots_to_test;
@@ -320,7 +324,7 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
 
             let responses = match self
                 .rpc
-                .slot_detector_tests(&requests, calldata, &B256::from_bytes(block_hash))
+                .slot_detector_tests(&requests, calldata)
                 .await
             {
                 Ok(responses) => responses,
@@ -433,7 +437,6 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
         &self,
         token_slots: DetectedSlotsResults,
         calldata: &Bytes,
-        block_hash: &BlockHash,
     ) -> TokenSlotResults {
         let mut detected_results = HashMap::new();
         let mut slots_to_test = Vec::new();
@@ -467,7 +470,7 @@ impl<S: SlotDetectionStrategy> SlotDetector<S> {
 
         // Test all slot candidates, trying alternate slots if needed
         let test_results = self
-            .test_slots_with_fallback(slots_to_test, calldata, block_hash)
+            .test_slots_with_fallback(slots_to_test, calldata)
             .await;
         detected_results.extend(test_results);
 
@@ -648,10 +651,7 @@ mod tests {
         transports::TransportResult,
     };
     use serde_json::{json, Value};
-    use tycho_common::{
-        models::{Address, BlockHash},
-        Bytes,
-    };
+    use tycho_common::{models::Address, Bytes};
 
     use crate::{
         rpc::EthereumRpcClient,
@@ -846,11 +846,10 @@ mod tests {
         let token1 = Address::from([0x11u8; 20]);
         let token2 = Address::from([0x22u8; 20]);
         let owner = Address::from([0x33u8; 20]);
-        let block_hash = BlockHash::from([0x44u8; 32]);
 
         let tokens = vec![token1.clone(), token2.clone()];
         let calldata = BalanceStrategy::encode_calldata(&owner);
-        let requests = detector.create_value_requests(&tokens, &calldata, &block_hash);
+        let requests = detector.create_value_requests(&tokens, &calldata);
 
         // Should create one joint requests per token
         let array = requests;
@@ -900,7 +899,6 @@ mod tests {
 
         let token = Address::from([0x11u8; 20]);
         let holder = Address::from([0x22u8; 20]);
-        let block_hash = BlockHash::from([0x33u8; 32]);
 
         let trace_response = json!([
             {
@@ -950,7 +948,7 @@ mod tests {
 
         // First call - should populate the cache
         let results1 = detector
-            .detect_slots_chunked(std::slice::from_ref(&token), &holder, &block_hash)
+            .detect_slots_chunked(std::slice::from_ref(&token), &holder)
             .await;
         assert!(results1[&token].is_ok(), "First call should succeed: {:?}", results1[&token]);
 
@@ -960,7 +958,7 @@ mod tests {
 
         // Second call - should use the cache
         let results2 = detector
-            .detect_slots_chunked(std::slice::from_ref(&token), &holder, &block_hash)
+            .detect_slots_chunked(std::slice::from_ref(&token), &holder)
             .await;
         assert!(results2[&token].is_ok(), "Second call should succeed from cache");
 

--- a/crates/tycho-ethereum/src/services/entrypoint_tracer/tracer.rs
+++ b/crates/tycho-ethereum/src/services/entrypoint_tracer/tracer.rs
@@ -91,7 +91,7 @@ impl EVMEntrypointService {
     pub(crate) fn create_trace_call_params(
         target: &Address,
         params: &RPCTracerParams,
-        block_hash: &BlockHash,
+        block_id: BlockId,
     ) -> Value {
         let caller = params.caller.as_ref().map(|addr| {
             AlloyAddress::try_from(addr.as_ref())
@@ -108,8 +108,6 @@ impl EVMEntrypointService {
             input: TransactionInput::new(AlloyBytes::from(params.calldata.to_vec())),
             ..Default::default()
         };
-
-        let block_id = BlockId::Hash(AlloyBlockHash::from_slice(block_hash.as_ref()).into());
 
         // Check if we have non-empty state overrides
         let has_state_overrides = params
@@ -154,7 +152,11 @@ impl EVMEntrypointService {
         block_hash: &BlockHash,
     ) -> Result<(HashMap<Address, HashSet<Bytes>>, GethTrace), RPCError> {
         let access_list_params = Self::create_access_list_params(target, params, block_hash);
-        let trace_call_params = Self::create_trace_call_params(target, params, block_hash);
+        let trace_call_params = Self::create_trace_call_params(
+            target,
+            params,
+            BlockId::Hash(AlloyBlockHash::from_slice(block_hash.as_ref()).into()),
+        );
 
         let (access_list_data, pre_state_trace) = self
             .rpc
@@ -1761,8 +1763,11 @@ mod tests {
         let params =
             RPCTracerParams::new(None, Bytes::from("0x00")).with_state_overrides(state_overrides);
 
-        let json_params =
-            EVMEntrypointService::create_trace_call_params(&target, &params, &block_hash);
+        let json_params = EVMEntrypointService::create_trace_call_params(
+            &target,
+            &params,
+            BlockId::Hash(AlloyBlockHash::from_slice(block_hash.as_ref()).into()),
+        );
 
         // Extract the stateOverrides from the JSON
         let tracing_options = json_params

--- a/crates/tycho-indexer/src/extractor/dynamic_contract_indexer/hooks/entrypoint_generator.rs
+++ b/crates/tycho-indexer/src/extractor/dynamic_contract_indexer/hooks/entrypoint_generator.rs
@@ -647,7 +647,7 @@ where
 
             let detection_results = self
                 .balance_slot_detector
-                .detect_balance_slots(&tokens, pool_manager, context.block.hash.clone())
+                .detect_balance_slots(&tokens, pool_manager)
                 .await;
 
             // Convert token-based results to the expected format
@@ -1392,7 +1392,7 @@ mod tests {
         let token0_clone = token0.clone();
         mock_detector
             .expect_detect_balance_slots()
-            .returning(move |tokens, _holder, _block_hash| {
+            .returning(move |tokens, _holder| {
                 let mut result = HashMap::new();
                 for token in tokens {
                     let storage_addr = token.clone();
@@ -1497,7 +1497,7 @@ mod tests {
         let mut mock_detector = MockBalanceSlotDetector::new();
         mock_detector
             .expect_detect_balance_slots()
-            .returning(|tokens, _holder, _block_hash| {
+            .returning(|tokens, _holder| {
                 let mut result = HashMap::new();
                 for token in tokens {
                     result.insert(token.clone(), Err("Detection failed".to_string()));

--- a/crates/tycho-test/src/execution/encoding.rs
+++ b/crates/tycho-test/src/execution/encoding.rs
@@ -209,7 +209,6 @@ fn encode_input(selector: &str, mut encoded_args: Vec<u8>) -> Vec<u8> {
 /// Tokens that fail slot detection are silently skipped and not included in the result.
 pub(crate) async fn detect_token_slots(
     rpc_tools: &RPCTools,
-    block: &Block,
     token_addresses: &[Bytes],
     to_address: &Bytes,
 ) -> HashMap<Bytes, TokenSlots> {
@@ -233,36 +232,14 @@ pub(crate) async fn detect_token_slots(
         return token_slots;
     }
 
-    // Pending (flashblock) blocks have a zero hash — slot layouts are immutable so any
-    // valid confirmed block hash works for detection.
-    let detection_hash = if block.header.hash == B256::ZERO {
-        let latest = rpc_tools
-            .provider
-            .get_block_by_number(BlockNumberOrTag::Latest)
-            .await
-            .ok()
-            .flatten();
-        match latest {
-            Some(b) => b.header.hash,
-            None => return HashMap::new(),
-        }
-    } else {
-        block.header.hash
-    };
-
     let balance_results = rpc_tools
         .evm_balance_slot_detector
-        .detect_balance_slots(&erc20_tokens, (**user_address).into(), (*detection_hash).into())
+        .detect_balance_slots(&erc20_tokens, (**user_address).into())
         .await;
 
     let allowance_results = rpc_tools
         .evm_allowance_slot_detector
-        .detect_allowance_slots(
-            &erc20_tokens,
-            (**user_address).into(),
-            to_address.clone(),
-            (*detection_hash).into(),
-        )
+        .detect_allowance_slots(&erc20_tokens, (**user_address).into(), to_address.clone())
         .await;
 
     for token_address in &erc20_tokens {

--- a/crates/tycho-test/src/execution/encoding.rs
+++ b/crates/tycho-test/src/execution/encoding.rs
@@ -245,12 +245,26 @@ pub(crate) async fn detect_token_slots(
     for token_address in &erc20_tokens {
         let balance_slot_data = match balance_results.get(token_address) {
             Some(Ok((storage_addr, slot))) => (storage_addr.clone(), slot.clone()),
-            Some(Err(_)) | None => continue, // Skip tokens with detection failures
+            Some(Err(e)) => {
+                tracing::warn!(token=%token_address, error=?e, "Balance slot detection failed");
+                continue;
+            }
+            None => {
+                tracing::warn!(token=%token_address, "Balance slot detection returned no result");
+                continue;
+            }
         };
 
         let allowance_slot_data = match allowance_results.get(token_address) {
             Some(Ok((storage_addr, slot))) => (storage_addr.clone(), slot.clone()),
-            Some(Err(_)) | None => continue, // Skip tokens with detection failures
+            Some(Err(e)) => {
+                tracing::warn!(token=%token_address, error=?e, "Allowance slot detection failed");
+                continue;
+            }
+            None => {
+                tracing::warn!(token=%token_address, "Allowance slot detection returned no result");
+                continue;
+            }
         };
 
         token_slots.insert(

--- a/crates/tycho-test/src/execution/mod.rs
+++ b/crates/tycho-test/src/execution/mod.rs
@@ -62,7 +62,7 @@ pub async fn simulate_swap_transaction(
         .into_iter()
         .collect();
 
-    let token_slots = detect_token_slots(rpc_tools, block, &token_addresses, &to_address).await;
+    let token_slots = detect_token_slots(rpc_tools, &token_addresses, &to_address).await;
 
     let router_overwrites: Option<AddressHashMap<AccountOverride>> =
         if let Some(router_overwrites_data) = router_overwrites_data {


### PR DESCRIPTION
## What

Balance and allowance storage-slot detection no longer takes a block hash. Every detection request (the `debug_traceCall` prestate scan and the `eth_call` verification) now queries the latest block instead of a caller-supplied block.

- `BalanceSlotDetector::detect_balance_slots` and `AllowanceSlotDetector::detect_allowance_slots` drop their `block_hash` parameter.
- The `tycho-ethereum` slot-detector RPC methods and the entrypoint tracer's `create_trace_call_params` are updated accordingly; the entrypoint tracer's own tracing still pins the block it is given.
- Detection failures in the execution test harness are now logged with the token and error instead of being silently skipped.

## How it was discovered

Running `tycho-integration-test` against a local indexer synced to the Polygon chain tip, slot detection intermittently failed with "Couldn't find storage slots for token". The chain of causes:

1. Detection pinned the block hash of the update it was handed — often the freshly produced tip block.
2. Load-balanced RPC backends had not yet made that block canonical on the node that served the request, so the trace returned `result: null` alongside a "hash not currently canonical" error.
3. `alloy` rejects a JSON-RPC response carrying both `result` and `error`, and this failed the deserialization of the entire batched request — discarding the valid results for every other token in the batch.
4. The per-token errors were then swallowed with a bare `continue`, so the only visible symptom was missing slots downstream.

Querying the latest block removes the trigger: the node always has a canonical latest block, so the trace does not return the non-canonical error, and the batch is not poisoned.

## Why this is safe

A token's storage layout is fixed, so the slot location does not depend on chain state at any particular block. Detection results are already cached per `(token, params)` with no block component, so passing a block never affected a cached lookup. The only caller that pinned a block — the dynamic contract indexer — passed the hash of the block it was processing, which could only hurt: a `debug_traceCall` pinned to a historical block during sync needs archive state a full node may not retain, and pinning a fresh tip block exposes the same non-canonical-block race observed in integration testing. Querying `latest` avoids both. Cases that need a fixed block for reproducible on-chain values (e.g. the rebasing-token balance assertion) use the general RPC primitives directly and keep their block selection.

## Breaking change

`BalanceSlotDetector::detect_balance_slots` and `AllowanceSlotDetector::detect_allowance_slots` drop their `block_hash` parameter.

## Testing

- Format and clippy clean; workspace unit tests pass.
- Slot-detector tests exercising the latest-block detection path directly, against live nodes: batch trace/tests, allowance detection, balance detection, the stETH rebasing verify (Ethereum), and the Arbitrum USDC/WETH precompile-selection regression case — all pass.
- End-to-end check: a `tycho-integration-test` run on the Polygon tip drove the detection path for the pool token set and executed override-based swaps at 0% slippage, confirming the detected slots are correct. Detection is cached per token, so this covers first-time detection of each token rather than every block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)