### PR TITLE
docs: Protocol testing supported node provider update: Tatum

### DIFF
--- a/docs/for-dexs/protocol-integration/3.-testing.md
+++ b/docs/for-dexs/protocol-integration/3.-testing.md
@@ -29,10 +29,10 @@ You need an EVM **Archive** node to fetch the state from a previous block. If yo
 
 The node also needs to support the <a href="https://www.quicknode.com/docs/ethereum/debug_storageRangeAt" target="_blank" rel="noopener noreferrer">debug\_storageRangeAt</a> method, which is required for our Token Quality Analysis.
 
-As of February 2026, Erigon is the only major client supporting debug\_storageRangeAt. The following API providers support archive nodes with debug\_storageRangeAt:
+As of July 2026, Erigon is the only major client supporting debug\_storageRangeAt. The following API providers support archive nodes with debug\_storageRangeAt:
 
-* <a href="https://www.chainnodes.org/" target="_blank" rel="noopener noreferrer">Chainnodes</a>
-* <a href="https://chainstack.com/" target="_blank" rel="noopener noreferrer">Chainstack</a>
+* <a href="https://tatum.io/" target="_blank" rel="noopener noreferrer">Tatum</a>
+* <a href="https://chainstack.com/" target="_blank" rel="noopener noreferrer">Chainstack</a> (only with a $2700/mo dedicated archive node)
 
 ### Test Configuration
 


### PR DESCRIPTION
Updated protocol testing documentation to list Tatum.io as a supported RPC provider, removing Chainnodes