### PR TITLE
docs: Protocol testing re-added Chainnodes as supported provider

### DIFF
--- a/docs/for-dexs/protocol-integration/3.-testing.md
+++ b/docs/for-dexs/protocol-integration/3.-testing.md
@@ -31,7 +31,8 @@ The node also needs to support the <a href="https://www.quicknode.com/docs/ether
 
 As of July 2026, Erigon is the only major client supporting debug\_storageRangeAt. The following API providers support archive nodes with debug\_storageRangeAt:
 
-* <a href="https://tatum.io/" target="_blank" rel="noopener noreferrer">Tatum</a>
+* <a href="https://www.chainnodes.org//" target="_blank" rel="noopener noreferrer">Chainnodes</a> (free account works)
+* <a href="https://tatum.io/" target="_blank" rel="noopener noreferrer">Tatum</a> (need any paid account for batch requests used by integration testing)
 * <a href="https://chainstack.com/" target="_blank" rel="noopener noreferrer">Chainstack</a> (only with a $2700/mo dedicated archive node)
 
 ### Test Configuration


### PR DESCRIPTION
Chainnodes just fixed `debug_storageRangeAt` (for the second time), so this PR re-adds it to the protocol integration testing docs as another supported RPC provider.