### PR TITLE
ci: grant PR validation read permissions

### DIFF
--- a/.github/workflows/validate-pr.yaml
+++ b/.github/workflows/validate-pr.yaml
@@ -10,6 +10,10 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   validate-pr:
     uses: propeller-heads/ci-cd-templates/.github/workflows/validate-pr.yaml@main


### PR DESCRIPTION
## Summary

- grants the reusable PR-title workflow read access to repository contents and pull requests
- restores compatibility with the updated ci-cd-templates validation workflow
- keeps the pull_request_target token read-only and scoped to the permissions the called workflow requests

## Root cause

The reusable validation workflow now requests contents: read and pull-requests: read. The caller did not declare those permissions, so GitHub rejected the workflow before creating validate-pr / main. Because that context is required by the main ruleset, affected PRs remain blocked even when all other checks and reviews pass.

## Validation

- actionlint .github/workflows/validate-pr.yaml
- YAML parser validation
- git diff --check

## Bootstrap note

This PR is expected to hit the same missing required check because pull_request_target loads the caller from the current main branch. An administrator must temporarily remove validate-pr / main from the required checks (or otherwise bypass it) to land this bootstrap fix, then restore the requirement.