### PR TITLE
fix(simulation): overwrite existing accounts on snapshot re-apply

### DIFF
--- a/crates/tycho-simulation/src/evm/account_storage.rs
+++ b/crates/tycho-simulation/src/evm/account_storage.rs
@@ -53,8 +53,12 @@ impl AccountStorage {
     /// # Notes
     ///
     /// This function checks if the `address` is already present in the `accounts`
-    /// collection. If so, it logs a warning and returns without modifying the instance.
+    /// collection. If so, it logs a trace message and returns without modifying the instance.
     /// Otherwise, it stores a new `Account` instance with the provided data at the given address.
+    ///
+    /// Init-if-absent is only safe for seeding placeholder accounts during engine setup;
+    /// authoritative data that can arrive again for a known account (e.g. a re-fetched contract
+    /// snapshot) must use [`overwrite_account`](Self::overwrite_account) instead.
     pub fn init_account(
         &mut self,
         address: Address,

--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -472,8 +472,8 @@ where
                 .map_err(|e| StreamDecodeError::Fatal(e.to_string()))?;
 
                 // Force-overwrite new proxy token accounts so that authoritative vm_storage data
-                // always wins over any empty placeholder previously inserted by another
-                // decoder's snapshot loop (which uses init_account / init-if-not-exists).
+                // always wins over any empty placeholder previously inserted by engine setup
+                // (which uses init_account / init-if-not-exists).
                 if !proxy_creates.is_empty() {
                     SHARED_TYCHO_DB
                         .force_update_accounts(proxy_creates)
@@ -738,8 +738,8 @@ where
 
                                 // Create proxy token account with original account's storage (at
                                 // original address). Track it separately so it can be
-                                // force-overwritten and win over any placeholder that another
-                                // decoder's snapshot loop may have written earlier.
+                                // force-overwritten and win over any placeholder that an engine
+                                // setup routine may have written earlier.
                                 let proxy_state = create_proxy_token_account(
                                     original_address,
                                     Some(impl_addr),
@@ -780,7 +780,7 @@ where
                 .map_err(|e| StreamDecodeError::Fatal(e.to_string()))?;
 
                 // Force-overwrite any newly-created proxy token accounts so they always win
-                // over placeholder entries inserted by other decoders' snapshot loops.
+                // over placeholder entries inserted by engine setup.
                 if !new_proxy_accounts.is_empty() {
                     SHARED_TYCHO_DB
                         .force_update_accounts(new_proxy_accounts)

--- a/crates/tycho-simulation/src/evm/engine_db/tycho_db.rs
+++ b/crates/tycho-simulation/src/evm/engine_db/tycho_db.rs
@@ -77,6 +77,15 @@ impl PreCachedDB {
         })
     }
 
+    /// Applies account changes for one block and advances the stored block header.
+    ///
+    /// Semantics per [`ChangeType`]:
+    /// - `Creation`: an authoritative full-account snapshot (code, native balance, complete slot
+    ///   map) that replaces any existing entry. Consumers re-deliver snapshots for already-known
+    ///   contracts when healing after a disconnect; the snapshot must win, otherwise the account
+    ///   keeps pre-outage storage whose changes were never delivered as deltas.
+    /// - `Update`: per-slot storage and balance deltas merged into the existing account.
+    /// - `Deletion`: not implemented.
     #[instrument(skip_all)]
     pub fn update(
         &self,
@@ -125,8 +134,9 @@ impl PreCachedDB {
                     // If the balance is not present, we set it to zero.
                     let balance = update.balance.unwrap_or(U256::ZERO);
 
-                    // Initialize the account.
-                    write_guard.accounts.init_account(
+                    // Replace, don't merge: snapshots omit zero-valued slots, so merging
+                    // would keep stale non-zero values for slots that are zero on-chain.
+                    write_guard.accounts.overwrite_account(
                         update.address,
                         AccountInfo::new(balance, 0, code.hash_slow(), code),
                         Some(update.slots.clone()),
@@ -142,12 +152,9 @@ impl PreCachedDB {
         Ok(())
     }
 
-    /// Like [`update()`](Self::update) but unconditionally overwrites existing accounts on
-    /// `Creation` updates.
-    ///
-    /// Use only for authoritative proxy-token accounts that must win over placeholder entries
-    /// inserted by other decoders' snapshot loops. Generic callers should use
-    /// [`update()`](Self::update).
+    /// Like [`update()`](Self::update) restricted to `Creation` updates, but leaves the stored
+    /// block header untouched. Used for proxy-token accounts written outside the regular
+    /// snapshot/delta flow; generic callers should use [`update()`](Self::update).
     pub fn force_update_accounts(
         &self,
         account_updates: Vec<AccountUpdate>,
@@ -502,6 +509,89 @@ mod tests {
         mock_db
             .storage_ref(mock_acc_address, storage_address)
             .unwrap();
+    }
+
+    fn header(number: u64) -> BlockHeader {
+        BlockHeader { number, ..Default::default() }
+    }
+
+    fn snapshot(address: Address, slots: &[(u64, u64)], balance: u64) -> AccountUpdate {
+        AccountUpdate {
+            address,
+            chain: Chain::Ethereum,
+            slots: slots
+                .iter()
+                .map(|(k, v)| (U256::from(*k), U256::from(*v)))
+                .collect(),
+            balance: Some(U256::from(balance)),
+            code: Some(vec![0x60, 0x00]),
+            change: ChangeType::Creation,
+        }
+    }
+
+    /// A consumer that re-fetches a snapshot for an already-known contract (client reconnect
+    /// healing, in-process stream rebuild, TVL re-entry) delivers it as `ChangeType::Creation`.
+    /// Snapshots are authoritative full state: slots that changed while the account was warm
+    /// must end up at the snapshot values, otherwise the DB is left mixed-epoch and VM-based
+    /// protocols quote against a state that never existed on-chain.
+    #[rstest]
+    fn test_creation_reapply_overwrites_existing_account(
+        mock_db: PreCachedDB,
+    ) -> Result<(), Box<dyn Error>> {
+        let address = Address::from_str("0xd51a44d3fae010294c616388b506acda1bfaae46")?;
+        let slot = U256::from(1);
+
+        mock_db.update(vec![snapshot(address, &[(1, 100)], 10)], Some(header(1)))?;
+        // Account is now warm; the outage window ends and a fresh full snapshot arrives.
+        mock_db.update(vec![snapshot(address, &[(1, 999), (2, 42)], 20)], Some(header(2)))?;
+
+        assert_eq!(
+            mock_db.get_storage(&address, &slot),
+            Some(U256::from(999)),
+            "re-applied snapshot must overwrite a stale slot on an existing account"
+        );
+        assert_eq!(
+            mock_db.get_storage(&address, &U256::from(2)),
+            Some(U256::from(42)),
+            "slots first seen in the re-applied snapshot must be present"
+        );
+        assert_eq!(
+            mock_db
+                .basic_ref(address)
+                .unwrap()
+                .map(|acc| acc.balance),
+            Some(U256::from(20)),
+            "re-applied snapshot must refresh the native balance"
+        );
+        Ok(())
+    }
+
+    /// Contrast case: the continuously-connected path. Per-block deltas arrive as
+    /// `ChangeType::Update` and must refresh slots on existing accounts.
+    #[rstest]
+    fn test_delta_update_refreshes_existing_slot(
+        mock_db: PreCachedDB,
+    ) -> Result<(), Box<dyn Error>> {
+        let address = Address::from_str("0xd51a44d3fae010294c616388b506acda1bfaae46")?;
+        let slot = U256::from(1);
+
+        mock_db.update(vec![snapshot(address, &[(1, 100)], 10)], Some(header(1)))?;
+        let delta = AccountUpdate {
+            address,
+            chain: Chain::Ethereum,
+            slots: HashMap::from([(slot, U256::from(200))]),
+            balance: None,
+            code: None,
+            change: ChangeType::Update,
+        };
+        mock_db.update(vec![delta], Some(header(2)))?;
+
+        assert_eq!(
+            mock_db.get_storage(&address, &slot),
+            Some(U256::from(200)),
+            "delta updates must refresh slots on existing accounts"
+        );
+        Ok(())
     }
 
     #[rstest]


### PR DESCRIPTION
## What

`PreCachedDB::update` applied `ChangeType::Creation` with init-if-absent semantics (`AccountStorage::init_account`), silently discarding any re-fetched snapshot for a contract already present in the DB. This PR applies snapshots with `overwrite_account` instead — the semantics proxy-token accounts already use — and documents the `ChangeType` contract on `update()`.

## Why

Long-lived consumers re-fetch full snapshots for contracts the process-global `SHARED_TYCHO_DB` already knows: tycho-client fetches a healing snapshot after a non-contiguous reconnect, consumers rebuild streams in-process, and components re-enter the tracked set. With init-if-absent all of those snapshots were dropped, so every state change from the outage window was lost. Later deltas healed the account slot by slot at each slot's on-chain write frequency, leaving mixed-epoch storage (e.g. fresh Curve balances/D with a frozen price_scale or balance slot). CryptoSwap math converts that inconsistency into a constant additive quote error: in production this produced quotes like 0.14 WBTC (~$9,000) out for a $1.6 input on tricrypto2, flagged by hindsight on 2026-07-14.

Root-cause analysis: https://propeller-heads.atlassian.net/wiki/spaces/~71202094d3d73818b5447b85231f4bd027b78c/pages/3833790465/Root-Cause+Analysis+Curve+Pools+Over+Under-Quoting+in+Hindsight

## Testing

- `test_creation_reapply_overwrites_existing_account`: red on the old semantics (slot kept its pre-outage value after a snapshot re-apply), green with this fix.
- `test_delta_update_refreshes_existing_slot`: guards the delta path, green before and after.
- End-to-end reproduction (branch `codex/debug-curve-tricrypto2-overquote`, `--curve-rebuild-repro`): tears down and rebuilds a vm:curve stream in one process with one tampered tricrypto2 storage slot in between. Before this fix the re-fetched snapshot is discarded and a dust-input quote returns 13,988,869 raw WBTC (a ~$9,000 phantom constant); with it the snapshot overwrites the tampered slot and the same probe returns 2 raw WBTC.

Affects every VM/hybrid protocol and every long-lived consumer, not only Curve or hindsight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)