### PR TITLE
feat(rfq): migrate Metric integration to v1 API

### DIFF
--- a/crates/tycho-execution/src/encoding/evm/swap_encoder/metric.rs
+++ b/crates/tycho-execution/src/encoding/evm/swap_encoder/metric.rs
@@ -1,37 +1,22 @@
 use std::collections::HashMap;
 
-use tokio::runtime::Handle;
-use tycho_common::{
-    models::{protocol::GetAmountOutParams, Chain},
-    Bytes,
-};
+use tycho_common::{models::Chain, Bytes};
 
 use crate::encoding::{
     errors::EncodingError,
-    evm::utils::{bytes_to_address, create_encoding_runtime, on_blocking_thread, SafeRuntime},
+    evm::utils::bytes_to_address,
     models::{EncodingContext, Swap},
     swap_encoder::SwapEncoder,
 };
 
-const ORACLE_UPDATE_POLICY_ATTR: &str = "oracle_update_policy";
-const ORACLE_UPDATE_ARGS_ATTR: &str = "oracle_update_0_args";
+// Oracle update mode byte consumed by MetricExecutor. Under the v1 heartbeat model Tycho never
+// relays an oracle update, so the encoder always emits `Never`. Kept as a named constant to stay
+// lined up with MetricExecutor's OracleUpdateMode enum.
+const ORACLE_UPDATE_MODE_NEVER: u8 = 0;
 
 #[derive(Clone)]
 pub struct MetricSwapEncoder {
     executor_address: Bytes,
-    runtime_handle: Handle,
-    #[allow(dead_code)]
-    runtime: SafeRuntime,
-}
-
-// Encoded into MetricExecutor calldata as one byte. Keep these values in sync with
-// tycho-simulation's MetricOracleUpdatePolicy and MetricExecutor's mode constants.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[repr(u8)]
-enum MetricOracleUpdatePolicy {
-    Never = 0,
-    Always = 1,
-    RetryOnRevert = 2,
 }
 
 impl SwapEncoder for MetricSwapEncoder {
@@ -40,14 +25,13 @@ impl SwapEncoder for MetricSwapEncoder {
         _chain: Chain,
         _config: Option<HashMap<String, String>>,
     ) -> Result<Self, EncodingError> {
-        let (runtime_handle, runtime) = create_encoding_runtime()?;
-        Ok(Self { executor_address, runtime_handle, runtime })
+        Ok(Self { executor_address })
     }
 
     fn encode_swap(
         &self,
         swap: &Swap,
-        encoding_context: &EncodingContext,
+        _encoding_context: &EncodingContext,
     ) -> Result<Vec<u8>, EncodingError> {
         let token_in = bytes_to_address(&swap.token_in().address)?;
         let token_out = bytes_to_address(&swap.token_out().address)?;
@@ -86,56 +70,13 @@ impl SwapEncoder for MetricSwapEncoder {
             )));
         };
 
-        let oracle_update_policy_attr = component
-            .static_attributes
-            .get(ORACLE_UPDATE_POLICY_ATTR)
-            .ok_or_else(|| {
-                EncodingError::FatalError(format!(
-                    "Metric component missing {ORACLE_UPDATE_POLICY_ATTR} static attribute"
-                ))
-            })?;
-        if oracle_update_policy_attr.len() != 1 {
-            return Err(EncodingError::InvalidInput(format!(
-                "Metric {ORACLE_UPDATE_POLICY_ATTR} attribute must be exactly one byte"
-            )));
-        }
-        let oracle_update_policy = match oracle_update_policy_attr[0] {
-            0 => MetricOracleUpdatePolicy::Never,
-            1 => MetricOracleUpdatePolicy::Always,
-            2 => MetricOracleUpdatePolicy::RetryOnRevert,
-            value => {
-                return Err(EncodingError::InvalidInput(format!(
-                    "Metric oracle update policy from {ORACLE_UPDATE_POLICY_ATTR} must be 0, 1, or 2, got {value}"
-                )))
-            }
-        };
-
-        let oracle_update = if matches!(
-            oracle_update_policy,
-            MetricOracleUpdatePolicy::Always | MetricOracleUpdatePolicy::RetryOnRevert
-        ) {
-            Some(self.request_oracle_update(swap, encoding_context)?)
-        } else {
-            None
-        };
-
         let mut encoded = Vec::with_capacity(62);
         encoded.extend_from_slice(token_in.as_slice());
         encoded.extend_from_slice(token_out.as_slice());
         encoded.extend_from_slice(pool.as_slice());
         encoded.push(u8::from(zero_for_one));
-        // Byte 61 is the oracle update policy consumed by MetricExecutor.
-        encoded.push(oracle_update_policy as u8);
-
-        if let Some(update) = oracle_update {
-            let args_len = u32::try_from(update.args.len()).map_err(|_| {
-                EncodingError::InvalidInput(
-                    "Metric oracle update args are too large to encode".to_string(),
-                )
-            })?;
-            encoded.extend_from_slice(&args_len.to_be_bytes());
-            encoded.extend_from_slice(&update.args);
-        }
+        // Byte 61 is the oracle update mode consumed by MetricExecutor.
+        encoded.push(ORACLE_UPDATE_MODE_NEVER);
 
         Ok(encoded)
     }
@@ -149,100 +90,23 @@ impl SwapEncoder for MetricSwapEncoder {
     }
 }
 
-#[derive(Debug)]
-struct MetricOracleUpdate {
-    args: Bytes,
-}
-
-impl MetricSwapEncoder {
-    fn request_oracle_update(
-        &self,
-        swap: &Swap,
-        encoding_context: &EncodingContext,
-    ) -> Result<MetricOracleUpdate, EncodingError> {
-        let protocol_state = swap
-            .protocol_state()
-            .as_ref()
-            .ok_or_else(|| {
-                EncodingError::FatalError(
-                    "protocol_state is required when Metric oracle updates are enabled".to_string(),
-                )
-            })?;
-        let amount_in = swap
-            .estimated_amount_in()
-            .as_ref()
-            .ok_or(EncodingError::FatalError(
-                "Estimated amount in is mandatory when Metric oracle updates are enabled"
-                    .to_string(),
-            ))?
-            .clone();
-        let router_address = encoding_context
-            .router_address
-            .clone()
-            .ok_or(EncodingError::FatalError(
-                "The router address is needed to request Metric oracle updates".to_string(),
-            ))?;
-
-        let signed_oracle_update = on_blocking_thread(|| {
-            self.runtime_handle.block_on(async {
-                protocol_state
-                    .as_indicatively_priced()?
-                    .request_signed_quote(GetAmountOutParams {
-                        amount_in,
-                        token_in: swap.token_in().address.clone(),
-                        token_out: swap.token_out().address.clone(),
-                        sender: router_address.clone(),
-                        receiver: router_address,
-                    })
-                    .await
-            })
-        })??;
-
-        let args = signed_oracle_update
-            .quote_attributes
-            .get(ORACLE_UPDATE_ARGS_ATTR)
-            .ok_or(EncodingError::FatalError(format!(
-                "Metric quote must have an {ORACLE_UPDATE_ARGS_ATTR} attribute"
-            )))?
-            .clone();
-        if args.is_empty() {
-            return Err(EncodingError::InvalidInput(format!(
-                "Metric {ORACLE_UPDATE_ARGS_ATTR} cannot be empty"
-            )));
-        }
-
-        Ok(MetricOracleUpdate { args })
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::{str::FromStr, sync::Arc};
+    use std::str::FromStr;
 
     use alloy::hex::encode;
     use num_bigint::BigUint;
     use tycho_common::models::protocol::ProtocolComponent;
 
     use super::*;
-    use crate::encoding::{
-        evm::{swap_encoder::metric::MetricSwapEncoder, testing_utils::MockRFQState},
-        models::default_token,
-    };
+    use crate::encoding::{evm::swap_encoder::metric::MetricSwapEncoder, models::default_token};
 
-    fn component_with_policy(
-        token0: &Bytes,
-        token1: &Bytes,
-        policy: MetricOracleUpdatePolicy,
-    ) -> ProtocolComponent {
+    fn component(token0: &Bytes, token1: &Bytes) -> ProtocolComponent {
         ProtocolComponent {
             id: "0x1111111111111111111111111111111111111111".to_string(),
             protocol_system: "rfq:metric".to_string(),
             tokens: vec![token0.clone(), token1.clone()],
             contract_addresses: Vec::new(),
-            static_attributes: HashMap::from([(
-                ORACLE_UPDATE_POLICY_ATTR.to_string(),
-                vec![policy as u8].into(),
-            )]),
             ..Default::default()
         }
     }
@@ -262,11 +126,11 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_metric_without_oracle_update() {
+    fn test_encode_metric_zero_for_one() {
         let token_in = Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap();
         let token_out = Bytes::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap();
         let swap = Swap::new(
-            component_with_policy(&token_in, &token_out, MetricOracleUpdatePolicy::Never),
+            component(&token_in, &token_out),
             default_token(token_in.clone()),
             default_token(token_out.clone()),
             BigUint::ZERO,
@@ -286,14 +150,15 @@ mod tests {
             "00",
         ));
         assert_eq!(hex_swap, expected);
+        assert_eq!(encoded_swap.len(), 62);
     }
 
     #[test]
-    fn test_encode_metric_one_for_zero_encodes_direction_without_price_limit() {
+    fn test_encode_metric_one_for_zero_encodes_direction() {
         let token0 = Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap();
         let token1 = Bytes::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap();
         let swap = Swap::new(
-            component_with_policy(&token0, &token1, MetricOracleUpdatePolicy::Never),
+            component(&token0, &token1),
             default_token(token1.clone()),
             default_token(token0.clone()),
             BigUint::ZERO,
@@ -305,86 +170,21 @@ mod tests {
             .unwrap();
         let hex_swap = encode(&encoded_swap);
 
+        // Byte 60 (direction) is 0 for one-for-zero, byte 61 (oracle mode) is always Never.
         assert_eq!(&hex_swap[120..122], "00");
         assert_eq!(&hex_swap[122..124], "00");
         assert_eq!(encoded_swap.len(), 62);
     }
 
     #[test]
-    fn test_encode_metric_with_oracle_update() {
-        let token_in = Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap();
-        let token_out = Bytes::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap();
-        let first_oracle_args = Bytes::from_str("0xaabbccdd").unwrap();
-        let second_oracle_args = Bytes::from_str("0x11223344").unwrap();
-        let quote_state = MockRFQState {
-            quote_amount_out: BigUint::from(1u64),
-            quote_data: HashMap::from([
-                (ORACLE_UPDATE_ARGS_ATTR.to_string(), first_oracle_args.clone()),
-                ("oracle_update_1_args".to_string(), second_oracle_args.clone()),
-            ]),
-        };
+    fn test_encode_metric_token_pair_mismatch_fails() {
+        let token0 = Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap();
+        let token1 = Bytes::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap();
+        let other = Bytes::from_str("0x0000000000000000000000000000000000000009").unwrap();
         let swap = Swap::new(
-            component_with_policy(&token_in, &token_out, MetricOracleUpdatePolicy::Always),
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
-            BigUint::ZERO,
-        )
-        .with_estimated_amount_in(BigUint::from(3_000_000_000u64))
-        .with_protocol_state(Arc::new(quote_state));
-        let encoder = encoder();
-
-        let encoded_swap = encoder
-            .encode_swap(&swap, &context())
-            .unwrap();
-        let hex_swap = encode(&encoded_swap);
-
-        let expected_suffix = String::from(concat!("01", "00000004", "aabbccdd",));
-        assert!(hex_swap.ends_with(&expected_suffix));
-        assert!(!hex_swap.contains("11223344"));
-    }
-
-    #[test]
-    fn test_encode_metric_with_retry_oracle_update() {
-        let token_in = Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap();
-        let token_out = Bytes::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap();
-        let oracle_args = Bytes::from_str("0xaabbccdd").unwrap();
-        let quote_state = MockRFQState {
-            quote_amount_out: BigUint::from(1u64),
-            quote_data: HashMap::from([(ORACLE_UPDATE_ARGS_ATTR.to_string(), oracle_args.clone())]),
-        };
-        let swap = Swap::new(
-            component_with_policy(&token_in, &token_out, MetricOracleUpdatePolicy::RetryOnRevert),
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
-            BigUint::ZERO,
-        )
-        .with_estimated_amount_in(BigUint::from(3_000_000_000u64))
-        .with_protocol_state(Arc::new(quote_state));
-        let encoder = encoder();
-
-        let encoded_swap = encoder
-            .encode_swap(&swap, &context())
-            .unwrap();
-        let hex_swap = encode(&encoded_swap);
-
-        let expected_suffix = String::from(concat!("02", "00000004", "aabbccdd",));
-        assert!(hex_swap.ends_with(&expected_suffix));
-    }
-
-    #[test]
-    fn test_metric_missing_oracle_update_policy_fails() {
-        let token_in = Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap();
-        let token_out = Bytes::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap();
-        let swap = Swap::new(
-            ProtocolComponent {
-                id: "0x1111111111111111111111111111111111111111".to_string(),
-                protocol_system: "rfq:metric".to_string(),
-                tokens: vec![token_in.clone(), token_out.clone()],
-                contract_addresses: Vec::new(),
-                ..Default::default()
-            },
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
+            component(&token0, &token1),
+            default_token(token0.clone()),
+            default_token(other.clone()),
             BigUint::ZERO,
         );
         let encoder = encoder();
@@ -393,25 +193,6 @@ mod tests {
             .encode_swap(&swap, &context())
             .unwrap_err();
 
-        assert!(matches!(err, EncodingError::FatalError(_)));
-    }
-
-    #[test]
-    fn test_metric_oracle_update_requires_protocol_state_when_enabled() {
-        let token_in = Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap();
-        let token_out = Bytes::from_str("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").unwrap();
-        let swap = Swap::new(
-            component_with_policy(&token_in, &token_out, MetricOracleUpdatePolicy::Always),
-            default_token(token_in.clone()),
-            default_token(token_out.clone()),
-            BigUint::ZERO,
-        );
-        let encoder = encoder();
-
-        let err = encoder
-            .encode_swap(&swap, &context())
-            .unwrap_err();
-
-        assert!(matches!(err, EncodingError::FatalError(_)));
+        assert!(matches!(err, EncodingError::InvalidInput(_)));
     }
 }

--- a/crates/tycho-execution/tests/protocol_integration_tests.rs
+++ b/crates/tycho-execution/tests/protocol_integration_tests.rs
@@ -2632,8 +2632,8 @@ fn test_single_encoding_strategy_liquorice_settle_single() {
 fn test_single_encoding_strategy_metric() {
     // Generates calldata for TychoRouterForMetricTest Solidity integration test.
     // WETH -> USDC via Metric RFQ on Base (wethusdc pool 0x770004fE).
-    // Uses the Never oracle update policy: the pool relies on its on-chain price
-    // at the fork block, so no signed oracle update is encoded.
+    // Under the v1 heartbeat model the encoder always emits the Never oracle update mode: the
+    // pool relies on its on-chain price at the fork block, so no signed oracle update is encoded.
     let weth_base = Bytes::from_str("0x4200000000000000000000000000000000000006").unwrap();
     let usdc_base = Bytes::from_str("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913").unwrap();
 
@@ -2643,11 +2643,6 @@ fn test_single_encoding_strategy_metric() {
         // Token order must match the pool's token0/token1 so the encoder can
         // derive the swap direction (WETH = token0, USDC = token1).
         tokens: vec![weth_base.clone(), usdc_base.clone()],
-        // oracle_update_policy = 0 (Never).
-        static_attributes: HashMap::from([(
-            "oracle_update_policy".to_string(),
-            Bytes::from(vec![0u8]),
-        )]),
         ..Default::default()
     };
 

--- a/crates/tycho-integration-test/src/stream_processor/rfq_stream_processor.rs
+++ b/crates/tycho-integration-test/src/stream_processor/rfq_stream_processor.rs
@@ -123,7 +123,6 @@ impl RFQStreamProcessor {
         let metric_enabled = if self.run_pamm_protocols {
             match MetricClientBuilder::new(self.chain)
                 .tokens(rfq_tokens.clone())
-                .token_metadata(all_tokens.clone())
                 .tvl_threshold(self.tvl_threshold)
                 .poll_time(Duration::from_secs(30))
                 .build()

--- a/crates/tycho-simulation/examples/rfq_quickstart/main.rs
+++ b/crates/tycho-simulation/examples/rfq_quickstart/main.rs
@@ -237,7 +237,6 @@ async fn main() {
         println!("Setting up Metric RFQ client...\n");
         match MetricClientBuilder::new(chain)
             .tokens(rfq_tokens.clone())
-            .token_metadata(all_tokens.clone())
             .tvl_threshold(cli.tvl_threshold)
             .build()
         {

--- a/crates/tycho-simulation/src/rfq/constants.rs
+++ b/crates/tycho-simulation/src/rfq/constants.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use crate::rfq::errors::RFQError;
 
-pub const DEFAULT_METRIC_API_URL: &str = "http://54.199.103.16:8080";
+pub const DEFAULT_METRIC_API_URL: &str = "https://api.metric.xyz";
 
 /// Hashflow authentication configuration
 pub struct HashflowAuth {
@@ -18,7 +18,7 @@ pub struct BebopAuth {
 /// Metric API configuration
 pub struct MetricConfig {
     pub base_url: String,
-    pub secret_key: Option<String>,
+    pub api_key: Option<String>,
 }
 
 /// Read Hashflow authentication from environment variables
@@ -65,17 +65,18 @@ pub fn get_bebop_auth() -> Result<BebopAuth, RFQError> {
 }
 
 /// Read Metric API configuration from environment variables.
-/// METRIC_API_URL defaults to the public Metric endpoint; METRIC_SECRET_KEY is optional.
+/// METRIC_API_URL defaults to the public Metric endpoint; METRIC_API_KEY is the Bearer trading key
+/// required by the authenticated endpoints (`bid_ask`).
 pub fn get_metric_config() -> MetricConfig {
     let base_url = env::var("METRIC_API_URL")
         .ok()
         .filter(|url| !url.trim().is_empty())
         .unwrap_or_else(|| DEFAULT_METRIC_API_URL.to_string());
-    let secret_key = env::var("METRIC_SECRET_KEY")
+    let api_key = env::var("METRIC_API_KEY")
         .ok()
         .filter(|key| !key.trim().is_empty());
 
-    MetricConfig { base_url, secret_key }
+    MetricConfig { base_url, api_key }
 }
 
 #[cfg(test)]
@@ -140,20 +141,20 @@ mod tests {
     #[test]
     fn test_metric_config_defaults_and_reads_env() {
         env::remove_var("METRIC_API_URL");
-        env::remove_var("METRIC_SECRET_KEY");
+        env::remove_var("METRIC_API_KEY");
 
         let config = get_metric_config();
         assert_eq!(config.base_url, DEFAULT_METRIC_API_URL);
-        assert_eq!(config.secret_key, None);
+        assert_eq!(config.api_key, None);
 
         env::set_var("METRIC_API_URL", "https://metric.example");
-        env::set_var("METRIC_SECRET_KEY", "secret");
+        env::set_var("METRIC_API_KEY", "secret");
 
         let config = get_metric_config();
         assert_eq!(config.base_url, "https://metric.example");
-        assert_eq!(config.secret_key.as_deref(), Some("secret"));
+        assert_eq!(config.api_key.as_deref(), Some("secret"));
 
         env::remove_var("METRIC_API_URL");
-        env::remove_var("METRIC_SECRET_KEY");
+        env::remove_var("METRIC_API_KEY");
     }
 }

--- a/crates/tycho-simulation/src/rfq/protocols/metric/client.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/metric/client.rs
@@ -1,25 +1,19 @@
 use std::{
     collections::{HashMap, HashSet},
-    str::FromStr,
     sync::LazyLock,
     time::SystemTime,
 };
 
-use alloy::{
-    primitives::{Address, Bytes as AlloyBytes, U256},
-    sol_types::SolValue,
-};
+use alloy::primitives::Address;
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 use num_bigint::BigUint;
-use num_traits::ToPrimitive;
 use reqwest::Client;
 use tokio::time::{interval, timeout, Duration};
 use tracing::{error, info, warn};
 use tycho_common::{
     models::{
         protocol::{GetAmountOutParams, ProtocolComponent, ProtocolComponentState},
-        token::Token,
         Chain,
     },
     simulation::indicatively_priced::SignedQuote,
@@ -27,15 +21,12 @@ use tycho_common::{
 };
 
 use crate::{
-    evm::protocol::u256_num::biguint_to_u256,
     rfq::{
         client::RFQClient,
         errors::RFQError,
         models::TimestampHeader,
         protocols::metric::models::{
-            MetricBidAskResponse, MetricMetadata, MetricOracleUpdatePolicy,
-            MetricSignedOracleUpdateResponse, MetricSignedOracleUpdateSlot,
-            ORACLE_UPDATE_POLICY_ATTR,
+            MetricBidAskResponse, MetricMetadata, PaginatedMetadataResponse,
         },
     },
     tycho_client::feed::synchronizer::{ComponentWithState, Snapshot, StateSyncMessage},
@@ -43,80 +34,47 @@ use crate::{
 
 static METRIC_HTTP_CLIENT: LazyLock<Client> = LazyLock::new(Client::new);
 
+/// Page size for the paginated metadata endpoint. The API clamps `count` to `[1, 500]`.
+const METADATA_PAGE_SIZE: u32 = 500;
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MetricClient {
     chain: Chain,
     metadata_endpoint: String,
-    // Prefix ending at /{chain}; pool-specific endpoints are derived from it.
+    // Prefix ending at /public/v1/evm/{chain_id}; pool-specific endpoints are derived from it.
     chain_endpoint: String,
     tokens: HashSet<Bytes>,
-    #[serde(default)]
-    token_metadata: HashMap<Bytes, Token>,
     tvl: f64,
-    quote_tokens: HashSet<Bytes>,
     #[serde(skip_serializing, default)]
-    secret_key: Option<String>,
+    api_key: Option<String>,
     poll_time: Duration,
     quote_timeout: Duration,
-    oracle_update_policy: MetricOracleUpdatePolicy,
 }
 
 impl MetricClient {
     pub const PROTOCOL_SYSTEM: &'static str = "rfq:metric";
 
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         chain: Chain,
         tokens: HashSet<Bytes>,
         tvl: f64,
-        quote_tokens: HashSet<Bytes>,
         base_url: String,
-        secret_key: Option<String>,
+        api_key: Option<String>,
         poll_time: Duration,
         quote_timeout: Duration,
     ) -> Result<Self, RFQError> {
-        Self::new_with_token_metadata(
-            chain,
-            tokens,
-            HashMap::new(),
-            tvl,
-            quote_tokens,
-            base_url,
-            secret_key,
-            poll_time,
-            quote_timeout,
-            MetricOracleUpdatePolicy::default_for_chain(chain),
-        )
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn new_with_token_metadata(
-        chain: Chain,
-        tokens: HashSet<Bytes>,
-        token_metadata: HashMap<Bytes, Token>,
-        tvl: f64,
-        quote_tokens: HashSet<Bytes>,
-        base_url: String,
-        secret_key: Option<String>,
-        poll_time: Duration,
-        quote_timeout: Duration,
-        oracle_update_policy: MetricOracleUpdatePolicy,
-    ) -> Result<Self, RFQError> {
-        let chain_path = chain_to_metric_path(chain)?;
+        let chain_id = chain_to_chain_id(chain)?;
         let base_url = base_url.trim_end_matches('/');
-        let chain_endpoint = format!("{base_url}/{chain_path}");
+        let chain_endpoint = format!("{base_url}/public/v1/evm/{chain_id}");
         Ok(Self {
             chain,
             metadata_endpoint: format!("{chain_endpoint}/metadata"),
             chain_endpoint,
             tokens,
-            token_metadata,
             tvl,
-            quote_tokens,
-            secret_key,
+            api_key,
             poll_time,
             quote_timeout,
-            oracle_update_policy,
         })
     }
 
@@ -131,13 +89,6 @@ impl MetricClient {
         bid_ask: &MetricBidAskResponse,
         tvl: f64,
     ) -> ComponentWithState {
-        let mut static_attributes = HashMap::new();
-        static_attributes.insert(
-            ORACLE_UPDATE_POLICY_ATTR.to_string(),
-            self.oracle_update_policy
-                .as_attribute_value(),
-        );
-
         let protocol_component = ProtocolComponent {
             id: component_id.clone(),
             protocol_system: Self::PROTOCOL_SYSTEM.to_string(),
@@ -145,7 +96,7 @@ impl MetricClient {
             chain: self.chain,
             tokens: vec![metadata.token0.clone(), metadata.token1.clone()],
             contract_addresses: Vec::new(),
-            static_attributes,
+            static_attributes: HashMap::new(),
             ..Default::default()
         };
 
@@ -158,20 +109,22 @@ impl MetricClient {
                 "total_token0_available",
                 bid_ask
                     .total_token0_available
-                    .as_bytes()
-                    .to_vec(),
+                    .clone()
+                    .unwrap_or_default()
+                    .into_bytes(),
             ),
             (
                 "total_token1_available",
                 bid_ask
                     .total_token1_available
-                    .as_bytes()
-                    .to_vec(),
+                    .clone()
+                    .unwrap_or_default()
+                    .into_bytes(),
             ),
             (
-                "latest_block",
+                "server_ts",
                 bid_ask
-                    .latest_block
+                    .server_ts
                     .to_string()
                     .into_bytes(),
             ),
@@ -190,71 +143,51 @@ impl MetricClient {
         }
     }
 
-    fn normalize_tvl(
-        &self,
-        pool: &MetricMetadata,
-        bid_ask: &MetricBidAskResponse,
-        pool_quotes: &[(MetricMetadata, MetricBidAskResponse)],
-    ) -> Option<f64> {
-        // Metric availability is raw ERC20 units. Token metadata comes from Tycho so customers can
-        // add new quote tokens without a source-code change.
-        let token1_amount = metric_available_human(
-            bid_ask.total_token1_available(),
-            self.token_metadata
-                .get(&pool.token1)?
-                .decimals,
-        )?;
-
-        if self.quote_tokens.contains(&pool.token1) {
-            return Some(token1_amount);
-        }
-
-        // For non-configured token1 values, normalize through one Metric pool that prices token1
-        // in a configured quote token.
-        let price = metric_price_in_quote_token(
-            &pool.token1,
-            pool_quotes,
-            &self.quote_tokens,
-            &self.token_metadata,
-        );
-        if price.is_none() {
-            warn!(
-                pool = ?pool.pool_address,
-                token1 = ?pool.token1,
-                "Metric one-hop TVL price not found for non-quote token"
-            );
-        }
-
-        price
-            .map(|price| token1_amount * price)
-            .filter(|tvl| tvl.is_finite() && *tvl >= 0.0)
-    }
-
+    /// Fetches every configured pool by paging through the metadata endpoint until the API reports
+    /// no next page.
     async fn fetch_metadata(&self) -> Result<Vec<MetricMetadata>, RFQError> {
-        let response = self
-            .http_client()
-            .get(&self.metadata_endpoint)
-            .header("accept", "application/json")
-            .send()
-            .await
-            .map_err(|e| {
-                RFQError::ConnectionError(format!("Failed to fetch Metric metadata: {e}"))
+        let mut pools = Vec::new();
+        let mut offset: u64 = 0;
+
+        loop {
+            let response = self
+                .http_client()
+                .get(&self.metadata_endpoint)
+                .header("accept", "application/json")
+                .query(&[("count", METADATA_PAGE_SIZE.to_string()), ("offset", offset.to_string())])
+                .send()
+                .await
+                .map_err(|e| {
+                    RFQError::ConnectionError(format!("Failed to fetch Metric metadata: {e}"))
+                })?;
+
+            if !response.status().is_success() {
+                return Err(RFQError::ConnectionError(format!(
+                    "Metric metadata HTTP error {}: {}",
+                    response.status(),
+                    response
+                        .text()
+                        .await
+                        .unwrap_or_default()
+                )));
+            }
+
+            let page: PaginatedMetadataResponse = response.json().await.map_err(|e| {
+                RFQError::ParsingError(format!("Failed to parse Metric metadata response: {e}"))
             })?;
 
-        if !response.status().is_success() {
-            return Err(RFQError::ConnectionError(format!(
-                "Metric metadata HTTP error {}: {}",
-                response.status(),
-                response
-                    .text()
-                    .await
-                    .unwrap_or_default()
-            )));
+            let page_len = page.data.len();
+            pools.extend(page.data);
+
+            // Stop when the API reports the last page, returns nothing, or fails to advance the
+            // offset (defensive guard against an infinite loop).
+            match page.next_offset {
+                Some(next) if page_len > 0 && next > offset => offset = next,
+                _ => break,
+            }
         }
 
-        response.json().await.map_err(|e| {
-            RFQError::ParsingError(format!("Failed to parse Metric metadata response: {e}"))
-        })
+        Ok(pools)
     }
 
     async fn fetch_bid_ask(&self, pool: &Bytes) -> Result<MetricBidAskResponse, RFQError> {
@@ -265,13 +198,21 @@ impl MetricClient {
             .get(endpoint)
             .header("accept", "application/json");
 
-        if let Some(secret_key) = &self.secret_key {
-            request = request.query(&[("secretKey", secret_key.as_str())]);
+        if let Some(api_key) = &self.api_key {
+            request = request.bearer_auth(api_key);
         }
 
-        let response = request.send().await.map_err(|e| {
-            RFQError::ConnectionError(format!("Failed to fetch Metric bid/ask: {e}"))
-        })?;
+        let response = timeout(self.quote_timeout, request.send())
+            .await
+            .map_err(|_| {
+                RFQError::ConnectionError(format!(
+                    "Metric bid/ask request timed out after {} seconds",
+                    self.quote_timeout.as_secs()
+                ))
+            })?
+            .map_err(|e| {
+                RFQError::ConnectionError(format!("Failed to fetch Metric bid/ask: {e}"))
+            })?;
 
         if !response.status().is_success() {
             return Err(RFQError::ConnectionError(format!(
@@ -289,92 +230,23 @@ impl MetricClient {
         })
     }
 
-    async fn fetch_signed_oracle_update(
+    fn find_pool<'a>(
         &self,
-        pool: &Bytes,
-    ) -> Result<MetricSignedOracleUpdateResponse, RFQError> {
-        let endpoint =
-            format!("{}/{}/get_signed_data", self.chain_endpoint, bytes_to_address_string(pool)?);
-        let mut request = self
-            .http_client()
-            .get(endpoint)
-            .header("accept", "application/json");
-
-        if let Some(secret_key) = &self.secret_key {
-            request = request.query(&[("secretKey", secret_key.as_str())]);
-        }
-
-        let response = timeout(self.quote_timeout, request.send())
-            .await
-            .map_err(|_| {
-                RFQError::ConnectionError(format!(
-                    "Metric oracle update request timed out after {} seconds",
-                    self.quote_timeout.as_secs()
-                ))
-            })?
-            .map_err(|e| {
-                RFQError::ConnectionError(format!("Failed to fetch Metric oracle update: {e}"))
-            })?;
-
-        if !response.status().is_success() {
-            return Err(RFQError::QuoteNotFound(format!(
-                "Metric oracle update HTTP error {}: {}",
-                response.status(),
-                response
-                    .text()
-                    .await
-                    .unwrap_or_default()
-            )));
-        }
-
-        response.json().await.map_err(|e| {
-            RFQError::ParsingError(format!("Failed to parse Metric oracle update response: {e}"))
-        })
-    }
-
-    pub async fn request_oracle_update_for_pool(
-        &self,
-        metadata: &MetricMetadata,
+        metadata: &'a [MetricMetadata],
         params: &GetAmountOutParams,
-        amount_out: BigUint,
-    ) -> Result<SignedQuote, RFQError> {
-        if !((params.token_in == metadata.token0 && params.token_out == metadata.token1) ||
-            (params.token_in == metadata.token1 && params.token_out == metadata.token0))
-        {
-            return Err(RFQError::InvalidInput(format!(
-                "Metric token pair mismatch: {} -> {} is not {} / {}",
-                params.token_in, params.token_out, metadata.token0, metadata.token1
-            )));
-        }
-
-        let oracle_update = self
-            .fetch_signed_oracle_update(&metadata.pool_address)
-            .await?;
-        // Metric may return multiple slots, but the API does not expose a reliable
-        // pool-to-slot mapping yet. Use the first signed slot until that rule is clarified.
-        let slot = oracle_update
-            .slots
-            .first()
+    ) -> Result<&'a MetricMetadata, RFQError> {
+        metadata
+            .iter()
+            .find(|pool| {
+                (params.token_in == pool.token0 && params.token_out == pool.token1) ||
+                    (params.token_in == pool.token1 && params.token_out == pool.token0)
+            })
             .ok_or_else(|| {
                 RFQError::QuoteNotFound(format!(
-                    "Metric oracle update returned no signed slots for pool {}",
-                    metadata.pool_address
+                    "Metric pool not found for {} -> {}",
+                    params.token_in, params.token_out
                 ))
-            })?;
-
-        let mut quote_attributes = HashMap::new();
-        quote_attributes.insert(
-            "oracle_update_0_args".to_string(),
-            encode_oracle_update_args(&oracle_update.feed_creator, slot)?,
-        );
-
-        Ok(SignedQuote {
-            base_token: params.token_in.clone(),
-            quote_token: params.token_out.clone(),
-            amount_in: params.amount_in.clone(),
-            amount_out,
-            quote_attributes,
-        })
+            })
     }
 }
 
@@ -401,11 +273,22 @@ impl RFQClient for MetricClient {
                     }
                 };
 
-                // Fetch every Metric pool first, even when `tokens` later filters emitted
-                // components. Non-emitted pools can still provide one-hop quote-token prices for
-                // TVL normalization, e.g. rETH/WETH using WETH/USDC.
-                let mut pool_quotes = Vec::new();
+                let mut new_components = HashMap::new();
                 for pool in &metadata {
+                    if !client.tokens.is_empty() &&
+                        (!client.tokens.contains(&pool.token0) ||
+                            !client.tokens.contains(&pool.token1))
+                    {
+                        continue;
+                    }
+
+                    // v1 metadata carries the fiat TVL directly, so no cross-pool price
+                    // normalization is needed.
+                    let tvl = pool.tvl_fiat.unwrap_or(0.0);
+                    if tvl < client.tvl {
+                        continue;
+                    }
+
                     let bid_ask = match client.fetch_bid_ask(&pool.pool_address).await {
                         Ok(bid_ask) => bid_ask,
                         Err(e) => {
@@ -416,33 +299,14 @@ impl RFQClient for MetricClient {
                             continue;
                         }
                     };
-                    if !bid_ask.quote_available {
-                        continue;
-                    }
-
-                    pool_quotes.push((pool.clone(), bid_ask));
-                }
-
-                let mut new_components = HashMap::new();
-                for (pool, bid_ask) in &pool_quotes {
-                    if !client.tokens.is_empty() &&
-                        (!client.tokens.contains(&pool.token0) ||
-                            !client.tokens.contains(&pool.token1))
-                    {
-                        continue;
-                    }
-
-                    let tvl = client
-                        .normalize_tvl(pool, bid_ask, &pool_quotes)
-                        .unwrap_or(0.0);
-                    if tvl < client.tvl {
+                    if !bid_ask.is_quotable() {
                         continue;
                     }
 
                     let component_id = pool.pool_address.to_string();
                     new_components.insert(
                         component_id.clone(),
-                        client.create_component_with_state(component_id, pool, bid_ask, tvl),
+                        client.create_component_with_state(component_id, pool, &bid_ask, tvl),
                     );
                 }
 
@@ -473,31 +337,25 @@ impl RFQClient for MetricClient {
         params: &GetAmountOutParams,
     ) -> Result<SignedQuote, RFQError> {
         let metadata = self.fetch_metadata().await?;
-        let pool = metadata
-            .iter()
-            .find(|pool| {
-                (params.token_in == pool.token0 && params.token_out == pool.token1) ||
-                    (params.token_in == pool.token1 && params.token_out == pool.token0)
-            })
-            .ok_or_else(|| {
-                RFQError::QuoteNotFound(format!(
-                    "Metric pool not found for {} -> {}",
-                    params.token_in, params.token_out
-                ))
-            })?;
+        // Validates that a pool exists for the requested pair.
+        self.find_pool(&metadata, params)?;
 
-        self.request_oracle_update_for_pool(pool, params, BigUint::default())
-            .await
+        // The v1 heartbeat updates the oracle on-chain every block, so no signed oracle-update args
+        // are relayed with the swap. The binding quote therefore carries no quote attributes.
+        Ok(SignedQuote {
+            base_token: params.token_in.clone(),
+            quote_token: params.token_out.clone(),
+            amount_in: params.amount_in.clone(),
+            amount_out: BigUint::default(),
+            quote_attributes: HashMap::new(),
+        })
     }
 }
 
-fn chain_to_metric_path(chain: Chain) -> Result<&'static str, RFQError> {
+fn chain_to_chain_id(chain: Chain) -> Result<u64, RFQError> {
     match chain {
-        Chain::Ethereum => Ok("ethereum"),
-        Chain::Base => Ok("base"),
-        Chain::Bsc => Ok("bsc"),
-        Chain::Arbitrum => Ok("arbitrum"),
-        Chain::Polygon => Ok("polygon"),
+        Chain::Ethereum => Ok(1),
+        Chain::Base => Ok(8453),
         unsupported => Err(RFQError::FatalError(format!(
             "Metric does not support chain in this integration: {unsupported:?}"
         ))),
@@ -511,122 +369,18 @@ fn bytes_to_address_string(address: &Bytes) -> Result<String, RFQError> {
     Ok(Address::from_slice(address).to_checksum(None))
 }
 
-fn bytes_to_alloy_address(address: &Bytes) -> Result<Address, RFQError> {
-    if address.len() != 20 {
-        return Err(RFQError::InvalidInput(format!("Invalid EVM address length: {address}")));
-    }
-    Ok(Address::from_slice(address))
-}
-
-fn encode_oracle_update_args(
-    feed_creator: &Bytes,
-    slot: &MetricSignedOracleUpdateSlot,
-) -> Result<Bytes, RFQError> {
-    Ok((
-        bytes_to_alloy_address(feed_creator)?,
-        U256::from(slot.deadline),
-        biguint_decimal_to_u256(&slot.new_slot_value)?,
-        AlloyBytes::from(slot.signature.to_vec()),
-    )
-        .abi_encode_params()
-        .into())
-}
-
-fn biguint_decimal_to_u256(value: &str) -> Result<U256, RFQError> {
-    let value = BigUint::from_str(value)
-        .map_err(|_| RFQError::ParsingError(format!("Failed to parse uint value: {value}")))?;
-    Ok(biguint_to_u256(&value))
-}
-
-fn metric_price_in_quote_token(
-    token: &Bytes,
-    pool_quotes: &[(MetricMetadata, MetricBidAskResponse)],
-    quote_tokens: &HashSet<Bytes>,
-    token_metadata: &HashMap<Bytes, Token>,
-) -> Option<f64> {
-    let mut best: Option<(f64, f64)> = None;
-
-    for (pool, bid_ask) in pool_quotes {
-        let Some(mid_price) = metric_mid_price(bid_ask) else {
-            continue;
-        };
-        let candidate = if &pool.token0 == token && quote_tokens.contains(&pool.token1) {
-            let Some(quote_token) = token_metadata.get(&pool.token1) else {
-                continue;
-            };
-            let Some(quote_tvl) =
-                metric_available_human(bid_ask.total_token1_available(), quote_token.decimals)
-            else {
-                continue;
-            };
-            Some((mid_price, quote_tvl))
-        } else if &pool.token1 == token && quote_tokens.contains(&pool.token0) {
-            let Some(quote_token) = token_metadata.get(&pool.token0) else {
-                continue;
-            };
-            let Some(quote_tvl) =
-                metric_available_human(bid_ask.total_token0_available(), quote_token.decimals)
-            else {
-                continue;
-            };
-            Some((1.0 / mid_price, quote_tvl))
-        } else {
-            None
-        };
-
-        let Some((price, quote_tvl)) = candidate else {
-            continue;
-        };
-
-        // Multiple Metric pools can price the same token in a configured quote token. Use the
-        // pool with the largest quote-side availability as the most liquid pricing source.
-        if price.is_finite() &&
-            price > 0.0 &&
-            quote_tvl.is_finite() &&
-            quote_tvl > 0.0 &&
-            best.as_ref()
-                .is_none_or(|(_, best_quote_tvl)| quote_tvl > *best_quote_tvl)
-        {
-            best = Some((price, quote_tvl));
-        }
-    }
-
-    best.map(|(price, _)| price)
-}
-
-fn metric_mid_price(bid_ask: &MetricBidAskResponse) -> Option<f64> {
-    let bid = bid_ask.bid_price().ok()?;
-    let ask = bid_ask.ask_price().ok()?;
-    let mid = (bid + ask) / 2.0;
-    (mid.is_finite() && mid > 0.0).then_some(mid)
-}
-
-fn metric_available_human(amount: Result<BigUint, RFQError>, decimals: u32) -> Option<f64> {
-    amount
-        .ok()?
-        .to_f64()
-        .map(|raw| raw / 10_f64.powi(decimals as i32))
-        .filter(|amount| amount.is_finite() && *amount >= 0.0)
-}
-
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
 
-    use tycho_common::models::token::Token;
-
     use super::*;
-    use crate::rfq::protocols::metric::{
-        client_builder::MetricClientBuilder,
-        models::{MetricBidAskResponse, MetricDepth},
-    };
+    use crate::rfq::protocols::metric::{client_builder::MetricClientBuilder, models::MetricDepth};
 
     fn client() -> MetricClient {
         MetricClient::new(
             Chain::Ethereum,
             HashSet::new(),
             0.0,
-            HashSet::new(),
             "http://localhost:8080".to_string(),
             None,
             Duration::from_secs(1),
@@ -636,36 +390,15 @@ mod tests {
     }
 
     fn live_client() -> MetricClient {
-        let base_url = std::env::var("METRIC_API_URL")
-            .unwrap_or_else(|_| "http://54.199.103.16:8080".to_string());
+        let config = crate::rfq::constants::get_metric_config();
         MetricClient::new(
             Chain::Ethereum,
             HashSet::new(),
             0.0,
-            HashSet::new(),
-            base_url,
-            None,
+            config.base_url,
+            config.api_key,
             Duration::from_secs(1),
             Duration::from_secs(5),
-        )
-        .unwrap()
-    }
-
-    fn client_with_tvl_config(
-        quote_tokens: HashSet<Bytes>,
-        token_metadata: HashMap<Bytes, Token>,
-    ) -> MetricClient {
-        MetricClient::new_with_token_metadata(
-            Chain::Ethereum,
-            HashSet::new(),
-            token_metadata,
-            0.0,
-            quote_tokens,
-            "http://localhost:8080".to_string(),
-            None,
-            Duration::from_secs(1),
-            Duration::from_secs(1),
-            MetricOracleUpdatePolicy::default_for_chain(Chain::Ethereum),
         )
         .unwrap()
     }
@@ -675,125 +408,52 @@ mod tests {
             pool_address: Bytes::from_str("0xbF48bCf474d57fF82A3215319229e0DE1476A557").unwrap(),
             token0: Bytes::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap(),
             token1: Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap(),
+            tvl_fiat: Some(3000.0),
         }
-    }
-
-    fn metric_address(seed: u8) -> Bytes {
-        Bytes::from(vec![seed; 20])
-    }
-
-    fn q64_price(price: u64) -> String {
-        (BigUint::from(price) << 64usize).to_string()
-    }
-
-    fn metadata_for_pool(token0: Bytes, token1: Bytes, seed: u8) -> MetricMetadata {
-        MetricMetadata { pool_address: metric_address(seed), token0, token1 }
     }
 
     fn bid_ask() -> MetricBidAskResponse {
         MetricBidAskResponse {
             bid_adj: "55340232221128654848000".to_string(),
             ask_adj: "55358678965202364400000".to_string(),
-            quote_available: true,
-            total_token0_available: "1000000000000000000".to_string(),
-            total_token1_available: "3000000000".to_string(),
-            latest_block: 100,
-            depth: MetricDepth::default(),
-        }
-    }
-
-    fn bid_ask_with_prices(
-        bid: u64,
-        ask: u64,
-        total_token0_available: &str,
-        total_token1_available: &str,
-    ) -> MetricBidAskResponse {
-        MetricBidAskResponse {
-            bid_adj: q64_price(bid),
-            ask_adj: q64_price(ask),
-            quote_available: true,
-            total_token0_available: total_token0_available.to_string(),
-            total_token1_available: total_token1_available.to_string(),
-            latest_block: 100,
+            total_token0_available: Some("1000000000000000000".to_string()),
+            total_token1_available: Some("3000000000".to_string()),
+            server_ts: 1_770_053_095,
             depth: MetricDepth::default(),
         }
     }
 
     #[test]
-    fn test_builder_uses_token_metadata_decimals() {
-        let usdc = Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap();
-        let all_tokens = HashMap::from([(
-            usdc.clone(),
-            Token::new(&usdc, "USDC", 6, 0, &[], Chain::Ethereum, 100),
-        )]);
+    fn test_chain_to_chain_id() {
+        assert_eq!(chain_to_chain_id(Chain::Ethereum).unwrap(), 1);
+        assert_eq!(chain_to_chain_id(Chain::Base).unwrap(), 8453);
+        assert!(chain_to_chain_id(Chain::Arbitrum).is_err());
+    }
 
+    #[test]
+    fn test_endpoints_use_numeric_chain_id() {
+        let client = MetricClient::new(
+            Chain::Base,
+            HashSet::new(),
+            0.0,
+            "https://api.metric.xyz".to_string(),
+            None,
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+        )
+        .unwrap();
+
+        assert_eq!(client.metadata_endpoint, "https://api.metric.xyz/public/v1/evm/8453/metadata");
+        assert_eq!(client.chain_endpoint, "https://api.metric.xyz/public/v1/evm/8453");
+    }
+
+    #[test]
+    fn test_builder_defaults_to_v1_base_url() {
         let client = MetricClientBuilder::new(Chain::Ethereum)
-            .token_metadata(all_tokens)
             .build()
             .unwrap();
 
-        assert_eq!(
-            client
-                .token_metadata
-                .get(&usdc)
-                .map(|token| token.decimals),
-            Some(6)
-        );
-    }
-
-    #[test]
-    fn test_normalize_tvl_uses_configured_quote_decimals() {
-        let pool = metadata();
-        let bid_ask = bid_ask();
-        let quote_tokens = HashSet::from([pool.token1.clone()]);
-        let token_metadata = HashMap::from([(
-            pool.token1.clone(),
-            Token::new(&pool.token1, "USDC", 6, 0, &[], Chain::Ethereum, 100),
-        )]);
-        let pool_quotes = vec![(pool.clone(), bid_ask.clone())];
-        let client = client_with_tvl_config(quote_tokens, token_metadata);
-
-        let tvl = client
-            .normalize_tvl(&pool, &bid_ask, &pool_quotes)
-            .unwrap();
-
-        assert_eq!(tvl, 3000.0);
-    }
-
-    #[test]
-    fn test_normalize_tvl_uses_best_one_hop_quote_pool() {
-        let reth = metric_address(10);
-        let weth = metric_address(20);
-        let usdc = metric_address(30);
-
-        let target = metadata_for_pool(reth, weth.clone(), 1);
-        let target_bid_ask =
-            bid_ask_with_prices(1, 1, "100000000000000000000", "2000000000000000000");
-        let low_liquidity_quote = metadata_for_pool(weth.clone(), usdc.clone(), 4);
-        let low_liquidity_bid_ask =
-            bid_ask_with_prices(3000, 3000, "1000000000000000000", "1000000000");
-        let high_liquidity_quote = metadata_for_pool(weth.clone(), usdc.clone(), 7);
-        // The higher-liquidity WETH/USDC pool has a different price. The expected TVL below proves
-        // normalization chooses it by quote-side availability, not by first match.
-        let high_liquidity_bid_ask =
-            bid_ask_with_prices(3100, 3100, "1000000000000000000", "5000000000");
-        let pool_quotes = vec![
-            (target.clone(), target_bid_ask.clone()),
-            (low_liquidity_quote, low_liquidity_bid_ask),
-            (high_liquidity_quote, high_liquidity_bid_ask),
-        ];
-        let quote_tokens = HashSet::from([usdc.clone()]);
-        let token_metadata = HashMap::from([
-            (weth.clone(), Token::new(&weth, "WETH", 18, 0, &[], Chain::Ethereum, 100)),
-            (usdc.clone(), Token::new(&usdc, "USDC", 6, 0, &[], Chain::Ethereum, 100)),
-        ]);
-        let client = client_with_tvl_config(quote_tokens, token_metadata);
-
-        let tvl = client
-            .normalize_tvl(&target, &target_bid_ask, &pool_quotes)
-            .unwrap();
-
-        assert_eq!(tvl, 6200.0);
+        assert_eq!(client.metadata_endpoint, "https://api.metric.xyz/public/v1/evm/1/metadata");
     }
 
     #[test]
@@ -811,10 +471,10 @@ mod tests {
             component.component.tokens,
             vec![metadata.token0.clone(), metadata.token1.clone()]
         );
-        assert_eq!(
-            component.component.static_attributes[ORACLE_UPDATE_POLICY_ATTR],
-            MetricOracleUpdatePolicy::RetryOnRevert.as_attribute_value()
-        );
+        assert!(component
+            .component
+            .static_attributes
+            .is_empty());
         assert_eq!(component.component.id, metadata.pool_address.to_string());
         assert!(component
             .component
@@ -824,25 +484,9 @@ mod tests {
             String::from_utf8(component.state.attributes["bid_adj"].to_vec()).unwrap(),
             "55340232221128654848000"
         );
-    }
-
-    #[test]
-    fn test_builder_sets_oracle_update_policy_attribute() {
-        let client = MetricClientBuilder::new(Chain::Ethereum)
-            .oracle_update_policy(MetricOracleUpdatePolicy::RetryOnRevert)
-            .build()
-            .unwrap();
-
-        let component = client.create_component_with_state(
-            "metric_ethusdc".to_string(),
-            &metadata(),
-            &bid_ask(),
-            3000.0,
-        );
-
         assert_eq!(
-            component.component.static_attributes[ORACLE_UPDATE_POLICY_ATTR],
-            MetricOracleUpdatePolicy::RetryOnRevert.as_attribute_value()
+            String::from_utf8(component.state.attributes["server_ts"].to_vec()).unwrap(),
+            "1770053095"
         );
     }
 
@@ -861,7 +505,7 @@ mod tests {
                 .await
             {
                 Ok(bid_ask) => {
-                    if bid_ask.quote_available &&
+                    if bid_ask.is_quotable() &&
                         !bid_ask.depth.asks.is_empty() &&
                         !bid_ask.depth.bids.is_empty()
                     {
@@ -875,7 +519,7 @@ mod tests {
 
         let Some((_pool, bid_ask)) = selected else {
             panic!(
-                "Metric live API returned no quoteAvailable bid_ask response with ask and bid depth across {} pools; last error: {:?}",
+                "Metric live API returned no quotable bid_ask response with ask and bid depth across {} pools; last error: {:?}",
                 metadata.len(),
                 last_error
             );
@@ -887,7 +531,7 @@ mod tests {
         assert!(ask_price.is_finite() && ask_price >= bid_price);
         assert!(bid_ask.total_token0_available().is_ok());
         assert!(bid_ask.total_token1_available().is_ok());
-        assert!(bid_ask.latest_block > 0);
+        assert!(bid_ask.server_ts > 0);
 
         for bin in bid_ask
             .depth
@@ -899,33 +543,5 @@ mod tests {
             assert!(bin.price().unwrap().is_finite());
             assert!(bin.cumulative_volume().is_ok());
         }
-    }
-
-    #[test]
-    fn test_encode_oracle_update_args() {
-        let feed_creator = Bytes::from_str("0x0000000000000000000000000000000000000001").unwrap();
-        let slot = MetricSignedOracleUpdateSlot {
-            deadline: 1_700_000_000,
-            new_slot_value: "42".to_string(),
-            signature: Bytes::from_str(
-                "0x111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111b",
-            )
-            .unwrap(),
-        };
-
-        let args = encode_oracle_update_args(&feed_creator, &slot).unwrap();
-
-        assert!(!args.starts_with(&[0x78, 0xce, 0x3a, 0xe1]));
-        assert!(!args.is_empty());
-
-        // Must be params-encoded (no leading tuple offset word), matching Solidity's
-        // `abi.decode(oracleArgs, (address, uint256, uint256, bytes))`. Params encoding is
-        // 256 bytes (address, deadline, new_slot_value, bytes offset, bytes len, 65-byte sig
-        // padded to 96); the wrapped `abi_encode` form prepends a 0x20 offset word (288 bytes)
-        // and shifts every field, which reverts on-chain.
-        assert_eq!(args.len(), 256);
-        // First word is the feed creator address (left-padded), not an ABI offset.
-        assert!(args[0..12].iter().all(|b| *b == 0));
-        assert_eq!(&args[12..32], feed_creator.as_ref());
     }
 }

--- a/crates/tycho-simulation/src/rfq/protocols/metric/client_builder.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/metric/client_builder.rs
@@ -1,45 +1,32 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use tokio::time::Duration;
-use tycho_common::{
-    models::{token::Token, Chain},
-    Bytes,
-};
+use tycho_common::{models::Chain, Bytes};
 
-use super::{client::MetricClient, models::MetricOracleUpdatePolicy};
-use crate::rfq::{
-    constants::get_metric_config, errors::RFQError,
-    protocols::utils::default_quote_tokens_for_chain,
-};
+use super::client::MetricClient;
+use crate::rfq::{constants::get_metric_config, errors::RFQError};
 
 pub struct MetricClientBuilder {
     chain: Chain,
     tokens: HashSet<Bytes>,
-    token_metadata: HashMap<Bytes, Token>,
     tvl: f64,
-    quote_tokens: Option<HashSet<Bytes>>,
     base_url: String,
-    secret_key: Option<String>,
+    api_key: Option<String>,
     poll_time: Duration,
     quote_timeout: Duration,
-    oracle_update_policy: MetricOracleUpdatePolicy,
 }
 
 impl MetricClientBuilder {
     pub fn new(chain: Chain) -> Self {
         let config = get_metric_config();
-        let oracle_update_policy = MetricOracleUpdatePolicy::default_for_chain(chain);
         Self {
             chain,
             tokens: HashSet::new(),
-            token_metadata: HashMap::new(),
             tvl: 0.0,
-            quote_tokens: None,
             base_url: config.base_url,
-            secret_key: config.secret_key,
+            api_key: config.api_key,
             poll_time: Duration::from_secs(5),
             quote_timeout: Duration::from_secs(5),
-            oracle_update_policy,
         }
     }
 
@@ -48,22 +35,8 @@ impl MetricClientBuilder {
         self
     }
 
-    /// Provide Tycho token metadata for Metric TVL normalization.
-    ///
-    /// The `tokens` filter above controls which RFQ pairs are emitted. This metadata is broader:
-    /// Metric may need token decimals for a one-hop quote-token pool that is not itself emitted.
-    pub fn token_metadata(mut self, tokens: HashMap<Bytes, Token>) -> Self {
-        self.token_metadata = tokens;
-        self
-    }
-
     pub fn tvl_threshold(mut self, tvl: f64) -> Self {
         self.tvl = tvl;
-        self
-    }
-
-    pub fn quote_tokens(mut self, quote_tokens: HashSet<Bytes>) -> Self {
-        self.quote_tokens = Some(quote_tokens);
         self
     }
 
@@ -72,8 +45,8 @@ impl MetricClientBuilder {
         self
     }
 
-    pub fn secret_key(mut self, secret_key: Option<String>) -> Self {
-        self.secret_key = secret_key;
+    pub fn api_key(mut self, api_key: Option<String>) -> Self {
+        self.api_key = api_key;
         self
     }
 
@@ -87,28 +60,15 @@ impl MetricClientBuilder {
         self
     }
 
-    pub fn oracle_update_policy(mut self, policy: MetricOracleUpdatePolicy) -> Self {
-        self.oracle_update_policy = policy;
-        self
-    }
-
     pub fn build(self) -> Result<MetricClient, RFQError> {
-        let quote_tokens = match self.quote_tokens {
-            Some(tokens) => tokens,
-            None => default_quote_tokens_for_chain(&self.chain)?,
-        };
-
-        MetricClient::new_with_token_metadata(
+        MetricClient::new(
             self.chain,
             self.tokens,
-            self.token_metadata,
             self.tvl,
-            quote_tokens,
             self.base_url,
-            self.secret_key,
+            self.api_key,
             self.poll_time,
             self.quote_timeout,
-            self.oracle_update_policy,
         )
     }
 }

--- a/crates/tycho-simulation/src/rfq/protocols/metric/decoder.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/metric/decoder.rs
@@ -67,14 +67,14 @@ impl TryFromWithBlock<ComponentWithState, TimestampHeader> for MetricState {
             pool_address,
             token0: token0_address.clone(),
             token1: token1_address.clone(),
+            tvl_fiat: None,
         };
         let bid_ask = MetricBidAskResponse {
             bid_adj: read_string_attr(&attrs, "bid_adj")?,
             ask_adj: read_string_attr(&attrs, "ask_adj")?,
-            quote_available: true,
-            total_token0_available: read_string_attr(&attrs, "total_token0_available")?,
-            total_token1_available: read_string_attr(&attrs, "total_token1_available")?,
-            latest_block: read_u64_attr(&attrs, "latest_block")?,
+            total_token0_available: Some(read_string_attr(&attrs, "total_token0_available")?),
+            total_token1_available: Some(read_string_attr(&attrs, "total_token1_available")?),
+            server_ts: read_u64_attr(&attrs, "server_ts")?,
             depth: read_optional_depth_attr(&attrs, "depth")?,
         };
 
@@ -183,7 +183,7 @@ mod tests {
         );
         attrs
             .insert("total_token1_available".to_string(), "30000000000".as_bytes().to_vec().into());
-        attrs.insert("latest_block".to_string(), "100".as_bytes().to_vec().into());
+        attrs.insert("server_ts".to_string(), "100".as_bytes().to_vec().into());
         attrs.insert("depth".to_string(), r#"{"asks":[],"bids":[]}"#.as_bytes().to_vec().into());
 
         let pool_address = Bytes::from_str("0xbF48bCf474d57fF82A3215319229e0DE1476A557").unwrap();
@@ -227,7 +227,7 @@ mod tests {
 
         assert_eq!(state.base_token.symbol, "WETH");
         assert_eq!(state.quote_token.symbol, "USDC");
-        assert_eq!(state.bid_ask.latest_block, 100);
+        assert_eq!(state.bid_ask.server_ts, 100);
     }
 
     #[tokio::test]

--- a/crates/tycho-simulation/src/rfq/protocols/metric/models.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/metric/models.rs
@@ -4,34 +4,19 @@ use alloy::primitives::Address;
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
-use tycho_common::{models::Chain, Bytes};
+use tycho_common::Bytes;
 
 use crate::rfq::errors::RFQError;
 
 const Q64_FLOAT: f64 = 18_446_744_073_709_551_616.0;
 
-pub const ORACLE_UPDATE_POLICY_ATTR: &str = "oracle_update_policy";
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[repr(u8)]
-pub enum MetricOracleUpdatePolicy {
-    #[default]
-    Never = 0,
-    Always = 1,
-    RetryOnRevert = 2,
-}
-
-impl MetricOracleUpdatePolicy {
-    pub fn default_for_chain(chain: Chain) -> Self {
-        match chain {
-            Chain::Ethereum => Self::RetryOnRevert,
-            _ => Self::Never,
-        }
-    }
-
-    pub fn as_attribute_value(self) -> Bytes {
-        vec![self as u8].into()
-    }
+/// The `PaginatedMetadataResponse` envelope returned by `GET /public/v1/evm/{chain_id}/metadata`.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct PaginatedMetadataResponse {
+    pub data: Vec<MetricMetadata>,
+    /// `offset` for the next page, or `None` on the last page.
+    #[serde(rename = "nextOffset", default)]
+    pub next_offset: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -42,6 +27,11 @@ pub struct MetricMetadata {
     pub token0: Bytes,
     #[serde(deserialize_with = "deserialize_address")]
     pub token1: Bytes,
+    /// Total value locked in the requested fiat currency. Absent when Metric has no price for the
+    /// pool; used directly as the component TVL. Not carried through the component attributes, so
+    /// it is `None` once a state is reconstructed by the decoder.
+    #[serde(rename = "tvlFiat", default)]
+    pub tvl_fiat: Option<f64>,
 }
 
 fn deserialize_address<'de, D>(deserializer: D) -> Result<Bytes, D::Error>
@@ -59,14 +49,15 @@ pub struct MetricBidAskResponse {
     pub bid_adj: String,
     #[serde(rename = "askAdj")]
     pub ask_adj: String,
-    #[serde(rename = "quoteAvailable")]
-    pub quote_available: bool,
-    #[serde(rename = "totalToken0Available")]
-    pub total_token0_available: String,
-    #[serde(rename = "totalToken1Available")]
-    pub total_token1_available: String,
-    #[serde(rename = "latestBlock")]
-    pub latest_block: u64,
+    /// Token0 available for the quote (raw units). `None` when the pool cannot currently quote.
+    #[serde(rename = "totalToken0Available", default)]
+    pub total_token0_available: Option<String>,
+    /// Token1 available for the quote (raw units). `None` when the pool cannot currently quote.
+    #[serde(rename = "totalToken1Available", default)]
+    pub total_token1_available: Option<String>,
+    /// Server Unix timestamp (seconds) when the quote was produced.
+    #[serde(rename = "serverTs")]
+    pub server_ts: u64,
     #[serde(default)]
     pub depth: MetricDepth,
 }
@@ -88,22 +79,6 @@ pub struct MetricDepthBin {
     pub cumulative_volume: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct MetricSignedOracleUpdateResponse {
-    #[serde(rename = "feedCreator", deserialize_with = "deserialize_address")]
-    pub feed_creator: Bytes,
-    #[serde(default)]
-    pub slots: Vec<MetricSignedOracleUpdateSlot>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct MetricSignedOracleUpdateSlot {
-    pub deadline: u64,
-    #[serde(rename = "newSlotValue")]
-    pub new_slot_value: String,
-    pub signature: Bytes,
-}
-
 impl MetricBidAskResponse {
     pub fn bid_price(&self) -> Result<f64, RFQError> {
         q64_decimal_to_f64(&self.bid_adj)
@@ -114,11 +89,20 @@ impl MetricBidAskResponse {
     }
 
     pub fn total_token0_available(&self) -> Result<BigUint, RFQError> {
-        parse_biguint(&self.total_token0_available, "totalToken0Available")
+        parse_optional_biguint(&self.total_token0_available, "totalToken0Available")
     }
 
     pub fn total_token1_available(&self) -> Result<BigUint, RFQError> {
-        parse_biguint(&self.total_token1_available, "totalToken1Available")
+        parse_optional_biguint(&self.total_token1_available, "totalToken1Available")
+    }
+
+    /// Whether the pool can currently be quoted. v1 has no `quoteAvailable` flag, so availability
+    /// is inferred from parseable bid/ask prices and both non-null availability figures.
+    pub fn is_quotable(&self) -> bool {
+        self.bid_price().is_ok() &&
+            self.ask_price().is_ok() &&
+            self.total_token0_available().is_ok() &&
+            self.total_token1_available().is_ok()
     }
 }
 
@@ -146,6 +130,13 @@ fn parse_biguint(value: &str, field: &str) -> Result<BigUint, RFQError> {
         .map_err(|_| RFQError::ParsingError(format!("Failed to parse {field}: {value}")))
 }
 
+fn parse_optional_biguint(value: &Option<String>, field: &str) -> Result<BigUint, RFQError> {
+    let value = value
+        .as_deref()
+        .ok_or_else(|| RFQError::ParsingError(format!("{field} is null")))?;
+    parse_biguint(value, field)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -161,10 +152,9 @@ mod tests {
         let response: MetricBidAskResponse = serde_json::from_value(serde_json::json!({
             "bidAdj": "55340232221128654848000",
             "askAdj": "55524699661865750400000",
-            "quoteAvailable": true,
             "totalToken0Available": "1000000000000000000",
             "totalToken1Available": "3000000000",
-            "latestBlock": 0,
+            "serverTs": 0,
             "depth": {
                 "asks": [{
                     "binIdx": 0,
@@ -191,5 +181,39 @@ mod tests {
                 .unwrap(),
             BigUint::from(3_000_000_000u64)
         );
+    }
+
+    #[test]
+    fn test_bid_ask_null_totals_are_not_quotable() {
+        let response: MetricBidAskResponse = serde_json::from_value(serde_json::json!({
+            "bidAdj": "55340232221128654848000",
+            "askAdj": "55524699661865750400000",
+            "totalToken0Available": null,
+            "totalToken1Available": null,
+            "serverTs": 1_770_053_095u64,
+        }))
+        .unwrap();
+
+        assert_eq!(response.total_token0_available, None);
+        assert!(!response.is_quotable());
+    }
+
+    #[test]
+    fn test_paginated_metadata_deserializes_tvl_fiat() {
+        let response: PaginatedMetadataResponse = serde_json::from_value(serde_json::json!({
+            "data": [{
+                "pair": "ethusdc",
+                "poolAddress": "0xbF48bCf474d57fF82A3215319229e0DE1476A557",
+                "token0": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                "token1": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                "tvlFiat": 1234.56
+            }],
+            "total": 1,
+            "nextOffset": null
+        }))
+        .unwrap();
+
+        assert_eq!(response.next_offset, None);
+        assert_eq!(response.data[0].tvl_fiat, Some(1234.56));
     }
 }

--- a/crates/tycho-simulation/src/rfq/protocols/metric/state.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/metric/state.rs
@@ -35,7 +35,7 @@ impl fmt::Debug for MetricState {
             .field("base_token", &self.base_token)
             .field("quote_token", &self.quote_token)
             .field("pool", &self.metadata.pool_address)
-            .field("latest_block", &self.bid_ask.latest_block)
+            .field("server_ts", &self.bid_ask.server_ts)
             .finish_non_exhaustive()
     }
 }
@@ -578,12 +578,15 @@ impl IndicativelyPriced for MetricState {
             .get_amount_out(params.amount_in.clone(), token_in, token_out)?
             .amount;
 
-        // Metric's swap path is independent from the quote API. Execution uses this hook to fetch
-        // signed oracle-update args that can be submitted before the pool swap.
-        Ok(self
-            .client
-            .request_oracle_update_for_pool(&self.metadata, &params, amount_out)
-            .await?)
+        // The v1 heartbeat updates the oracle on-chain every block, so execution relays no signed
+        // oracle-update args with the swap. The quote therefore carries no quote attributes.
+        Ok(SignedQuote {
+            base_token: params.token_in.clone(),
+            quote_token: params.token_out.clone(),
+            amount_in: params.amount_in.clone(),
+            amount_out,
+            quote_attributes: HashMap::new(),
+        })
     }
 }
 
@@ -628,23 +631,22 @@ mod tests {
             pool_address: Bytes::from_str("0xbF48bCf474d57fF82A3215319229e0DE1476A557").unwrap(),
             token0: weth.address.clone(),
             token1: usdc.address.clone(),
+            tvl_fiat: Some(3000.0),
         };
         let bid_ask = MetricBidAskResponse {
             // 3000 * 2^64
             bid_adj: "55340232221128654848000".to_string(),
             // 3010 * 2^64
             ask_adj: "55524699661865750400000".to_string(),
-            quote_available: true,
-            total_token0_available: "10000000000000000000".to_string(),
-            total_token1_available: "30000000000".to_string(),
-            latest_block: 100,
+            total_token0_available: Some("10000000000000000000".to_string()),
+            total_token1_available: Some("30000000000".to_string()),
+            server_ts: 100,
             depth: MetricDepth::default(),
         };
         let client = MetricClient::new(
             Chain::Ethereum,
             HashSet::new(),
             0.0,
-            HashSet::new(),
             "http://localhost:8080".to_string(),
             None,
             Duration::from_secs(1),
@@ -681,7 +683,7 @@ mod tests {
     #[test]
     fn test_get_amount_out_caps_to_available_liquidity() {
         let mut state = state();
-        state.bid_ask.total_token1_available = "1500000000".to_string();
+        state.bid_ask.total_token1_available = Some("1500000000".to_string());
         let err = state
             .get_amount_out(
                 BigUint::from(1_000_000_000_000_000_000u128),
@@ -879,29 +881,32 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "hits Metric's public API"]
-    async fn test_live_metric_api_state_get_amount_out_and_oracle_update() {
+    async fn test_live_metric_api_state_get_amount_out_and_signed_quote() {
+        use crate::rfq::protocols::metric::models::PaginatedMetadataResponse;
+
         let weth = weth();
         let usdc = usdc();
-        let base_url = std::env::var("METRIC_API_URL")
-            .unwrap_or_else(|_| "http://54.199.103.16:8080".to_string())
+        let config = crate::rfq::constants::get_metric_config();
+        let base_url = config
+            .base_url
             .trim_end_matches('/')
             .to_string();
         let client = MetricClient::new(
             Chain::Ethereum,
             HashSet::from([weth.address.clone(), usdc.address.clone()]),
             0.0,
-            HashSet::new(),
             base_url.clone(),
-            None,
+            config.api_key.clone(),
             Duration::from_secs(1),
             Duration::from_secs(5),
         )
         .unwrap();
 
         let http_client = reqwest::Client::new();
-        let metadata: Vec<MetricMetadata> = http_client
-            .get(format!("{base_url}/ethereum/metadata"))
+        let metadata: PaginatedMetadataResponse = http_client
+            .get(format!("{base_url}/public/v1/evm/1/metadata"))
             .header("accept", "application/json")
+            .query(&[("count", "500")])
             .send()
             .await
             .unwrap()
@@ -911,12 +916,19 @@ mod tests {
 
         let mut selected = None;
         for pool in metadata
+            .data
             .into_iter()
             .filter(|pool| pool.token0 == weth.address && pool.token1 == usdc.address)
         {
-            let bid_ask: MetricBidAskResponse = http_client
-                .get(format!("{base_url}/ethereum/{}/bid_ask", pool.pool_address))
-                .header("accept", "application/json")
+            let checksummed =
+                alloy::primitives::Address::from_slice(&pool.pool_address).to_checksum(None);
+            let mut request = http_client
+                .get(format!("{base_url}/public/v1/evm/1/{checksummed}/bid_ask"))
+                .header("accept", "application/json");
+            if let Some(api_key) = &config.api_key {
+                request = request.bearer_auth(api_key);
+            }
+            let bid_ask: MetricBidAskResponse = request
                 .send()
                 .await
                 .unwrap()
@@ -927,7 +939,7 @@ mod tests {
                 .total_token1_available()
                 .map(|available| available > BigUint::from(10u8))
                 .unwrap_or(false);
-            if bid_ask.quote_available && has_enough_quote_liquidity {
+            if bid_ask.is_quotable() && has_enough_quote_liquidity {
                 selected = Some((pool, bid_ask));
                 break;
             }
@@ -939,7 +951,7 @@ mod tests {
         };
 
         let state = MetricState::new(weth, usdc, metadata, bid_ask, client);
-        assert!(state.bid_ask.quote_available);
+        assert!(state.bid_ask.is_quotable());
 
         let amount_in = BigUint::from(1_000_000_000u64);
         let indicative_quote = state
@@ -961,6 +973,7 @@ mod tests {
         assert!(signed_quote.amount_out > BigUint::from(0u8));
         assert_eq!(signed_quote.base_token, state.base_token.address);
         assert_eq!(signed_quote.quote_token, state.quote_token.address);
-        assert!(!signed_quote.quote_attributes["oracle_update_0_args"].is_empty());
+        // The heartbeat model relays no oracle-update args, so the quote carries no attributes.
+        assert!(signed_quote.quote_attributes.is_empty());
     }
 }

--- a/protocols/substreams/polygon-ramses-v3/src/abi/factory.rs
+++ b/protocols/substreams/polygon-ramses-v3/src/abi/factory.rs
@@ -18,9 +18,38 @@ pub mod events {
     }
     impl PoolCreated {
         const TOPIC_ID: [u8; 32] = [
-            120u8, 60u8, 202u8, 28u8, 4u8, 18u8, 221u8, 13u8, 105u8, 94u8, 120u8, 69u8, 104u8,
-            201u8, 109u8, 162u8, 233u8, 194u8, 47u8, 249u8, 137u8, 53u8, 122u8, 46u8, 139u8, 29u8,
-            155u8, 43u8, 78u8, 107u8, 113u8, 24u8,
+            120u8,
+            60u8,
+            202u8,
+            28u8,
+            4u8,
+            18u8,
+            221u8,
+            13u8,
+            105u8,
+            94u8,
+            120u8,
+            69u8,
+            104u8,
+            201u8,
+            109u8,
+            162u8,
+            233u8,
+            194u8,
+            47u8,
+            249u8,
+            137u8,
+            53u8,
+            122u8,
+            46u8,
+            139u8,
+            29u8,
+            155u8,
+            43u8,
+            78u8,
+            107u8,
+            113u8,
+            24u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 4usize {
@@ -29,22 +58,23 @@ pub mod events {
             if log.data.len() != 64usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[ethabi::ParamType::Int(24usize), ethabi::ParamType::Address],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[ethabi::ParamType::Int(24usize), ethabi::ParamType::Address],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
-                token0: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                token0: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
                     .map_err(|e| {
                         format!(
                             "unable to decode param 'token0' from topic of type 'address': {:?}",
@@ -57,7 +87,10 @@ pub mod events {
                     .expect(INTERNAL_ERR)
                     .as_bytes()
                     .to_vec(),
-                token1: ethabi::decode(&[ethabi::ParamType::Address], log.topics[2usize].as_ref())
+                token1: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[2usize].as_ref(),
+                    )
                     .map_err(|e| {
                         format!(
                             "unable to decode param 'token1' from topic of type 'address': {:?}",
@@ -73,17 +106,20 @@ pub mod events {
                 fee: {
                     let mut v = [0 as u8; 32];
                     ethabi::decode(
-                        &[ethabi::ParamType::Uint(24usize)],
-                        log.topics[3usize].as_ref(),
-                    )
-                    .map_err(|e| {
-                        format!("unable to decode param 'fee' from topic of type 'uint24': {:?}", e)
-                    })?
-                    .pop()
-                    .expect(INTERNAL_ERR)
-                    .into_uint()
-                    .expect(INTERNAL_ERR)
-                    .to_big_endian(v.as_mut_slice());
+                            &[ethabi::ParamType::Uint(24usize)],
+                            log.topics[3usize].as_ref(),
+                        )
+                        .map_err(|e| {
+                            format!(
+                                "unable to decode param 'fee' from topic of type 'uint24': {:?}",
+                                e
+                            )
+                        })?
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
                     substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
                 },
                 tick_spacing: {

--- a/protocols/substreams/polygon-ramses-v3/src/abi/pool.rs
+++ b/protocols/substreams/polygon-ramses-v3/src/abi/pool.rs
@@ -19,9 +19,38 @@ pub mod events {
     }
     impl Burn {
         const TOPIC_ID: [u8; 32] = [
-            12u8, 57u8, 108u8, 217u8, 137u8, 163u8, 159u8, 68u8, 89u8, 181u8, 250u8, 26u8, 237u8,
-            106u8, 154u8, 141u8, 205u8, 188u8, 69u8, 144u8, 138u8, 207u8, 214u8, 126u8, 2u8, 140u8,
-            213u8, 104u8, 218u8, 152u8, 152u8, 44u8,
+            12u8,
+            57u8,
+            108u8,
+            217u8,
+            137u8,
+            163u8,
+            159u8,
+            68u8,
+            89u8,
+            181u8,
+            250u8,
+            26u8,
+            237u8,
+            106u8,
+            154u8,
+            141u8,
+            205u8,
+            188u8,
+            69u8,
+            144u8,
+            138u8,
+            207u8,
+            214u8,
+            126u8,
+            2u8,
+            140u8,
+            213u8,
+            104u8,
+            218u8,
+            152u8,
+            152u8,
+            44u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 4usize {
@@ -30,26 +59,27 @@ pub mod events {
             if log.data.len() != 96usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[
-                    ethabi::ParamType::Uint(128usize),
-                    ethabi::ParamType::Uint(256usize),
-                    ethabi::ParamType::Uint(256usize),
-                ],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[
+                        ethabi::ParamType::Uint(128usize),
+                        ethabi::ParamType::Uint(256usize),
+                        ethabi::ParamType::Uint(256usize),
+                    ],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
-                owner: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                owner: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
                     .map_err(|e| {
                         format!(
                             "unable to decode param 'owner' from topic of type 'address': {:?}",
@@ -121,9 +151,38 @@ pub mod events {
     }
     impl Collect {
         const TOPIC_ID: [u8; 32] = [
-            112u8, 147u8, 83u8, 56u8, 230u8, 151u8, 117u8, 69u8, 106u8, 133u8, 221u8, 239u8, 34u8,
-            108u8, 57u8, 95u8, 182u8, 104u8, 182u8, 63u8, 160u8, 17u8, 95u8, 95u8, 32u8, 97u8,
-            11u8, 56u8, 142u8, 108u8, 169u8, 192u8,
+            112u8,
+            147u8,
+            83u8,
+            56u8,
+            230u8,
+            151u8,
+            117u8,
+            69u8,
+            106u8,
+            133u8,
+            221u8,
+            239u8,
+            34u8,
+            108u8,
+            57u8,
+            95u8,
+            182u8,
+            104u8,
+            182u8,
+            63u8,
+            160u8,
+            17u8,
+            95u8,
+            95u8,
+            32u8,
+            97u8,
+            11u8,
+            56u8,
+            142u8,
+            108u8,
+            169u8,
+            192u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 4usize {
@@ -132,26 +191,27 @@ pub mod events {
             if log.data.len() != 96usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[
-                    ethabi::ParamType::Address,
-                    ethabi::ParamType::Uint(128usize),
-                    ethabi::ParamType::Uint(128usize),
-                ],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[
+                        ethabi::ParamType::Address,
+                        ethabi::ParamType::Uint(128usize),
+                        ethabi::ParamType::Uint(128usize),
+                    ],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
-                owner: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                owner: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
                     .map_err(|e| {
                         format!(
                             "unable to decode param 'owner' from topic of type 'address': {:?}",
@@ -218,9 +278,38 @@ pub mod events {
     }
     impl CollectProtocol {
         const TOPIC_ID: [u8; 32] = [
-            89u8, 107u8, 87u8, 57u8, 6u8, 33u8, 141u8, 52u8, 17u8, 133u8, 11u8, 38u8, 166u8, 180u8,
-            55u8, 214u8, 196u8, 82u8, 47u8, 219u8, 67u8, 210u8, 210u8, 56u8, 98u8, 99u8, 248u8,
-            109u8, 80u8, 184u8, 177u8, 81u8,
+            89u8,
+            107u8,
+            87u8,
+            57u8,
+            6u8,
+            33u8,
+            141u8,
+            52u8,
+            17u8,
+            133u8,
+            11u8,
+            38u8,
+            166u8,
+            180u8,
+            55u8,
+            214u8,
+            196u8,
+            82u8,
+            47u8,
+            219u8,
+            67u8,
+            210u8,
+            210u8,
+            56u8,
+            98u8,
+            99u8,
+            248u8,
+            109u8,
+            80u8,
+            184u8,
+            177u8,
+            81u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 3usize {
@@ -229,22 +318,26 @@ pub mod events {
             if log.data.len() != 64usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[ethabi::ParamType::Uint(128usize), ethabi::ParamType::Uint(128usize)],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[
+                        ethabi::ParamType::Uint(128usize),
+                        ethabi::ParamType::Uint(128usize),
+                    ],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
-                sender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                sender: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
                     .map_err(|e| {
                         format!(
                             "unable to decode param 'sender' from topic of type 'address': {:?}",
@@ -258,21 +351,21 @@ pub mod events {
                     .as_bytes()
                     .to_vec(),
                 recipient: ethabi::decode(
-                    &[ethabi::ParamType::Address],
-                    log.topics[2usize].as_ref(),
-                )
-                .map_err(|e| {
-                    format!(
-                        "unable to decode param 'recipient' from topic of type 'address': {:?}",
-                        e
+                        &[ethabi::ParamType::Address],
+                        log.topics[2usize].as_ref(),
                     )
-                })?
-                .pop()
-                .expect(INTERNAL_ERR)
-                .into_address()
-                .expect(INTERNAL_ERR)
-                .as_bytes()
-                .to_vec(),
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'recipient' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
                 amount0: {
                     let mut v = [0 as u8; 32];
                     values
@@ -312,9 +405,38 @@ pub mod events {
     }
     impl FeeAdjustment {
         const TOPIC_ID: [u8; 32] = [
-            12u8, 186u8, 135u8, 24u8, 144u8, 85u8, 211u8, 181u8, 171u8, 5u8, 201u8, 111u8, 189u8,
-            100u8, 27u8, 199u8, 102u8, 87u8, 108u8, 158u8, 124u8, 240u8, 209u8, 149u8, 189u8,
-            251u8, 88u8, 160u8, 198u8, 166u8, 223u8, 36u8,
+            12u8,
+            186u8,
+            135u8,
+            24u8,
+            144u8,
+            85u8,
+            211u8,
+            181u8,
+            171u8,
+            5u8,
+            201u8,
+            111u8,
+            189u8,
+            100u8,
+            27u8,
+            199u8,
+            102u8,
+            87u8,
+            108u8,
+            158u8,
+            124u8,
+            240u8,
+            209u8,
+            149u8,
+            189u8,
+            251u8,
+            88u8,
+            160u8,
+            198u8,
+            166u8,
+            223u8,
+            36u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 1usize {
@@ -323,19 +445,20 @@ pub mod events {
             if log.data.len() != 64usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[ethabi::ParamType::Uint(24usize), ethabi::ParamType::Uint(24usize)],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[
+                        ethabi::ParamType::Uint(24usize),
+                        ethabi::ParamType::Uint(24usize),
+                    ],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
                 old_fee: {
@@ -381,9 +504,38 @@ pub mod events {
     }
     impl Flash {
         const TOPIC_ID: [u8; 32] = [
-            189u8, 189u8, 183u8, 29u8, 120u8, 96u8, 55u8, 107u8, 165u8, 43u8, 37u8, 165u8, 2u8,
-            139u8, 238u8, 162u8, 53u8, 129u8, 54u8, 74u8, 64u8, 82u8, 47u8, 107u8, 207u8, 184u8,
-            107u8, 177u8, 242u8, 220u8, 166u8, 51u8,
+            189u8,
+            189u8,
+            183u8,
+            29u8,
+            120u8,
+            96u8,
+            55u8,
+            107u8,
+            165u8,
+            43u8,
+            37u8,
+            165u8,
+            2u8,
+            139u8,
+            238u8,
+            162u8,
+            53u8,
+            129u8,
+            54u8,
+            74u8,
+            64u8,
+            82u8,
+            47u8,
+            107u8,
+            207u8,
+            184u8,
+            107u8,
+            177u8,
+            242u8,
+            220u8,
+            166u8,
+            51u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 3usize {
@@ -392,27 +544,28 @@ pub mod events {
             if log.data.len() != 128usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[
-                    ethabi::ParamType::Uint(256usize),
-                    ethabi::ParamType::Uint(256usize),
-                    ethabi::ParamType::Uint(256usize),
-                    ethabi::ParamType::Uint(256usize),
-                ],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[
+                        ethabi::ParamType::Uint(256usize),
+                        ethabi::ParamType::Uint(256usize),
+                        ethabi::ParamType::Uint(256usize),
+                        ethabi::ParamType::Uint(256usize),
+                    ],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
-                sender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                sender: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
                     .map_err(|e| {
                         format!(
                             "unable to decode param 'sender' from topic of type 'address': {:?}",
@@ -426,21 +579,21 @@ pub mod events {
                     .as_bytes()
                     .to_vec(),
                 recipient: ethabi::decode(
-                    &[ethabi::ParamType::Address],
-                    log.topics[2usize].as_ref(),
-                )
-                .map_err(|e| {
-                    format!(
-                        "unable to decode param 'recipient' from topic of type 'address': {:?}",
-                        e
+                        &[ethabi::ParamType::Address],
+                        log.topics[2usize].as_ref(),
                     )
-                })?
-                .pop()
-                .expect(INTERNAL_ERR)
-                .into_address()
-                .expect(INTERNAL_ERR)
-                .as_bytes()
-                .to_vec(),
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'recipient' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
                 amount0: {
                     let mut v = [0 as u8; 32];
                     values
@@ -500,9 +653,38 @@ pub mod events {
     }
     impl Initialize {
         const TOPIC_ID: [u8; 32] = [
-            152u8, 99u8, 96u8, 54u8, 203u8, 102u8, 169u8, 193u8, 154u8, 55u8, 67u8, 94u8, 252u8,
-            30u8, 144u8, 20u8, 33u8, 144u8, 33u8, 78u8, 138u8, 190u8, 184u8, 33u8, 189u8, 186u8,
-            63u8, 41u8, 144u8, 221u8, 76u8, 149u8,
+            152u8,
+            99u8,
+            96u8,
+            54u8,
+            203u8,
+            102u8,
+            169u8,
+            193u8,
+            154u8,
+            55u8,
+            67u8,
+            94u8,
+            252u8,
+            30u8,
+            144u8,
+            20u8,
+            33u8,
+            144u8,
+            33u8,
+            78u8,
+            138u8,
+            190u8,
+            184u8,
+            33u8,
+            189u8,
+            186u8,
+            63u8,
+            41u8,
+            144u8,
+            221u8,
+            76u8,
+            149u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 1usize {
@@ -511,19 +693,20 @@ pub mod events {
             if log.data.len() != 64usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[ethabi::ParamType::Uint(160usize), ethabi::ParamType::Int(24usize)],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[
+                        ethabi::ParamType::Uint(160usize),
+                        ethabi::ParamType::Int(24usize),
+                    ],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
                 sqrt_price_x96: {
@@ -571,9 +754,38 @@ pub mod events {
     }
     impl Mint {
         const TOPIC_ID: [u8; 32] = [
-            215u8, 130u8, 24u8, 192u8, 211u8, 4u8, 232u8, 137u8, 60u8, 179u8, 32u8, 10u8, 190u8,
-            57u8, 75u8, 188u8, 141u8, 91u8, 120u8, 4u8, 217u8, 197u8, 31u8, 35u8, 109u8, 249u8,
-            253u8, 207u8, 72u8, 29u8, 2u8, 211u8,
+            215u8,
+            130u8,
+            24u8,
+            192u8,
+            211u8,
+            4u8,
+            232u8,
+            137u8,
+            60u8,
+            179u8,
+            32u8,
+            10u8,
+            190u8,
+            57u8,
+            75u8,
+            188u8,
+            141u8,
+            91u8,
+            120u8,
+            4u8,
+            217u8,
+            197u8,
+            31u8,
+            35u8,
+            109u8,
+            249u8,
+            253u8,
+            207u8,
+            72u8,
+            29u8,
+            2u8,
+            211u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 4usize {
@@ -582,28 +794,29 @@ pub mod events {
             if log.data.len() != 160usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[
-                    ethabi::ParamType::Address,
-                    ethabi::ParamType::Uint(256usize),
-                    ethabi::ParamType::Uint(128usize),
-                    ethabi::ParamType::Uint(256usize),
-                    ethabi::ParamType::Uint(256usize),
-                ],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[
+                        ethabi::ParamType::Address,
+                        ethabi::ParamType::Uint(256usize),
+                        ethabi::ParamType::Uint(128usize),
+                        ethabi::ParamType::Uint(256usize),
+                        ethabi::ParamType::Uint(256usize),
+                    ],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
-                owner: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                owner: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
                     .map_err(|e| {
                         format!(
                             "unable to decode param 'owner' from topic of type 'address': {:?}",
@@ -693,9 +906,38 @@ pub mod events {
     }
     impl Swap {
         const TOPIC_ID: [u8; 32] = [
-            196u8, 32u8, 121u8, 249u8, 74u8, 99u8, 80u8, 215u8, 230u8, 35u8, 95u8, 41u8, 23u8,
-            73u8, 36u8, 249u8, 40u8, 204u8, 42u8, 200u8, 24u8, 235u8, 100u8, 254u8, 216u8, 0u8,
-            78u8, 17u8, 95u8, 188u8, 202u8, 103u8,
+            196u8,
+            32u8,
+            121u8,
+            249u8,
+            74u8,
+            99u8,
+            80u8,
+            215u8,
+            230u8,
+            35u8,
+            95u8,
+            41u8,
+            23u8,
+            73u8,
+            36u8,
+            249u8,
+            40u8,
+            204u8,
+            42u8,
+            200u8,
+            24u8,
+            235u8,
+            100u8,
+            254u8,
+            216u8,
+            0u8,
+            78u8,
+            17u8,
+            95u8,
+            188u8,
+            202u8,
+            103u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 3usize {
@@ -704,28 +946,29 @@ pub mod events {
             if log.data.len() != 160usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[
-                    ethabi::ParamType::Int(256usize),
-                    ethabi::ParamType::Int(256usize),
-                    ethabi::ParamType::Uint(160usize),
-                    ethabi::ParamType::Uint(128usize),
-                    ethabi::ParamType::Int(24usize),
-                ],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[
+                        ethabi::ParamType::Int(256usize),
+                        ethabi::ParamType::Int(256usize),
+                        ethabi::ParamType::Uint(160usize),
+                        ethabi::ParamType::Uint(128usize),
+                        ethabi::ParamType::Int(24usize),
+                    ],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
-                sender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                sender: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
                     .map_err(|e| {
                         format!(
                             "unable to decode param 'sender' from topic of type 'address': {:?}",
@@ -739,21 +982,21 @@ pub mod events {
                     .as_bytes()
                     .to_vec(),
                 recipient: ethabi::decode(
-                    &[ethabi::ParamType::Address],
-                    log.topics[2usize].as_ref(),
-                )
-                .map_err(|e| {
-                    format!(
-                        "unable to decode param 'recipient' from topic of type 'address': {:?}",
-                        e
+                        &[ethabi::ParamType::Address],
+                        log.topics[2usize].as_ref(),
                     )
-                })?
-                .pop()
-                .expect(INTERNAL_ERR)
-                .into_address()
-                .expect(INTERNAL_ERR)
-                .as_bytes()
-                .to_vec(),
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'recipient' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
                 amount0: {
                     let mut v = [0 as u8; 32];
                     values


### PR DESCRIPTION
## Summary

Replaces the legacy Metric RFQ integration with the v1 API at `https://api.metric.xyz`. Integration mode stays RFQ. The legacy integration is removed rather than kept in parallel.

Endpoints move to `/public/v1/evm/{chain_id}/...` with numeric chain ids (Ethereum, Base), Bearer auth on `bid_ask`, and paginated metadata. TVL is read from the metadata `tvlFiat` field, replacing the previous one-hop quote-token normalization.

## Oracle model

Under v1 the on-chain oracle is updated by a per-block heartbeat, so no signed oracle update is relayed with the swap. The signed oracle-update path is removed end to end (no `get_signed_data` fetch, no `oracle_update_0_args`, no `oracle_update_policy` attribute, no `MetricOracleUpdatePolicy`). The swap encoder always emits the `Never` mode byte, so the deployed `MetricExecutor` still validates and swaps unchanged — its `updateBySignature` path is now unused by Tycho.

Tradeoff: a swap can revert if the block's oracle update has not landed yet; there is no `RetryOnRevert` fallback.

## Changes

- **constants**: default URL to v1; `METRIC_SECRET_KEY` → `METRIC_API_KEY` (Bearer).
- **models**: add `PaginatedMetadataResponse`, `tvlFiat`, `serverTs`, nullable totals, `is_quotable()`; remove signed-oracle models and update policy.
- **client**: v1 endpoints, metadata pagination, Bearer auth, `chain_to_chain_id` (ETH=1, Base=8453); TVL from `tvlFiat`; skip pools with null availability.
- **state / decoder**: `server_ts` rename; `request_signed_quote` returns empty quote attributes.
- **execution encoder**: always `Never` mode; drop oracle-args encoding.
- Drop `.token_metadata(...)` at the quickstart and integration-test call sites.

`MetricExecutor.sol` and the shared `rfq/protocols/utils.rs` are unchanged.

## Test plan

- [x] `cargo check --workspace --all-features --all-targets`
- [x] `cargo test -p tycho-simulation -p tycho-execution` (metric) — passing; 2 live tests `#[ignore]`d
- [x] `cargo clippy` (both crates, all-targets/all-features)
- [x] `cargo +nightly fmt --check`
- [ ] Run the `#[ignore]` live tests with `METRIC_API_KEY` against `https://api.metric.xyz` to confirm real `bid_ask`/metadata shapes

## Open items before merge

- Confirm `bid_ask` availability semantics against the live API (v1 has no `quoteAvailable`; availability is inferred from non-null `totalToken{0,1}Available`).
- Confirm Base's permissionless oracle is updated frequently enough for heartbeat reliance to hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
