### PR TITLE
feat(testing): support custom ports to run beside another tycho stack

### DIFF
--- a/protocols/testing/CLAUDE.md
+++ b/protocols/testing/CLAUDE.md
@@ -17,4 +17,10 @@ cargo run -- full  --package "ethereum-balancer-v2"          # creation block to
 cargo run -- range --package "base-aerodrome-slipstreams" --chain base
 ```
 
+WARNING: each run drops and recreates the database named in `DATABASE_URL`. The spawned
+tycho-indexer listens on `TYCHO_SERVER_PORT` / `--tycho-server-port` (default 4242). To run
+alongside another Tycho stack, isolate both the database and the port — see `README.md`
+("Running alongside another Tycho stack"). The compose db host port is `DB_HOST_PORT`
+(default 5431).
+
 Docker Compose is available for isolated runs — see `README.md`.

--- a/protocols/testing/README.md
+++ b/protocols/testing/README.md
@@ -32,6 +32,23 @@ cargo run -- range --package "base-aerodrome-slipstreams" --chain base
 docker compose down
 ```
 
+### Running alongside another Tycho stack
+
+The defaults collide with a locally running Tycho stack (Postgres on host port 5431, indexer
+on port 4242). Worse, each run drops and recreates the database named in `DATABASE_URL` — so
+never point it at a database another instance is using. To run in parallel, isolate all ports:
+
+```bash
+# Start a dedicated Postgres on a free host port
+DB_HOST_PORT=5433 docker compose up db -d
+
+# Point the test runner at it and pick a free indexer port
+export DATABASE_URL=postgres://postgres:mypassword@localhost:5433/tycho_indexer_0
+export TYCHO_SERVER_PORT=4243   # or pass --tycho-server-port 4243
+
+cargo run -- range --package "ethereum-balancer-v2"
+```
+
 ## How to Run with Docker
 
 ```bash

--- a/protocols/testing/docker-compose.yaml
+++ b/protocols/testing/docker-compose.yaml
@@ -15,8 +15,10 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_DB: tycho_indexer_0
     command: postgres -c shared_preload_libraries=pg_partman_bgw,pg_cron -c cron.database_name=tycho_indexer_0
+    # Host port for Postgres. Override when 5431 is taken, e.g. by another tycho stack:
+    # DB_HOST_PORT=5433 docker compose up db -d
     ports:
-      - "5431:5432"
+      - "${DB_HOST_PORT:-5431}:5432"
     shm_size: "1gb"
     volumes:
       - postgres_data:/var/lib/postgresql/data

--- a/protocols/testing/src/main.rs
+++ b/protocols/testing/src/main.rs
@@ -54,6 +54,7 @@ impl FullTestCommand {
             args.package,
             args.db_url,
             args.rpc_url,
+            args.tycho_server_port,
             args.vm_simulation_traces,
             args.reuse_last_sync,
         )?
@@ -82,6 +83,7 @@ impl RangeTestCommand {
             args.package,
             args.db_url,
             args.rpc_url,
+            args.tycho_server_port,
             args.vm_simulation_traces,
             args.reuse_last_sync,
         )?
@@ -113,6 +115,11 @@ struct CommonArgs {
 
     #[arg(long, env = "RPC_URL")]
     rpc_url: String,
+
+    /// Port for the spawned tycho-indexer HTTP/WS server. Set this to a free port when
+    /// another tycho-indexer instance (e.g. a full sync) already occupies the default.
+    #[arg(long, env = "TYCHO_SERVER_PORT", default_value_t = 4242)]
+    tycho_server_port: u16,
 
     /// Enable tracing during vm simulations
     #[arg(long, default_value_t = false)]

--- a/protocols/testing/src/test_runner.rs
+++ b/protocols/testing/src/test_runner.rs
@@ -94,6 +94,7 @@ pub struct TestRunner {
     test_type: TestType,
     chain: Chain,
     db_url: String,
+    tycho_server_port: u16,
     substreams_path: PathBuf,
     config_file_path: PathBuf,
     vm_simulation_traces: bool,
@@ -113,6 +114,7 @@ impl TestRunner {
         protocol: String,
         db_url: String,
         rpc_url: String,
+        tycho_server_port: u16,
         vm_simulation_traces: bool,
         reuse_last_sync: bool,
     ) -> miette::Result<Self> {
@@ -143,6 +145,7 @@ impl TestRunner {
             test_type,
             chain,
             db_url,
+            tycho_server_port,
             substreams_path,
             config_file_path,
             vm_simulation_traces,
@@ -257,7 +260,7 @@ impl TestRunner {
         });
 
         // Wait for protocol to be synced before starting live testing
-        let tycho_client = TychoClient::new("http://localhost:4242", Some("dummy".to_string()))
+        let tycho_client = TychoClient::new(&self.tycho_http_url(), Some("dummy".to_string()))
             .into_diagnostic()
             .wrap_err("Failed to create Tycho client for sync check")?;
 
@@ -281,7 +284,7 @@ impl TestRunner {
         let chain = self.chain;
         // Load tokens for the stream
         let all_tokens = tycho_simulation::utils::load_all_tokens(
-            "localhost:4242",
+            &self.tycho_host(),
             true,
             Some("dummy"),
             true,
@@ -296,7 +299,8 @@ impl TestRunner {
         let _ = tycho_simulation::evm::engine_db::SHARED_TYCHO_DB.clear();
 
         let protocol_stream_builder =
-            ProtocolStreamBuilder::new("localhost:4242/", chain).skip_state_decode_failures(true);
+            ProtocolStreamBuilder::new(&format!("{}/", self.tycho_host()), chain)
+                .skip_state_decode_failures(true);
 
         let adapter_contract_path = self.get_adapter_contract_path(
             &config.adapter_contract,
@@ -637,14 +641,33 @@ impl TestRunner {
         Ok(())
     }
 
-    async fn empty_database(&self) -> Result<(), tokio_postgres::Error> {
-        // Remove db name from URL. This is required because we cannot drop a database that we are
-        // currently connected to.
-        let base_url = match self.db_url.rfind('/') {
-            Some(pos) => &self.db_url[..pos],
-            None => self.db_url.as_str(),
+    /// Host and port of the spawned tycho-indexer server, e.g. `localhost:4242`.
+    fn tycho_host(&self) -> String {
+        format!("localhost:{}", self.tycho_server_port)
+    }
+
+    /// HTTP URL of the spawned tycho-indexer server, e.g. `http://localhost:4242`.
+    fn tycho_http_url(&self) -> String {
+        format!("http://{}", self.tycho_host())
+    }
+
+    async fn empty_database(&self) -> miette::Result<()> {
+        // Split the URL into the server part and the database name. We must connect without the
+        // database name because we cannot drop a database that we are currently connected to.
+        let (base_url, db_name) = match self.db_url.rfind('/') {
+            Some(pos) => (&self.db_url[..pos], &self.db_url[pos + 1..]),
+            None => (self.db_url.as_str(), ""),
         };
-        let (client, connection) = tokio_postgres::connect(base_url, NoTls).await?;
+        if db_name.is_empty() {
+            return Err(miette!(
+                "Database URL '{}' has no database name; expected e.g. \
+                 postgres://user:password@host:port/db_name",
+                self.db_url
+            ));
+        }
+        let (client, connection) = tokio_postgres::connect(base_url, NoTls)
+            .await
+            .into_diagnostic()?;
 
         // Spawn the connection handler
         tokio::spawn(async move {
@@ -653,12 +676,16 @@ impl TestRunner {
             }
         });
 
+        // Identifiers cannot be bound as query parameters; quote them, escaping embedded quotes.
+        let quoted_name = format!("\"{}\"", db_name.replace('"', "\"\""));
         client
-            .execute("DROP DATABASE IF EXISTS \"tycho_indexer_0\" WITH (FORCE)", &[])
-            .await?;
+            .execute(&format!("DROP DATABASE IF EXISTS {quoted_name} WITH (FORCE)"), &[])
+            .await
+            .into_diagnostic()?;
         client
-            .execute("CREATE DATABASE \"tycho_indexer_0\"", &[])
-            .await?;
+            .execute(&format!("CREATE DATABASE {quoted_name}"), &[])
+            .await
+            .into_diagnostic()?;
 
         Ok(())
     }
@@ -667,10 +694,14 @@ impl TestRunner {
         if !self.reuse_last_sync {
             self.empty_database()
                 .await
-                .into_diagnostic()
                 .wrap_err("Failed to empty the database")?;
         }
-        Ok(TychoRunner::new(self.chain, self.db_url.to_string(), initialized_accounts))
+        Ok(TychoRunner::new(
+            self.chain,
+            self.db_url.to_string(),
+            self.tycho_server_port,
+            initialized_accounts,
+        ))
     }
 
     fn run_tvl_import(&self) -> miette::Result<()> {
@@ -768,7 +799,7 @@ impl TestRunner {
         info!("Fetching protocol data from Tycho with stop block {}...", stop_block);
 
         // Create Tycho client for the RPC server
-        let tycho_client = TychoClient::new("http://localhost:4242", None)
+        let tycho_client = TychoClient::new(&self.tycho_http_url(), None)
             .into_diagnostic()
             .wrap_err("Failed to create Tycho client")?;
 
@@ -1478,6 +1509,7 @@ mod tests {
             "test-protocol".to_string(),
             "".to_string(),
             rpc_url,
+            4242,
             false,
             false,
         )

--- a/protocols/testing/src/tycho_runner.rs
+++ b/protocols/testing/src/tycho_runner.rs
@@ -13,6 +13,7 @@ use tycho_simulation::tycho_common::models::Chain;
 pub struct TychoRunner {
     chain: Chain,
     db_url: String,
+    server_port: u16,
     initialized_accounts: Vec<String>,
 }
 
@@ -22,8 +23,13 @@ pub struct TychoRpcServer {
 }
 
 impl TychoRunner {
-    pub fn new(chain: Chain, db_url: String, initialized_accounts: Vec<String>) -> Self {
-        Self { chain, db_url, initialized_accounts }
+    pub fn new(
+        chain: Chain,
+        db_url: String,
+        server_port: u16,
+        initialized_accounts: Vec<String>,
+    ) -> Self {
+        Self { chain, db_url, server_port, initialized_accounts }
     }
 
     pub fn run_tycho(
@@ -46,6 +52,8 @@ impl TychoRunner {
         cmd.args([
             "--database-url",
             self.db_url.as_str(),
+            "--server-port",
+            &self.server_port.to_string(),
             "--endpoint",
             get_default_endpoint(&self.chain)
                 .unwrap_or_else(|| panic!("Unknown endpoint for chain {}", self.chain))
@@ -109,11 +117,18 @@ impl TychoRunner {
     pub fn start_rpc_server(&self) -> miette::Result<TychoRpcServer> {
         let (tx, rx): (Sender<bool>, Receiver<bool>) = mpsc::channel();
         let db_url = self.db_url.clone();
+        let server_port = self.server_port.to_string();
 
         // Start the RPC server in a separate thread
         let thread_handle = thread::spawn(move || {
             let mut cmd = Command::new("tycho-indexer")
-                .args(["--database-url", db_url.as_str(), "rpc"])
+                .args([
+                    "--database-url",
+                    db_url.as_str(),
+                    "--server-port",
+                    server_port.as_str(),
+                    "rpc",
+                ])
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
                 .env(
@@ -202,6 +217,8 @@ impl TychoRunner {
         cmd.args([
             "--database-url",
             self.db_url.as_str(),
+            "--server-port",
+            &self.server_port.to_string(),
             "--endpoint",
             get_default_endpoint(&self.chain)
                 .unwrap_or_else(|| panic!("Unknown endpoint for chain {}", self.chain))


### PR DESCRIPTION
## What

Makes `protocol-testing` runnable in parallel with another Tycho stack on the same host.

- Add `--tycho-server-port` / `TYCHO_SERVER_PORT` (default 4242). The port is passed to every spawned `tycho-indexer` process (`run`, `rpc`, `index`) via `--server-port`, and all client URLs (sync wait, token loading, stream builder, RPC fetch) use it instead of the previously hardcoded `localhost:4242`.
- `empty_database()` now drops and recreates the database named in `DATABASE_URL` instead of the hardcoded `tycho_indexer_0`. Previously, pointing the runner at a custom database still dropped `tycho_indexer_0` on that server, which could destroy another instance's data. A URL without a database name is now an error.
- The compose db host port is configurable via `DB_HOST_PORT` (default 5431).
- README gains a "Running alongside another Tycho stack" section; `CLAUDE.md` documents the drop behavior and the new variables.

## Testing

- `cargo clippy -p protocol-testing --all-targets --all-features`: clean
- `cargo test -p protocol-testing`: 3 passed; the 4 failing tests require a real Ethereum RPC endpoint and fail identically on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)