### PR TITLE
fix(adapter-integration): align curve manifest capabilities with contract

### DIFF
--- a/protocols/adapter-integration/evm/src/curve/manifest.yaml
+++ b/protocols/adapter-integration/evm/src/curve/manifest.yaml
@@ -9,7 +9,6 @@ constants:
   # minimum capabilities we can expect, individual pools may extend these
   capabilities:
     - SellSide
-    - PriceFunction
 
 # The file containing the adapter contract
 contract: CurveAdapter.sol


### PR DESCRIPTION
## What

Removes `PriceFunction` from the curve adapter manifest's capability list.

## Why

`CurveAdapter.getCapabilities()` returns only `SellOrder`, and `CurveAdapter.price()` reverts with `NotImplemented("CurveAdapter.price")`. The manifest claimed `PriceFunction` anyway.

The mismatch is harmless at runtime — tycho-simulation queries `getCapabilities()` on the contract and never reads the manifest — but the manifest is misleading for anyone auditing which adapters support the price function (e.g. when assessing the blast radius of the `price()` caller change in #1049).

Note: no automated check validates manifest capabilities against `getCapabilities()` today; the manifests are not consumed anywhere in this repo's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)