### PR TITLE
fix: preserve block history across reinit for flashblock reverts

### DIFF
--- a/crates/tycho-client/src/feed/block_history.rs
+++ b/crates/tycho-client/src/feed/block_history.rs
@@ -267,7 +267,8 @@ impl BlockHistory {
                 // sibling is canonical, so we do not flip the tip here. Classify it as Delayed:
                 // if it is the losing fork it simply waits, and if it is canonical the next block
                 // (number > tip) arrives as Advanced and triggers a block-history reinit that
-                // rebuilds from the synchronizers' converged headers.
+                // rebuilds from the retained history merged with the synchronizers' converged
+                // headers.
                 BlockPosition::Delayed
             } else {
                 // anything else raises e.g. a completely detached, revert=false block

--- a/crates/tycho-client/src/feed/block_history.rs
+++ b/crates/tycho-client/src/feed/block_history.rs
@@ -66,6 +66,11 @@ impl BlockHistory {
 
             // Find connected blocks in sequence
             for block in history.iter().skip(1) {
+                // Skip duplicates or same-height forks. The input may contain overlapping blocks
+                // (e.g. when merging retained history with current stream headers on reinit).
+                if block.number >= current_number {
+                    continue;
+                }
                 // If we find a gap in block numbers, stop building the chain
                 if block.number != current_number - 1 {
                     break;
@@ -290,6 +295,11 @@ impl BlockHistory {
     pub fn oldest(&self) -> Option<&BlockHeader> {
         self.history.front()
     }
+
+    /// Returns the retained block headers, oldest first.
+    pub fn blocks(&self) -> impl Iterator<Item = &BlockHeader> {
+        self.history.iter()
+    }
 }
 
 #[cfg(test)]
@@ -400,6 +410,21 @@ mod test {
         assert_eq!(history.history, exp_history);
         assert!(history.reverts.contains(&int_hash(3)));
         assert!(history.reverts.contains(&int_hash(4)));
+    }
+
+    #[test]
+    fn test_new_tolerates_duplicate_blocks() {
+        // Reinit seeds `new` with retained history plus current stream headers, so the same block
+        // number can appear more than once. A duplicate must not truncate the connected chain.
+        let mut blocks = generate_blocks(4, 5, None); // blocks 5,6,7,8
+        blocks.push(blocks[2].clone()); // duplicate block 7
+
+        let history = BlockHistory::new(blocks, 10).expect("failed to create history");
+
+        // All four connected blocks are retained despite the duplicate.
+        assert_eq!(history.history.len(), 4);
+        assert_eq!(history.oldest().unwrap().number, 5);
+        assert_eq!(history.latest().unwrap().number, 8);
     }
 
     #[test]

--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -976,11 +976,12 @@ where
             .ok_or(BlockHistoryError::EmptyHistory)?
             .clone();
         // Preserve the previously retained history so a revert to a block below the advanced tip
-        // can still find its fork point. Seeding only from current stream headers would root the
-        // new history at the advanced block and drop the ancestors a later revert needs, which
-        // surfaces as `RevertPositionNotFound` ("History exceeded"). `BlockHistory::new` keeps the
-        // longest connected chain ending at the latest header, so detached older blocks (a genuine
-        // gap, e.g. after a restart) are still discarded.
+        // can still find its fork point. Seeding only from current stream headers roots the new
+        // history at the oldest header the streams happen to hold, dropping the ancestors a later
+        // revert needs: a revert targeting that root drains the deque looking for its parent and
+        // fails with `RevertPositionNotFound` ("History exceeded"). `BlockHistory::new` keeps the
+        // connected chain ending at the highest-numbered header, so detached older blocks (a
+        // genuine gap, e.g. after a restart) are still discarded.
         let mut blocks: Vec<BlockHeader> = block_history
             .blocks()
             .cloned()
@@ -1494,6 +1495,42 @@ mod tests {
         new_history
             .push(revert)
             .expect("revert below advanced tip must not exceed history");
+    }
+
+    /// Preserving history must not resurrect blocks across a real gap. When the advanced block is
+    /// genuinely detached (e.g. a synchronizer restarted and jumped ahead), the retained blocks do
+    /// not connect to it and must still be discarded, leaving the history rooted at the advanced
+    /// block rather than stitching together a discontinuous chain.
+    #[test]
+    fn test_reinit_discards_retained_history_on_detached_advanced_block() {
+        let old_blocks = vec![
+            full_header(323, 323, 322),
+            full_header(324, 324, 323),
+            full_header(325, 325, 324),
+        ];
+        let mut old_history = BlockHistory::new(old_blocks, BLOCK_HISTORY_SIZE).unwrap();
+
+        // Advanced block is far ahead and its parent is unknown to the retained history.
+        let mut streams = vec![stream_in_state(
+            "aerodrome",
+            SynchronizerState::Advanced(full_header(400, 400, 399)),
+        )];
+
+        let new_history = BlockSynchronizer::<MockStateSync>::reinit_block_history(
+            &mut streams,
+            &mut old_history,
+        )
+        .expect("reinit failed");
+
+        let retained: Vec<u64> = new_history
+            .blocks()
+            .map(|b| b.number)
+            .collect();
+        assert_eq!(
+            retained,
+            vec![400],
+            "detached advanced block must not be stitched to old history"
+        );
     }
 
     #[test(tokio::test)]

--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -33,6 +33,11 @@ pub mod component_tracker;
 pub mod dto;
 pub mod synchronizer;
 
+/// Number of block headers retained by the `BlockHistory` ring buffer. Bounds how deep a revert
+/// can unwind before the fork point is evicted. Used both on startup and on reinitialization so
+/// the retained depth stays consistent across an `Advanced`-triggered reinit.
+const BLOCK_HISTORY_SIZE: usize = 15;
+
 /// A trait representing a minimal interface for types that behave like a block header.
 ///
 /// This abstraction allows working with either full block headers (`BlockHeader`)
@@ -783,7 +788,7 @@ where
 
         // Fail fast if no synchronizer produced a ready first message.
         Self::require_active_stream(&sync_streams)?;
-        let mut block_history = BlockHistory::new(initial_headers, 15)?;
+        let mut block_history = BlockHistory::new(initial_headers, BLOCK_HISTORY_SIZE)?;
         // Determine the starting header for synchronization.
         // Safe: require_active_stream above guarantees at least one Ready stream,
         // so initial_headers is non-empty and block_history.latest() is Some.
@@ -968,13 +973,25 @@ where
         let previous = block_history
             .latest()
             // Old block history should not be empty, startup should have populated it at this point
-            .ok_or(BlockHistoryError::EmptyHistory)?;
-        let blocks = sync_streams
-            .iter()
-            .filter_map(SynchronizerStream::get_current_header)
+            .ok_or(BlockHistoryError::EmptyHistory)?
+            .clone();
+        // Preserve the previously retained history so a revert to a block below the advanced tip
+        // can still find its fork point. Seeding only from current stream headers would root the
+        // new history at the advanced block and drop the ancestors a later revert needs, which
+        // surfaces as `RevertPositionNotFound` ("History exceeded"). `BlockHistory::new` keeps the
+        // longest connected chain ending at the latest header, so detached older blocks (a genuine
+        // gap, e.g. after a restart) are still discarded.
+        let mut blocks: Vec<BlockHeader> = block_history
+            .blocks()
             .cloned()
             .collect();
-        let new_block_history = BlockHistory::new(blocks, 10)?;
+        blocks.extend(
+            sync_streams
+                .iter()
+                .filter_map(SynchronizerStream::get_current_header)
+                .cloned(),
+        );
+        let new_block_history = BlockHistory::new(blocks, BLOCK_HISTORY_SIZE)?;
         let latest = new_block_history
             .latest()
             // Block history should not be empty, we just populated it.
@@ -1261,6 +1278,29 @@ mod tests {
         }
     }
 
+    /// Builds a full (non-partial) block header. Hash and parent_hash are derived from the given
+    /// numbers so that a chain can be built by setting `parent = number - 1`.
+    fn full_header(number: u64, hash: u64, parent: u64) -> BlockHeader {
+        BlockHeader {
+            number,
+            hash: Bytes::from(hash.to_be_bytes()),
+            parent_hash: Bytes::from(parent.to_be_bytes()),
+            revert: false,
+            timestamp: 1000,
+            partial_block_index: None,
+        }
+    }
+
+    /// Builds a `SynchronizerStream` pinned to a given state, for exercising state-transition
+    /// logic without a live synchronizer. The receiver is never polled by these tests.
+    fn stream_in_state(name: &str, state: SynchronizerState) -> SynchronizerStream {
+        let (_tx, rx) = mpsc::channel(1);
+        let id = ExtractorIdentity { chain: Chain::Ethereum, name: name.to_string() };
+        let mut stream = SynchronizerStream::new(&id, rx);
+        stream.state = state;
+        stream
+    }
+
     async fn receive_message(rx: &mut Receiver<BlockSyncResult<FeedMessage>>) -> FeedMessage {
         timeout(Duration::from_millis(100), rx.recv())
             .await
@@ -1409,6 +1449,51 @@ mod tests {
         assert_eq!(second_feed_msg, exp2);
 
         shutdown_block_synchronizer(nanny_handle, rx).await;
+    }
+
+    /// Regression test for the "Reverting block's insert position not found! History exceeded"
+    /// crash seen on Base with flashblocks enabled.
+    ///
+    /// When one synchronizer races ahead (e.g. one partial block), it is classified `Advanced`
+    /// and the block history is reinitialized. If the reinit discards the previously retained
+    /// history, a subsequent revert to a block *below* the advanced tip can no longer find its
+    /// fork point and the whole stream terminates. Reinit must preserve the prior history so the
+    /// revert still resolves.
+    #[test]
+    fn test_reinit_preserves_history_for_revert_below_advanced_tip() {
+        // Old history: connected chain 323 -> 324 -> 325 (hash == number).
+        let old_blocks = vec![
+            full_header(323, 323, 322),
+            full_header(324, 324, 323),
+            full_header(325, 325, 324),
+        ];
+        let mut old_history = BlockHistory::new(old_blocks, 15).unwrap();
+
+        // One stream raced ahead to 326 (connected to 325) -> Advanced, triggering reinit.
+        // Another stream is still at 325 (Delayed).
+        let mut streams = vec![
+            stream_in_state("aerodrome", SynchronizerState::Advanced(full_header(326, 326, 325))),
+            stream_in_state("uniswap_v3", SynchronizerState::Delayed(full_header(325, 325, 324))),
+        ];
+
+        let mut new_history = BlockSynchronizer::<MockStateSync>::reinit_block_history(
+            &mut streams,
+            &mut old_history,
+        )
+        .expect("reinit failed");
+
+        // A revert to block 325 must still find its fork point (324) in the retained history.
+        let revert = BlockHeader {
+            number: 325,
+            hash: Bytes::from(325u64.to_be_bytes()),
+            parent_hash: Bytes::from(324u64.to_be_bytes()),
+            revert: true,
+            timestamp: 1000,
+            partial_block_index: None,
+        };
+        new_history
+            .push(revert)
+            .expect("revert below advanced tip must not exceed history");
     }
 
     #[test(tokio::test)]


### PR DESCRIPTION
## Problem

On Base with flashblocks enabled, `base-fynd` pods crash-loop with:

```
ERROR tycho_simulation::evm::stream: Block stream ended with terminal error:
Failed to process new block: Reverting block's insert position not found! History exceeded
```

The error is `BlockHistoryError::RevertPositionNotFound`, raised in `BlockHistory::push` when a revert drains the whole retained deque looking for its fork point.

## Root cause (confirmed from prod-fynd logs)

Reconstructed from the crashed container (`base-fynd-spot`, extractor `aerodrome_slipstreams`):

| Time | Event |
|------|-------|
| `14:59:58.338191` | `aerodrome_slipstreams` transition to **advanced** — jumped to `#48928326 (partial 1)` while the tip was `#48928325 (partial 11)` |
| `14:59:58.338235` | **Reinitialized block history** — rebuilt from stream headers only |
| `14:59:58.3–58.7` | history advances to `#48928327` |
| `14:59:59.711` | **crash** processing `aerodrome_slipstreams` revert to `#48928325 (partial 10)` → `RevertPositionNotFound` |

With flashblocks, one synchronizer regularly races a partial block ahead of the others. A detached higher block is classified `Advanced`, which triggers `reinit_block_history`. The old reinit rebuilt the history from `get_current_header()` of each stream only — one header per stream, all clustered at the leading blocks.

The precise mechanism: that seed rooted the new history at `#48928325 (p10)` (a slower stream's header, which is also the parent the advanced `#48928326 p1` connected to — hence it was `Advanced` rather than `NextExpected`, since its parent was `p10`, not the tip `p11`). Everything below that root — critically `#48928324` — was dropped. When the revert to `#48928325` arrived, `determine_block_position` classified it `NextExpected` (its hash is in history and `revert=true`, block_history.rs:236-251), so `push` drained the deque hunting for parent `#48928324`, never found it, and errored.

Note the ordering constraint: the revert target must itself still be **retained as the oldest block**. Had `#48928325` been dropped entirely, the revert would have been classified `Delayed` (`block.number < oldest.number`) and silently ignored — no crash. The failure needs the target retained as the root with its parent evicted.

## Why simply increasing the buffer size does not fix it

The initially suggested fix was to raise the two hardcoded `BlockHistory::new` sizes (`15` on startup, `10` on reinit). This would **not** have prevented the crash:

- The buffer did not overflow and evict the fork point. The reinit **rebuilt** the history from a seed that never contained `#48928324` at all, so `BlockHistory::new(seed, 10_000)` builds the identical `[325, 326]` chain and crashes the same way. Capacity is irrelevant when the block is absent from the seed.
- The startup `size = 15` is discarded by the reinit, so it has no bearing on this crash.
- Without the reinit, the revert from `#48928327` to `#48928325` is only two blocks deep and the existing `size = 10` buffer would have held it comfortably. The reinit is what threw away the history the revert needed.

## Fix

- `reinit_block_history` seeds the new history with the **retained blocks plus** current stream headers, so a revert to a block below the advanced tip still finds its fork point. `BlockHistory::new` keeps the connected chain ending at the highest-numbered header, so a genuinely detached advanced block (a real gap after a restart) still discards the old history rather than stitching a discontinuous chain.
- `BlockHistory::new` skips duplicate / same-height entries instead of truncating the chain, since the merged seed can contain the same block number twice. This half is load-bearing: without it the merged seed `[323,324,325,326,325]` breaks at the duplicate and yields `[325,326]` again.
- Startup and reinit share a single `BLOCK_HISTORY_SIZE` constant, so reinit no longer shrinks the retained depth from 15 to 10.

## Known residual (pre-existing, not introduced here)

If the advanced block's parent matches no retained or streamed header (possible with ephemeral flashblock hashes), the rebuilt history is still rooted at the advanced block. A later revert below it is then classified `Delayed` and silently dropped — the history never rewinds, and recovery waits for a subsequent reinit. That is a no-op rather than a crash, and is unchanged by this PR.

## Tests

- `test_reinit_preserves_history_for_revert_below_advanced_tip` reproduces the crash and fails with `RevertPositionNotFound` on the old code. It covers **both** halves of the fix — it also fails with the `mod.rs` change alone.
- `test_new_tolerates_duplicate_blocks` covers the duplicate-seed chain-building change.
- `test_reinit_discards_retained_history_on_detached_advanced_block` locks in that a real gap still discards old history.
- Full `tycho-client` suite passes (145 lib tests); workspace clippy and nightly fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)