### PR TITLE
fix(uniswap_v4): correct spot_price for hook-attached pools

### DIFF
--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/decoder.rs
@@ -9,7 +9,10 @@ use super::state::UniswapV4State;
 use crate::{
     evm::protocol::{
         uniswap_v4::{
-            hooks::hook_handler_creator::{instantiate_hook_handler, HookCreationParams},
+            hooks::{
+                hook_handler_creator::{instantiate_hook_handler, HookCreationParams},
+                utils::{has_permission, HookOptions},
+            },
             state::UniswapV4Fees,
         },
         utils::uniswap::{i24_be_bytes_to_i32, tick_list::TickInfo},
@@ -99,7 +102,7 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for UniswapV4State {
                 .ok_or_else(|| InvalidSnapshotError::MissingAttribute("tick".to_string()))?,
         );
 
-        let ticks: Result<Vec<_>, _> = snapshot
+        let ticks: Vec<_> = snapshot
             .state
             .attributes
             .iter()
@@ -120,31 +123,45 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for UniswapV4State {
                     None
                 }
             })
-            .collect();
+            .try_collect()?;
 
-        let hook_address = snapshot
+        let hook_bytes: [u8; 20] = snapshot
             .component
             .static_attributes
-            .get("hooks");
+            .get("hooks")
+            .ok_or_else(|| InvalidSnapshotError::MissingAttribute("hooks".to_string()))?
+            .as_ref()
+            .try_into()
+            .map_err(|_| {
+                InvalidSnapshotError::ValueError(
+                    "hooks attribute must be a 20-byte address".to_string(),
+                )
+            })?;
+        let hook_address = Address::from(hook_bytes);
 
-        let mut ticks = match ticks {
-            Ok(ticks) if !ticks.is_empty() => ticks
+        // A hook can reshape swaps or manage the pool's liquidity only if it exposes a
+        // before/after-swap permission — which also covers the *ReturnsDelta variants (v4 requires
+        // the base swap flag to be set for those) and any protocol-specific handler (e.g. Angstrom,
+        // Euler), since those hooks necessarily intercept swaps.
+        let hook_affects_swaps = has_permission(hook_address, HookOptions::BeforeSwap) ||
+            has_permission(hook_address, HookOptions::AfterSwap);
+
+        let ticks = if ticks.is_empty() {
+            // An empty tick set is legitimate when the pool holds no active liquidity (a
+            // freshly-created or fully-drained pool) or when a hook manages swaps/liquidity.
+            // Active liquidity with no tick data, on the other hand, is a malformed snapshot.
+            if hook_affects_swaps || liquidity == 0 {
+                Vec::new()
+            } else {
+                return Err(InvalidSnapshotError::MissingAttribute("tick_liquidities".to_string()));
+            }
+        } else {
+            ticks
                 .into_iter()
                 .filter(|t| t.net_liquidity != 0)
-                .collect::<Vec<_>>(),
-            _ => {
-                // there might be pools where the liquidity is managed by the hook
-                if hook_address.is_some() {
-                    Vec::new()
-                } else {
-                    return Err(InvalidSnapshotError::MissingAttribute(
-                        "tick_liquidities".to_string(),
-                    ));
-                }
-            }
+                .sorted_unstable_by_key(|t| t.index)
+                .collect()
         };
-
-        ticks.sort_by_key(|tick| tick.index);
 
         let mut state = UniswapV4State::new(liquidity, sqrt_price, fees, tick, tick_spacing, ticks)
             .map_err(|err| {
@@ -156,9 +173,7 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for UniswapV4State {
                 InvalidSnapshotError::ValueError(err.to_string())
             })?;
 
-        if let Some(hook_address) = hook_address {
-            let hook_address = Address::from_slice(&hook_address.0);
-
+        if hook_affects_swaps {
             // Merge state attributes into static_attributes for hook creation
             let mut merged_attributes = snapshot
                 .component
@@ -178,7 +193,7 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for UniswapV4State {
 
             let hook_handler = instantiate_hook_handler(&hook_address, hook_params)?;
             state.set_hook_handler(hook_handler);
-        };
+        }
 
         for tokens in snapshot
             .component
@@ -222,6 +237,7 @@ mod tests {
         let static_attributes: HashMap<String, Bytes> = HashMap::from([
             ("key_lp_fee".to_string(), Bytes::from(500_i32.to_be_bytes().to_vec())),
             ("tick_spacing".to_string(), Bytes::from(60_i32.to_be_bytes().to_vec())),
+            ("hooks".to_string(), Bytes::from(vec![0u8; 20])),
         ]);
 
         ProtocolComponent {
@@ -288,6 +304,123 @@ mod tests {
 
     #[tokio::test]
     #[rstest]
+    // The zero address (no-op hook) and any non-zero address without before/after-swap permission
+    // bits must NOT get a hook handler attached: the pool prices via the sqrt-price branch.
+    #[case::zero_address(vec![0u8; 20])]
+    #[case::non_zero_without_swap_permissions({
+        let mut a = vec![0u8; 20];
+        a[19] = 0x01; // low permission byte with BeforeSwap (bit 7) / AfterSwap (bit 6) clear
+        a
+    })]
+    async fn test_usv4_no_handler_for_permissionless_hook(#[case] hook_bytes: Vec<u8>) {
+        let mut component = usv4_component();
+        component
+            .static_attributes
+            .insert("hooks".to_string(), Bytes::from(hook_bytes));
+
+        let snapshot = ComponentWithState {
+            state: ProtocolComponentState {
+                component_id: "State1".to_owned(),
+                attributes: usv4_attributes(),
+                balances: HashMap::new(),
+            },
+            component,
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        };
+
+        let result = try_decode_snapshot_with_defaults::<UniswapV4State>(snapshot)
+            .await
+            .unwrap();
+
+        assert!(result.hook.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_usv4_tick_decode_error_propagates() {
+        // A malformed tick attribute must surface as a decoding (ValueError) error, not be
+        // masked as missing/empty tick liquidity.
+        let mut attributes = usv4_attributes();
+        attributes.insert(
+            "ticks/not_an_int/net_liquidity".to_string(),
+            Bytes::from(400_i128.to_be_bytes().to_vec()),
+        );
+
+        let snapshot = ComponentWithState {
+            state: ProtocolComponentState {
+                component_id: "State1".to_owned(),
+                attributes,
+                balances: HashMap::new(),
+            },
+            component: usv4_component(),
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        };
+
+        let result = try_decode_snapshot_with_defaults::<UniswapV4State>(snapshot).await;
+        assert!(matches!(result, Err(InvalidSnapshotError::ValueError(_))));
+    }
+
+    #[tokio::test]
+    async fn test_usv4_malformed_hooks_length_errors() {
+        // A `hooks` attribute that is not a 20-byte address must error, not panic.
+        let mut component = usv4_component();
+        component
+            .static_attributes
+            .insert("hooks".to_string(), Bytes::from(vec![0u8; 19]));
+
+        let snapshot = ComponentWithState {
+            state: ProtocolComponentState {
+                component_id: "State1".to_owned(),
+                attributes: usv4_attributes(),
+                balances: HashMap::new(),
+            },
+            component,
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        };
+
+        let result = try_decode_snapshot_with_defaults::<UniswapV4State>(snapshot).await;
+        assert!(matches!(result, Err(InvalidSnapshotError::ValueError(_))));
+    }
+
+    #[tokio::test]
+    async fn test_usv4_empty_hookless_pool_decodes() {
+        // A hookless pool with zero active liquidity and no tick data is valid (e.g. a freshly
+        // created or fully-drained pool) and must decode as an empty pool, not be rejected.
+        let mut attributes = usv4_attributes();
+        attributes.insert("liquidity".to_string(), Bytes::from(0_u64.to_be_bytes().to_vec()));
+        attributes.remove("ticks/60/net_liquidity");
+
+        let snapshot = ComponentWithState {
+            state: ProtocolComponentState {
+                component_id: "State1".to_owned(),
+                attributes,
+                balances: HashMap::new(),
+            },
+            component: usv4_component(), // hooks = zero address
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        };
+
+        let result = try_decode_snapshot_with_defaults::<UniswapV4State>(snapshot)
+            .await
+            .unwrap();
+
+        let expected = UniswapV4State::new(
+            0,
+            U256::from(79228162514264337593543950336_u128),
+            UniswapV4Fees::new(0, 0, 500),
+            300,
+            60,
+            vec![],
+        )
+        .unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[tokio::test]
+    #[rstest]
     #[case::missing_liquidity("liquidity")]
     #[case::missing_sqrt_price("sqrt_price")]
     #[case::missing_tick("tick")]
@@ -295,6 +428,7 @@ mod tests {
     #[case::missing_fee("key_lp_fee")]
     #[case::missing_fee("protocol_fees/one2zero")]
     #[case::missing_fee("protocol_fees/zero2one")]
+    #[case::missing_hooks("hooks")]
     async fn test_usv4_try_from_invalid(#[case] missing_attribute: String) {
         // remove missing attribute
         let mut component = usv4_component();
@@ -313,6 +447,12 @@ mod tests {
             component
                 .static_attributes
                 .remove("key_lp_fee");
+        }
+
+        if missing_attribute == "hooks" {
+            component
+                .static_attributes
+                .remove("hooks");
         }
 
         let snapshot = ComponentWithState {

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
@@ -172,6 +172,72 @@ impl UniswapV4State {
         })
     }
 
+    /// Buy price of `base` denominated in `quote`, derived from the pool's `sqrt_price` and LP
+    /// fee: `pre_fee_price / (1 - fee)` — the `ProtocolSim::spot_price` convention. Ignores any
+    /// hook-specific pricing effects; a hook that reshapes execution should implement its own
+    /// `HookHandler::spot_price`.
+    fn sqrt_price_buy_quote(&self, base: &Token, quote: &Token) -> Result<f64, SimulationError> {
+        let zero_for_one = base < quote;
+        let fee = self
+            .fees
+            .calculate_swap_fees_pips(zero_for_one, None) as f64 /
+            1_000_000.0;
+
+        let price = if zero_for_one {
+            sqrt_price_q96_to_f64(self.sqrt_price, base.decimals, quote.decimals)?
+        } else {
+            1.0f64 / sqrt_price_q96_to_f64(self.sqrt_price, quote.decimals, base.decimals)?
+        };
+
+        Ok(add_fee_markup(price, fee))
+    }
+
+    /// Marginal buy price of `base` denominated in `quote`, derived from `get_amount_out(quote ->
+    /// base)` at a negligibly small size. Unlike [`Self::sqrt_price_buy_quote`], this reflects the
+    /// hook's execution — the native `sqrt_price` is meaningless for hook-managed-liquidity pools
+    /// (e.g. Euler) — and is expressed as a buy price (`quote` per `base`) consistent with the
+    /// `spot_price` convention: the reciprocal of the marginal `base`-out per `quote`-in.
+    fn hook_marginal_buy_quote(&self, base: &Token, quote: &Token) -> Result<f64, SimulationError> {
+        // Two small quote-denominated probes approximate d(base_out)/d(quote_in).
+        let x1 = BigUint::from(10u64).pow(quote.decimals) / BigUint::from(100u64); // 0.01 quote
+        let x2 = &x1 + (&x1 / BigUint::from(100u64));
+
+        let base_out_1 = self
+            .get_amount_out(x1.clone(), quote, base)?
+            .amount;
+        let base_out_2 = self
+            .get_amount_out(x2.clone(), quote, base)?
+            .amount;
+
+        let delta_quote = x2.checked_sub(&x1).ok_or_else(|| {
+            SimulationError::FatalError("spot price: quote probe underflow".to_string())
+        })?;
+        let delta_base = base_out_2
+            .checked_sub(&base_out_1)
+            .ok_or_else(|| {
+                SimulationError::RecoverableError(
+                    "spot price: base output not monotonic in quote input".to_string(),
+                )
+            })?;
+
+        if delta_base.is_zero() {
+            return Err(SimulationError::RecoverableError(
+                "spot price: zero base output delta".to_string(),
+            ));
+        }
+
+        let delta_quote_f64 = delta_quote.to_f64().ok_or_else(|| {
+            SimulationError::FatalError("spot price: quote delta to f64".to_string())
+        })?;
+        let delta_base_f64 = delta_base.to_f64().ok_or_else(|| {
+            SimulationError::FatalError("spot price: base delta to f64".to_string())
+        })?;
+
+        // quote-per-base (human) = (Δquote_raw / Δbase_raw) * 10^(base.decimals - quote.decimals)
+        let token_correction = 10f64.powi(base.decimals as i32 - quote.decimals as i32);
+        Ok(delta_quote_f64 / delta_base_f64 * token_correction)
+    }
+
     fn swap(
         &self,
         zero_for_one: bool,
@@ -437,77 +503,19 @@ impl ProtocolSim for UniswapV4State {
     }
 
     fn spot_price(&self, base: &Token, quote: &Token) -> Result<f64, SimulationError> {
-        if let Some(hook) = &self.hook {
-            match hook.spot_price(base, quote) {
-                Ok(price) => return Ok(price),
-                Err(SimulationError::RecoverableError(_)) => {
-                    // Calculate spot price by swapping two amounts and use the approximation
-                    // to get the derivative, following the pattern from vm/state.rs
-
-                    // Calculate the first sell amount (x1) as a small amount
-                    let x1 = BigUint::from(10u64).pow(base.decimals) / BigUint::from(100u64); // 0.01 token
-
-                    // Calculate the second sell amount (x2) as x1 + 1% of x1
-                    let x2 = &x1 + (&x1 / BigUint::from(100u64));
-
-                    // Perform swaps to get the received amounts
-                    let y1 = self.get_amount_out(x1.clone(), base, quote)?;
-                    let y2 = self.get_amount_out(x2.clone(), base, quote)?;
-
-                    // Calculate the marginal price
-                    let num = y2
-                        .amount
-                        .checked_sub(&y1.amount)
-                        .ok_or_else(|| {
-                            SimulationError::FatalError(
-                                "Cannot calculate spot price: y2 < y1".to_string(),
-                            )
-                        })?;
-                    let den = x2.checked_sub(&x1).ok_or_else(|| {
-                        SimulationError::FatalError(
-                            "Cannot calculate spot price: x2 < x1".to_string(),
-                        )
-                    })?;
-
-                    if den == BigUint::from(0u64) {
-                        return Err(SimulationError::FatalError(
-                            "Cannot calculate spot price: denominator is zero".to_string(),
-                        ));
-                    }
-
-                    // Convert to f64 and adjust for decimals
-                    let num_f64 = num.to_f64().ok_or_else(|| {
-                        SimulationError::FatalError(
-                            "Failed to convert numerator to f64".to_string(),
-                        )
-                    })?;
-                    let den_f64 = den.to_f64().ok_or_else(|| {
-                        SimulationError::FatalError(
-                            "Failed to convert denominator to f64".to_string(),
-                        )
-                    })?;
-
-                    let token_correction = 10f64.powi(base.decimals as i32 - quote.decimals as i32);
-
-                    return Ok(num_f64 / den_f64 * token_correction);
-                }
-                Err(e) => return Err(e),
-            }
-        }
-
-        let zero_for_one = base < quote;
-        let fee_pips = self
-            .fees
-            .calculate_swap_fees_pips(zero_for_one, None);
-        let fee = fee_pips as f64 / 1_000_000.0;
-
-        let price = if zero_for_one {
-            sqrt_price_q96_to_f64(self.sqrt_price, base.decimals, quote.decimals)?
-        } else {
-            1.0f64 / sqrt_price_q96_to_f64(self.sqrt_price, quote.decimals, base.decimals)?
+        let Some(hook) = &self.hook else {
+            return self.sqrt_price_buy_quote(base, quote);
         };
 
-        Ok(add_fee_markup(price, fee))
+        hook.spot_price(base, quote)
+            .or_else(|err| match err {
+                // The hook does not override spot pricing (e.g. the generic VM handler). Derive the
+                // price from `get_amount_out` so it reflects the hook's execution — the native
+                // `sqrt_price` is a placeholder for hook-managed-liquidity pools (e.g. Euler) — and
+                // express it as a buy price (see `hook_marginal_buy_quote`).
+                SimulationError::RecoverableError(_) => self.hook_marginal_buy_quote(base, quote),
+                e => Err(e),
+            })
     }
 
     fn get_amount_out(
@@ -1019,6 +1027,54 @@ mod tests {
         },
         protocol::models::{DecoderContext, TryFromWithBlock},
     };
+
+    /// The `spot_price` hook fallback (`hook_marginal_buy_quote`) derives the price from
+    /// `get_amount_out`, so it reflects hook execution, and expresses it as a buy price — hence
+    /// the round-trip `spot(a,b) * spot(b,a)` equals `1/(1-fee)^2` (> 1). On an ordinary CL pool
+    /// the native curve is the execution path, so it also tracks the sqrt-price buy quote. Tested
+    /// directly (no hook needed) since the method only depends on `get_amount_out`.
+    #[test]
+    fn test_v4_hook_marginal_buy_quote_is_buy_price() {
+        let pool = create_basic_v4_test_pool();
+        let x = token_x();
+        let y = token_y();
+        let fee = pool.fees.lp_fee as f64 / 1_000_000.0;
+        let expected_buy = 1.0 / (1.0 - fee).powi(2);
+
+        let fwd = pool
+            .hook_marginal_buy_quote(&x, &y)
+            .unwrap();
+        let rev = pool
+            .hook_marginal_buy_quote(&y, &x)
+            .unwrap();
+        let product = fwd * rev;
+
+        assert!(product > 1.0, "round-trip {product} must be > 1 (buy-price convention)");
+        // Finite-difference of get_amount_out, so within probe tolerance of 1/(1-fee)^2.
+        assert!(
+            (product - expected_buy).abs() / expected_buy < 5e-3,
+            "round-trip {product} should be ~1/(1-fee)^2 {expected_buy}"
+        );
+
+        // On this ordinary CL pool the native curve is the execution path, so the execution-aware
+        // fallback tracks the sqrt-price buy quote.
+        assert!(
+            (fwd - pool
+                .sqrt_price_buy_quote(&x, &y)
+                .unwrap())
+            .abs() /
+                fwd <
+                5e-3
+        );
+        assert!(
+            (rev - pool
+                .sqrt_price_buy_quote(&y, &x)
+                .unwrap())
+            .abs() /
+                rev <
+                5e-3
+        );
+    }
 
     // Helper methods to create commonly used tokens
     fn usdc() -> Token {


### PR DESCRIPTION
## Summary

Uniswap v4 `spot_price` returned a fee-inclusive sell rate for any pool with a hook
attached, instead of the documented buy price (`pre_fee_price / (1 - fee)`). This PR makes
hookless and no-op-hook pools price off the pool's `sqrt_price`, and makes hooked pools
derive the buy price from `get_amount_out`.

After this change, for a single pool `spot_price(a, b) * spot_price(b, a) == 1/(1 - fee)^2`.

## How this was discovered

A searcher forensics report flagged the v4 CLANKER/USDC pool
(`0xdf43c40188c1a711bc49fa5922198b8d732918000462d9c8b4cf6db0b37d3dcd`, Base block
48843205) where `get_amount_out` deviated up to ~68% from `spot_price`.

Reconstructing the pool from its indexed state showed `get_amount_out` was correct and
`spot_price` was wrong:

| | v0.337.1 (before) | this PR |
|---|---|---|
| `spot_price(CLANKER->USDC)` (buy) | 8.07 | 13.80 |
| `get_amount_out` realized rate (sell) | 13.63 | 13.63 (unchanged) |
| gap: realized vs spot | +68.9% | -1.25% |
| round-trip product | 0.566 | 1.006 (= 1/(1-fee)^2) |

The remaining -1.25% is the expected buy-vs-sell fee spread (`1 - (1-fee)^2`) plus probe
slippage, not an inconsistency.

The pool has no hook (`hooks` is the zero address, 20 zero bytes), so this was not
hook-specific behaviour. A single-block Ethereum mainnet audit across all v4 pools confirmed
it was systemic: of the pools whose round-trip product was below 1, 1161/1161 had a hook
handler attached.

## Root cause

Two things combined:

1. The decoder attached a hook handler to **every** v4 pool. The `hooks` field of the v4
   PoolKey is always present in the component attributes, including the zero address for
   hookless pools, and the decoder attached a handler whenever the attribute existed. With
   no handler registered for the zero address, it used the default `GenericVMHookHandler`.

2. **No hook handler implements `spot_price`.** `GenericVMHookHandler` (used for the zero
   address and for Euler), and the `AngstromHookHandler`, both return `RecoverableError`
   from `spot_price`. So every hook — the no-op zero address, the two known hooks (Angstrom
   and Euler), and any unknown hook — fell through to `UniswapV4State::spot_price`'s fallback,
   which took a finite difference of `get_amount_out` and returned it directly. That is a
   fee-inclusive *sell* rate (marginal output per input), below the intended buy price, so
   the round-trip product collapsed to `(1-fee)^2 < 1`.

## Changes

- The decoder attaches a hook handler only when the hook has a before/after-swap permission
  (which also covers the `*ReturnsDelta` variants, since v4 requires the base swap flag).
  Hookless and no-op-hook pools now carry no handler and use the `sqrt_price` buy quote.
- When an attached hook does not override `spot_price`, `UniswapV4State::spot_price` derives
  the buy price from `get_amount_out(quote -> base)` and takes its reciprocal. This reflects
  the hook's execution — the native `sqrt_price` is a placeholder for hook-managed-liquidity
  pools such as Euler — and is expressed in the buy-price convention.
- `hooks` is now a required decode attribute, converted into a 20-byte address (a wrong
  length returns an error rather than panicking).
- Empty tick liquidity is tolerated only for hook-managed or zero-liquidity pools; an
  ordinary pool missing tick liquidity is an invalid snapshot. Tick decode errors propagate
  as `ValueError` instead of being masked as missing/empty.

## Testing

- `cargo test -p tycho-simulation --lib uniswap_v4 -- --include-ignored`: 74 pass (includes
  the VM-backed Euler, Angstrom, and generic hook execution tests).
- Full `tycho-simulation` lib suite passes; `cargo +nightly fmt` and `clippy` clean.
- Added: decoder tests for permission-less hook -> no handler, empty hookless pool decodes,
  tick decode error propagates, missing `hooks` errors; and a state test that the hook
  fallback yields a buy price with round-trip product `1/(1-fee)^2`.
