### PR TITLE
fix(fermiswap): follow engine migration to 0x90f73fEA

### DIFF
--- a/crates/tycho-test/src/execution/encoding.rs
+++ b/crates/tycho-test/src/execution/encoding.rs
@@ -40,7 +40,10 @@ pub const EXECUTOR_ADDRESS: &str = "0xaE04CA7E9Ed79cBD988f6c536CE11C621166f41B";
 // Fixed address used to plant FeeCalculator bytecode in state overrides.
 pub const FEE_CALCULATOR_ADDRESS: &str = "0xfEEcA1C0fEEcA1C0fEEcA1C0fEEcA1C0fEEcA1C0";
 const FERMISWAP_REGISTRY_ADDRESS: &str = "0xDA7AFeEd01fe625cF15D187A19F94B45F00b8C5f";
-const FERMISWAP_TARGET_ADDRESS: &str = "0xe514A3c48DA8B233f65b5d15BA1905d6d35BFE48";
+// The Fermi engine currently pointed at by the swapper's storage slot 2. Fermi migrates engines
+// by re-pointing the swapper (last: 2026-07-21, block 25581704); update this together with
+// `engine_address` in the fermiswap substreams params, or lane overwrites patch a dead slot.
+const FERMISWAP_TARGET_ADDRESS: &str = "0x90f73fEA1Ee2Dc514d4dbAc0bfF7ff04b933767f";
 // BopAMM prices its books from the same PrioUpdateRegistry as FermiSwap; only the registry
 // `target` differs — it is the pricing module, and the lane index is the book's `assetId`.
 const BOPAMM_REGISTRY_ADDRESS: &str = "0xDA7AFeEd01fe625cF15D187A19F94B45F00b8C5f";

--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-fermiswap"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/protocols/substreams/ethereum-fermiswap/CHANGELOG.md
+++ b/protocols/substreams/ethereum-fermiswap/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+## v0.2.0
+
+### Changed
+
+- Follow the Fermi engine migration of 2026-07-21: `engine_address` now points at the new engine
+  `0x90f73fEA1Ee2Dc514d4dbAc0bfF7ff04b933767f` (deployed block 25581530). Fermi migrates engines
+  by re-pointing the swapper's engine slot (re-point tx at block 25581704); with the old address
+  the package missed pair registrations and pause events on the new engine, no longer matched the
+  registry `updateState` calls that feed the `override_block_timestamp` attribute, and simulation
+  failed with `MissingAccount(<new engine>)` because the new engine's storage was never indexed.
+- Retarget the integration tests to the new engine's history. Stop blocks are constrained by the
+  engine's oracle staleness window (~30s, `StaleUpdate`): state decoding snapshots at the stop
+  block and quotes through the adapter, so the stop block must come after the swapper re-point and
+  the first `updateState` for every tested lane. Execution checks are enabled (the `vm:fermiswap`
+  executor is registered and deployed).
+- Deduplicate the manifest: single anchored `initialBlock` and params entry instead of the
+  per-module `networks` map. `initialBlock` stays at the trader-vault creation block 24936662 — it
+  must remain at or before the creation of every tracked contract, because account rows are only
+  created for in-range deployments and storage deltas against absent accounts kill the extractor.
+
+### Migration
+
+Requires a full resync of the `vm:fermiswap` extractor. Existing components carry the old engine
+in their contract set and cannot be patched forward; the new engine re-registered all pairs, so
+components are re-created (same component ids — `keccak(base ++ quote)` is engine-independent).
+Stale components from the old engine must be wiped, not left in place: Fermi poisons the outgoing
+engine with garbage prices during wind-down (last old-engine update quoted WETH at 9.53 USDC).
+
+The engine address is also hardcoded as `FERMISWAP_TARGET_ADDRESS` in
+`crates/tycho-test/src/execution/encoding.rs` (updated together with this release) — it must be
+kept in sync with `engine_address` on every future migration, or the execution harness's lane
+staleness overwrite patches a dead registry slot.

--- a/protocols/substreams/ethereum-fermiswap/Cargo.toml
+++ b/protocols/substreams/ethereum-fermiswap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-fermiswap"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-fermiswap/integration_test.tycho.yaml
+++ b/protocols/substreams/ethereum-fermiswap/integration_test.tycho.yaml
@@ -7,7 +7,7 @@ skip_balance_check: true
 
 initialized_accounts:
   - "0xb1076fE3AB5e28005C7c323Bac5AC06a680d452e" # FermiSwapper used by the adapter.
-  - "0xe514A3c48DA8B233f65b5d15BA1905d6d35BFE48" # Current Fermi engine.
+  - "0x90f73fEA1Ee2Dc514d4dbAc0bfF7ff04b933767f" # Current Fermi engine.
   - "0x585d44727129B9C69791B10238Ca605932938B4F" # Shared trader vault.
   - "0xDA7AFeEd01fe625cF15D187A19F94B45F00b8C5f" # Registry address
 
@@ -15,9 +15,14 @@ protocol_type_names:
   - "fermiswap_pool"
 
 tests:
-  - name: test_weth_usdt_pair_creation
-    start_block: 25192975
-    stop_block: 25194975
+  - name: test_pair_creation
+    start_block: 25581590
+    # The stop block must cover, in order: the 8 PairRegistered events (25581596-25581615), the
+    # swapper re-point to the new engine (25581704), and the first oracle updateState for both
+    # test pairs' lanes (25581893 WETH/USDT, 25581903 WETH/USDC). State decoding snapshots at the
+    # stop block and runs the adapter: stopping before the re-point fails with
+    # MissingAccount(old engine), stopping before the lane updates reverts with StaleUpdate.
+    stop_block: 25581903
     expected_components:
       - id: "0x7c85004568584fbf3665f41ebe85146ee0483587d65d9ea5a56c79816bb720d0"
         tokens:
@@ -25,8 +30,8 @@ tests:
           - "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" # USDC
         static_attributes:
           self_contained_tokens: "0x5b22307863303261616133396232323366653864306130653563346632376561643930383363373536636332222c22307861306238363939316336323138623336633164313964346132653965623063653336303665623438225d" # ["0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"]
-        creation_tx: "0x74bfa8b999532fe15fadd2c1ead24f881e2f375abe26c1b730f71de1d8e440e5"
-        skip_simulation: true # Fair price for this pair is stale at this test's stop block.
+        creation_tx: "0xea087163fb89f2f3e36b1feaeb9ccc579ee5c6977c3a195241d0a8de3ad41ad5"
+        skip_simulation: true # Indexing-only test; simulation/execution covered by test_pair_simulation.
         skip_execution: true
       - id: "0x2b2f5776e38002e0c013d0d89828fdb06fee595ea2d5ed4b194e3883e823e350"
         tokens:
@@ -34,13 +39,17 @@ tests:
           - "0xdAC17F958D2ee523a2206206994597C13D831ec7" # USDT
         static_attributes:
           self_contained_tokens: "0x5b22307863303261616133396232323366653864306130653563346632376561643930383363373536636332222c22307864616331376639353864326565353233613232303632303639393435393763313364383331656337225d" # ["0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","0xdac17f958d2ee523a2206206994597c13d831ec7"]
-        creation_tx: "0x4fc82812010c571f17fbb75f4c5c68f6bf3bc25097c06cd324070071748325c4"
-        skip_simulation: false
+        creation_tx: "0x989f0d2d7f9b467937f3348eb31880424d09065907d80735b2a789c2deffbdfa"
+        skip_simulation: true # Indexing-only test; simulation/execution covered by test_pair_simulation.
         skip_execution: true
 
-  - name: test_weth_usdc_pair_creation
-    start_block: 25192975
-    stop_block: 25200492 # WETH/USDC oracle updateState lane in the registry.
+  - name: test_pair_simulation
+    start_block: 25581590
+    # The engine rejects oracle state older than ~30s (StaleUpdate). The execution check patches
+    # the lane timestamps (tycho-test setup_fermiswap_overwrites), but both lanes also update
+    # back-to-back here (WETH/USDT at 25584583, WETH/USDC at 25584584), so the test stays valid
+    # even without that patch.
+    stop_block: 25584584
     expected_components:
       - id: "0x7c85004568584fbf3665f41ebe85146ee0483587d65d9ea5a56c79816bb720d0"
         tokens:
@@ -48,15 +57,15 @@ tests:
           - "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" # USDC
         static_attributes:
           self_contained_tokens: "0x5b22307863303261616133396232323366653864306130653563346632376561643930383363373536636332222c22307861306238363939316336323138623336633164313964346132653965623063653336303665623438225d" # ["0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"]
-        creation_tx: "0x74bfa8b999532fe15fadd2c1ead24f881e2f375abe26c1b730f71de1d8e440e5"
+        creation_tx: "0xea087163fb89f2f3e36b1feaeb9ccc579ee5c6977c3a195241d0a8de3ad41ad5"
         skip_simulation: false
-        skip_execution: true # No vm:fermiswap executor is registered yet.
+        skip_execution: false
       - id: "0x2b2f5776e38002e0c013d0d89828fdb06fee595ea2d5ed4b194e3883e823e350"
         tokens:
           - "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" # WETH
           - "0xdAC17F958D2ee523a2206206994597C13D831ec7" # USDT
         static_attributes:
           self_contained_tokens: "0x5b22307863303261616133396232323366653864306130653563346632376561643930383363373536636332222c22307864616331376639353864326565353233613232303632303639393435393763313364383331656337225d" # ["0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","0xdac17f958d2ee523a2206206994597c13d831ec7"]
-        creation_tx: "0x4fc82812010c571f17fbb75f4c5c68f6bf3bc25097c06cd324070071748325c4"
-        skip_simulation: true # Fair price for this pair is stale at this test's stop block.
-        skip_execution: true # No vm:fermiswap executor is registered yet.
+        creation_tx: "0x989f0d2d7f9b467937f3348eb31880424d09065907d80735b2a789c2deffbdfa"
+        skip_simulation: false
+        skip_execution: false

--- a/protocols/substreams/ethereum-fermiswap/src/modules.rs
+++ b/protocols/substreams/ethereum-fermiswap/src/modules.rs
@@ -501,6 +501,8 @@ fn map_protocol_changes(
             .sorted_unstable_by_key(|(index, _)| *index)
             .filter_map(|(_, builder)| builder.build())
             .collect::<Vec<_>>(),
+        // Currently these storage changes don't have a consumer. We still emit them for the case
+        // that we manually add DCI entrypoints later.
         storage_changes: get_block_storage_changes(&block),
     })
 }

--- a/protocols/substreams/ethereum-fermiswap/src/modules.rs
+++ b/protocols/substreams/ethereum-fermiswap/src/modules.rs
@@ -33,6 +33,7 @@ use tycho_substreams::{
     abi::{erc20, weth},
     attributes::json_serialize_address_list,
     balances::aggregate_balances_changes,
+    block_storage::get_block_storage_changes,
     contract::extract_contract_changes_builder,
     prelude::*,
 };
@@ -500,6 +501,6 @@ fn map_protocol_changes(
             .sorted_unstable_by_key(|(index, _)| *index)
             .filter_map(|(_, builder)| builder.build())
             .collect::<Vec<_>>(),
-        storage_changes: vec![],
+        storage_changes: get_block_storage_changes(&block),
     })
 }

--- a/protocols/substreams/ethereum-fermiswap/substreams.yaml
+++ b/protocols/substreams/ethereum-fermiswap/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "ethereum_fermiswap"
-  version: v0.1.1
+  version: v0.2.0
 
 protobuf:
   files:
@@ -24,26 +24,17 @@ binaries:
     file: ../target/wasm32-unknown-unknown/release/ethereum_fermiswap.wasm
 
 network: mainnet
-networks:
-  mainnet:
-    initialBlock:
-      map_protocol_components: 24936662 # trader_vault creation block
-      store_pairs: 24936662
-      store_lane_components: 24936662
-      store_token_pairs: 24936662
-      map_token_balance_deltas: 24936662
-      store_token_balances: 24936662
-      map_balance_deltas: 24936662
-      store_balances: 24936662
-      map_protocol_changes: 24936662
-    params:
-      map_protocol_components: "engine_address=e514A3c48DA8B233f65b5d15BA1905d6d35BFE48&trader_vault=585d44727129B9C69791B10238Ca605932938B4F&swapper_address=b1076fE3AB5e28005C7c323Bac5AC06a680d452e&registry_address=DA7AFeEd01fe625cF15D187A19F94B45F00b8C5f"
-      map_token_balance_deltas: "engine_address=e514A3c48DA8B233f65b5d15BA1905d6d35BFE48&trader_vault=585d44727129B9C69791B10238Ca605932938B4F&swapper_address=b1076fE3AB5e28005C7c323Bac5AC06a680d452e&registry_address=DA7AFeEd01fe625cF15D187A19F94B45F00b8C5f"
-      map_protocol_changes: "engine_address=e514A3c48DA8B233f65b5d15BA1905d6d35BFE48&trader_vault=585d44727129B9C69791B10238Ca605932938B4F&swapper_address=b1076fE3AB5e28005C7c323Bac5AC06a680d452e&registry_address=DA7AFeEd01fe625cF15D187A19F94B45F00b8C5f"
+
+params:
+  map_protocol_components: &fermiswap_params "engine_address=90f73fEA1Ee2Dc514d4dbAc0bfF7ff04b933767f&trader_vault=585d44727129B9C69791B10238Ca605932938B4F&swapper_address=b1076fE3AB5e28005C7c323Bac5AC06a680d452e&registry_address=DA7AFeEd01fe625cF15D187A19F94B45F00b8C5f"
+  map_token_balance_deltas: *fermiswap_params
+  map_protocol_changes: *fermiswap_params
 
 modules:
   - name: map_protocol_components
     kind: map
+    # trader_vault creation block, the earliest of the tracked contracts.
+    initialBlock: &initial_block 24936662
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -73,6 +64,7 @@ modules:
 
   - name: map_token_balance_deltas
     kind: map
+    initialBlock: *initial_block
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block
@@ -111,6 +103,7 @@ modules:
 
   - name: map_protocol_changes
     kind: map
+    initialBlock: *initial_block
     inputs:
       - params: string
       - source: sf.ethereum.type.v2.Block


### PR DESCRIPTION
## Problem

`vm:fermiswap` stopped being simulatable on 2026-07-21:

```
StateDecodingFailure pool="0xa6175c23…" error=Unable to set up vm state on the engine:
Recoverable error: Storage error: MissingAccount(0x90f73fea1ee2dc514d4dbac0bff7ff04b933767f)
```

Fermi migrates engines by re-pointing the swapper's engine slot (storage slot 2). On 2026-07-21 they deployed a new engine `0x90f73fEA…` (block 25581530, upgraded bytecode — ABI is a strict superset of the old engine's), re-registered all 8 pairs on it (blocks 25581596–25581615), and re-pointed the swapper (tx `0xf4ed64dc…`, block 25581704). Our substreams params still tracked the old engine `0xe514A3c4…`, so:

- the new engine's storage was never indexed → every quote path through the swapper hit `MissingAccount`,
- `PairRegistered`/`PairActiveSet`/`PairUnregistered` on the new engine were invisible,
- registry `updateState` calls no longer matched the target filter → `override_block_timestamp` attributes froze → even decodable pools would price against stale oracle state.

## Changes

- **`ethereum-fermiswap` 0.2.0**: `engine_address` → `0x90f73fEA…`. `initialBlock` stays at the vault creation block 24936662 — it must cover the creation of every tracked contract, since account rows are only created for in-range deployments and storage deltas against absent accounts kill the extractor (now documented in the manifest).
- **Manifest dedup**: single anchored `initialBlock` + `params` entry (same pattern as base-aerodrome-slipstreams) instead of the 9-entry `networks` map.
- **Integration tests retargeted** to the new engine's history, execution enabled (executor is registered and deployed). Stop blocks are constrained by the engine's ~30s oracle staleness window (`StaleUpdate`, `0x666a2814`); the comments in the yaml document the constraints.
- **`tycho-test`**: `FERMISWAP_TARGET_ADDRESS` → new engine. `setup_fermiswap_overwrites` computes the registry lane slot as `keccak(abi.encode(target, laneIndex))`; with the old target it patched a dead slot, silently disabling the staleness workaround in both protocols/testing and tycho-integration-test.
- **Record `storage_changes`** in `map_protocol_changes` via `get_block_storage_changes` (same helper as balancer, uniswap-v4, fluid, curve, erc4626). DCI-only data — inert while fermiswap emits no entrypoints, but groundwork for DCI-based engine discovery.
- **CHANGELOG.md** added for the package.

## Operational rollout

1. Release the `ethereum-fermiswap` v0.2.0 spkg.
2. **Full resync of the `vm:fermiswap` extractor from block 24936662 (~650k blocks), with the extractor's existing data wiped first.** A rolling update is not possible: existing components carry the old engine in their contract set and there are no new `PairRegistered` deltas to re-create them from an existing cursor. Component ids are stable across the migration (`keccak(base ++ quote)` is engine-independent), so consumers keep their ids.
3. Wiping the stale components matters beyond hygiene: Fermi poisons the outgoing engine with garbage prices during wind-down (its last oracle update quoted WETH at 9.53 USDC vs ~1926 real). Old components left simulatable would mis-price by ~200×, not just revert.
4. `tycho-test` ships in the same deploy so the execution harnesses patch the live lane slot again.

**For the next migration** (this will recur — the engine pointer is a mutable slot): the signature is `MissingAccount(<unknown new address>)` on fermiswap pools, and `cast storage 0xb1076fE3…5C7c323Bac5AC06a680d452e 2` shows the current engine. `engine_address` (substreams) and `FERMISWAP_TARGET_ADDRESS` (tycho-test) must move together; the staleness window is engine-version-specific (old: ~12s, new: ~30s) and should be re-measured. Follow-up worth considering: DCI-based engine discovery via the swapper's slot 2 to remove the static coupling.

## Verification

All harness results below were produced at c2b1fa8ca; the follow-up 33120d102 only populates `storage_changes` and was verified separately with a live `substreams run` (module executes on the extended block model, output populated: 412/347 per-tx storage entries at blocks 24936663/24936664; ignored by the indexer absent DCI entrypoints).

- On-chain: registry writes the new-engine lane at the slot the code computes (timestamp prefix confirmed at block 25584584); a single-slot timestamp override flips a stale quote to success, proving the engine reads exactly that slot; both test pairs quote successfully at the test stop blocks.
- protocols/testing `range`: both yaml tests pass — indexing, simulation, and execution (12/12) at the pinned stop blocks.
- protocols/testing `full` (live, against a locally resynced DB): continuous execution checks at the chain tip. With the harness's default token-quality filter only WETH/USDC and WBTC/USDC are exercised (12/12 per update block); with all six tokens loaded (local quality curation), every decodable pool is exercised — 36/36 simulations + executions per update block, USDT pairs included.
- tycho-integration-test against the local resync (24936662 → tip): 456/456 simulations passed over 60 blocks (get_limits / get_amount_out / debug_traceCall execution), slippage 0.0000%; a second 30-block run passed 276/276 with slippage within ±0.11%. A live fill (block 25594963) was observed flowing through the pipeline in the same block.
- The 100% execution rate directly validates the tycho-test target fix: most tested blocks had oracle lanes older than the ~30s staleness window, so executions only pass if the lane overwrite patches the live registry slot.

Detailed test results and issues found during testing: see the test-results comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

