### PR TITLE
fix: guard NG curve solvers against out-of-domain balances

### DIFF
--- a/crates/tycho-simulation/src/evm/protocol/curve/math/core/tricrypto_ng.rs
+++ b/crates/tycho-simulation/src/evm/protocol/curve/math/core/tricrypto_ng.rs
@@ -96,12 +96,19 @@ pub fn cbrt(x: U256) -> U256 {
 }
 
 /// Domain guard ported from the Vyper math contract's `get_y` safety asserts
-/// (`dev: unsafe values D` / `Unsafe values x[i]`).
+/// (`dev: unsafe values D` / `Unsafe values x[i]`):
+/// <https://github.com/curvefi/tricrypto-ng/blob/ecaa8161c240f21dd7c3712eefc5637e1dac742b/contracts/main/CurveCryptoMathOptimized3.vy#L48-L57>
+/// (`_newton_y` re-asserts the balance bounds at L250).
 ///
 /// The unchecked arithmetic in the solvers below is only sound inside this domain; the
 /// deployed contract reverts outside it, so quoting returns `None`. Without this guard,
 /// out-of-domain balances (e.g. an absurdly large `dx`) wrap the I256 cubic coefficients
 /// and drive `newton_y_3` into a division by zero.
+///
+/// The A and gamma asserts from the same block are intentionally not ported: pool
+/// parameters come from the deployed contract, which already enforces them at deploy
+/// time, while `D` and the balances are recomputed during simulation and can leave the
+/// domain through caller-supplied amounts.
 fn check_solver_domain(x: &[U256; 3], d: U256, i: usize) -> Option<()> {
     let p = |exp: u32| -> U256 { U256::from(10u64).pow(U256::from(exp)) };
     if d < p(17) || d > p(33) {

--- a/crates/tycho-simulation/src/evm/protocol/curve/math/core/tricrypto_ng.rs
+++ b/crates/tycho-simulation/src/evm/protocol/curve/math/core/tricrypto_ng.rs
@@ -95,7 +95,32 @@ pub fn cbrt(x: U256) -> U256 {
     }
 }
 
+/// Domain guard ported from the Vyper math contract's `get_y` safety asserts
+/// (`dev: unsafe values D` / `Unsafe values x[i]`).
+///
+/// The unchecked arithmetic in the solvers below is only sound inside this domain; the
+/// deployed contract reverts outside it, so quoting returns `None`. Without this guard,
+/// out-of-domain balances (e.g. an absurdly large `dx`) wrap the I256 cubic coefficients
+/// and drive `newton_y_3` into a division by zero.
+fn check_solver_domain(x: &[U256; 3], d: U256, i: usize) -> Option<()> {
+    let p = |exp: u32| -> U256 { U256::from(10u64).pow(U256::from(exp)) };
+    if d < p(17) || d > p(33) {
+        return None;
+    }
+    for (k, x_k) in x.iter().enumerate() {
+        if k == i {
+            continue;
+        }
+        let frac = x_k.checked_mul(WAD)? / d;
+        if frac < p(16) || frac > p(20) {
+            return None;
+        }
+    }
+    Some(())
+}
+
 pub fn newton_y_3(ann: U256, gamma: U256, x: [U256; 3], d: U256, j: usize) -> Option<U256> {
+    check_solver_domain(&x, d, j)?;
     let n = U256::from(3u64);
     let mut others: Vec<U256> = x
         .iter()
@@ -158,6 +183,7 @@ pub fn newton_y_3(ann: U256, gamma: U256, x: [U256; 3], d: U256, j: usize) -> Op
 }
 
 pub fn get_y_3_ng(ann: U256, gamma: U256, x: [U256; 3], d: U256, i: usize) -> Option<(U256, U256)> {
+    check_solver_domain(&x, d, i)?;
     // These closures convert known small constants from the Vyper Cardano solver into I256.
     // All values are hardcoded literals (max 10^36 << 2^255), so try_from never fails.
     let s = |v: u128| -> I256 { I256::try_from(v).expect("i256 const") };
@@ -320,6 +346,29 @@ mod tests {
         let (y, _k0) = result.expect("converge");
         assert!(y > U256::ZERO);
         assert!(y < d);
+    }
+
+    #[test]
+    fn get_y_3_ng_rejects_out_of_domain_balances() {
+        // Deployed contract reverts with "Unsafe values x[i]" when a balance is far out of
+        // proportion to D; the solver must reject instead of panicking on such inputs.
+        let (ann, gamma, x, d) = realistic_params();
+        let huge = U256::from(10u64).pow(U256::from(47u64));
+        assert!(get_y_3_ng(ann, gamma, [huge, x[1], x[2]], d, 2).is_none());
+    }
+
+    #[test]
+    fn newton_y_3_rejects_out_of_domain_balances() {
+        let (ann, gamma, x, d) = realistic_params();
+        let huge = U256::from(10u64).pow(U256::from(47u64));
+        assert!(newton_y_3(ann, gamma, [huge, x[1], x[2]], d, 2).is_none());
+    }
+
+    #[test]
+    fn get_y_3_ng_rejects_out_of_domain_d() {
+        let (ann, gamma, x, _) = realistic_params();
+        assert!(get_y_3_ng(ann, gamma, x, U256::from(10u64).pow(U256::from(16u64)), 2).is_none());
+        assert!(get_y_3_ng(ann, gamma, x, U256::from(10u64).pow(U256::from(34u64)), 2).is_none());
     }
 
     #[test]

--- a/crates/tycho-simulation/src/evm/protocol/curve/math/core/tricrypto_ng.rs
+++ b/crates/tycho-simulation/src/evm/protocol/curve/math/core/tricrypto_ng.rs
@@ -127,6 +127,9 @@ fn check_solver_domain(x: &[U256; 3], d: U256, i: usize) -> Option<()> {
 }
 
 pub fn newton_y_3(ann: U256, gamma: U256, x: [U256; 3], d: U256, j: usize) -> Option<U256> {
+    if j >= 3 {
+        return None;
+    }
     check_solver_domain(&x, d, j)?;
     let n = U256::from(3u64);
     let mut others: Vec<U256> = x
@@ -369,6 +372,13 @@ mod tests {
         let (ann, gamma, x, d) = realistic_params();
         let huge = U256::from(10u64).pow(U256::from(47u64));
         assert!(newton_y_3(ann, gamma, [huge, x[1], x[2]], d, 2).is_none());
+    }
+
+    #[test]
+    fn solvers_reject_out_of_range_index() {
+        let (ann, gamma, x, d) = realistic_params();
+        assert!(get_y_3_ng(ann, gamma, x, d, 3).is_none());
+        assert!(newton_y_3(ann, gamma, x, d, 3).is_none());
     }
 
     #[test]

--- a/crates/tycho-simulation/src/evm/protocol/curve/math/core/twocrypto_ng.rs
+++ b/crates/tycho-simulation/src/evm/protocol/curve/math/core/twocrypto_ng.rs
@@ -122,6 +122,9 @@ pub fn newton_y_2_ng(
     i: usize,
     lim_mul: U256,
 ) -> Option<U256> {
+    if i >= 2 {
+        return None;
+    }
     let n = U256::from(2u64);
     let x_j = x[1 - i];
     let mut y = d * d / (x_j * U256::from(4u64));
@@ -171,6 +174,9 @@ pub fn newton_y_2_ng(
 }
 
 pub fn get_y_2_ng(ann: U256, gamma: U256, x: [U256; 2], d: U256, i: usize) -> Option<(U256, U256)> {
+    if i >= 2 {
+        return None;
+    }
     // These closures convert known small constants from the Vyper Cardano solver into I256.
     // All values are hardcoded literals (max 10^36 << 2^255), so try_from never fails.
     let s = |v: u128| -> I256 { I256::try_from(v).expect("i256 const") };
@@ -391,6 +397,18 @@ mod tests {
         let result = cbrt(x);
         // result should be approximately 2e18 (depending on scaling)
         assert!(result > U256::ZERO);
+    }
+
+    #[test]
+    fn get_y_2_ng_rejects_out_of_range_index() {
+        let wad = WAD;
+        let ann = U256::from(540_000u64) * A_MULTIPLIER;
+        let gamma = U256::from(11_809_167_828_997u64);
+        let x = [U256::from(5000u64) * wad, U256::from(5000u64) * wad];
+        let d = U256::from(10000u64) * wad;
+        let lim_mul = U256::from(100u64) * wad;
+        assert!(get_y_2_ng(ann, gamma, x, d, 2).is_none());
+        assert!(newton_y_2_ng(ann, gamma, x, d, 2, lim_mul).is_none());
     }
 
     #[test]

--- a/crates/tycho-simulation/src/evm/protocol/curve/math/swap/tricrypto_ng.rs
+++ b/crates/tycho-simulation/src/evm/protocol/curve/math/swap/tricrypto_ng.rs
@@ -27,12 +27,19 @@ pub fn get_amount_out(
     let wad = U256::from(WAD);
 
     let mut bal = *balances;
-    bal[i] += dx;
+    bal[i] = bal[i].checked_add(dx)?;
 
+    // Checked: an oversized dx must yield None, not wrap into a plausible-looking xp.
     let xp: [U256; 3] = [
-        bal[0] * precisions[0],
-        bal[1] * price_scale[0] * precisions[1] / wad,
-        bal[2] * price_scale[1] * precisions[2] / wad,
+        bal[0].checked_mul(precisions[0])?,
+        bal[1]
+            .checked_mul(price_scale[0])?
+            .checked_mul(precisions[1])? /
+            wad,
+        bal[2]
+            .checked_mul(price_scale[1])?
+            .checked_mul(precisions[2])? /
+            wad,
     ];
 
     // NG uses hybrid cubic+Newton solver
@@ -92,11 +99,13 @@ pub fn get_amount_in(
     // First pass: estimate fee from pre-swap state
     let fee_est = crypto_fee(&xp_orig, mid_fee, out_fee, fee_gamma)?;
     let complement_est = fee_denom - fee_est;
-    let dy_native = (desired_output * fee_denom + complement_est - U256::from(1)) / complement_est;
+    // Checked: an oversized desired_output must yield None, not wrap.
+    let dy_native =
+        (desired_output.checked_mul(fee_denom)? + complement_est - U256::from(1)) / complement_est;
 
-    let mut dy_internal = dy_native * precisions[j];
+    let mut dy_internal = dy_native.checked_mul(precisions[j])?;
     if j > 0 {
-        dy_internal = (dy_internal * price_scale[j - 1] + wad - U256::from(1)) / wad;
+        dy_internal = (dy_internal.checked_mul(price_scale[j - 1])? + wad - U256::from(1)) / wad;
     }
     dy_internal += U256::from(1);
     if xp_orig[j] <= dy_internal {
@@ -113,11 +122,11 @@ pub fn get_amount_in(
     xp_after[j] = y;
     let fee_actual = crypto_fee(&xp_after, mid_fee, out_fee, fee_gamma)?;
     let complement_actual = fee_denom - fee_actual;
-    let dy_native =
-        (desired_output * fee_denom + complement_actual - U256::from(1)) / complement_actual;
-    let mut dy_internal = dy_native * precisions[j];
+    let dy_native = (desired_output.checked_mul(fee_denom)? + complement_actual - U256::from(1)) /
+        complement_actual;
+    let mut dy_internal = dy_native.checked_mul(precisions[j])?;
     if j > 0 {
-        dy_internal = (dy_internal * price_scale[j - 1] + wad - U256::from(1)) / wad;
+        dy_internal = (dy_internal.checked_mul(price_scale[j - 1])? + wad - U256::from(1)) / wad;
     }
     dy_internal += U256::from(1);
     if xp_orig[j] <= dy_internal {
@@ -218,6 +227,51 @@ pub fn spot_price(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// TricryptoUSDC-shaped pool: USDC (6 dec) / WBTC (8 dec) / WETH (18 dec).
+    fn usdc_pool_amount_out(dx: U256) -> Option<U256> {
+        let wad = U256::from(1_000_000_000_000_000_000u128);
+        get_amount_out(
+            &[
+                U256::from(7_000_000_000_000u64), // 7M USDC
+                U256::from(6_000_000_000u64),     // 60 WBTC
+                U256::from(1840u64) * wad,        // 1840 WETH
+            ],
+            &[U256::from(1_000_000_000_000u64), U256::from(10_000_000_000u64), U256::from(1u64)],
+            &[U256::from(118_000u64) * wad, U256::from(3_800u64) * wad],
+            U256::from(21u64) * U256::from(10u64).pow(U256::from(24u64)),
+            U256::from(1707629u64) * U256::from(10_000u64),
+            U256::from(11_809_167_828_997u64),
+            U256::from(3_000_000u64),
+            U256::from(30_000_000u64),
+            U256::from(230_000_000_000_000u64),
+            0,
+            2,
+            dx,
+        )
+    }
+
+    #[test]
+    fn get_amount_out_rejects_absurd_amount_in() {
+        // Quote amount from the 2026-07-23 prod incident: drove the balances outside the
+        // contract's safe domain and panicked the solver (division by zero in newton_y_3).
+        let poison: U256 = "79274803880378691797489662351102500"
+            .parse()
+            .expect("literal");
+        assert!(usdc_pool_amount_out(poison).is_none());
+        assert!(usdc_pool_amount_out(U256::from(10u64).pow(U256::from(38u64))).is_none());
+    }
+
+    #[test]
+    fn get_amount_out_rejects_amount_overflowing_xp() {
+        assert!(usdc_pool_amount_out(U256::MAX).is_none());
+    }
+
+    #[test]
+    fn get_amount_out_accepts_normal_amounts() {
+        let dy = usdc_pool_amount_out(U256::from(1_000_000_000u64)).expect("1k USDC quote");
+        assert!(dy > U256::ZERO);
+    }
 
     #[test]
     fn roundtrip() {

--- a/crates/tycho-simulation/src/evm/protocol/curve/math/swap/tricrypto_ng.rs
+++ b/crates/tycho-simulation/src/evm/protocol/curve/math/swap/tricrypto_ng.rs
@@ -20,6 +20,11 @@ pub fn get_amount_out(
     j: usize,
     dx: U256,
 ) -> Option<U256> {
+    // Vyper pool contract: `assert i != j and i < N_COINS and j < N_COINS
+    //                        # dev: coin index out of range`
+    if i >= 3 || j >= 3 || i == j {
+        return None;
+    }
     if dx.is_zero() {
         return None;
     }
@@ -83,6 +88,11 @@ pub fn get_amount_in(
     j: usize,
     desired_output: U256,
 ) -> Option<U256> {
+    // Vyper pool contract: `assert i != j and i < N_COINS and j < N_COINS
+    //                        # dev: coin index out of range`
+    if i >= 3 || j >= 3 || i == j {
+        return None;
+    }
     if desired_output.is_zero() {
         return None;
     }
@@ -265,6 +275,68 @@ mod tests {
     #[test]
     fn get_amount_out_rejects_amount_overflowing_xp() {
         assert!(usdc_pool_amount_out(U256::MAX).is_none());
+    }
+
+    fn usdc_pool_with_indices(i: usize, j: usize, forward: bool, amount: U256) -> Option<U256> {
+        let wad = U256::from(1_000_000_000_000_000_000u128);
+        let balances = [
+            U256::from(7_000_000_000_000u64),
+            U256::from(6_000_000_000u64),
+            U256::from(1840u64) * wad,
+        ];
+        let precisions =
+            [U256::from(1_000_000_000_000u64), U256::from(10_000_000_000u64), U256::from(1u64)];
+        let price_scale = [U256::from(118_000u64) * wad, U256::from(3_800u64) * wad];
+        let d = U256::from(21u64) * U256::from(10u64).pow(U256::from(24u64));
+        let ann = U256::from(1707629u64) * U256::from(10_000u64);
+        let gamma = U256::from(11_809_167_828_997u64);
+        let (mid_fee, out_fee, fee_gamma) = (
+            U256::from(3_000_000u64),
+            U256::from(30_000_000u64),
+            U256::from(230_000_000_000_000u64),
+        );
+        if forward {
+            get_amount_out(
+                &balances,
+                &precisions,
+                &price_scale,
+                d,
+                ann,
+                gamma,
+                mid_fee,
+                out_fee,
+                fee_gamma,
+                i,
+                j,
+                amount,
+            )
+        } else {
+            get_amount_in(
+                &balances,
+                &precisions,
+                &price_scale,
+                d,
+                ann,
+                gamma,
+                mid_fee,
+                out_fee,
+                fee_gamma,
+                i,
+                j,
+                amount,
+            )
+        }
+    }
+
+    #[test]
+    fn rejects_out_of_range_coin_indices() {
+        let dx = U256::from(1_000_000_000u64);
+        for forward in [true, false] {
+            assert!(usdc_pool_with_indices(3, 2, forward, dx).is_none());
+            assert!(usdc_pool_with_indices(0, 3, forward, dx).is_none());
+            assert!(usdc_pool_with_indices(7, 9, forward, dx).is_none());
+            assert!(usdc_pool_with_indices(1, 1, forward, dx).is_none());
+        }
     }
 
     #[test]

--- a/crates/tycho-simulation/src/evm/protocol/curve/math/swap/twocrypto_ng.rs
+++ b/crates/tycho-simulation/src/evm/protocol/curve/math/swap/twocrypto_ng.rs
@@ -42,11 +42,13 @@ pub fn get_amount_out(
     }
 
     let wad = U256::from(WAD);
-    let price_scale_local = price_scale * precisions[1];
+    let price_scale_local = price_scale.checked_mul(precisions[1])?;
 
     let mut bal = *balances;
-    bal[i] += dx;
-    let xp: [U256; 2] = [bal[0] * precisions[0], bal[1] * price_scale_local / wad];
+    bal[i] = bal[i].checked_add(dx)?;
+    // Checked: an oversized dx must yield None, not wrap into a plausible-looking xp.
+    let xp: [U256; 2] =
+        [bal[0].checked_mul(precisions[0])?, bal[1].checked_mul(price_scale_local)? / wad];
 
     // NG uses Cardano cubic solver
     let (y, _k0) = get_y_2_ng(ann, gamma, xp, d, j)?;
@@ -93,19 +95,21 @@ pub fn get_amount_in(
 
     let wad = U256::from(WAD);
     let fee_denom = U256::from(FEE_DENOMINATOR);
-    let price_scale_local = price_scale * precisions[1];
+    let price_scale_local = price_scale.checked_mul(precisions[1])?;
 
     let xp_orig: [U256; 2] = [balances[0] * precisions[0], balances[1] * price_scale_local / wad];
 
     // First pass: estimate fee from pre-swap state
     let fee_est = crypto_fee(&xp_orig, mid_fee, out_fee, fee_gamma)?;
     let complement_est = fee_denom - fee_est;
-    let dy_native = (desired_output * fee_denom + complement_est - U256::from(1)) / complement_est;
+    // Checked: an oversized desired_output must yield None, not wrap.
+    let dy_native =
+        (desired_output.checked_mul(fee_denom)? + complement_est - U256::from(1)) / complement_est;
 
     let dy_internal = if j > 0 {
-        (dy_native * price_scale_local + wad - U256::from(1)) / wad
+        (dy_native.checked_mul(price_scale_local)? + wad - U256::from(1)) / wad
     } else {
-        dy_native * precisions[0]
+        dy_native.checked_mul(precisions[0])?
     } + U256::from(1);
     if xp_orig[j] <= dy_internal {
         return None;
@@ -121,12 +125,12 @@ pub fn get_amount_in(
     xp_after[j] = y;
     let fee_actual = crypto_fee(&xp_after, mid_fee, out_fee, fee_gamma)?;
     let complement_actual = fee_denom - fee_actual;
-    let dy_native =
-        (desired_output * fee_denom + complement_actual - U256::from(1)) / complement_actual;
+    let dy_native = (desired_output.checked_mul(fee_denom)? + complement_actual - U256::from(1)) /
+        complement_actual;
     let dy_internal = if j > 0 {
-        (dy_native * price_scale_local + wad - U256::from(1)) / wad
+        (dy_native.checked_mul(price_scale_local)? + wad - U256::from(1)) / wad
     } else {
-        dy_native * precisions[0]
+        dy_native.checked_mul(precisions[0])?
     } + U256::from(1);
     if xp_orig[j] <= dy_internal {
         return None;
@@ -226,6 +230,44 @@ pub fn spot_price(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// USDC-paired pool: USDC (6 dec) / 18-dec token at ~$0.50.
+    fn usdc_pool_amount_out(dx: U256) -> Option<U256> {
+        let wad = U256::from(1_000_000_000_000_000_000u128);
+        get_amount_out(
+            &[U256::from(2_000_000_000_000u64), U256::from(4_000_000u64) * wad],
+            &[U256::from(1_000_000_000_000u64), U256::from(1u64)],
+            U256::from(500_000_000_000_000_000u64),
+            U256::from(4u64) * U256::from(10u64).pow(U256::from(24u64)),
+            U256::from(540_000u64) * U256::from(10_000u64),
+            U256::from(11_809_167_828_997u64),
+            U256::from(3_000_000u64),
+            U256::from(30_000_000u64),
+            U256::from(230_000_000_000_000u64),
+            0,
+            1,
+            dx,
+        )
+    }
+
+    #[test]
+    fn get_amount_out_rejects_absurd_amount_in() {
+        let poison: U256 = "79274803880378691797489662351102500"
+            .parse()
+            .expect("literal");
+        assert!(usdc_pool_amount_out(poison).is_none());
+    }
+
+    #[test]
+    fn get_amount_out_rejects_amount_overflowing_xp() {
+        assert!(usdc_pool_amount_out(U256::MAX).is_none());
+    }
+
+    #[test]
+    fn get_amount_out_accepts_normal_amounts() {
+        let dy = usdc_pool_amount_out(U256::from(1_000_000_000u64)).expect("1k USDC quote");
+        assert!(dy > U256::ZERO);
+    }
 
     #[test]
     fn roundtrip() {

--- a/crates/tycho-simulation/src/evm/protocol/curve/math/swap/twocrypto_ng.rs
+++ b/crates/tycho-simulation/src/evm/protocol/curve/math/swap/twocrypto_ng.rs
@@ -37,6 +37,11 @@ pub fn get_amount_out(
     j: usize,
     dx: U256,
 ) -> Option<U256> {
+    // Vyper pool contract: `assert i != j and i < N_COINS and j < N_COINS
+    //                        # dev: coin index out of range`
+    if i >= 2 || j >= 2 || i == j {
+        return None;
+    }
     if dx.is_zero() {
         return None;
     }
@@ -89,6 +94,11 @@ pub fn get_amount_in(
     j: usize,
     desired_output: U256,
 ) -> Option<U256> {
+    // Vyper pool contract: `assert i != j and i < N_COINS and j < N_COINS
+    //                        # dev: coin index out of range`
+    if i >= 2 || j >= 2 || i == j {
+        return None;
+    }
     if desired_output.is_zero() {
         return None;
     }
@@ -261,6 +271,63 @@ mod tests {
     #[test]
     fn get_amount_out_rejects_amount_overflowing_xp() {
         assert!(usdc_pool_amount_out(U256::MAX).is_none());
+    }
+
+    fn usdc_pool_with_indices(i: usize, j: usize, forward: bool, amount: U256) -> Option<U256> {
+        let wad = U256::from(1_000_000_000_000_000_000u128);
+        let balances = [U256::from(2_000_000_000_000u64), U256::from(4_000_000u64) * wad];
+        let precisions = [U256::from(1_000_000_000_000u64), U256::from(1u64)];
+        let price_scale = U256::from(500_000_000_000_000_000u64);
+        let d = U256::from(4u64) * U256::from(10u64).pow(U256::from(24u64));
+        let ann = U256::from(540_000u64) * U256::from(10_000u64);
+        let gamma = U256::from(11_809_167_828_997u64);
+        let (mid_fee, out_fee, fee_gamma) = (
+            U256::from(3_000_000u64),
+            U256::from(30_000_000u64),
+            U256::from(230_000_000_000_000u64),
+        );
+        if forward {
+            get_amount_out(
+                &balances,
+                &precisions,
+                price_scale,
+                d,
+                ann,
+                gamma,
+                mid_fee,
+                out_fee,
+                fee_gamma,
+                i,
+                j,
+                amount,
+            )
+        } else {
+            get_amount_in(
+                &balances,
+                &precisions,
+                price_scale,
+                d,
+                ann,
+                gamma,
+                mid_fee,
+                out_fee,
+                fee_gamma,
+                i,
+                j,
+                amount,
+            )
+        }
+    }
+
+    #[test]
+    fn rejects_out_of_range_coin_indices() {
+        let dx = U256::from(1_000_000_000u64);
+        for forward in [true, false] {
+            assert!(usdc_pool_with_indices(2, 1, forward, dx).is_none());
+            assert!(usdc_pool_with_indices(0, 2, forward, dx).is_none());
+            assert!(usdc_pool_with_indices(5, 6, forward, dx).is_none());
+            assert!(usdc_pool_with_indices(1, 1, forward, dx).is_none());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

- `curve/math/core/tricrypto_ng.rs`: ports the Vyper math contract's `get_y` safety asserts (`dev: unsafe values D`, `Unsafe values x[i]`) as a `check_solver_domain` guard at the top of `get_y_3_ng` and `newton_y_3`: `D` must be in `[1e17, 1e33]` and every non-solved balance must satisfy `x[k]*1e18/D ∈ [1e16, 1e20]`. Outside that domain the function returns `None`, matching the deployed contract's revert.
- `curve/math/swap/tricrypto_ng.rs` / `swap/twocrypto_ng.rs`: the `dx`/`desired_output` scaling (`bal[i] += dx`, `xp` products, `dy_native` products) is now checked arithmetic, so oversized amounts return `None` instead of wrapping into plausible-looking balances.

TwoCryptoNG's core solver already has the equivalent guard (`k0_i` vs `lim_mul` bounds); TriCryptoNG was missing it. All stableswap variants use fully checked math and are unaffected.

## Why

Production incident 2026-07-23 (fynd, ethereum): a quote request for ~7.9e28 USDC against a TricryptoNG pool killed every solver worker thread with

```
panicked at ruint-1.18.0/src/algorithms/div/mod.rs:66:17:
attempt to divide by zero
```

Mechanism: with a balance far out of proportion to `D`, the I256 cubic coefficients in `get_y_3_ng` overflow. `alloy_primitives::Signed` ops only `debug_assert!` on overflow, so release builds wrap silently; the garbage values force the `newton_y_3` fallback, where the iterate `y` truncates to zero and `yfprime / y` divides by zero. The deployed Vyper contract cannot reach this state because its `get_y` asserts the domain first — those asserts were not ported.

Reproduced exactly (same crate version, same panic location) by feeding the incident's amount into the vendored math in a release build; with this change the same sweep (dx from 1e18 to 1e40 and the incident amount, three pool shapes) returns `None` with no panics, and in-domain quotes are byte-identical to before.

## Tests

- `core::tricrypto_ng`: `get_y_3_ng`/`newton_y_3` reject out-of-domain balances and out-of-domain `D` (previously: overflow panic in debug, division-by-zero panic in release)
- `swap::tricrypto_ng`: TricryptoUSDC-shaped pool (6/8/18 decimals, real price scales) returns `None` for the incident amount and for `U256::MAX`, still quotes normal amounts
- `swap::twocrypto_ng`: same shape of tests as regression coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)