### PR TITLE
docs: add troubleshooting entry for silent firehose poller stall

### DIFF
--- a/docs/for-solvers/self-hosted-evm-chain.md
+++ b/docs/for-solvers/self-hosted-evm-chain.md
@@ -260,7 +260,7 @@ For dashboards, logs, and traces, enable the `observability` profile alongside `
 
   Rule out two benign causes first: a cold start that has not yet reached your extractor's `start_block` (normal — see above), and a Firehose that never became healthy (`:10016` closed).
 
-  Otherwise, the poller — not the merger — is stuck. The merger only bundles blocks 200 behind the newest block the poller delivered, and waits for more **silently by design** — so a stalled poller freezes `merged-blocks` at a fixed height with no error in any log. The known trigger is an RPC node that mishandled a reorg and serves an inconsistent view of a few heights: the poller retries the bad block forever (its default retry count is infinite) while still following the chain head, so the process looks alive.
+  Otherwise, the poller — not the merger — is stuck. The merger only bundles blocks 200 behind the newest block the poller delivered, and waits for more **silently by design** — so a stalled poller freezes `merged-blocks` at a fixed height with no error in any log. The trigger is an RPC endpoint that returns wrong or inconsistent data for specific heights — seen in the wild with a caching RPC proxy (eRPC) mishandling **empty blocks**, and equally possible with a node serving a non-canonical view after a mishandled reorg. The poller retries the bad block forever (its default retry count is infinite) while still following the chain head, so the process looks alive.
 
   Confirm it:
 
@@ -274,9 +274,9 @@ For dashboards, logs, and traces, enable the `observability` profile alongside `
     sh -c 'ls /data/storage/one-blocks/ | sort | tail -3'
   ```
 
-  Then compare your node against an independent RPC around that height (`eth_getBlockByNumber`, ~20 blocks): a `hash` mismatch between endpoints, or a `parentHash` on your node that does not match its own previous block, confirms your node serves a non-canonical view.
+  Then compare your endpoint against an independent RPC around that height (`eth_getBlockByNumber` and `eth_getBlockReceipts`, ~20 blocks): a `hash` mismatch between endpoints, receipts that disagree, or a `parentHash` that does not match your endpoint's own previous block all confirm the endpoint serves a wrong view. Note the bad data can poison your own debugging — query the independent endpoint, not the suspect one, when checking what a block "really" contains.
 
-  **Fix:** switch `RPC_URL` to a healthy endpoint (everywhere the stack uses it) and restart; the poller resumes from the last stored one-block file, so no resync is needed. Unwind the broken node to below the divergent range, or resync it, separately.
+  **Fix:** switch `RPC_URL` to a healthy endpoint (everywhere the stack uses it) and restart; the poller resumes from the last stored one-block file, so no resync is needed. Then repair the original source separately: fix the proxy's empty-block/cache handling if a proxy sits in front of your node, or unwind the node to below the divergent range (or resync it) if the node itself diverged.
 
 ## Performance tuning
 

--- a/docs/for-solvers/self-hosted-evm-chain.md
+++ b/docs/for-solvers/self-hosted-evm-chain.md
@@ -256,6 +256,28 @@ For dashboards, logs, and traces, enable the `observability` profile alongside `
 
 - **Cold start takes a long time.** `START_BLOCK` is the Firehose poller's start block (where it begins fetching from the RPC), separate from each extractor's `start_block`. A fresh chain must fetch and merge every block from `START_BLOCK` before your protocols' deployment blocks appear. Set `START_BLOCK` at or just below your earliest protocol `start_block` so the poller skips irrelevant history.
 
+- **Consumers report the extractor as `Stale`, or the indexer's committed height stops climbing.** The block stream from the self-hosted Firehose stopped advancing.
+
+  Rule out two benign causes first: a cold start that has not yet reached your extractor's `start_block` (normal — see above), and a Firehose that never became healthy (`:10016` closed).
+
+  Otherwise, the poller — not the merger — is stuck. The merger only bundles blocks 200 behind the newest block the poller delivered, and waits for more **silently by design** — so a stalled poller freezes `merged-blocks` at a fixed height with no error in any log. The known trigger is an RPC node that mishandled a reorg and serves an inconsistent view of a few heights: the poller retries the bad block forever (its default retry count is infinite) while still following the chain head, so the process looks alive.
+
+  Confirm it:
+
+  ```bash
+  # 1. highest block the poller processed — look for one block number repeating in fetch errors
+  docker compose --profile substreams-endpoint logs substreams-endpoint 2>&1 \
+    | grep '"processing block"' | tail -3
+  # 2. where one-block files stop (filename = num-time-hash-parenthash-libnum);
+  #    expect the highest ~200-300 blocks above the frozen bundle
+  docker compose --profile substreams-endpoint exec substreams-endpoint \
+    sh -c 'ls /data/storage/one-blocks/ | sort | tail -3'
+  ```
+
+  Then compare your node against an independent RPC around that height (`eth_getBlockByNumber`, ~20 blocks): a `hash` mismatch between endpoints, or a `parentHash` on your node that does not match its own previous block, confirms your node serves a non-canonical view.
+
+  **Fix:** switch `RPC_URL` to a healthy endpoint (everywhere the stack uses it) and restart; the poller resumes from the last stored one-block file, so no resync is needed. Unwind the broken node to below the divergent range, or resync it, separately.
+
 ## Performance tuning
 
 - **`--interval-between-fetch`** (poller) — delay between RPC fetches. The compose file sets `0ms` (no delay) for maximum throughput. Raise it to throttle a rate-limited RPC.


### PR DESCRIPTION
## What

Adds a troubleshooting entry to the self-hosted EVM chain guide for the case where consumers report an extractor as `Stale` and the indexer's committed height stops climbing, while every component looks healthy.

The entry covers:
- ruling out benign causes (cold start below the extractor `start_block`, Firehose never healthy)
- why a stalled poller shows up as a silent merger freeze (the merger bundles only blocks 200 behind the poller's newest delivery and waits without logging)
- the known trigger: an RPC node serving a non-canonical view after a mishandled reorg, which the poller retries forever
- confirmation commands (poller log tail, one-block file tail, node-vs-independent-RPC hash comparison) and the recovery path, which needs no resync

## Why

A user running the stack on Plasma hit this and lost days to the silent failure mode; we root-caused it against fireeth v2.19.0 source and a live repro. The diagnosis steps in the entry are the ones that discriminate the causes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)