### PR TITLE
fix(slipstreams): default fee when dynamic-fee module marker absent

### DIFF
--- a/crates/tycho-simulation/src/evm/protocol/aerodrome_slipstreams/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/aerodrome_slipstreams/decoder.rs
@@ -296,18 +296,17 @@ mod tests {
     #[case::missing_module(None)]
     #[case::stale_module(Some(Bytes::from(STALE_DYNAMIC_FEE_MODULE)))]
     #[tokio::test]
-    async fn unsupported_dynamic_fee_module_fails_to_decode(
+    async fn missing_or_unsupported_module_falls_back_to_default_config(
         #[case] dynamic_fee_module: Option<Bytes>,
     ) {
+        // Still decodable with a default config, not dropped: these pools quote their default_fee.
         let decoded = try_decode_snapshot_with_defaults::<AerodromeSlipstreamsState>(snapshot(
             dynamic_fee_module,
         ))
-        .await;
+        .await
+        .expect("pools without a supported marker should remain decodable");
 
-        assert!(
-            matches!(decoded, Err(InvalidSnapshotError::ValueError(_))),
-            "unsupported modules should be skipped, got {decoded:?}"
-        );
+        assert_eq!(decoded, expected_state(DynamicFeeConfig::default()));
     }
 
     #[rstest]

--- a/crates/tycho-simulation/src/evm/protocol/aerodrome_slipstreams/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/aerodrome_slipstreams/state.rs
@@ -707,17 +707,22 @@ mod tests {
     }
 
     #[test]
-    fn dynamic_fee_update_rejects_unsupported_module() {
+    fn dynamic_fee_update_falls_back_to_default_for_unsupported_module() {
+        // An unsupported-module delta resets to default rather than erroring; pool keeps
+        // default_fee.
         let mut pool = create_basic_test_pool();
         pool.dfc = DynamicFeeConfig::new(4500, 10_000, 1, false, 0);
         let delta =
             dynamic_fee_delta(hex_literal::hex!("DB45818A6db280ecfeB33cbeBd445423d0216b5D"));
 
-        let result = pool.delta_transition(delta, &HashMap::new(), &Balances::default());
+        pool.delta_transition(delta, &HashMap::new(), &Balances::default())
+            .expect("unsupported module delta should decode to the default config");
 
-        assert!(
-            matches!(result, Err(TransitionError::DecodeError(_))),
-            "unsupported module deltas should be rejected, got {result:?}"
+        assert_eq!(pool.dfc, DynamicFeeConfig::default());
+        assert_eq!(
+            pool.get_fee()
+                .expect("fee should be computable"),
+            3000
         );
     }
 

--- a/crates/tycho-simulation/src/evm/protocol/utils/slipstreams/dynamic_fee_module.rs
+++ b/crates/tycho-simulation/src/evm/protocol/utils/slipstreams/dynamic_fee_module.rs
@@ -19,7 +19,7 @@ const SUPPORTED_DYNAMIC_FEE_MODULES: [Address; 2] = [
 ];
 const DYNAMIC_FEE_MODULE_ATTRIBUTE: &str = "dynamic_fee_module";
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DynamicFeeConfig {
     base_fee: u32,
     fee_cap: u32,
@@ -47,9 +47,9 @@ impl DynamicFeeConfig {
 
     /// Builds a config from a full snapshot's attributes.
     ///
-    /// Errors when the `dynamic_fee_module` marker is absent or is not one of the supported
-    /// replacement deployments, so the caller can skip the pool rather than trust stale fee
-    /// attributes left by a retired module. The error message is complete and ready to wrap.
+    /// An absent or unsupported `dynamic_fee_module` marker yields the default config, whose
+    /// `base_fee == 0` makes `get_dynamic_fee` fall back to the pool's static `default_fee`. Only
+    /// errors when a supported marker is present but a dynamic-fee attribute is missing.
     pub(crate) fn from_attributes(
         attributes: &HashMap<String, Bytes>,
     ) -> Result<Self, &'static str> {
@@ -57,7 +57,7 @@ impl DynamicFeeConfig {
             .get(DYNAMIC_FEE_MODULE_ATTRIBUTE)
             .is_some_and(|module| is_supported_dynamic_fee_module(module))
         {
-            return Err("dynamic fee module is missing or not one of the supported deployments");
+            return Ok(Self::default());
         }
 
         Ok(Self {
@@ -92,9 +92,8 @@ impl DynamicFeeConfig {
 
     /// Applies a delta's attribute updates.
     ///
-    /// A delta carrying the `dynamic_fee_module` marker fully re-initializes the config (and errors
-    /// on an unsupported module); markerless deltas apply only the dynamic-fee fields they contain,
-    /// leaving the rest untouched.
+    /// A delta carrying the `dynamic_fee_module` marker fully re-initializes the config; markerless
+    /// deltas apply only the dynamic-fee fields they contain, leaving the rest untouched.
     pub(crate) fn update_from_attributes(
         &mut self,
         attributes: &HashMap<String, Bytes>,
@@ -322,7 +321,8 @@ mod tests {
     #[rstest]
     #[case::missing_module(None)]
     #[case::unsupported_module(Some(Bytes::from([0x11; 20])))]
-    fn from_attributes_rejects_unsupported_modules(#[case] module: Option<Bytes>) {
+    fn from_attributes_defaults_for_missing_or_unsupported_module(#[case] module: Option<Bytes>) {
+        // Attributes are present but untrusted without a supported marker: fall back to default.
         let mut attributes = HashMap::from([
             ("dfc_baseFee".to_string(), Bytes::from(200_u32.to_be_bytes())),
             ("dfc_feeCap".to_string(), Bytes::from(1_000_u32.to_be_bytes())),
@@ -332,6 +332,23 @@ mod tests {
             attributes.insert(DYNAMIC_FEE_MODULE_ATTRIBUTE.to_string(), module);
         }
 
-        assert!(DynamicFeeConfig::from_attributes(&attributes).is_err());
+        assert_eq!(DynamicFeeConfig::from_attributes(&attributes), Ok(DynamicFeeConfig::default()));
+    }
+
+    #[test]
+    fn default_config_falls_back_to_static_default_fee() {
+        // base_fee == 0 must resolve to the pool's static default fee (3000 here).
+        let dfc = DynamicFeeConfig::default();
+        let observations = Observations::new(vec![Observation {
+            block_timestamp: 100,
+            initialized: true,
+            index: 0,
+            ..Default::default()
+        }]);
+
+        let fee = get_dynamic_fee(&dfc, 3000, 0, 1, 0, 1, &observations, 100)
+            .expect("Failed to calculate dynamic fee");
+
+        assert_eq!(fee, 3000);
     }
 }

--- a/crates/tycho-simulation/src/evm/protocol/utils/slipstreams/dynamic_fee_module.rs
+++ b/crates/tycho-simulation/src/evm/protocol/utils/slipstreams/dynamic_fee_module.rs
@@ -184,14 +184,21 @@ fn calculate_dynamic_fee(
     if observation_cardinality < (DEFAULT_SECONDS_AGO / MIN_SECONDS_AGO) as u16 {
         return Ok(0);
     };
-    let tw_avg_tick = match observations.observe(
+    // Mirror the on-chain module's `try pool.observe(...) { ... } catch { return 0; }`: a failed
+    // observation (e.g. a ring buffer Tycho only partially indexed) contributes no dynamic
+    // component instead of failing the whole quote.
+    let observed = match observations.observe(
         blocktime,
         &[DEFAULT_SECONDS_AGO, 0],
         current_tick,
         observation_index,
         liquidity,
         observation_cardinality,
-    )? {
+    ) {
+        Ok(observed) => observed,
+        Err(_) => return Ok(0),
+    };
+    let tw_avg_tick = match observed {
         (tick_cumulatives, _) if tick_cumulatives.len() >= 2 => {
             ((tick_cumulatives[1] - tick_cumulatives[0]) / DEFAULT_SECONDS_AGO as i64) as i32
         }
@@ -348,6 +355,33 @@ mod tests {
 
         let fee = get_dynamic_fee(&dfc, 3000, 0, 1, 0, 1, &observations, 100)
             .expect("Failed to calculate dynamic fee");
+
+        assert_eq!(fee, 3000);
+    }
+
+    #[test]
+    fn observe_failure_falls_back_to_base_fee() {
+        // cardinality clears the min-history guard but exceeds the indexed buffer, so observe()
+        // errors out of bounds. Like the on-chain try/catch, the dynamic component is 0 and the
+        // fee falls back to the base fee, instead of failing the quote.
+        let dfc = DynamicFeeConfig::default();
+        let observations = Observations::new(vec![
+            Observation {
+                block_timestamp: 999_000,
+                initialized: true,
+                index: 0,
+                ..Default::default()
+            },
+            Observation {
+                block_timestamp: 999_500,
+                initialized: true,
+                index: 1,
+                ..Default::default()
+            },
+        ]);
+
+        let fee = get_dynamic_fee(&dfc, 3000, 0, 1, 1, 300, &observations, 1_000_000)
+            .expect("observe failure should fall back to the base fee, not error");
 
         assert_eq!(fee, 3000);
     }


### PR DESCRIPTION
## Summary

Follow-up to #1196. Two fixes so slipstream pools that are governed by a supported fee module but
carry no custom dynamic config quote their static fee instead of being dropped.

### 1. Missing/unsupported marker falls back to the default fee

#1196 made `DynamicFeeConfig::from_attributes` error (→ `StateDecodingFailure`, pool skipped)
whenever the `dynamic_fee_module` marker was absent or not one of the supported deployments. That
conflates two cases:

1. A marker present but from an unsupported/retired module — untrusted config.
2. **No custom dynamic config at all** — the pool is still governed by a supported module, which
   returns its static default fee.

On-chain the factory's active (supported) module `getFee` returns `tickSpacingToFee(tickSpacing)`
for any pool with no `dynamicFeeConfig` entry, so case 2 pools have a well-defined fee. Skipping
them removed them from simulation entirely.

`from_attributes` now returns `DynamicFeeConfig::default()` (`base_fee == 0`) for a missing or
unsupported marker; `get_dynamic_fee` already treats `base_fee == 0` as "use the pool's
`default_fee`". A supported marker with a missing dynamic-fee attribute still errors.

### 2. A failed observation contributes zero dynamic fee

Once those pools decode, some have a large observation cardinality but only a partially-indexed
ring buffer, so the TWAP `observe()` hits an out-of-bounds index and previously failed the whole
`get_amount_out`. This mirrors the on-chain module, which wraps the call in
`try pool.observe(...) { ... } catch { return 0; }`: `calculate_dynamic_fee` now treats an
`observe` error as a zero dynamic component and falls back to the base fee.

Also restores the `Default` derive on `DynamicFeeConfig`, updates the affected tests, and adds
regression tests (default config → static fee; marker-less snapshot decodes; observe failure →
base fee).

## Validation

- On-chain check of the 56 tracked (tvl ≥ 100) Base slipstream pools: 15 carry no supported marker;
  all 15 are governed by a supported module and use their static default fee
  (`getFee == pool.fee() == tickSpacingToFee`, empty `dynamicFeeConfig`).
- Dev integration test (`base-aerodrome-slipstreams`, 100 blocks) against `tycho-base-dev`:

  | | #1196 as merged | this PR |
  |---|---|---|
  | `StateDecodingFailure` | 15 | 0 |
  | pools simulated | 40 | 54 |
  | `get_amount_out` failures | (pools skipped) | 0 |
  | simulations | 2838 (100% ok) | 3172 (100% ok) |
  | avg / max slippage | 0.0053% / 0.26% | 0.0059% / 0.27% |

  The dropped pools are restored and quote successfully (including the default-fee pool that hit the
  observation out-of-bounds). The remaining ~0.26% on one pool (WETH/AERO) is a separate,
  pre-existing `initialFee` timing issue unrelated to this change.

- `cargo clippy -p tycho-simulation --all-features --tests` clean; 33 slipstream unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
