### PR TITLE
feat(execution): prefetch Angstrom attestations in the background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9501,6 +9501,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
  "tycho-common",
  "tycho-execution",
  "typetag",

--- a/crates/tycho-execution/CLAUDE.md
+++ b/crates/tycho-execution/CLAUDE.md
@@ -233,6 +233,27 @@ from `config/executor_addresses.json`. Protocol name prefixes: `vm:` (simulation
 e.g. `vm:balancer_v2`, `vm:curve`), `rfq:` (request-for-quote, e.g. `rfq:bebop`), bare (on-chain,
 e.g. `uniswap_v2`, `fluid_v1`).
 
+### Angstrom attestations (`evm/swap_encoder/angstrom.rs`)
+
+Angstrom's Uniswap V4 pools start every block locked. A swap against one carries a pool unlock attestation, signed by
+the current Angstrom leader, as its `hookData`. The attestation is scoped to a block number and says nothing about the
+swap, so one fetched window (covering `ANGSTROM_BLOCKS_IN_FUTURE` blocks, default 5) serves every swap, pool and route.
+
+`AttestationCache` therefore keeps the window in a process-wide cache instead of fetching it during encoding:
+
+- A dedicated OS thread (`angstrom-attestations`) refreshes the window every 2s. Not a `tokio` task — the encoder must
+  work without a runtime, and `reqwest`'s blocking client cannot be driven from inside one.
+- `AttestationCache::global()` starts the thread on first call. `UniswapV4SwapEncoder::new` calls it when
+  `angstrom_hook_address` is configured for the chain (`config/protocol_specific_addresses.json`), so registry
+  construction warms the cache. `ANGSTROM_API_KEY` / `ANGSTROM_API_URL` / `ANGSTROM_BLOCKS_IN_FUTURE` are read once, at
+  that point; without the API key the thread never starts and Angstrom swaps fail to encode with a `FatalError`.
+- `encode_swap` reads the cache. A window older than `ANGSTROM_ATTESTATION_MAX_AGE` (24s, ~2 blocks) triggers one
+  inline fetch on a scoped thread, so encoding degrades to the old behavior instead of failing. Fetch failures are
+  `RecoverableError`.
+- On chain, `UniswapV4Executor._selectAttestation` picks the 93-byte entry (8-byte block number + 85-byte attestation)
+  matching `block.number` and returns empty bytes when none match. Entries for blocks that already passed only cost
+  calldata; a window that covers no upcoming block falls back to Angstrom's protocol-driven empty-batch unlock.
+
 ### Gas estimation
 
 `Swap::new(component, token_in: Token, token_out: Token, estimated_gas: BigUint)` carries a per-swap simulation gas

--- a/crates/tycho-execution/CLAUDE.md
+++ b/crates/tycho-execution/CLAUDE.md
@@ -241,15 +241,15 @@ swap, so one fetched window (covering `ANGSTROM_BLOCKS_IN_FUTURE` blocks, defaul
 
 `AttestationCache` therefore keeps the window in a process-wide cache instead of fetching it during encoding:
 
-- A dedicated OS thread (`angstrom-attestations`) refreshes the window every 2s. Not a `tokio` task — the encoder must
-  work without a runtime, and `reqwest`'s blocking client cannot be driven from inside one.
+- A dedicated OS thread (`angstrom-attestations`) refreshes the window every
+  `ANGSTROM_ATTESTATION_REFRESH_INTERVAL`, twice per Ethereum block. Not a `tokio` task — the encoder must work without
+  a runtime, and `reqwest`'s blocking client cannot be driven from inside one.
 - `AttestationCache::global()` starts the thread on first call. `UniswapV4SwapEncoder::new` calls it when
   `angstrom_hook_address` is configured for the chain (`config/protocol_specific_addresses.json`), so registry
   construction warms the cache. `ANGSTROM_API_KEY` / `ANGSTROM_API_URL` / `ANGSTROM_BLOCKS_IN_FUTURE` are read once, at
   that point; without the API key the thread never starts and Angstrom swaps fail to encode with a `FatalError`.
-- `encode_swap` reads the cache. A window older than `ANGSTROM_ATTESTATION_MAX_AGE` (24s, ~2 blocks) triggers one
-  inline fetch on a scoped thread, so encoding degrades to the old behavior instead of failing. Fetch failures are
-  `RecoverableError`.
+- `encode_swap` reads the cache. A window older than `ANGSTROM_ATTESTATION_MAX_AGE` triggers one inline fetch on a
+  scoped thread, so encoding degrades to the old behavior instead of failing. Fetch failures are `RecoverableError`.
 - On chain, `UniswapV4Executor._selectAttestation` picks the 93-byte entry (8-byte block number + 85-byte attestation)
   matching `block.number` and returns empty bytes when none match. Entries for blocks that already passed only cost
   calldata; a window that covers no upcoming block falls back to Angstrom's protocol-driven empty-batch unlock.

--- a/crates/tycho-execution/Cargo.toml
+++ b/crates/tycho-execution/Cargo.toml
@@ -36,6 +36,7 @@ serde      = { workspace = true }
 serde_json = { workspace = true }
 thiserror  = { workspace = true }
 tokio      = { workspace = true }
+tracing    = { workspace = true }
 tycho-common = { workspace = true }
 typetag    = { workspace = true, optional = true }
 alloy      = { workspace = true, features = ["providers", "rpc-types-eth", "eip712", "signer-local", "node-bindings", "sol-types", "transport-http", "reqwest-rustls-tls"], optional = true }

--- a/crates/tycho-execution/src/encoding/evm/constants.rs
+++ b/crates/tycho-execution/src/encoding/evm/constants.rs
@@ -72,11 +72,12 @@ const ETHEREUM_SLOT_SECS: u64 = 12;
 
 /// How many of the fetched window's blocks may elapse before the cache refetches while encoding.
 ///
-/// A window fetched during block `N` covers `N` through `N + ANGSTROM_BLOCKS_IN_FUTURE`, so this
-/// spends part of that span and leaves the rest for the transaction to land in. At the default of
-/// 5 blocks in the future, 2 blocks of age leaves 3 covered blocks. Raising it past half the
-/// window leaves too little runway; the transaction would land after the last attested block.
-const ANGSTROM_ATTESTATION_MAX_AGE_BLOCKS: u64 = 2;
+/// A window fetched during block `N` covers `N` through `N + ANGSTROM_BLOCKS_IN_FUTURE`. Every
+/// block that elapses before encoding spends one of those: it removes a block the transaction
+/// could still have landed in, and adds an attestation the executor will skip. Keeping this at a
+/// single block preserves all but one block of the caller's slack, at the price of refetching
+/// inline sooner when the background refresh stalls.
+const ANGSTROM_ATTESTATION_MAX_AGE_BLOCKS: u64 = 1;
 
 /// How old a cached Angstrom attestation window may be before it is refetched while encoding.
 ///

--- a/crates/tycho-execution/src/encoding/evm/constants.rs
+++ b/crates/tycho-execution/src/encoding/evm/constants.rs
@@ -64,12 +64,26 @@ pub(crate) const ANGSTROM_ATTESTATION_SIZE: usize = 85;
 /// current or previous block.
 pub(crate) const ANGSTROM_ATTESTATION_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 
+/// Ethereum's slot time, used to express the attestation window's block span as an age.
+///
+/// Slots are fixed at 12 seconds and can only be missed, never shortened, so treating every
+/// 12 seconds as a block always overestimates how many blocks have elapsed.
+const ETHEREUM_SLOT_SECS: u64 = 12;
+
+/// How many of the fetched window's blocks may elapse before the cache refetches while encoding.
+///
+/// A window fetched during block `N` covers `N` through `N + ANGSTROM_BLOCKS_IN_FUTURE`, so this
+/// spends part of that span and leaves the rest for the transaction to land in. At the default of
+/// 5 blocks in the future, 2 blocks of age leaves 3 covered blocks. Raising it past half the
+/// window leaves too little runway; the transaction would land after the last attested block.
+const ANGSTROM_ATTESTATION_MAX_AGE_BLOCKS: u64 = 2;
+
 /// How old a cached Angstrom attestation window may be before it is refetched while encoding.
 ///
-/// A window covers `ANGSTROM_BLOCKS_IN_FUTURE` blocks from the block it was fetched in, so it
-/// keeps covering upcoming blocks for a while after it was fetched. Two blocks of age leaves at
-/// least three covered blocks for the transaction to land in.
-pub(crate) const ANGSTROM_ATTESTATION_MAX_AGE: Duration = Duration::from_secs(24);
+/// Only reached when the background refresh has stopped keeping up: a healthy refresher replaces
+/// the window every `ANGSTROM_ATTESTATION_REFRESH_INTERVAL`.
+pub(crate) const ANGSTROM_ATTESTATION_MAX_AGE: Duration =
+    Duration::from_secs(ETHEREUM_SLOT_SECS * ANGSTROM_ATTESTATION_MAX_AGE_BLOCKS);
 
 /// How long a single request to the Angstrom API may take before it is aborted.
 pub(crate) const ANGSTROM_API_TIMEOUT: Duration = Duration::from_secs(2);

--- a/crates/tycho-execution/src/encoding/evm/constants.rs
+++ b/crates/tycho-execution/src/encoding/evm/constants.rs
@@ -95,7 +95,13 @@ pub(crate) const ANGSTROM_ATTESTATION_MAX_AGE: Duration =
     Duration::from_secs(ETHEREUM_MIN_BLOCK_TIME_SECS * ANGSTROM_ATTESTATION_MAX_AGE_BLOCKS);
 
 /// How long a single request to the Angstrom API may take before it is aborted.
-pub(crate) const ANGSTROM_API_TIMEOUT: Duration = Duration::from_secs(2);
+///
+/// Half the refresh interval, so one timed-out refresh cannot reach the encoding path: the next
+/// refresh still replaces the window within `ANGSTROM_ATTESTATION_MAX_AGE` of the previous one
+/// (3s aborted + 6s sleep + at most 3s for the retry). The slowest read measured against the
+/// live API was 902ms, including DNS and TLS on a cold connection.
+pub(crate) const ANGSTROM_API_TIMEOUT: Duration =
+    Duration::from_secs(ANGSTROM_ATTESTATION_REFRESH_INTERVAL.as_secs() / 2);
 
 /// These protocols support the optimization of grouping swaps.
 ///
@@ -119,3 +125,22 @@ pub static NON_PLE_ENCODED_PROTOCOLS: LazyLock<HashSet<&'static str>> = LazyLock
     set.insert("ekubo_v3");
     set
 });
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The timings only keep inline fetches off the encoding path while a timed-out refresh plus
+    /// the retry that follows it still fit inside the maximum window age.
+    #[test]
+    fn test_one_timed_out_refresh_cannot_stale_the_window() {
+        let slowest_recovery =
+            ANGSTROM_API_TIMEOUT + ANGSTROM_ATTESTATION_REFRESH_INTERVAL + ANGSTROM_API_TIMEOUT;
+
+        assert!(
+            slowest_recovery <= ANGSTROM_ATTESTATION_MAX_AGE,
+            "a single timed-out refresh leaves the window stale for {slowest_recovery:?}, past \
+             the {ANGSTROM_ATTESTATION_MAX_AGE:?} maximum age"
+        );
+    }
+}

--- a/crates/tycho-execution/src/encoding/evm/constants.rs
+++ b/crates/tycho-execution/src/encoding/evm/constants.rs
@@ -58,17 +58,25 @@ pub(crate) const ANGSTROM_DEFAULT_API_URL: &str =
 /// `8 + ANGSTROM_ATTESTATION_SIZE` byte entries.
 pub(crate) const ANGSTROM_ATTESTATION_SIZE: usize = 85;
 
-/// How long the background prefetcher waits between Angstrom attestation refreshes.
+/// The shortest time Ethereum can take to produce a block, which both the refresh interval and
+/// the maximum window age derive from.
 ///
-/// Shorter than a block, so that every block is encoded against a window fetched during the
-/// current or previous block.
-pub(crate) const ANGSTROM_ATTESTATION_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
+/// Ethereum proposes at most one block every 12 seconds, and a skipped proposal only makes the
+/// gap longer. Treating 12 seconds as one block therefore always overestimates how many blocks
+/// have elapsed, which is the safe direction for both constants below.
+const ETHEREUM_MIN_BLOCK_TIME_SECS: u64 = 12;
 
-/// Ethereum's slot time, used to express the attestation window's block span as an age.
+/// How many times per block the background prefetcher refreshes the attestation window.
 ///
-/// Slots are fixed at 12 seconds and can only be missed, never shortened, so treating every
-/// 12 seconds as a block always overestimates how many blocks have elapsed.
-const ETHEREUM_SLOT_SECS: u64 = 12;
+/// The window's contents only change when a block is produced, so refreshing more than once per
+/// block fetches nothing new. It is still more than once because the refresher has no block feed
+/// to align to: sampling twice a block bounds how long it keeps serving the previous block's
+/// window after a new one becomes available, without polling the API for the sake of it.
+const ANGSTROM_ATTESTATION_REFRESHES_PER_BLOCK: u64 = 2;
+
+/// How long the background prefetcher waits between Angstrom attestation refreshes.
+pub(crate) const ANGSTROM_ATTESTATION_REFRESH_INTERVAL: Duration =
+    Duration::from_secs(ETHEREUM_MIN_BLOCK_TIME_SECS / ANGSTROM_ATTESTATION_REFRESHES_PER_BLOCK);
 
 /// How many of the fetched window's blocks may elapse before the cache refetches while encoding.
 ///
@@ -84,7 +92,7 @@ const ANGSTROM_ATTESTATION_MAX_AGE_BLOCKS: u64 = 1;
 /// Only reached when the background refresh has stopped keeping up: a healthy refresher replaces
 /// the window every `ANGSTROM_ATTESTATION_REFRESH_INTERVAL`.
 pub(crate) const ANGSTROM_ATTESTATION_MAX_AGE: Duration =
-    Duration::from_secs(ETHEREUM_SLOT_SECS * ANGSTROM_ATTESTATION_MAX_AGE_BLOCKS);
+    Duration::from_secs(ETHEREUM_MIN_BLOCK_TIME_SECS * ANGSTROM_ATTESTATION_MAX_AGE_BLOCKS);
 
 /// How long a single request to the Angstrom API may take before it is aborted.
 pub(crate) const ANGSTROM_API_TIMEOUT: Duration = Duration::from_secs(2);

--- a/crates/tycho-execution/src/encoding/evm/constants.rs
+++ b/crates/tycho-execution/src/encoding/evm/constants.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     sync::LazyLock,
+    time::Duration,
 };
 
 use tycho_common::{models::Chain, Bytes};
@@ -46,6 +47,32 @@ pub static ROUTER_ETH_ADDRESS: LazyLock<Bytes> = LazyLock::new(|| {
 /// Tycho Router, resulting in a higher gas usage. Fetching fewer blocks may result in attestations
 /// expiring if the transaction is not sent fast enough.
 pub const ANGSTROM_DEFAULT_BLOCKS_IN_FUTURE: u64 = 5;
+
+/// The endpoint serving Angstrom pool unlock attestations.
+pub(crate) const ANGSTROM_DEFAULT_API_URL: &str =
+    "https://attestations.angstrom.xyz/getAttestations";
+
+/// The size of a single Angstrom attestation, without its block number prefix.
+///
+/// The Uniswap V4 executor rejects attestation data that is not a whole number of
+/// `8 + ANGSTROM_ATTESTATION_SIZE` byte entries.
+pub(crate) const ANGSTROM_ATTESTATION_SIZE: usize = 85;
+
+/// How long the background prefetcher waits between Angstrom attestation refreshes.
+///
+/// Shorter than a block, so that every block is encoded against a window fetched during the
+/// current or previous block.
+pub(crate) const ANGSTROM_ATTESTATION_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
+
+/// How old a cached Angstrom attestation window may be before it is refetched while encoding.
+///
+/// A window covers `ANGSTROM_BLOCKS_IN_FUTURE` blocks from the block it was fetched in, so it
+/// keeps covering upcoming blocks for a while after it was fetched. Two blocks of age leaves at
+/// least three covered blocks for the transaction to land in.
+pub(crate) const ANGSTROM_ATTESTATION_MAX_AGE: Duration = Duration::from_secs(24);
+
+/// How long a single request to the Angstrom API may take before it is aborted.
+pub(crate) const ANGSTROM_API_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// These protocols support the optimization of grouping swaps.
 ///

--- a/crates/tycho-execution/src/encoding/evm/swap_encoder/angstrom.rs
+++ b/crates/tycho-execution/src/encoding/evm/swap_encoder/angstrom.rs
@@ -30,16 +30,16 @@ use crate::encoding::{
 
 static CACHE: OnceLock<Arc<AttestationCache>> = OnceLock::new();
 
-/// The attestation window every Angstrom swap encodes, kept warm by a background thread.
+/// Fetches attestations for the current block and the next `ANGSTROM_BLOCKS_IN_FUTURE` blocks.
+type WindowFetcher = Box<dyn Fn() -> Result<AttestationResponse, EncodingError> + Send + Sync>;
+
+/// How to fetch an attestation window, or why it cannot be fetched, plus the last one fetched.
 ///
-/// Every refresh replaces the whole window rather than appending to it, so the cache holds one
-/// window of `ANGSTROM_BLOCKS_IN_FUTURE + 1` attestations at a time and does not grow with
-/// uptime.
+/// A refresh replaces the whole window rather than appending to it, so this holds one window of
+/// `ANGSTROM_BLOCKS_IN_FUTURE + 1` attestations and does not grow with uptime.
 pub(crate) struct AttestationCache {
-    /// The configured API client, or the reason Angstrom swaps cannot be encoded.
-    api: Result<ApiConfig, String>,
-    /// The window from the most recent successful fetch, or `None` until the first one lands.
-    latest: RwLock<Option<CachedWindow>>,
+    fetcher: Result<WindowFetcher, String>,
+    window: RwLock<Option<CachedWindow>>,
 }
 
 impl AttestationCache {
@@ -50,7 +50,8 @@ impl AttestationCache {
     /// already finds a warm cache.
     pub(crate) fn global() -> &'static Arc<Self> {
         CACHE.get_or_init(|| {
-            let cache = Arc::new(Self { api: ApiConfig::from_env(), latest: RwLock::new(None) });
+            let fetcher = ApiConfig::from_env().map(ApiConfig::into_fetcher);
+            let cache = Arc::new(Self { fetcher, window: RwLock::new(None) });
             Arc::clone(&cache).spawn_refresher();
             cache
         })
@@ -65,16 +66,16 @@ impl AttestationCache {
     /// Returns an error if the fallback fetch fails, or if it is needed while the Angstrom API
     /// is unconfigured.
     pub(crate) fn hook_data(&self) -> Result<Vec<u8>, EncodingError> {
-        let latest = self
-            .latest
+        let cached = self
+            .window
             .read()
             .unwrap_or_else(PoisonError::into_inner);
-        if let Some(window) = latest.as_ref() {
+        if let Some(window) = cached.as_ref() {
             if window.fetched_at.elapsed() <= ANGSTROM_ATTESTATION_MAX_AGE {
                 return Ok(window.encoded.clone());
             }
         }
-        drop(latest);
+        drop(cached);
 
         warn!("Angstrom attestation cache is cold or stale, fetching while encoding");
         self.refresh()
@@ -82,14 +83,14 @@ impl AttestationCache {
 
     /// Fetches the current attestation window into the cache and returns it.
     fn refresh(&self) -> Result<Vec<u8>, EncodingError> {
-        let api = self
-            .api
+        let fetcher = self
+            .fetcher
             .as_ref()
             .map_err(|reason| EncodingError::FatalError(reason.clone()))?;
 
-        let encoded = encode_attestations(&api.fetch_off_runtime()?)?;
+        let encoded = encode_attestations(&fetcher()?)?;
         *self
-            .latest
+            .window
             .write()
             .unwrap_or_else(PoisonError::into_inner) =
             Some(CachedWindow { encoded: encoded.clone(), fetched_at: Instant::now() });
@@ -104,7 +105,7 @@ impl AttestationCache {
     /// or not its consumer runs a runtime, and because the blocking API client cannot be driven
     /// from inside one.
     fn spawn_refresher(self: Arc<Self>) {
-        if self.api.is_err() {
+        if self.fetcher.is_err() {
             return;
         }
 
@@ -166,6 +167,12 @@ impl ApiConfig {
         };
 
         Ok(Self { client, url, key, blocks_in_future })
+    }
+
+    /// Moves the client behind the cache's fetch, keeping its connection pool warm across
+    /// refreshes.
+    fn into_fetcher(self) -> WindowFetcher {
+        Box::new(move || self.fetch_off_runtime())
     }
 
     /// Fetches the current attestation window on a thread of its own.
@@ -287,7 +294,10 @@ pub(crate) struct AttestationData {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{
+        sync::atomic::{AtomicUsize, Ordering},
+        time::Duration,
+    };
 
     use super::*;
 
@@ -308,10 +318,32 @@ mod tests {
         }
     }
 
-    /// A cache with no API configured, so that any fetch fails with a known message instead of
-    /// reaching the network.
-    fn unconfigured_cache(window: Option<CachedWindow>) -> AttestationCache {
-        AttestationCache { api: Err("no API key".to_string()), latest: RwLock::new(window) }
+    /// A cache serving `fetcher` instead of the Angstrom API.
+    fn cache_with(fetcher: WindowFetcher, window: Option<CachedWindow>) -> AttestationCache {
+        AttestationCache { fetcher: Ok(fetcher), window: RwLock::new(window) }
+    }
+
+    /// A fetch answering `attestation_response()` from memory, alongside its call count.
+    fn counted_fetch() -> (WindowFetcher, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&calls);
+
+        let fetcher: WindowFetcher = Box::new(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+            Ok(attestation_response())
+        });
+
+        (fetcher, calls)
+    }
+
+    /// A fetch standing in for an Angstrom API that cannot be reached.
+    fn failing_fetch() -> WindowFetcher {
+        Box::new(|| Err(EncodingError::RecoverableError("the API is down".to_string())))
+    }
+
+    /// The window `counted_fetch` puts in the cache, as `hook_data` returns it.
+    fn fetched_window() -> Vec<u8> {
+        encode_attestations(&attestation_response()).unwrap()
     }
 
     fn window_fetched_ago(age: Duration) -> Option<CachedWindow> {
@@ -321,39 +353,65 @@ mod tests {
         Some(CachedWindow { encoded: vec![1, 2, 3], fetched_at })
     }
 
+    fn stale() -> Option<CachedWindow> {
+        window_fetched_ago(ANGSTROM_ATTESTATION_MAX_AGE + Duration::from_secs(1))
+    }
+
     #[test]
-    fn test_fresh_window_is_served_without_the_api() {
-        let cache = unconfigured_cache(window_fetched_ago(Duration::ZERO));
+    fn test_fresh_window_is_served_without_a_fetch() {
+        let (fetch, calls) = counted_fetch();
+        let cache = cache_with(fetch, window_fetched_ago(Duration::ZERO));
 
         assert_eq!(cache.hook_data().unwrap(), vec![1, 2, 3]);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
     }
 
     #[test]
-    fn test_stale_window_triggers_a_fetch() {
-        let stale = ANGSTROM_ATTESTATION_MAX_AGE + Duration::from_secs(1);
-        let cache = unconfigured_cache(window_fetched_ago(stale));
+    fn test_stale_window_is_replaced_by_a_fetch() {
+        let (fetch, calls) = counted_fetch();
+        let cache = cache_with(fetch, stale());
 
-        let err = cache.hook_data().unwrap_err();
-
-        assert_eq!(err, EncodingError::FatalError("no API key".to_string()));
+        assert_eq!(cache.hook_data().unwrap(), fetched_window());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     #[test]
-    fn test_cold_cache_triggers_a_fetch() {
-        let err = unconfigured_cache(None)
-            .hook_data()
-            .unwrap_err();
+    fn test_cold_cache_is_filled_by_a_fetch() {
+        let (fetch, calls) = counted_fetch();
+        let cache = cache_with(fetch, None);
 
-        assert_eq!(err, EncodingError::FatalError("no API key".to_string()));
+        assert_eq!(cache.hook_data().unwrap(), fetched_window());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_fetched_window_is_served_to_the_next_caller() {
+        let (fetch, calls) = counted_fetch();
+        let cache = cache_with(fetch, None);
+
+        cache.hook_data().unwrap();
+
+        assert_eq!(cache.hook_data().unwrap(), fetched_window());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     #[test]
     fn test_failed_refresh_keeps_the_previous_window() {
-        let cache = unconfigured_cache(window_fetched_ago(Duration::ZERO));
+        let cache = cache_with(failing_fetch(), window_fetched_ago(Duration::ZERO));
 
-        cache.refresh().unwrap_err();
+        let err = cache.refresh().unwrap_err();
 
+        assert_eq!(err, EncodingError::RecoverableError("the API is down".to_string()));
         assert_eq!(cache.hook_data().unwrap(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_failed_fetch_surfaces_on_a_stale_window() {
+        let cache = cache_with(failing_fetch(), stale());
+
+        let err = cache.hook_data().unwrap_err();
+
+        assert_eq!(err, EncodingError::RecoverableError("the API is down".to_string()));
     }
 
     #[test]

--- a/crates/tycho-execution/src/encoding/evm/swap_encoder/angstrom.rs
+++ b/crates/tycho-execution/src/encoding/evm/swap_encoder/angstrom.rs
@@ -32,10 +32,6 @@ static CACHE: OnceLock<Arc<AttestationCache>> = OnceLock::new();
 
 /// The attestation window every Angstrom swap encodes, kept warm by a background thread.
 ///
-/// One cache exists per process, shared by every swap encoder through `global`. Callers only
-/// need two methods: `global` to obtain the cache and start its refresh thread, and `hook_data`
-/// to read the current window while encoding. Everything below those two is internal.
-///
 /// Every refresh replaces the whole window rather than appending to it, so the cache holds one
 /// window of `ANGSTROM_BLOCKS_IN_FUTURE + 1` attestations at a time and does not grow with
 /// uptime.
@@ -348,6 +344,73 @@ mod tests {
         cache.refresh().unwrap_err();
 
         assert_eq!(cache.hook_data().unwrap(), vec![1, 2, 3]);
+    }
+
+    /// Reads the current block number over JSON-RPC, using `RPC_URL`.
+    fn current_block_number() -> u64 {
+        let url = env::var("RPC_URL").expect("RPC_URL must be set");
+        let response: serde_json::Value = reqwest::blocking::Client::new()
+            .post(url)
+            .json(&serde_json::json!({
+                "jsonrpc": "2.0", "method": "eth_blockNumber", "params": [], "id": 1
+            }))
+            .send()
+            .expect("the RPC must answer")
+            .json()
+            .expect("the RPC must return JSON");
+
+        let block_number = response["result"]
+            .as_str()
+            .expect("eth_blockNumber must return a result");
+
+        u64::from_str_radix(block_number.trim_start_matches("0x"), 16)
+            .expect("eth_blockNumber must return a hex number")
+    }
+
+    /// Guards the assumption the whole cache rests on: that a fetched window brackets the block
+    /// the transaction will land in. Nothing in the encoder checks the block numbers it encodes,
+    /// so an API that started returning only past blocks would otherwise go unnoticed.
+    #[test]
+    #[ignore] // Performs real Angstrom API and RPC calls
+    fn test_live_window_brackets_the_current_block() {
+        let api = ApiConfig::from_env().expect("ANGSTROM_API_KEY must be set");
+
+        // Fetch the window first: a block arriving before the RPC call keeps the head inside the
+        // window, whereas one arriving after would push the window past the head.
+        let response = api
+            .fetch_off_runtime()
+            .expect("the Angstrom API must answer");
+        let head = current_block_number();
+
+        let mut blocks: Vec<u64> = response
+            .attestations
+            .iter()
+            .map(|attestation| attestation.block_number)
+            .collect();
+        blocks.sort_unstable();
+
+        assert_eq!(
+            blocks.len() as u64,
+            ANGSTROM_DEFAULT_BLOCKS_IN_FUTURE + 1,
+            "expected the current block plus {ANGSTROM_DEFAULT_BLOCKS_IN_FUTURE} future ones, \
+             got {blocks:?}"
+        );
+        assert!(
+            blocks
+                .windows(2)
+                .all(|pair| pair[1] == pair[0] + 1),
+            "attested blocks are not consecutive: {blocks:?}"
+        );
+        assert!(
+            blocks.contains(&head),
+            "window {blocks:?} does not cover the current block {head}"
+        );
+        assert!(
+            blocks
+                .last()
+                .is_some_and(|last| *last > head),
+            "window {blocks:?} leaves no future block for the transaction to land in, head {head}"
+        );
     }
 
     #[test]

--- a/crates/tycho-execution/src/encoding/evm/swap_encoder/angstrom.rs
+++ b/crates/tycho-execution/src/encoding/evm/swap_encoder/angstrom.rs
@@ -35,9 +35,14 @@ static CACHE: OnceLock<Arc<AttestationCache>> = OnceLock::new();
 /// One cache exists per process, shared by every swap encoder through `global`. Callers only
 /// need two methods: `global` to obtain the cache and start its refresh thread, and `hook_data`
 /// to read the current window while encoding. Everything below those two is internal.
+///
+/// Every refresh replaces the whole window rather than appending to it, so the cache holds one
+/// window of `ANGSTROM_BLOCKS_IN_FUTURE + 1` attestations at a time and does not grow with
+/// uptime.
 pub(crate) struct AttestationCache {
     /// The configured API client, or the reason Angstrom swaps cannot be encoded.
     api: Result<ApiConfig, String>,
+    /// The window from the most recent successful fetch, or `None` until the first one lands.
     latest: RwLock<Option<CachedWindow>>,
 }
 

--- a/crates/tycho-execution/src/encoding/evm/swap_encoder/angstrom.rs
+++ b/crates/tycho-execution/src/encoding/evm/swap_encoder/angstrom.rs
@@ -1,0 +1,434 @@
+//! Angstrom pool unlock attestations.
+//!
+//! Angstrom's Uniswap V4 pools start every block locked, so a swap that wants to trade against
+//! one in the same block has to carry an attestation signed by the current Angstrom leader as
+//! `hookData`. An attestation is scoped to a block number and carries nothing about the swap
+//! itself, so a single fetched window serves every swap, pool and route.
+//!
+//! Attestations are therefore fetched by a background thread into a process-wide cache and read
+//! from that cache while encoding, which keeps the Angstrom API's latency off the encoding path.
+//! The API returns a window covering the next [`ANGSTROM_DEFAULT_BLOCKS_IN_FUTURE`] blocks; the
+//! executor picks the entry matching `block.number` on chain and ignores the rest.
+
+use std::{
+    env,
+    sync::{Arc, OnceLock, PoisonError, RwLock},
+    thread,
+    time::Instant,
+};
+
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use crate::encoding::{
+    errors::EncodingError,
+    evm::constants::{
+        ANGSTROM_API_TIMEOUT, ANGSTROM_ATTESTATION_MAX_AGE, ANGSTROM_ATTESTATION_REFRESH_INTERVAL,
+        ANGSTROM_ATTESTATION_SIZE, ANGSTROM_DEFAULT_API_URL, ANGSTROM_DEFAULT_BLOCKS_IN_FUTURE,
+    },
+};
+
+static CACHE: OnceLock<Arc<AttestationCache>> = OnceLock::new();
+
+/// The attestation unlocking Angstrom's pools for one block.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct AttestationData {
+    #[serde(rename = "blockNumber")]
+    pub(crate) block_number: u64,
+    #[serde(rename = "unlockData")]
+    pub(crate) attestation: String,
+}
+
+/// Response from the Angstrom attestation API.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct AttestationResponse {
+    pub(crate) success: bool,
+    pub(crate) attestations: Vec<AttestationData>,
+}
+
+/// Encodes attestations into the `hookData` layout the Uniswap V4 executor expects.
+///
+/// Every attestation takes exactly `8 + ANGSTROM_ATTESTATION_SIZE` bytes: a big endian block
+/// number followed by the attestation itself. Entries for blocks that have already passed are
+/// harmless, since the executor selects the entry matching `block.number`.
+///
+/// Returns an error if an attestation is not [`ANGSTROM_ATTESTATION_SIZE`] bytes long, which the
+/// executor would reject on chain.
+fn encode_attestations(response: &AttestationResponse) -> Result<Vec<u8>, EncodingError> {
+    let mut encoded =
+        Vec::with_capacity(response.attestations.len() * (8 + ANGSTROM_ATTESTATION_SIZE));
+    for data in &response.attestations {
+        let attestation_hex = data
+            .attestation
+            .strip_prefix("0x")
+            .unwrap_or(&data.attestation);
+
+        let attestation = hex::decode(attestation_hex).map_err(|e| {
+            EncodingError::FatalError(format!(
+                "Failed to decode Angstrom attestation for block {}: {}",
+                data.block_number, e
+            ))
+        })?;
+
+        if attestation.len() != ANGSTROM_ATTESTATION_SIZE {
+            return Err(EncodingError::FatalError(format!(
+                "Angstrom attestation for block {} is {} bytes, expected {}",
+                data.block_number,
+                attestation.len(),
+                ANGSTROM_ATTESTATION_SIZE
+            )));
+        }
+
+        encoded.extend_from_slice(&data.block_number.to_be_bytes());
+        encoded.extend_from_slice(&attestation);
+    }
+
+    Ok(encoded)
+}
+
+/// Angstrom API access, or the reason why it is unavailable.
+enum Api {
+    Ready(ApiConfig),
+    Unavailable(String),
+}
+
+impl Api {
+    /// Reads the Angstrom API configuration from the environment.
+    ///
+    /// Returns `Api::Unavailable` when `ANGSTROM_API_KEY` is unset, which is how consumers that
+    /// do not route over Angstrom opt out.
+    fn from_env() -> Self {
+        let Ok(key) = env::var("ANGSTROM_API_KEY") else {
+            return Self::Unavailable(
+                "ANGSTROM_API_KEY environment variable is required for Angstrom swaps".to_string(),
+            );
+        };
+
+        let client = reqwest::blocking::Client::builder()
+            .timeout(ANGSTROM_API_TIMEOUT)
+            .build();
+        let client = match client {
+            Ok(client) => client,
+            Err(e) => {
+                return Self::Unavailable(format!("Failed to build the Angstrom API client: {e}"))
+            }
+        };
+
+        let url =
+            env::var("ANGSTROM_API_URL").unwrap_or_else(|_| ANGSTROM_DEFAULT_API_URL.to_string());
+        let blocks_in_future = env::var("ANGSTROM_BLOCKS_IN_FUTURE")
+            .ok()
+            .and_then(|blocks| blocks.parse().ok())
+            .unwrap_or(ANGSTROM_DEFAULT_BLOCKS_IN_FUTURE);
+
+        Self::Ready(ApiConfig { client, url, key, blocks_in_future })
+    }
+}
+
+/// A single Angstrom API client, reused across fetches to keep its connection pool warm.
+struct ApiConfig {
+    client: reqwest::blocking::Client,
+    url: String,
+    key: String,
+    blocks_in_future: u64,
+}
+
+impl ApiConfig {
+    /// Fetches the current attestation window.
+    ///
+    /// Must not be called from within an async runtime: the request is blocking. Use
+    /// [`fetch_off_runtime`] when the calling thread may be running inside one.
+    fn fetch(&self) -> Result<AttestationResponse, EncodingError> {
+        let response = self
+            .client
+            .post(&self.url)
+            .header("accept", "application/json")
+            .header("X-Api-Key", &self.key)
+            .header("Content-Type", "application/json")
+            .json(&serde_json::json!({ "blocks_in_future": self.blocks_in_future }))
+            .send()
+            .map_err(|e| {
+                EncodingError::RecoverableError(format!("Failed to fetch attestations: {e}"))
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response
+                .text()
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(EncodingError::RecoverableError(format!(
+                "Angstrom API request failed with status {status}: {error_text}"
+            )));
+        }
+
+        let response: AttestationResponse = response.json().map_err(|e| {
+            EncodingError::RecoverableError(format!("Failed to parse attestation response: {e}"))
+        })?;
+
+        if !response.success {
+            return Err(EncodingError::RecoverableError(
+                "Angstrom API returned success=false".to_string(),
+            ));
+        }
+
+        Ok(response)
+    }
+}
+
+/// Runs [`ApiConfig::fetch`] on a thread of its own.
+///
+/// The blocking client cannot be driven from inside an async runtime, and callers of
+/// `encode_swap` usually are.
+fn fetch_off_runtime(api: &ApiConfig) -> Result<AttestationResponse, EncodingError> {
+    thread::scope(|scope| {
+        scope
+            .spawn(|| api.fetch())
+            .join()
+            .map_err(|_| {
+                EncodingError::RecoverableError("Angstrom attestation fetch panicked".to_string())
+            })
+    })?
+}
+
+/// An encoded attestation window and the time it was fetched.
+struct CachedWindow {
+    encoded: Vec<u8>,
+    fetched_at: Instant,
+}
+
+/// Process-wide cache of Angstrom attestations, kept warm by a background thread.
+pub(crate) struct AttestationCache {
+    api: Api,
+    latest: RwLock<Option<CachedWindow>>,
+}
+
+impl AttestationCache {
+    /// Returns the process-wide cache, starting its refresh thread on the first call.
+    ///
+    /// The thread is only started when the Angstrom API is configured, and then runs for the
+    /// lifetime of the process. Call this as early as possible so that the first encoded swap
+    /// already finds a warm cache.
+    pub(crate) fn global() -> &'static Arc<Self> {
+        CACHE.get_or_init(|| {
+            let cache = Arc::new(Self::new(Api::from_env()));
+            Arc::clone(&cache).spawn_refresher();
+            cache
+        })
+    }
+
+    fn new(api: Api) -> Self {
+        Self { api, latest: RwLock::new(None) }
+    }
+
+    /// Returns the attestation bytes to pass as `hookData` for a swap on an Angstrom pool.
+    ///
+    /// Served from the cache whenever the background refresh is healthy, which costs no network
+    /// access. A cold or stale cache falls back to a single blocking fetch so that encoding still
+    /// succeeds, at the cost of one API round trip.
+    ///
+    /// Returns an error if the Angstrom API is unconfigured, or if the fallback fetch fails.
+    pub(crate) fn hook_data(&self) -> Result<Vec<u8>, EncodingError> {
+        let api = match &self.api {
+            Api::Ready(api) => api,
+            Api::Unavailable(reason) => return Err(EncodingError::FatalError(reason.clone())),
+        };
+
+        if let Some(encoded) = self.fresh_window() {
+            return Ok(encoded);
+        }
+
+        warn!("Angstrom attestation cache is cold or stale, fetching while encoding");
+        let encoded = encode_attestations(&fetch_off_runtime(api)?)?;
+        self.store(encoded.clone(), Instant::now());
+        Ok(encoded)
+    }
+
+    /// Returns the cached window while it is young enough to still cover an upcoming block.
+    fn fresh_window(&self) -> Option<Vec<u8>> {
+        let latest = self
+            .latest
+            .read()
+            .unwrap_or_else(PoisonError::into_inner);
+        let window = latest.as_ref()?;
+        if window.fetched_at.elapsed() > ANGSTROM_ATTESTATION_MAX_AGE {
+            return None;
+        }
+        Some(window.encoded.clone())
+    }
+
+    fn store(&self, encoded: Vec<u8>, fetched_at: Instant) {
+        let mut latest = self
+            .latest
+            .write()
+            .unwrap_or_else(PoisonError::into_inner);
+        *latest = Some(CachedWindow { encoded, fetched_at });
+    }
+
+    /// Spawns the thread that keeps the cache warm.
+    ///
+    /// A dedicated thread is used rather than a `tokio` task so that the encoder works whether
+    /// or not its consumer runs a runtime, and because the blocking API client cannot be driven
+    /// from inside one.
+    fn spawn_refresher(self: Arc<Self>) {
+        match self.api {
+            Api::Unavailable(_) => return,
+            Api::Ready(_) => {}
+        }
+
+        let spawned = thread::Builder::new()
+            .name("angstrom-attestations".to_string())
+            .spawn(move || loop {
+                self.refresh();
+                thread::sleep(ANGSTROM_ATTESTATION_REFRESH_INTERVAL);
+            });
+
+        if let Err(e) = spawned {
+            warn!(
+                "Failed to start the Angstrom attestation refresher: {e}. Attestations will be \
+                 fetched while encoding instead."
+            );
+        }
+    }
+
+    /// Fetches the current window into the cache, keeping the previous one on failure.
+    fn refresh(&self) {
+        let api = match &self.api {
+            Api::Ready(api) => api,
+            Api::Unavailable(_) => return,
+        };
+
+        match api
+            .fetch()
+            .and_then(|response| encode_attestations(&response))
+        {
+            Ok(encoded) => self.store(encoded, Instant::now()),
+            Err(e) => warn!("Angstrom attestation refresh failed: {e}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    /// Two attestations retrieved from the Angstrom API in the past.
+    fn attestation_response() -> AttestationResponse {
+        AttestationResponse {
+            success: true,
+            attestations: vec![
+                AttestationData {
+                    block_number: 12345678,
+                    attestation: "0xd437f3372f3add2c2bc3245e6bd6f9c202e61bb367c79a6f740c7c12ca9c54a760bead943516fafaf8a4fe65a907b31d45c2ab4b525f9f32ec2771033e0832359ceb2e38d9288a755c7c366ce889b0df24b5821b1c".to_string(),
+                },
+                AttestationData {
+                    block_number: 12345679,
+                    attestation: "0xd437f3372f3add2c2bc3245e6bd6f9c202e61bb30c337ddae661e68cc6986c7784cd0aaec455b1f7514b6cd91bff26f002ce7cb42b3b1e2092ea4d1c1fb1e0641cbccfb021b31de25462f25b355cc99c7d509cdc1b".to_string(),
+                },
+            ],
+        }
+    }
+
+    fn disabled_cache() -> AttestationCache {
+        AttestationCache::new(Api::Unavailable("no API key".to_string()))
+    }
+
+    #[test]
+    fn test_encode_attestations_format() {
+        let encoded = encode_attestations(&attestation_response()).unwrap();
+
+        // 8 bytes block number + 85 bytes attestation, twice
+        assert_eq!(encoded.len(), 186);
+        assert_eq!(
+            hex::encode(&encoded),
+            String::from(concat!(
+                // First attestation block number (12345678)
+                "0000000000bc614e",
+                // First attestation data
+                "d437f3372f3add2c2bc3245e6bd6f9c202e61bb367c79a6f740c7c12ca9c54a760bead943516fafaf8a4fe65a907b31d45c2ab4b525f9f32ec2771033e0832359ceb2e38d9288a755c7c366ce889b0df24b5821b1c",
+                // Second attestation block number (12345679)
+                "0000000000bc614f",
+                // Second attestation data
+                "d437f3372f3add2c2bc3245e6bd6f9c202e61bb30c337ddae661e68cc6986c7784cd0aaec455b1f7514b6cd91bff26f002ce7cb42b3b1e2092ea4d1c1fb1e0641cbccfb021b31de25462f25b355cc99c7d509cdc1b"
+            ))
+        );
+    }
+
+    #[test]
+    fn test_encode_attestations_empty_window() {
+        let empty = AttestationResponse { success: true, attestations: vec![] };
+        assert!(encode_attestations(&empty)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn test_encode_attestations_rejects_wrong_size() {
+        let response = AttestationResponse {
+            success: true,
+            attestations: vec![AttestationData {
+                block_number: 12345678,
+                attestation: "0xdeadbeef".to_string(),
+            }],
+        };
+
+        let err = encode_attestations(&response).unwrap_err();
+        assert!(format!("{err}").contains("is 4 bytes, expected 85"));
+    }
+
+    #[test]
+    fn test_encode_attestations_rejects_invalid_hex() {
+        let response = AttestationResponse {
+            success: true,
+            attestations: vec![AttestationData {
+                block_number: 12345678,
+                attestation: "0xnothex".to_string(),
+            }],
+        };
+
+        let err = encode_attestations(&response).unwrap_err();
+        assert!(format!("{err}").contains("Failed to decode Angstrom attestation for block"));
+    }
+
+    #[test]
+    fn test_fresh_window_is_served_from_cache() {
+        let cache = disabled_cache();
+        cache.store(vec![1, 2, 3], Instant::now());
+
+        assert_eq!(cache.fresh_window(), Some(vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn test_stale_window_is_not_served_from_cache() {
+        let cache = disabled_cache();
+        let stale = Instant::now()
+            .checked_sub(ANGSTROM_ATTESTATION_MAX_AGE + Duration::from_secs(1))
+            .expect("the monotonic clock is past the maximum attestation age");
+        cache.store(vec![1, 2, 3], stale);
+
+        assert_eq!(cache.fresh_window(), None);
+    }
+
+    #[test]
+    fn test_cold_cache_is_not_served() {
+        assert_eq!(disabled_cache().fresh_window(), None);
+    }
+
+    #[test]
+    fn test_hook_data_without_api_key_errors() {
+        let err = disabled_cache()
+            .hook_data()
+            .unwrap_err();
+        assert_eq!(err, EncodingError::FatalError("no API key".to_string()));
+    }
+
+    #[test]
+    fn test_refresh_keeps_the_previous_window_when_unavailable() {
+        let cache = disabled_cache();
+        cache.store(vec![1, 2, 3], Instant::now());
+        cache.refresh();
+
+        assert_eq!(cache.fresh_window(), Some(vec![1, 2, 3]));
+    }
+}

--- a/crates/tycho-execution/src/encoding/evm/swap_encoder/angstrom.rs
+++ b/crates/tycho-execution/src/encoding/evm/swap_encoder/angstrom.rs
@@ -225,9 +225,16 @@ impl ApiConfig {
 /// number followed by the attestation itself. Entries for blocks that have already passed are
 /// harmless, since the executor selects the entry matching `block.number`.
 ///
-/// Returns an error if an attestation is not `ANGSTROM_ATTESTATION_SIZE` bytes long, which the
+/// Returns an error if the window is empty, since encoding it would produce a swap whose pool
+/// stays locked, or if an attestation is not `ANGSTROM_ATTESTATION_SIZE` bytes long, which the
 /// executor would reject on chain.
 fn encode_attestations(response: &AttestationResponse) -> Result<Vec<u8>, EncodingError> {
+    if response.attestations.is_empty() {
+        return Err(EncodingError::RecoverableError(
+            "Angstrom API returned an empty attestation window".to_string(),
+        ));
+    }
+
     let mut encoded =
         Vec::with_capacity(response.attestations.len() * (8 + ANGSTROM_ATTESTATION_SIZE));
     for data in &response.attestations {
@@ -435,12 +442,17 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_attestations_empty_window() {
+    fn test_encode_attestations_rejects_empty_window() {
         let empty = AttestationResponse { success: true, attestations: vec![] };
 
-        assert!(encode_attestations(&empty)
-            .unwrap()
-            .is_empty());
+        let err = encode_attestations(&empty).unwrap_err();
+
+        assert_eq!(
+            err,
+            EncodingError::RecoverableError(
+                "Angstrom API returned an empty attestation window".to_string()
+            )
+        );
     }
 
     #[test]

--- a/crates/tycho-execution/src/encoding/evm/swap_encoder/angstrom.rs
+++ b/crates/tycho-execution/src/encoding/evm/swap_encoder/angstrom.rs
@@ -144,7 +144,8 @@ impl ApiConfig {
     /// Reads the Angstrom API configuration from the environment.
     ///
     /// Returns the reason Angstrom swaps cannot be encoded when `ANGSTROM_API_KEY` is unset,
-    /// which is how consumers that do not route over Angstrom opt out.
+    /// which is how consumers that do not route over Angstrom opt out, or when
+    /// `ANGSTROM_BLOCKS_IN_FUTURE` is set to something that is not a block count.
     fn from_env() -> Result<Self, String> {
         let key = env::var("ANGSTROM_API_KEY").map_err(|_| {
             "ANGSTROM_API_KEY environment variable is required for Angstrom swaps".to_string()
@@ -157,10 +158,12 @@ impl ApiConfig {
 
         let url =
             env::var("ANGSTROM_API_URL").unwrap_or_else(|_| ANGSTROM_DEFAULT_API_URL.to_string());
-        let blocks_in_future = env::var("ANGSTROM_BLOCKS_IN_FUTURE")
-            .ok()
-            .and_then(|blocks| blocks.parse().ok())
-            .unwrap_or(ANGSTROM_DEFAULT_BLOCKS_IN_FUTURE);
+        let blocks_in_future = match env::var("ANGSTROM_BLOCKS_IN_FUTURE") {
+            Ok(blocks) => blocks.parse().map_err(|e| {
+                format!("ANGSTROM_BLOCKS_IN_FUTURE is set to '{blocks}', not a block count: {e}")
+            })?,
+            Err(_) => ANGSTROM_DEFAULT_BLOCKS_IN_FUTURE,
+        };
 
         Ok(Self { client, url, key, blocks_in_future })
     }
@@ -351,6 +354,23 @@ mod tests {
         cache.refresh().unwrap_err();
 
         assert_eq!(cache.hook_data().unwrap(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_unparsable_blocks_in_future_is_rejected() {
+        env::set_var("ANGSTROM_API_KEY", "test-key");
+        env::set_var("ANGSTROM_BLOCKS_IN_FUTURE", "five");
+
+        let err = ApiConfig::from_env().err();
+
+        env::remove_var("ANGSTROM_BLOCKS_IN_FUTURE");
+        env::remove_var("ANGSTROM_API_KEY");
+
+        let err = err.expect("an unparsable block count must be rejected");
+        assert!(
+            err.contains("ANGSTROM_BLOCKS_IN_FUTURE is set to 'five'"),
+            "unexpected error: {err}"
+        );
     }
 
     /// Reads the current block number over JSON-RPC, using `RPC_URL`.

--- a/crates/tycho-execution/src/encoding/evm/swap_encoder/angstrom.rs
+++ b/crates/tycho-execution/src/encoding/evm/swap_encoder/angstrom.rs
@@ -7,8 +7,8 @@
 //!
 //! Attestations are therefore fetched by a background thread into a process-wide cache and read
 //! from that cache while encoding, which keeps the Angstrom API's latency off the encoding path.
-//! The API returns a window covering the next [`ANGSTROM_DEFAULT_BLOCKS_IN_FUTURE`] blocks; the
-//! executor picks the entry matching `block.number` on chain and ignores the rest.
+//! The API returns a window covering the next `ANGSTROM_BLOCKS_IN_FUTURE` blocks; the executor
+//! picks the entry matching `block.number` on chain and ignores the rest.
 
 use std::{
     env,
@@ -30,99 +30,105 @@ use crate::encoding::{
 
 static CACHE: OnceLock<Arc<AttestationCache>> = OnceLock::new();
 
-/// The attestation unlocking Angstrom's pools for one block.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub(crate) struct AttestationData {
-    #[serde(rename = "blockNumber")]
-    pub(crate) block_number: u64,
-    #[serde(rename = "unlockData")]
-    pub(crate) attestation: String,
+/// The attestation window every Angstrom swap encodes, kept warm by a background thread.
+///
+/// One cache exists per process, shared by every swap encoder through `global`. Callers only
+/// need two methods: `global` to obtain the cache and start its refresh thread, and `hook_data`
+/// to read the current window while encoding. Everything below those two is internal.
+pub(crate) struct AttestationCache {
+    /// The configured API client, or the reason Angstrom swaps cannot be encoded.
+    api: Result<ApiConfig, String>,
+    latest: RwLock<Option<CachedWindow>>,
 }
 
-/// Response from the Angstrom attestation API.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub(crate) struct AttestationResponse {
-    pub(crate) success: bool,
-    pub(crate) attestations: Vec<AttestationData>,
-}
+impl AttestationCache {
+    /// Returns the process-wide cache, starting its refresh thread on the first call.
+    ///
+    /// The thread is only started when the Angstrom API is configured, and then runs for the
+    /// lifetime of the process. Call this as early as possible so that the first encoded swap
+    /// already finds a warm cache.
+    pub(crate) fn global() -> &'static Arc<Self> {
+        CACHE.get_or_init(|| {
+            let cache = Arc::new(Self { api: ApiConfig::from_env(), latest: RwLock::new(None) });
+            Arc::clone(&cache).spawn_refresher();
+            cache
+        })
+    }
 
-/// Encodes attestations into the `hookData` layout the Uniswap V4 executor expects.
-///
-/// Every attestation takes exactly `8 + ANGSTROM_ATTESTATION_SIZE` bytes: a big endian block
-/// number followed by the attestation itself. Entries for blocks that have already passed are
-/// harmless, since the executor selects the entry matching `block.number`.
-///
-/// Returns an error if an attestation is not [`ANGSTROM_ATTESTATION_SIZE`] bytes long, which the
-/// executor would reject on chain.
-fn encode_attestations(response: &AttestationResponse) -> Result<Vec<u8>, EncodingError> {
-    let mut encoded =
-        Vec::with_capacity(response.attestations.len() * (8 + ANGSTROM_ATTESTATION_SIZE));
-    for data in &response.attestations {
-        let attestation_hex = data
-            .attestation
-            .strip_prefix("0x")
-            .unwrap_or(&data.attestation);
+    /// Returns the attestation bytes to pass as `hookData` for a swap on an Angstrom pool.
+    ///
+    /// Costs no network access while the background refresh is healthy. A window older than
+    /// `ANGSTROM_ATTESTATION_MAX_AGE`, or a cache that has never been filled, falls back to a
+    /// single blocking fetch so that encoding still succeeds at the cost of one API round trip.
+    ///
+    /// Returns an error if the fallback fetch fails, or if it is needed while the Angstrom API
+    /// is unconfigured.
+    pub(crate) fn hook_data(&self) -> Result<Vec<u8>, EncodingError> {
+        let latest = self
+            .latest
+            .read()
+            .unwrap_or_else(PoisonError::into_inner);
+        if let Some(window) = latest.as_ref() {
+            if window.fetched_at.elapsed() <= ANGSTROM_ATTESTATION_MAX_AGE {
+                return Ok(window.encoded.clone());
+            }
+        }
+        drop(latest);
 
-        let attestation = hex::decode(attestation_hex).map_err(|e| {
-            EncodingError::FatalError(format!(
-                "Failed to decode Angstrom attestation for block {}: {}",
-                data.block_number, e
-            ))
-        })?;
+        warn!("Angstrom attestation cache is cold or stale, fetching while encoding");
+        self.refresh()
+    }
 
-        if attestation.len() != ANGSTROM_ATTESTATION_SIZE {
-            return Err(EncodingError::FatalError(format!(
-                "Angstrom attestation for block {} is {} bytes, expected {}",
-                data.block_number,
-                attestation.len(),
-                ANGSTROM_ATTESTATION_SIZE
-            )));
+    /// Fetches the current attestation window into the cache and returns it.
+    fn refresh(&self) -> Result<Vec<u8>, EncodingError> {
+        let api = self
+            .api
+            .as_ref()
+            .map_err(|reason| EncodingError::FatalError(reason.clone()))?;
+
+        let encoded = encode_attestations(&api.fetch_off_runtime()?)?;
+        *self
+            .latest
+            .write()
+            .unwrap_or_else(PoisonError::into_inner) =
+            Some(CachedWindow { encoded: encoded.clone(), fetched_at: Instant::now() });
+
+        Ok(encoded)
+    }
+
+    /// Spawns the thread that keeps the cache warm, leaving the previous window in place
+    /// whenever a refresh fails.
+    ///
+    /// A dedicated thread is used rather than a `tokio` task so that the encoder works whether
+    /// or not its consumer runs a runtime, and because the blocking API client cannot be driven
+    /// from inside one.
+    fn spawn_refresher(self: Arc<Self>) {
+        if self.api.is_err() {
+            return;
         }
 
-        encoded.extend_from_slice(&data.block_number.to_be_bytes());
-        encoded.extend_from_slice(&attestation);
-    }
+        let spawned = thread::Builder::new()
+            .name("angstrom-attestations".to_string())
+            .spawn(move || loop {
+                if let Err(e) = self.refresh() {
+                    warn!("Angstrom attestation refresh failed: {e}");
+                }
+                thread::sleep(ANGSTROM_ATTESTATION_REFRESH_INTERVAL);
+            });
 
-    Ok(encoded)
-}
-
-/// Angstrom API access, or the reason why it is unavailable.
-enum Api {
-    Ready(ApiConfig),
-    Unavailable(String),
-}
-
-impl Api {
-    /// Reads the Angstrom API configuration from the environment.
-    ///
-    /// Returns `Api::Unavailable` when `ANGSTROM_API_KEY` is unset, which is how consumers that
-    /// do not route over Angstrom opt out.
-    fn from_env() -> Self {
-        let Ok(key) = env::var("ANGSTROM_API_KEY") else {
-            return Self::Unavailable(
-                "ANGSTROM_API_KEY environment variable is required for Angstrom swaps".to_string(),
+        if let Err(e) = spawned {
+            warn!(
+                "Failed to start the Angstrom attestation refresher: {e}. Attestations will be \
+                 fetched while encoding instead."
             );
-        };
-
-        let client = reqwest::blocking::Client::builder()
-            .timeout(ANGSTROM_API_TIMEOUT)
-            .build();
-        let client = match client {
-            Ok(client) => client,
-            Err(e) => {
-                return Self::Unavailable(format!("Failed to build the Angstrom API client: {e}"))
-            }
-        };
-
-        let url =
-            env::var("ANGSTROM_API_URL").unwrap_or_else(|_| ANGSTROM_DEFAULT_API_URL.to_string());
-        let blocks_in_future = env::var("ANGSTROM_BLOCKS_IN_FUTURE")
-            .ok()
-            .and_then(|blocks| blocks.parse().ok())
-            .unwrap_or(ANGSTROM_DEFAULT_BLOCKS_IN_FUTURE);
-
-        Self::Ready(ApiConfig { client, url, key, blocks_in_future })
+        }
     }
+}
+
+/// An encoded attestation window and the time it was fetched.
+struct CachedWindow {
+    encoded: Vec<u8>,
+    fetched_at: Instant,
 }
 
 /// A single Angstrom API client, reused across fetches to keep its connection pool warm.
@@ -134,10 +140,47 @@ struct ApiConfig {
 }
 
 impl ApiConfig {
-    /// Fetches the current attestation window.
+    /// Reads the Angstrom API configuration from the environment.
     ///
-    /// Must not be called from within an async runtime: the request is blocking. Use
-    /// [`fetch_off_runtime`] when the calling thread may be running inside one.
+    /// Returns the reason Angstrom swaps cannot be encoded when `ANGSTROM_API_KEY` is unset,
+    /// which is how consumers that do not route over Angstrom opt out.
+    fn from_env() -> Result<Self, String> {
+        let key = env::var("ANGSTROM_API_KEY").map_err(|_| {
+            "ANGSTROM_API_KEY environment variable is required for Angstrom swaps".to_string()
+        })?;
+
+        let client = reqwest::blocking::Client::builder()
+            .timeout(ANGSTROM_API_TIMEOUT)
+            .build()
+            .map_err(|e| format!("Failed to build the Angstrom API client: {e}"))?;
+
+        let url =
+            env::var("ANGSTROM_API_URL").unwrap_or_else(|_| ANGSTROM_DEFAULT_API_URL.to_string());
+        let blocks_in_future = env::var("ANGSTROM_BLOCKS_IN_FUTURE")
+            .ok()
+            .and_then(|blocks| blocks.parse().ok())
+            .unwrap_or(ANGSTROM_DEFAULT_BLOCKS_IN_FUTURE);
+
+        Ok(Self { client, url, key, blocks_in_future })
+    }
+
+    /// Fetches the current attestation window on a thread of its own.
+    ///
+    /// The blocking client cannot be driven from inside an async runtime, and callers of
+    /// `encode_swap` usually are.
+    fn fetch_off_runtime(&self) -> Result<AttestationResponse, EncodingError> {
+        thread::scope(|scope| {
+            scope
+                .spawn(|| self.fetch())
+                .join()
+                .map_err(|_| {
+                    EncodingError::RecoverableError(
+                        "Angstrom attestation fetch panicked".to_string(),
+                    )
+                })
+        })?
+    }
+
     fn fetch(&self) -> Result<AttestationResponse, EncodingError> {
         let response = self
             .client
@@ -175,136 +218,60 @@ impl ApiConfig {
     }
 }
 
-/// Runs [`ApiConfig::fetch`] on a thread of its own.
+/// Encodes attestations into the `hookData` layout the Uniswap V4 executor expects.
 ///
-/// The blocking client cannot be driven from inside an async runtime, and callers of
-/// `encode_swap` usually are.
-fn fetch_off_runtime(api: &ApiConfig) -> Result<AttestationResponse, EncodingError> {
-    thread::scope(|scope| {
-        scope
-            .spawn(|| api.fetch())
-            .join()
-            .map_err(|_| {
-                EncodingError::RecoverableError("Angstrom attestation fetch panicked".to_string())
-            })
-    })?
+/// Every attestation takes exactly `8 + ANGSTROM_ATTESTATION_SIZE` bytes: a big endian block
+/// number followed by the attestation itself. Entries for blocks that have already passed are
+/// harmless, since the executor selects the entry matching `block.number`.
+///
+/// Returns an error if an attestation is not `ANGSTROM_ATTESTATION_SIZE` bytes long, which the
+/// executor would reject on chain.
+fn encode_attestations(response: &AttestationResponse) -> Result<Vec<u8>, EncodingError> {
+    let mut encoded =
+        Vec::with_capacity(response.attestations.len() * (8 + ANGSTROM_ATTESTATION_SIZE));
+    for data in &response.attestations {
+        let attestation_hex = data
+            .attestation
+            .strip_prefix("0x")
+            .unwrap_or(&data.attestation);
+
+        let attestation = hex::decode(attestation_hex).map_err(|e| {
+            EncodingError::FatalError(format!(
+                "Failed to decode Angstrom attestation for block {}: {}",
+                data.block_number, e
+            ))
+        })?;
+
+        if attestation.len() != ANGSTROM_ATTESTATION_SIZE {
+            return Err(EncodingError::FatalError(format!(
+                "Angstrom attestation for block {} is {} bytes, expected {}",
+                data.block_number,
+                attestation.len(),
+                ANGSTROM_ATTESTATION_SIZE
+            )));
+        }
+
+        encoded.extend_from_slice(&data.block_number.to_be_bytes());
+        encoded.extend_from_slice(&attestation);
+    }
+
+    Ok(encoded)
 }
 
-/// An encoded attestation window and the time it was fetched.
-struct CachedWindow {
-    encoded: Vec<u8>,
-    fetched_at: Instant,
+/// Response from the Angstrom attestation API.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct AttestationResponse {
+    pub(crate) success: bool,
+    pub(crate) attestations: Vec<AttestationData>,
 }
 
-/// Process-wide cache of Angstrom attestations, kept warm by a background thread.
-pub(crate) struct AttestationCache {
-    api: Api,
-    latest: RwLock<Option<CachedWindow>>,
-}
-
-impl AttestationCache {
-    /// Returns the process-wide cache, starting its refresh thread on the first call.
-    ///
-    /// The thread is only started when the Angstrom API is configured, and then runs for the
-    /// lifetime of the process. Call this as early as possible so that the first encoded swap
-    /// already finds a warm cache.
-    pub(crate) fn global() -> &'static Arc<Self> {
-        CACHE.get_or_init(|| {
-            let cache = Arc::new(Self::new(Api::from_env()));
-            Arc::clone(&cache).spawn_refresher();
-            cache
-        })
-    }
-
-    fn new(api: Api) -> Self {
-        Self { api, latest: RwLock::new(None) }
-    }
-
-    /// Returns the attestation bytes to pass as `hookData` for a swap on an Angstrom pool.
-    ///
-    /// Served from the cache whenever the background refresh is healthy, which costs no network
-    /// access. A cold or stale cache falls back to a single blocking fetch so that encoding still
-    /// succeeds, at the cost of one API round trip.
-    ///
-    /// Returns an error if the Angstrom API is unconfigured, or if the fallback fetch fails.
-    pub(crate) fn hook_data(&self) -> Result<Vec<u8>, EncodingError> {
-        let api = match &self.api {
-            Api::Ready(api) => api,
-            Api::Unavailable(reason) => return Err(EncodingError::FatalError(reason.clone())),
-        };
-
-        if let Some(encoded) = self.fresh_window() {
-            return Ok(encoded);
-        }
-
-        warn!("Angstrom attestation cache is cold or stale, fetching while encoding");
-        let encoded = encode_attestations(&fetch_off_runtime(api)?)?;
-        self.store(encoded.clone(), Instant::now());
-        Ok(encoded)
-    }
-
-    /// Returns the cached window while it is young enough to still cover an upcoming block.
-    fn fresh_window(&self) -> Option<Vec<u8>> {
-        let latest = self
-            .latest
-            .read()
-            .unwrap_or_else(PoisonError::into_inner);
-        let window = latest.as_ref()?;
-        if window.fetched_at.elapsed() > ANGSTROM_ATTESTATION_MAX_AGE {
-            return None;
-        }
-        Some(window.encoded.clone())
-    }
-
-    fn store(&self, encoded: Vec<u8>, fetched_at: Instant) {
-        let mut latest = self
-            .latest
-            .write()
-            .unwrap_or_else(PoisonError::into_inner);
-        *latest = Some(CachedWindow { encoded, fetched_at });
-    }
-
-    /// Spawns the thread that keeps the cache warm.
-    ///
-    /// A dedicated thread is used rather than a `tokio` task so that the encoder works whether
-    /// or not its consumer runs a runtime, and because the blocking API client cannot be driven
-    /// from inside one.
-    fn spawn_refresher(self: Arc<Self>) {
-        match self.api {
-            Api::Unavailable(_) => return,
-            Api::Ready(_) => {}
-        }
-
-        let spawned = thread::Builder::new()
-            .name("angstrom-attestations".to_string())
-            .spawn(move || loop {
-                self.refresh();
-                thread::sleep(ANGSTROM_ATTESTATION_REFRESH_INTERVAL);
-            });
-
-        if let Err(e) = spawned {
-            warn!(
-                "Failed to start the Angstrom attestation refresher: {e}. Attestations will be \
-                 fetched while encoding instead."
-            );
-        }
-    }
-
-    /// Fetches the current window into the cache, keeping the previous one on failure.
-    fn refresh(&self) {
-        let api = match &self.api {
-            Api::Ready(api) => api,
-            Api::Unavailable(_) => return,
-        };
-
-        match api
-            .fetch()
-            .and_then(|response| encode_attestations(&response))
-        {
-            Ok(encoded) => self.store(encoded, Instant::now()),
-            Err(e) => warn!("Angstrom attestation refresh failed: {e}"),
-        }
-    }
+/// The attestation unlocking Angstrom's pools for one block.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct AttestationData {
+    #[serde(rename = "blockNumber")]
+    pub(crate) block_number: u64,
+    #[serde(rename = "unlockData")]
+    pub(crate) attestation: String,
 }
 
 #[cfg(test)]
@@ -330,8 +297,52 @@ mod tests {
         }
     }
 
-    fn disabled_cache() -> AttestationCache {
-        AttestationCache::new(Api::Unavailable("no API key".to_string()))
+    /// A cache with no API configured, so that any fetch fails with a known message instead of
+    /// reaching the network.
+    fn unconfigured_cache(window: Option<CachedWindow>) -> AttestationCache {
+        AttestationCache { api: Err("no API key".to_string()), latest: RwLock::new(window) }
+    }
+
+    fn window_fetched_ago(age: Duration) -> Option<CachedWindow> {
+        let fetched_at = Instant::now()
+            .checked_sub(age)
+            .expect("the monotonic clock is past the requested age");
+        Some(CachedWindow { encoded: vec![1, 2, 3], fetched_at })
+    }
+
+    #[test]
+    fn test_fresh_window_is_served_without_the_api() {
+        let cache = unconfigured_cache(window_fetched_ago(Duration::ZERO));
+
+        assert_eq!(cache.hook_data().unwrap(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_stale_window_triggers_a_fetch() {
+        let stale = ANGSTROM_ATTESTATION_MAX_AGE + Duration::from_secs(1);
+        let cache = unconfigured_cache(window_fetched_ago(stale));
+
+        let err = cache.hook_data().unwrap_err();
+
+        assert_eq!(err, EncodingError::FatalError("no API key".to_string()));
+    }
+
+    #[test]
+    fn test_cold_cache_triggers_a_fetch() {
+        let err = unconfigured_cache(None)
+            .hook_data()
+            .unwrap_err();
+
+        assert_eq!(err, EncodingError::FatalError("no API key".to_string()));
+    }
+
+    #[test]
+    fn test_failed_refresh_keeps_the_previous_window() {
+        let cache = unconfigured_cache(window_fetched_ago(Duration::ZERO));
+
+        cache.refresh().unwrap_err();
+
+        assert_eq!(cache.hook_data().unwrap(), vec![1, 2, 3]);
     }
 
     #[test]
@@ -358,6 +369,7 @@ mod tests {
     #[test]
     fn test_encode_attestations_empty_window() {
         let empty = AttestationResponse { success: true, attestations: vec![] };
+
         assert!(encode_attestations(&empty)
             .unwrap()
             .is_empty());
@@ -374,6 +386,7 @@ mod tests {
         };
 
         let err = encode_attestations(&response).unwrap_err();
+
         assert!(format!("{err}").contains("is 4 bytes, expected 85"));
     }
 
@@ -388,47 +401,7 @@ mod tests {
         };
 
         let err = encode_attestations(&response).unwrap_err();
+
         assert!(format!("{err}").contains("Failed to decode Angstrom attestation for block"));
-    }
-
-    #[test]
-    fn test_fresh_window_is_served_from_cache() {
-        let cache = disabled_cache();
-        cache.store(vec![1, 2, 3], Instant::now());
-
-        assert_eq!(cache.fresh_window(), Some(vec![1, 2, 3]));
-    }
-
-    #[test]
-    fn test_stale_window_is_not_served_from_cache() {
-        let cache = disabled_cache();
-        let stale = Instant::now()
-            .checked_sub(ANGSTROM_ATTESTATION_MAX_AGE + Duration::from_secs(1))
-            .expect("the monotonic clock is past the maximum attestation age");
-        cache.store(vec![1, 2, 3], stale);
-
-        assert_eq!(cache.fresh_window(), None);
-    }
-
-    #[test]
-    fn test_cold_cache_is_not_served() {
-        assert_eq!(disabled_cache().fresh_window(), None);
-    }
-
-    #[test]
-    fn test_hook_data_without_api_key_errors() {
-        let err = disabled_cache()
-            .hook_data()
-            .unwrap_err();
-        assert_eq!(err, EncodingError::FatalError("no API key".to_string()));
-    }
-
-    #[test]
-    fn test_refresh_keeps_the_previous_window_when_unavailable() {
-        let cache = disabled_cache();
-        cache.store(vec![1, 2, 3], Instant::now());
-        cache.refresh();
-
-        assert_eq!(cache.fresh_window(), Some(vec![1, 2, 3]));
     }
 }

--- a/crates/tycho-execution/src/encoding/evm/swap_encoder/angstrom.rs
+++ b/crates/tycho-execution/src/encoding/evm/swap_encoder/angstrom.rs
@@ -77,6 +77,10 @@ impl AttestationCache {
         }
         drop(cached);
 
+        if let Err(reason) = &self.fetcher {
+            return Err(EncodingError::FatalError(reason.clone()));
+        }
+
         warn!("Angstrom attestation cache is cold or stale, fetching while encoding");
         self.refresh()
     }
@@ -336,6 +340,11 @@ mod tests {
         (fetcher, calls)
     }
 
+    /// A cache belonging to a consumer that never configured the Angstrom API.
+    fn unconfigured_cache() -> AttestationCache {
+        AttestationCache { fetcher: Err("no API key".to_string()), window: RwLock::new(None) }
+    }
+
     /// A fetch standing in for an Angstrom API that cannot be reached.
     fn failing_fetch() -> WindowFetcher {
         Box::new(|| Err(EncodingError::RecoverableError("the API is down".to_string())))
@@ -393,6 +402,15 @@ mod tests {
 
         assert_eq!(cache.hook_data().unwrap(), fetched_window());
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_unconfigured_cache_reports_the_configuration_error() {
+        let err = unconfigured_cache()
+            .hook_data()
+            .unwrap_err();
+
+        assert_eq!(err, EncodingError::FatalError("no API key".to_string()));
     }
 
     #[test]

--- a/crates/tycho-execution/src/encoding/evm/swap_encoder/mod.rs
+++ b/crates/tycho-execution/src/encoding/evm/swap_encoder/mod.rs
@@ -1,4 +1,5 @@
 mod aerodrome_v1;
+mod angstrom;
 mod balancer_v2;
 mod balancer_v3;
 mod bebop;

--- a/crates/tycho-execution/src/encoding/evm/swap_encoder/uniswap_v4.rs
+++ b/crates/tycho-execution/src/encoding/evm/swap_encoder/uniswap_v4.rs
@@ -597,8 +597,23 @@ mod tests {
                 format!("{}{}", encode(&first_encoded), encode(ple_encode(vec![second_encoded])));
 
             write_calldata_to_file("test_encode_angstrom_grouped_swap", combined_hex.as_str());
-            // Any different length could indicate we didn't encode attestation data
-            assert!(combined_hex.len() == 2510);
+
+            // Both hops carry the same attestation window, on top of 140 bytes of pool params:
+            // 90 for the first swap and 50 for the length-prefixed second one. The API decides
+            // how many attestations a window holds, so assert the shape rather than the count.
+            const POOL_PARAMS_HEX: usize = 280;
+            const ATTESTATION_HEX_PER_HOP: usize = 186;
+            let attestation_hex = combined_hex
+                .len()
+                .checked_sub(POOL_PARAMS_HEX)
+                .expect("calldata is shorter than the pool params alone");
+
+            assert!(attestation_hex > 0, "no attestation data encoded");
+            assert_eq!(
+                attestation_hex % (2 * ATTESTATION_HEX_PER_HOP),
+                0,
+                "attestation data is not a whole number of attestations on both hops"
+            );
         }
     }
 }

--- a/crates/tycho-execution/src/encoding/evm/swap_encoder/uniswap_v4.rs
+++ b/crates/tycho-execution/src/encoding/evm/swap_encoder/uniswap_v4.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str::FromStr};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use alloy::{
     primitives::{Address, Bytes as AlloyBytes},
@@ -10,7 +10,7 @@ use tycho_common::{models::Chain, Bytes};
 use crate::encoding::{
     errors::EncodingError,
     evm::{
-        constants::ANGSTROM_DEFAULT_BLOCKS_IN_FUTURE,
+        swap_encoder::angstrom::AttestationCache,
         utils::{
             bytes_to_address, convert_to_router_token, get_static_attribute,
             pad_or_truncate_to_size,
@@ -20,103 +20,28 @@ use crate::encoding::{
     swap_encoder::SwapEncoder,
 };
 
+/// The Angstrom hook deployed on this chain, together with its attestation cache.
+#[derive(Clone)]
+struct AngstromConfig {
+    hook_address: Bytes,
+    attestations: Arc<AttestationCache>,
+}
+
 /// Encodes a swap on a Uniswap V4 pool through the given executor address.
 ///
 /// # Fields
 /// * `executor_address` - The address of the executor contract that will perform the swap.
+/// * `angstrom` - Set on chains where Angstrom is deployed. Swaps on a pool using the Angstrom hook
+///   carry a pool unlock attestation as their hook data.
 #[derive(Clone)]
 pub struct UniswapV4SwapEncoder {
     executor_address: Bytes,
-    angstrom_hook_address: Bytes,
+    angstrom: Option<AngstromConfig>,
 }
 
 impl UniswapV4SwapEncoder {
     fn get_zero_to_one(sell_token_address: Address, buy_token_address: Address) -> bool {
         sell_token_address < buy_token_address
-    }
-
-    /// Fetches attestations from the Angstrom API (blocking)
-    fn fetch_angstrom_attestations() -> Result<AttestationResponse, EncodingError> {
-        let client = reqwest::blocking::Client::new();
-
-        let api_url = std::env::var("ANGSTROM_API_URL")
-            .unwrap_or("https://attestations.angstrom.xyz/getAttestations".to_string());
-
-        let api_key = std::env::var("ANGSTROM_API_KEY").map_err(|_| {
-            EncodingError::FatalError(
-                "ANGSTROM_API_KEY environment variable is required for Angstrom swaps".to_string(),
-            )
-        })?;
-        let blocks_in_future = std::env::var("ANGSTROM_BLOCKS_IN_FUTURE")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(ANGSTROM_DEFAULT_BLOCKS_IN_FUTURE);
-
-        let request_body = serde_json::json!({
-            "blocks_in_future": blocks_in_future
-        });
-
-        let response = client
-            .post(&api_url)
-            .header("accept", "application/json")
-            .header("X-Api-Key", api_key)
-            .header("Content-Type", "application/json")
-            .json(&request_body)
-            .send()
-            .map_err(|e| {
-                EncodingError::FatalError(format!("Failed to fetch attestations: {}", e))
-            })?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let error_text = response
-                .text()
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            return Err(EncodingError::FatalError(format!(
-                "Angstrom API request failed with status {}: {}",
-                status, error_text
-            )));
-        }
-
-        let attestation_response: AttestationResponse = response.json().map_err(|e| {
-            EncodingError::FatalError(format!("Failed to parse attestation response: {}", e))
-        })?;
-
-        if !attestation_response.success {
-            return Err(EncodingError::FatalError(
-                "Angstrom API returned success=false".to_string(),
-            ));
-        }
-
-        Ok(attestation_response)
-    }
-
-    /// Encodes attestations into bytes
-    ///
-    /// Uses fixed-length format: each attestation is exactly 93 bytes
-    /// (8 bytes block number + 85 bytes attestation)
-    fn encode_angstrom_attestations(
-        attestations: &AttestationResponse,
-    ) -> Result<Vec<u8>, EncodingError> {
-        let mut encoded = Vec::new();
-        for att_data in &attestations.attestations {
-            // Encode block number (first 8 bytes)
-            encoded.extend_from_slice(&att_data.block_number.to_be_bytes());
-
-            let attestation_hex = att_data
-                .attestation
-                .strip_prefix("0x")
-                .unwrap_or(&att_data.attestation);
-
-            let attestation_bytes = hex::decode(attestation_hex).map_err(|e| {
-                EncodingError::FatalError(format!("Failed to decode attestation hex: {}", e))
-            })?;
-
-            // Encode attestation data for block (next 85 bytes)
-            encoded.extend_from_slice(&attestation_bytes);
-        }
-
-        Ok(encoded)
     }
 }
 
@@ -126,18 +51,25 @@ impl SwapEncoder for UniswapV4SwapEncoder {
         _chain: Chain,
         config: Option<HashMap<String, String>>,
     ) -> Result<Self, EncodingError> {
-        let angstrom_hook_address = match config {
-            // Allow for no config, since Angstrom is not on every chain
-            None => Bytes::new(),
-            Some(cfg) => cfg
-                .get("angstrom_hook_address")
-                .map_or(Ok(Bytes::new()), |s| {
-                    Bytes::from_str(s).map_err(|_| {
-                        EncodingError::FatalError("Invalid Angstrom hook address".to_string())
-                    })
-                })?,
+        // Allow for no config, since Angstrom is not on every chain
+        let hook_address = config
+            .as_ref()
+            .and_then(|cfg| cfg.get("angstrom_hook_address"));
+
+        let angstrom = match hook_address {
+            None => None,
+            Some(address) => {
+                let hook_address = Bytes::from_str(address).map_err(|_| {
+                    EncodingError::FatalError("Invalid Angstrom hook address".to_string())
+                })?;
+                // Starting the cache here warms it up while the encoder is built, so that the
+                // first encoded Angstrom swap does not wait on the Angstrom API.
+                let attestations = Arc::clone(AttestationCache::global());
+                Some(AngstromConfig { hook_address, attestations })
+            }
         };
-        Ok(Self { executor_address, angstrom_hook_address })
+
+        Ok(Self { executor_address, angstrom })
     }
 
     fn encode_swap(
@@ -163,17 +95,16 @@ impl SwapEncoder for UniswapV4SwapEncoder {
             Err(_) => Address::ZERO,
         };
 
-        let is_angstrom_hook = **hook_address == *self.angstrom_hook_address;
-        let hook_data = if is_angstrom_hook {
-            // Angstrom hook - obtain hook data from API
-            let attestations = std::thread::scope(|s| {
-                s.spawn(Self::fetch_angstrom_attestations)
-                    .join()
-                    .expect("attestation fetch panicked")
-            })?;
-            Self::encode_angstrom_attestations(&attestations)?
-        } else {
-            v4_user_data.hook_data.to_vec()
+        let angstrom = self
+            .angstrom
+            .as_ref()
+            .filter(|angstrom| **hook_address == *angstrom.hook_address);
+
+        let hook_data = match angstrom {
+            // Angstrom pools are locked at the start of every block, so they need an unlock
+            // attestation as their hook data.
+            Some(angstrom) => angstrom.attestations.hook_data()?,
+            None => v4_user_data.hook_data.to_vec(),
         };
 
         let hook_data_length = (hook_data.len() as u16).to_be_bytes();
@@ -265,22 +196,6 @@ impl UniswapV4UserData {
             _ => Ok(Self::default()),
         }
     }
-}
-
-/// Attestation data for Angstrom swaps
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AttestationData {
-    #[serde(rename = "blockNumber")]
-    pub block_number: u64,
-    #[serde(rename = "unlockData")]
-    pub attestation: String,
-}
-
-/// Response from Angstrom attestation API
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AttestationResponse {
-    pub success: bool,
-    pub attestations: Vec<AttestationData>,
 }
 
 #[cfg(test)]
@@ -600,55 +515,8 @@ mod tests {
     mod uniswap_v4_angstrom {
         use super::*;
         use crate::encoding::evm::{
-            swap_encoder::uniswap_v4::{
-                AttestationData, AttestationResponse, UniswapV4SwapEncoder,
-            },
-            utils::ple_encode,
+            swap_encoder::uniswap_v4::UniswapV4SwapEncoder, utils::ple_encode,
         };
-
-        #[test]
-        fn test_encode_attestations_format() {
-            // Create mock attestation data with real attestations retrieved in the past
-            let attestations = AttestationResponse {
-            success: true,
-            attestations: vec![
-                AttestationData {
-                    block_number: 12345678,
-                    attestation: "0xd437f3372f3add2c2bc3245e6bd6f9c202e61bb367c79a6f740c7c12ca9c54a760bead943516fafaf8a4fe65a907b31d45c2ab4b525f9f32ec2771033e0832359ceb2e38d9288a755c7c366ce889b0df24b5821b1c".to_string(),
-                },
-                AttestationData {
-                    block_number: 12345679,
-                    attestation: "0xd437f3372f3add2c2bc3245e6bd6f9c202e61bb30c337ddae661e68cc6986c7784cd0aaec455b1f7514b6cd91bff26f002ce7cb42b3b1e2092ea4d1c1fb1e0641cbccfb021b31de25462f25b355cc99c7d509cdc1b".to_string(),
-                },
-            ],
-        };
-
-            let encoded =
-                UniswapV4SwapEncoder::encode_angstrom_attestations(&attestations).unwrap();
-
-            // Verify the structure with fixed-length format:
-            // - For each attestation:
-            //   - 8 bytes: block number
-            //   - 85 bytes: attestation data
-            // Total: 93 bytes per attestation, 186 bytes for 2 attestations
-
-            assert_eq!(encoded.len(), 186);
-            let encoded_hex = hex::encode(&encoded);
-
-            assert_eq!(
-            encoded_hex,
-            String::from(concat!(
-            // First attestation block number (12345678)
-            "0000000000bc614e",
-            // First attestation data
-            "d437f3372f3add2c2bc3245e6bd6f9c202e61bb367c79a6f740c7c12ca9c54a760bead943516fafaf8a4fe65a907b31d45c2ab4b525f9f32ec2771033e0832359ceb2e38d9288a755c7c366ce889b0df24b5821b1c",
-            // Second attestation block number (12345679)
-            "0000000000bc614f",
-            // Second attestation data
-            "d437f3372f3add2c2bc3245e6bd6f9c202e61bb30c337ddae661e68cc6986c7784cd0aaec455b1f7514b6cd91bff26f002ce7cb42b3b1e2092ea4d1c1fb1e0641cbccfb021b31de25462f25b355cc99c7d509cdc1b"
-            ))
-        );
-        }
 
         #[test]
         #[ignore] // Performs real Angstrom API call

--- a/crates/tycho-simulation/src/evm/stream.rs
+++ b/crates/tycho-simulation/src/evm/stream.rs
@@ -146,9 +146,9 @@ const EXCHANGES_REQUIRING_FILTER: [&str; 4] = ["vm:balancer_v2", "fluid_v1", "er
 
 /// The client-side filter applied to exchange `name` when the caller provides none.
 ///
-/// `uniswap_v4_hooks`: without `ANGSTROM_API_KEY`, Angstrom swaps cannot be encoded (encoding
-/// fetches per-block attestations from the Angstrom API), so Angstrom pools are excluded up
-/// front rather than failing every route that selects them at encoding time.
+/// `uniswap_v4_hooks`: without `ANGSTROM_API_KEY`, Angstrom swaps cannot be encoded (they carry
+/// per-block attestations from the Angstrom API), so Angstrom pools are excluded up front rather
+/// than failing every route that selects them at encoding time.
 fn default_filter_fn(name: &str) -> Option<fn(&ComponentWithState) -> bool> {
     if name == "uniswap_v4_hooks" && std::env::var("ANGSTROM_API_KEY").is_err() {
         warn!(

--- a/docs/for-solvers/supported-protocols.md
+++ b/docs/for-solvers/supported-protocols.md
@@ -118,9 +118,9 @@ Angstrom locks its pools at the start of every block. A swap that trades against
 
 If `ANGSTROM_API_KEY` is not set, `ProtocolStreamBuilder` excludes Angstrom pools from `uniswap_v4_hooks` by default (unless you pass your own filter function), since routes over these pools would fail at encoding without attestations.
 
-**Attestations are prefetched**, so encoding an Angstrom swap makes no API call. A background thread refreshes the attestation window every two seconds and encoding reads the result from a process-wide cache. The thread starts when you build a `SwapEncoderRegistry` for Ethereum with `ANGSTROM_API_KEY` set, and it reads all three environment variables once, at that point.
+**Attestations are prefetched**, so encoding an Angstrom swap makes no API call. A background thread refreshes the attestation window twice per block and encoding reads the result from a process-wide cache. The thread starts when you build a `SwapEncoderRegistry` for Ethereum with `ANGSTROM_API_KEY` set, and it reads all three environment variables once, at that point.
 
 Two consequences for your setup:
 
 * **Build the encoder once at startup and reuse it.** Encoding still works if you build a new encoder per quote, but the first Angstrom swap it encodes waits for the first fetch to finish.
-* **Watch your logs for `Angstrom attestation cache is cold or stale`.** When the cached window is older than 24 seconds, encoding fetches a fresh one inline and logs that warning. Encoding then pays the API round trip, so a steady stream of these means the background refresh is failing — the refresh logs its own error alongside them.
+* **Watch your logs for `Angstrom attestation cache is cold or stale`.** When the cached window is more than one block old, encoding fetches a fresh one inline and logs that warning. Encoding then pays the API round trip, so a steady stream of these means the background refresh is failing — the refresh logs its own error alongside them.

--- a/docs/for-solvers/supported-protocols.md
+++ b/docs/for-solvers/supported-protocols.md
@@ -107,9 +107,9 @@ Interested in adding a protocol? Refer to the [Tycho Simulation for DEXs](../for
 
 While most protocols work out of the box, some require additional configuration or have specific considerations you should be aware of.
 
-#### Angstrom (Uniswap V4 Hook)
+#### Angstrom (Uniswap V4 Hook) <a href="#angstrom-uniswap-v4-hook" id="angstrom-uniswap-v4-hook"></a>
 
-Angstrom requires querying their <a href="https://docs.angstrom.xyz/l1/core-mechanisms/pool-unlock#2-user-initiated-off-chain-signature-unlock" target="_blank" rel="noopener noreferrer">API for attestations</a> per block to unlock their contract. If execution comes too late, the contract can no longer be unlocked for that block.
+Angstrom locks its pools at the start of every block. A swap that trades against one in the same block must carry a pool unlock <a href="https://docs.angstrom.xyz/l1/core-mechanisms/pool-unlock#2-user-initiated-off-chain-signature-unlock" target="_blank" rel="noopener noreferrer">attestation</a>, which Tycho fetches from Angstrom's API, as its hook data. If the transaction lands after the attested blocks have passed, the attestation no longer unlocks the pool.
 
 **Required configuration**:
 
@@ -117,3 +117,10 @@ Angstrom requires querying their <a href="https://docs.angstrom.xyz/l1/core-mech
 * Set `ANGSTROM_BLOCKS_IN_FUTURE` environment variable (if you want to override the <a href="https://github.com/propeller-heads/tycho-indexer/blob/main/crates/tycho-execution/src/encoding/evm/constants.rs" target="_blank" rel="noopener noreferrer">default value</a> of 5 blocks). **Important trade-off**: The more blocks you fetch, the more calldata will be sent to the Tycho Router, making execution more gas expensive.
 
 If `ANGSTROM_API_KEY` is not set, `ProtocolStreamBuilder` excludes Angstrom pools from `uniswap_v4_hooks` by default (unless you pass your own filter function), since routes over these pools would fail at encoding without attestations.
+
+**Attestations are prefetched**, so encoding an Angstrom swap makes no API call. A background thread refreshes the attestation window every two seconds and encoding reads the result from a process-wide cache. The thread starts when you build a `SwapEncoderRegistry` for Ethereum with `ANGSTROM_API_KEY` set, and it reads all three environment variables once, at that point.
+
+Two consequences for your setup:
+
+* **Build the encoder once at startup and reuse it.** Encoding still works if you build a new encoder per quote, but the first Angstrom swap it encodes waits for the first fetch to finish.
+* **Watch your logs for `Angstrom attestation cache is cold or stale`.** When the cached window is older than 24 seconds, encoding fetches a fresh one inline and logs that warning. Encoding then pays the API round trip, so a steady stream of these means the background refresh is failing — the refresh logs its own error alongside them.


### PR DESCRIPTION
## Why

Every Angstrom hop made its own blocking API call while encoding, so a multi-hop route made several calls one after another. Measured against the live API: **902ms for the first read, 11µs once the cache is filled.**

Caching is correct because an attestation is valid for one block number and does not depend on the swap, the pool or the route, so <a href="https://docs.angstrom.xyz/l1/core-mechanisms/pool-unlock" target="_blank" rel="noopener noreferrer">one fetch covers every swap</a>. A background thread fetches a window every 6 seconds and stores it in one process-wide cache that encoding reads. Each fetch overwrites the previous window, so the cache always holds exactly one.

If the cache is empty or its window is more than one block old, encoding fetches a window itself rather than failing the route.

## What the transaction carries

`ANGSTROM_BLOCKS_IN_FUTURE=5` returns 6 entries, verified against the live API as `head+0 … head+5`:

```
6 × 93 bytes = 558 bytes of hook data per Angstrom hop
```

Same count as before. What changed: every hop now encodes the same block numbers. Each hop used to fetch on its own, so a block arriving between two fetches left them covering different ranges, and the transaction could only land in a block both of them covered.

## What Fynd needs

**No source changes.** Fynd's workspace compiles against this branch with only a `[patch]` added, and it already builds the registry once in `Solver::build()`.

1. `cargo update -p tycho-execution` once this releases — the version requirement is already `>=0.341.7`.
2. Set `ANGSTROM_API_KEY` before `Solver::build()` runs. It is read once when the registry is built, not on every fetch, so setting it after that does nothing. It is missing from Fynd's `.env` and compose files today.

Fetch failures now return `RecoverableError` instead of `FatalError`. Fynd converts both to `SolveError::FailedEncoding`, so this does not affect it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
