### PR TITLE
fix(ekubo_v3): exclude SignedExclusiveSwap pools by default

### DIFF
--- a/crates/tycho-simulation/src/evm/protocol/ekubo_v3/mod.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ekubo_v3/mod.rs
@@ -1,4 +1,4 @@
-use decoder::extension_type;
+use decoder::{extension_type, ExtensionType};
 use revm::primitives::Address;
 use tycho_client::feed::synchronizer::ComponentWithState;
 
@@ -11,14 +11,104 @@ pub mod state;
 #[cfg(test)]
 mod test_cases;
 
-/// Filters out unsupported ekubo_v3 extensions.
-pub fn filter_fn(component: &ComponentWithState) -> bool {
-    component
+/// The extension type of `component`, or `None` if the extension attribute is missing, malformed,
+/// or unsupported.
+fn component_extension_type(component: &ComponentWithState) -> Option<ExtensionType> {
+    let extension_bytes = component
         .component
         .static_attributes
-        .get("extension")
-        .is_some_and(|extension_bytes| {
-            Address::try_from(&extension_bytes[..])
-                .is_ok_and(|extension| extension_type(extension).is_some())
-        })
+        .get("extension")?;
+
+    extension_type(Address::try_from(&extension_bytes[..]).ok()?)
+}
+
+/// Filters out unsupported ekubo_v3 extensions, as well as SignedExclusiveSwap pools.
+///
+/// Swapping on a SignedExclusiveSwap pool requires a per-swap signature obtained off-chain and
+/// passed to the encoder as `user_data`. Without it the swap fails at encoding time — after route
+/// selection — so consumers with no signature source should exclude these pools up front. Use
+/// `filter_fn_with_signed_exclusive_swap` to include them.
+pub fn filter_fn(component: &ComponentWithState) -> bool {
+    component_extension_type(component)
+        .is_some_and(|extension| !matches!(extension, ExtensionType::SignedExclusiveSwap))
+}
+
+/// Filters out unsupported ekubo_v3 extensions, keeping SignedExclusiveSwap pools.
+///
+/// Only use this if you can supply the per-swap signature these pools require; see `filter_fn`.
+pub fn filter_fn_with_signed_exclusive_swap(component: &ComponentWithState) -> bool {
+    component_extension_type(component).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use revm::primitives::address;
+    use tycho_common::{
+        models::protocol::{ProtocolComponent, ProtocolComponentState},
+        Bytes,
+    };
+
+    use super::{
+        addresses::{ORACLE_ADDRESS, SIGNED_EXCLUSIVE_SWAP_ADDRESS},
+        *,
+    };
+
+    fn component(extension: Option<Bytes>) -> ComponentWithState {
+        let static_attributes = extension
+            .map(|bytes| HashMap::from([("extension".to_string(), bytes)]))
+            .unwrap_or_default();
+
+        ComponentWithState {
+            state: ProtocolComponentState::new("test_pool", HashMap::new(), HashMap::new()),
+            component: ProtocolComponent { static_attributes, ..Default::default() },
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        }
+    }
+
+    fn with_extension(extension: Address) -> ComponentWithState {
+        component(Some(Bytes::from(extension.as_slice().to_vec())))
+    }
+
+    #[test]
+    fn signed_exclusive_swap_excluded_by_default() {
+        let signed = with_extension(SIGNED_EXCLUSIVE_SWAP_ADDRESS);
+
+        assert!(!filter_fn(&signed));
+        assert!(filter_fn_with_signed_exclusive_swap(&signed));
+    }
+
+    #[test]
+    fn supported_extension_kept_by_both_filters() {
+        // Oracle hooks beforeSwap, so it only passes via the known-address check.
+        let oracle = with_extension(ORACLE_ADDRESS);
+
+        assert!(filter_fn(&oracle));
+        assert!(filter_fn_with_signed_exclusive_swap(&oracle));
+
+        // An extension without swap call points passes regardless of its address.
+        let no_call_points = with_extension(address!("0x0000000000000000000000000000000000000001"));
+
+        assert!(filter_fn(&no_call_points));
+        assert!(filter_fn_with_signed_exclusive_swap(&no_call_points));
+    }
+
+    #[test]
+    fn unsupported_extension_excluded_by_both_filters() {
+        // Unknown address with the beforeSwap call point set.
+        let unknown = with_extension(address!("0x6000000000000000000000000000000000000001"));
+
+        assert!(!filter_fn(&unknown));
+        assert!(!filter_fn_with_signed_exclusive_swap(&unknown));
+    }
+
+    #[test]
+    fn missing_or_malformed_extension_excluded_by_both_filters() {
+        for case in [component(None), component(Some(Bytes::from(vec![0u8; 19])))] {
+            assert!(!filter_fn(&case));
+            assert!(!filter_fn_with_signed_exclusive_swap(&case));
+        }
+    }
 }

--- a/crates/tycho-simulation/src/evm/protocol/filters.rs
+++ b/crates/tycho-simulation/src/evm/protocol/filters.rs
@@ -4,7 +4,10 @@ use tracing::{debug, info};
 use tycho_client::feed::synchronizer::ComponentWithState;
 use tycho_common::Bytes;
 
-pub use crate::evm::protocol::ekubo_v3::filter_fn as ekubo_v3_extension_filter;
+pub use crate::evm::protocol::ekubo_v3::{
+    filter_fn as ekubo_v3_extension_filter,
+    filter_fn_with_signed_exclusive_swap as ekubo_v3_extension_filter_with_signed_exclusive_swap,
+};
 
 /// Filters out pools that DCI currently fails to find some accounts for
 pub fn balancer_v2_pool_filter(component: &ComponentWithState) -> bool {

--- a/docs/for-solvers/supported-protocols.md
+++ b/docs/for-solvers/supported-protocols.md
@@ -16,7 +16,7 @@ Currently, Tycho supports the following protocols:
 <tr><td><code>pancakeswap_v3</code></td><td>Native (<code>UniswapV3State</code>)</td><td>20 μs (0.02 ms)</td><td>Ethereum, Base</td><td></td></tr>
 <tr><td><code>quickswap_v2</code></td><td>Native (<code>UniswapV2State</code>)</td><td>3 μs (0.003 ms)</td><td>Polygon</td><td></td></tr>
 <tr><td><code>ekubo_v2</code></td><td>Native (<code>EkuboState</code>)</td><td>1.5 μs (0.0015 ms)</td><td>Ethereum</td><td></td></tr>
-<tr><td><code>ekubo_v3</code></td><td>Native (<code>EkuboV3State</code>)</td><td>9μs</td><td>Ethereum</td><td>Some extensions are unsupported. Use <code>ekubo_v3_extension_filter</code>.</td></tr>
+<tr><td><code>ekubo_v3</code></td><td>Native (<code>EkuboV3State</code>)</td><td>9μs</td><td>Ethereum</td><td>Some extensions are unsupported. Use <code>ekubo_v3_extension_filter</code>. It also drops SignedExclusiveSwap pools, which need a per-swap signature passed to the encoder as <code>user_data</code>. If you can supply that signature, use <code>ekubo_v3_extension_filter_with_signed_exclusive_swap</code> instead to keep those pools.</td></tr>
 <tr><td><code>vm:maverick_v2</code></td><td>VM (<code>EVMPoolState</code>)</td><td>-</td><td>Ethereum</td><td></td></tr>
 <tr><td><code>vm:bopamm</code></td><td>VM (<code>EVMPoolState</code>)</td><td>-</td><td>Ethereum</td><td></td></tr>
 <tr><td><code>vm:fermiswap</code></td><td>VM (<code>EVMPoolState</code>)</td><td>4 ms</td><td>Ethereum</td><td></td></tr>


### PR DESCRIPTION
Ekubo's default `filter_fn` now drops `SignedExclusiveSwap` pools, which need a per-swap signature passed to the encoder as user_data. Consumers that can supply that signature can opt in with `filter_fn_with_signed_exclusive_swap` (re-exported as `ekubo_v3_extension_filter_with_signed_exclusive_swap`).