### PR TITLE
feat: add Robinhood Chain substreams YAML configs (Uniswap V2 + V3)

### DIFF
--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-uniswap-v2"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-uniswap-v3-logs-only"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/protocols/substreams/ethereum-uniswap-v2/CHANGELOG.md
+++ b/protocols/substreams/ethereum-uniswap-v2/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.3.2
+
+- Add the Robinhood Chain Uniswap V2 manifest.

--- a/protocols/substreams/ethereum-uniswap-v2/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v2"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-uniswap-v2/robinhood-uniswap-v2.yaml
+++ b/protocols/substreams/ethereum-uniswap-v2/robinhood-uniswap-v2.yaml
@@ -1,0 +1,49 @@
+specVersion: v0.1.0
+package:
+  name: "robinhood_uniswap_v2"
+  version: v0.3.2
+  url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v2"
+
+protobuf:
+  files:
+    - tycho/evm/v1/common.proto
+    - uniswap.proto
+  importPaths:
+    - ./proto/v1
+    - ../../../proto/
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v2.wasm
+
+modules:
+  - name: map_pools_created
+    kind: map
+    initialBlock: 8928
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+  - name: store_pools
+    kind: store
+    initialBlock: 8928
+    updatePolicy: set_if_not_exists
+    valueType: proto:tycho.evm.uniswap.v2.Pool
+    inputs:
+      - map: map_pools_created
+
+  - name: map_pool_events
+    kind: map
+    initialBlock: 8928
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - map: map_pools_created
+      - store: store_pools
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+params:
+  map_pools_created: factory_address=8bcEaA40B9AcdfAedF85AdF4FF01F5Ad6517937f&protocol_type_name=uniswap_v2_pool

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/CHANGELOG.md
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## v0.1.3
+
+- Add the Robinhood Chain Uniswap V3 logs-only manifest.
+- Remove a redundant reference in a store-key format argument.

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v3-logs-only"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/robinhood-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/robinhood-uniswap-v3.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "robinhood_uniswap_v3_logs_only"
-  version: v0.1.2
+  version: v0.1.3
   url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
 
 protobuf:

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/robinhood-uniswap-v3.yaml
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/robinhood-uniswap-v3.yaml
@@ -1,0 +1,128 @@
+specVersion: v0.1.0
+package:
+  name: "robinhood_uniswap_v3_logs_only"
+  version: v0.1.2
+  url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v3-logs-only"
+
+protobuf:
+  files:
+    - tycho/evm/v1/common.proto
+    - tycho/evm/v1/utils.proto
+    - uniswap.proto
+  importPaths:
+    - ./proto/v1
+    - ../../../proto/
+  excludePaths:
+    - sf/ethereum
+    - google
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v3_logs_only.wasm
+
+modules:
+  - name: map_pools_created
+    kind: map
+    initialBlock: 8930
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+  - name: store_pools
+    kind: store
+    initialBlock: 8930
+    updatePolicy: set_if_not_exists
+    valueType: proto:uniswap.v3.Pool
+    inputs:
+      - map: map_pools_created
+
+  - name: map_events
+    kind: map
+    initialBlock: 8930
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - store: store_pools
+    output:
+      type: proto:uniswap.v3.Events
+
+  - name: map_balance_changes
+    kind: map
+    initialBlock: 8930
+    inputs:
+      - map: map_events
+    output:
+      type: proto:tycho.evm.v1.BlockBalanceDeltas
+
+  - name: store_pools_balances
+    kind: store
+    initialBlock: 8930
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_balance_changes
+
+  - name: map_ticks_changes
+    kind: map
+    initialBlock: 8930
+    inputs:
+      - map: map_events
+    output:
+      type: proto:uniswap.v3.TickDeltas
+
+  - name: store_ticks_liquidity
+    kind: store
+    initialBlock: 8930
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_ticks_changes
+
+  - name: store_pool_current_tick
+    kind: store
+    initialBlock: 8930
+    updatePolicy: set
+    valueType: int64
+    inputs:
+      - map: map_events
+
+  - name: map_liquidity_changes
+    kind: map
+    initialBlock: 8930
+    inputs:
+      - map: map_events
+      - store: store_pool_current_tick
+    output:
+      type: proto:uniswap.v3.LiquidityChanges
+
+  - name: store_liquidity
+    kind: store
+    initialBlock: 8930
+    updatePolicy: set_sum
+    valueType: bigint
+    inputs:
+      - map: map_liquidity_changes
+
+  - name: map_protocol_changes
+    kind: map
+    initialBlock: 8930
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - map: map_pools_created
+      - map: map_events
+      - map: map_balance_changes
+      - store: store_pools_balances
+        mode: deltas
+      - map: map_ticks_changes
+      - store: store_ticks_liquidity
+        mode: deltas
+      - map: map_liquidity_changes
+      - store: store_liquidity
+        mode: deltas
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+params:
+  map_pools_created: "1f7d7550B1b028f7571E69A784071F0205FD2EfA"

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/4_map_and_store_liquidity.rs
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/src/modules/4_map_and_store_liquidity.rs
@@ -36,7 +36,7 @@ pub fn map_liquidity_changes(
         .map(|e| {
             (
                 pools_current_tick_store
-                    .get_at(e.log_ordinal, format!("pool:{0}", &e.pool_address))
+                    .get_at(e.log_ordinal, format!("pool:{0}", e.pool_address))
                     .unwrap_or(0),
                 e,
             )


### PR DESCRIPTION
Add Robinhood Chain substreams YAML configs for Uniswap V2 and V3 (logs-only). V2 factory: 0x8bcEaA40B9AcdfAedF85AdF4FF01F5Ad6517937f (block 8928). V3 factory: 0x1f7d7550B1b028f7571E69A784071F0205FD2EfA (block 8930). Chain ID: 4663. Refs: ENG-6261, ENG-6259