### PR TITLE
feat: add Robinhood simulation examples

### DIFF
--- a/crates/tycho-client-py/python/tycho_indexer_client/dto.py
+++ b/crates/tycho-client-py/python/tycho_indexer_client/dto.py
@@ -47,6 +47,7 @@ class Chain(str, Enum):
     unichain = "unichain"
     polygon = "polygon"
     plasma = "plasma"
+    robinhood = "robinhood"
 
 
 class CustomChain(BaseModel):

--- a/crates/tycho-client/src/stream.rs
+++ b/crates/tycho-client/src/stream.rs
@@ -135,8 +135,8 @@ impl TychoStreamBuilder {
             Chain::Base => (2, 12, 50),
             Chain::Bsc => (1, 12, 50),
             Chain::Unichain => (1, 10, 100),
-            Chain::Polygon => (2, 12, 50), // ~2s block time
-            Chain::Plasma => (1, 10, 100), // ~1s block time
+            Chain::Polygon => (2, 12, 50),   // ~2s block time
+            Chain::Plasma => (1, 10, 100),   // ~1s block time
             Chain::Robinhood => (1, 2, 100), // ~1s block time, Arbitrum Orbit
             _ => {
                 let block_time = chain.block_time_secs();

--- a/crates/tycho-client/src/stream.rs
+++ b/crates/tycho-client/src/stream.rs
@@ -137,6 +137,7 @@ impl TychoStreamBuilder {
             Chain::Unichain => (1, 10, 100),
             Chain::Polygon => (2, 12, 50), // ~2s block time
             Chain::Plasma => (1, 10, 100), // ~1s block time
+            Chain::Robinhood => (1, 2, 100), // ~1s block time, Arbitrum Orbit
             _ => {
                 let block_time = chain.block_time_secs();
                 (block_time, block_time * 3, 50)

--- a/crates/tycho-common/src/dto.rs
+++ b/crates/tycho-common/src/dto.rs
@@ -46,6 +46,7 @@ pub enum Chain {
     Unichain,
     Polygon,
     Plasma,
+    Robinhood,
     #[schema(value_type = String)]
     Custom(ArrayString<32>),
 }
@@ -113,6 +114,7 @@ impl From<models::Chain> for Chain {
             models::Chain::Unichain => Chain::Unichain,
             models::Chain::Polygon => Chain::Polygon,
             models::Chain::Plasma => Chain::Plasma,
+            models::Chain::Robinhood => Chain::Robinhood,
             models::Chain::Custom(id) => Chain::Custom(
                 ArrayString::from(id.as_str())
                     .expect("custom chain name is already within 32 bytes"),

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -94,6 +94,7 @@ pub enum Chain {
     Unichain,
     Polygon,
     Plasma,
+    Robinhood,
     /// User-defined chain resolved via the [`chain_config`] registry; see the enum docs.
     Custom(CustomChainId),
 }
@@ -117,6 +118,7 @@ impl Chain {
             "unichain" => Some(Chain::Unichain),
             "polygon" => Some(Chain::Polygon),
             "plasma" => Some(Chain::Plasma),
+            "robinhood" => Some(Chain::Robinhood),
             _ => None,
         }
     }
@@ -155,6 +157,7 @@ impl Display for Chain {
             Chain::Unichain => f.write_str("unichain"),
             Chain::Polygon => f.write_str("polygon"),
             Chain::Plasma => f.write_str("plasma"),
+            Chain::Robinhood => f.write_str("robinhood"),
             Chain::Custom(name) => f.write_str(name.as_str()),
         }
     }
@@ -172,6 +175,7 @@ impl From<dto::Chain> for Chain {
             dto::Chain::Unichain => Chain::Unichain,
             dto::Chain::Polygon => Chain::Polygon,
             dto::Chain::Plasma => Chain::Plasma,
+            dto::Chain::Robinhood => Chain::Robinhood,
             dto::Chain::Custom(name) => Chain::custom(name.as_str()).unwrap_or_else(|e| {
                 panic!(
                     "received custom chain '{name}' with no registered config: {e}; install it via \
@@ -333,6 +337,7 @@ impl Chain {
             Chain::Unichain => 130,
             Chain::Polygon => 137,
             Chain::Plasma => 9745,
+            Chain::Robinhood => 4663,
             Chain::Custom(id) => try_resolve_custom(id, chain_registry())?.chain_id,
         })
     }
@@ -360,21 +365,23 @@ impl Chain {
             // ETH-native chains: 10 ETH ≈ $20K, 100 ETH ≈ $200K.
             // Starknet uses ETH-denominated TVL in Tycho (STRK tracked separately).
             (
-                Chain::Ethereum |
-                Chain::Starknet |
-                Chain::ZkSync |
-                Chain::Arbitrum |
-                Chain::Base |
-                Chain::Unichain,
+                Chain::Ethereum
+                | Chain::Starknet
+                | Chain::ZkSync
+                | Chain::Arbitrum
+                | Chain::Base
+                | Chain::Unichain
+                | Chain::Robinhood,
                 TvlThresholdTier::Low,
             ) => 10.0,
             (
-                Chain::Ethereum |
-                Chain::Starknet |
-                Chain::ZkSync |
-                Chain::Arbitrum |
-                Chain::Base |
-                Chain::Unichain,
+                Chain::Ethereum
+                | Chain::Starknet
+                | Chain::ZkSync
+                | Chain::Arbitrum
+                | Chain::Base
+                | Chain::Unichain
+                | Chain::Robinhood,
                 TvlThresholdTier::Medium,
             ) => 100.0,
 
@@ -424,6 +431,7 @@ impl Chain {
             Chain::Unichain => native_eth(Chain::Unichain),
             Chain::Polygon => native_pol(Chain::Polygon),
             Chain::Plasma => native_xpl(Chain::Plasma),
+            Chain::Robinhood => native_eth(Chain::Robinhood),
             Chain::Custom(id) => native_custom(*self, try_resolve_custom(id, chain_registry())?),
         })
     }
@@ -466,6 +474,9 @@ impl Chain {
             Chain::Plasma => {
                 wrapped_native_xpl(Chain::Plasma, "0x6100E367285b01F48D07953803A2d8dCA5D19873")
             }
+            Chain::Robinhood => {
+                wrapped_native_eth(Chain::Robinhood, "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73")
+            }
             Chain::Custom(id) => {
                 wrapped_native_custom(*self, try_resolve_custom(id, chain_registry())?)
             }
@@ -491,6 +502,7 @@ impl Chain {
             Chain::Unichain => 1,
             Chain::Polygon => 2,
             Chain::Plasma => 1,
+            Chain::Robinhood => 1,
             Chain::Custom(id) => try_resolve_custom(id, chain_registry())?.block_time_secs,
         })
     }

--- a/crates/tycho-common/src/models/mod.rs
+++ b/crates/tycho-common/src/models/mod.rs
@@ -365,23 +365,23 @@ impl Chain {
             // ETH-native chains: 10 ETH ≈ $20K, 100 ETH ≈ $200K.
             // Starknet uses ETH-denominated TVL in Tycho (STRK tracked separately).
             (
-                Chain::Ethereum
-                | Chain::Starknet
-                | Chain::ZkSync
-                | Chain::Arbitrum
-                | Chain::Base
-                | Chain::Unichain
-                | Chain::Robinhood,
+                Chain::Ethereum |
+                Chain::Starknet |
+                Chain::ZkSync |
+                Chain::Arbitrum |
+                Chain::Base |
+                Chain::Unichain |
+                Chain::Robinhood,
                 TvlThresholdTier::Low,
             ) => 10.0,
             (
-                Chain::Ethereum
-                | Chain::Starknet
-                | Chain::ZkSync
-                | Chain::Arbitrum
-                | Chain::Base
-                | Chain::Unichain
-                | Chain::Robinhood,
+                Chain::Ethereum |
+                Chain::Starknet |
+                Chain::ZkSync |
+                Chain::Arbitrum |
+                Chain::Base |
+                Chain::Unichain |
+                Chain::Robinhood,
                 TvlThresholdTier::Medium,
             ) => 100.0,
 

--- a/crates/tycho-simulation/examples/price_printer/main.rs
+++ b/crates/tycho-simulation/examples/price_printer/main.rs
@@ -108,6 +108,7 @@ fn register_exchanges(
             builder = builder
                 .exchange::<UniswapV2State>("uniswap_v2", tvl_filter.clone(), None)
                 .exchange::<UniswapV3State>("uniswap_v3", tvl_filter.clone(), None)
+                .exchange::<UniswapV4State>("uniswap_v4", tvl_filter.clone(), None)
         }
         _ => {}
     }

--- a/crates/tycho-simulation/examples/price_printer/main.rs
+++ b/crates/tycho-simulation/examples/price_printer/main.rs
@@ -104,6 +104,11 @@ fn register_exchanges(
         Chain::Polygon => {
             builder = builder.exchange::<RamsesV3State>("ramses_v3", tvl_filter.clone(), None)
         }
+        Chain::Robinhood => {
+            builder = builder
+                .exchange::<UniswapV2State>("uniswap_v2", tvl_filter.clone(), None)
+                .exchange::<UniswapV3State>("uniswap_v3", tvl_filter.clone(), None)
+        }
         _ => {}
     }
     builder

--- a/crates/tycho-simulation/examples/quickstart/main.rs
+++ b/crates/tycho-simulation/examples/quickstart/main.rs
@@ -98,6 +98,7 @@ impl Cli {
                 "base" => "0x4200000000000000000000000000000000000006".to_string(),
                 "unichain" => "0x4200000000000000000000000000000000000006".to_string(),
                 "arbitrum" => "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1".to_string(),
+                "robinhood" => "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73".to_string(),
                 _ => panic!("Execution does not yet support chain {chain}", chain = self.chain),
             });
         }
@@ -108,6 +109,7 @@ impl Cli {
                 "base" => "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913".to_string(),
                 "unichain" => "0x078d782b760474a361dda0af3839290b0ef57ad6".to_string(),
                 "arbitrum" => "0xaf88d065e77c8cC2239327C5EDb3A432268e5831".to_string(),
+                "robinhood" => "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168".to_string(),
                 _ => panic!("Execution does not yet support chain {chain}", chain = self.chain),
             });
         }
@@ -250,6 +252,11 @@ async fn main() {
         Chain::Polygon => {
             protocol_stream =
                 protocol_stream.exchange::<RamsesV3State>("ramses_v3", tvl_filter.clone(), None)
+        }
+        Chain::Robinhood => {
+            protocol_stream = protocol_stream
+                .exchange::<UniswapV2State>("uniswap_v2", tvl_filter.clone(), None)
+                .exchange::<UniswapV3State>("uniswap_v3", tvl_filter.clone(), None)
         }
         _ => {}
     }

--- a/crates/tycho-simulation/examples/quickstart/main.rs
+++ b/crates/tycho-simulation/examples/quickstart/main.rs
@@ -257,6 +257,7 @@ async fn main() {
             protocol_stream = protocol_stream
                 .exchange::<UniswapV2State>("uniswap_v2", tvl_filter.clone(), None)
                 .exchange::<UniswapV3State>("uniswap_v3", tvl_filter.clone(), None)
+                .exchange::<UniswapV4State>("uniswap_v4", tvl_filter.clone(), None)
         }
         _ => {}
     }

--- a/crates/tycho-simulation/src/utils.rs
+++ b/crates/tycho-simulation/src/utils.rs
@@ -117,6 +117,7 @@ pub fn get_default_url(chain: &Chain) -> Option<String> {
         Chain::Unichain => Some("tycho-unichain-beta.propellerheads.xyz".to_string()),
         Chain::Bsc => Some("tycho-bsc-beta.propellerheads.xyz".to_string()),
         Chain::Arbitrum => Some("tycho-arbitrum-beta.propellerheads.xyz".to_string()),
+        Chain::Robinhood => Some("tycho-robinhood-beta.propellerheads.xyz".to_string()),
         _ => None,
     }
 }


### PR DESCRIPTION
Add Robinhood Chain support to simulation price-printer and quickstart examples. Refs: ENG-6267, ENG-6259