### PR TITLE
feat: add Robinhood Uniswap V4 no-hooks Substreams manifest

### DIFF
--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-uniswap-v4-no-hooks"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ethabi 18.0.0",
  "ethereum-uniswap-v4-shared",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-uniswap-v4-shared"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/protocols/substreams/ethereum-uniswap-v4/no-hooks/CHANGELOG.md
+++ b/protocols/substreams/ethereum-uniswap-v4/no-hooks/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.4.2
+
+- Add the Robinhood Chain Uniswap V4 no-hooks manifest.

--- a/protocols/substreams/ethereum-uniswap-v4/no-hooks/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v4/no-hooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v4-no-hooks"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-uniswap-v4/no-hooks/robinhood-uniswap-v4-no-hooks.yaml
+++ b/protocols/substreams/ethereum-uniswap-v4/no-hooks/robinhood-uniswap-v4-no-hooks.yaml
@@ -1,0 +1,139 @@
+specVersion: v0.1.0
+package:
+  name: "robinhood_uniswap_v4_no_hooks"
+  version: v0.4.1
+  url: "https://github.com/propeller-heads/tycho-indexer/tree/main/protocols/substreams/ethereum-uniswap-v4/no-hooks"
+
+protobuf:
+  files:
+    - tycho/evm/v1/entity.proto
+    - tycho/evm/v1/common.proto
+    - tycho/evm/v1/utils.proto
+    - uniswap.proto
+  importPaths:
+    - ../../../../proto
+    - ../shared/proto
+  excludePaths:
+    - sf/substreams
+    - google
+    - tycho
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v4_no_hooks.wasm
+
+modules:
+  - name: map_pools_created
+    kind: map
+    initialBlock: 9070
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.evm.v1.BlockEntityChanges
+
+  - name: store_pools
+    kind: store
+    initialBlock: 9070
+    updatePolicy: set_if_not_exists
+    valueType: proto:uniswap.v4.Pool
+    inputs:
+      - map: map_pools_created
+
+  - name: map_events
+    kind: map
+    initialBlock: 9070
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - store: store_pools
+    output:
+      type: proto:uniswap.v4.Events
+
+  - name: store_pool_current_tick
+    kind: store
+    initialBlock: 9070
+    updatePolicy: set
+    valueType: int64
+    inputs:
+      - map: map_events
+
+  - name: store_pool_current_sqrt_price
+    kind: store
+    initialBlock: 9070
+    updatePolicy: set
+    valueType: bigint
+    inputs:
+      - map: map_events
+
+  - name: map_balance_changes
+    kind: map
+    initialBlock: 9070
+    inputs:
+      - map: map_events
+      - store: store_pool_current_sqrt_price
+    output:
+      type: proto:tycho.evm.v1.BlockBalanceDeltas
+
+  - name: store_pools_balances
+    kind: store
+    initialBlock: 9070
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_balance_changes
+
+  - name: map_ticks_changes
+    kind: map
+    initialBlock: 9070
+    inputs:
+      - map: map_events
+    output:
+      type: proto:uniswap.v4.TickDeltas
+
+  - name: store_ticks_liquidity
+    kind: store
+    initialBlock: 9070
+    updatePolicy: add
+    valueType: bigint
+    inputs:
+      - map: map_ticks_changes
+
+  - name: map_liquidity_changes
+    kind: map
+    initialBlock: 9070
+    inputs:
+      - map: map_events
+      - store: store_pool_current_tick
+    output:
+      type: proto:uniswap.v4.LiquidityChanges
+
+  - name: store_liquidity
+    kind: store
+    initialBlock: 9070
+    updatePolicy: set_sum
+    valueType: bigint
+    inputs:
+      - map: map_liquidity_changes
+
+  - name: map_protocol_changes
+    kind: map
+    initialBlock: 9070
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - map: map_pools_created
+      - map: map_events
+      - map: map_balance_changes
+      - store: store_pools_balances
+        mode: deltas
+      - map: map_ticks_changes
+      - store: store_ticks_liquidity
+        mode: deltas
+      - map: map_liquidity_changes
+      - store: store_liquidity
+        mode: deltas
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+params:
+  map_pools_created: "8366a39CC670B4001A1121B8F6A443A643e40951"

--- a/protocols/substreams/ethereum-uniswap-v4/no-hooks/robinhood-uniswap-v4-no-hooks.yaml
+++ b/protocols/substreams/ethereum-uniswap-v4/no-hooks/robinhood-uniswap-v4-no-hooks.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: "robinhood_uniswap_v4_no_hooks"
-  version: v0.4.1
+  version: v0.4.2
   url: "https://github.com/propeller-heads/tycho-indexer/tree/main/protocols/substreams/ethereum-uniswap-v4/no-hooks"
 
 protobuf:

--- a/protocols/substreams/ethereum-uniswap-v4/shared/CHANGELOG.md
+++ b/protocols/substreams/ethereum-uniswap-v4/shared/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.5.2
+
+- Remove redundant references in format arguments to retain compatibility with current Clippy.

--- a/protocols/substreams/ethereum-uniswap-v4/shared/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v4/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v4-shared"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-uniswap-v4/shared/src/modules/3_map_events.rs
+++ b/protocols/substreams/ethereum-uniswap-v4/shared/src/modules/3_map_events.rs
@@ -50,7 +50,7 @@ fn log_to_event(
         // We need to track initialization again to keep track of pool current tick, which is set on
         // initialization and changed on swaps.
         let pool_id = init.id.to_vec().to_hex();
-        let pool = pools_store.get_last(format!("{}:{}", "pool", &pool_id))?;
+        let pool = pools_store.get_last(format!("{}:{}", "pool", pool_id))?;
         Some(PoolEvent {
             log_ordinal: event.ordinal,
             pool_id,
@@ -67,7 +67,7 @@ fn log_to_event(
         })
     } else if let Some(swap) = Swap::match_and_decode(event) {
         let pool_id = swap.id.to_vec().to_hex();
-        let pool = pools_store.get_last(format!("{}:{}", "pool", &pool_id))?;
+        let pool = pools_store.get_last(format!("{}:{}", "pool", pool_id))?;
         Some(PoolEvent {
             log_ordinal: event.ordinal,
             pool_id,
@@ -102,7 +102,7 @@ fn log_to_event(
     //     })
     } else if let Some(modify_liquidity) = ModifyLiquidity::match_and_decode(event) {
         let pool_id = modify_liquidity.id.to_vec().to_hex();
-        let pool = pools_store.get_last(format!("{}:{}", "pool", &pool_id))?;
+        let pool = pools_store.get_last(format!("{}:{}", "pool", pool_id))?;
         Some(PoolEvent {
             log_ordinal: event.ordinal,
             pool_id,
@@ -124,7 +124,7 @@ fn log_to_event(
             .id
             .to_vec()
             .to_hex();
-        let pool = pools_store.get_last(format!("{}:{}", "pool", &pool_id))?;
+        let pool = pools_store.get_last(format!("{}:{}", "pool", pool_id))?;
         Some(PoolEvent {
             log_ordinal: event.ordinal,
             pool_id: pool_id.clone(),

--- a/protocols/substreams/ethereum-uniswap-v4/shared/src/modules/5_map_store_balance_changes.rs
+++ b/protocols/substreams/ethereum-uniswap-v4/shared/src/modules/5_map_store_balance_changes.rs
@@ -28,7 +28,7 @@ pub fn map_balance_changes(
         .map(|e| {
             (
                 pools_current_sqrt_price_store
-                    .get_at(e.log_ordinal, format!("pool:{0}", &e.pool_id))
+                    .get_at(e.log_ordinal, format!("pool:{0}", e.pool_id))
                     .unwrap_or(BigInt::zero()),
                 e,
             )

--- a/protocols/substreams/ethereum-uniswap-v4/shared/src/modules/5_map_store_liquidity.rs
+++ b/protocols/substreams/ethereum-uniswap-v4/shared/src/modules/5_map_store_liquidity.rs
@@ -24,7 +24,7 @@ pub fn map_liquidity_changes(
         .map(|e| {
             (
                 pools_current_tick_store
-                    .get_at(e.log_ordinal, format!("pool:{0}", &e.pool_id))
+                    .get_at(e.log_ordinal, format!("pool:{0}", e.pool_id))
                     .unwrap_or(0),
                 e,
             )
@@ -45,14 +45,14 @@ pub fn store_liquidity(ticks_deltas: LiquidityChanges, store: StoreSetSumBigInt)
             LiquidityChangeType::Delta => {
                 store.sum(
                     changes.ordinal,
-                    format!("pool:{0}", &changes.pool_address.to_hex()),
+                    format!("pool:{0}", changes.pool_address.to_hex()),
                     BigInt::from_signed_bytes_be(&changes.value),
                 );
             }
             LiquidityChangeType::Absolute => {
                 store.set(
                     changes.ordinal,
-                    format!("pool:{0}", &changes.pool_address.to_hex()),
+                    format!("pool:{0}", changes.pool_address.to_hex()),
                     BigInt::from_signed_bytes_be(&changes.value),
                 );
             }

--- a/protocols/substreams/ethereum-uniswap-v4/shared/src/modules/5_map_store_ticks.rs
+++ b/protocols/substreams/ethereum-uniswap-v4/shared/src/modules/5_map_store_ticks.rs
@@ -35,7 +35,7 @@ pub fn store_ticks_liquidity(ticks_deltas: TickDeltas, store: StoreAddBigInt) {
     deltas.iter().for_each(|delta| {
         store.add(
             delta.ordinal,
-            format!("pool:{0}:tick:{1}", &delta.pool_address.to_hex(), delta.tick_index,),
+            format!("pool:{0}:tick:{1}", delta.pool_address.to_hex(), delta.tick_index,),
             BigInt::from_signed_bytes_be(&delta.liquidity_net_delta),
         );
     });


### PR DESCRIPTION
Add the Robinhood Chain Uniswap V4 no-hooks manifest for PoolManager 0x8366a39CC670B4001A1121B8F6A443A643e40951 at block 9070. Bump the no-hooks package to v0.4.3. Refs: ENG-6275, ENG-6259.