### PR TITLE
docs(substreams): add package release changelogs

### DIFF
--- a/protocols/substreams/base-aerodrome-slipstreams/CHANGELOG.md
+++ b/protocols/substreams/base-aerodrome-slipstreams/CHANGELOG.md
@@ -71,3 +71,15 @@ exact reconstruction of the short historical interval between the April 1 snapsh
 rotations. The v0.1.3 package listens only to the replacement modules, so retired-module updates in
 that interval are not replayed, while replacement-module configuration written before Factory
 activation is indexed immediately. Keep Simulation isolated until replay reaches the current head.
+
+## v0.1.2
+
+- Bump the package version for the release.
+
+## v0.1.1
+
+- Add the factory static attribute.
+
+## v0.3.1
+
+- Initial release.

--- a/protocols/substreams/base-aerodrome-v1/CHANGELOG.md
+++ b/protocols/substreams/base-aerodrome-v1/CHANGELOG.md
@@ -6,3 +6,11 @@
   `[workspace.members]`, so cargo refused to build it ("current package
   believes it's in a workspace when it's not"). Dependencies now resolve from
   the shared workspace lockfile.
+
+## v0.1.1
+
+- Bump the package version for the release.
+
+## v0.1.0
+
+- Add the Aerodrome V1 Substreams integration for Base.

--- a/protocols/substreams/base-lunarbase/CHANGELOG.md
+++ b/protocols/substreams/base-lunarbase/CHANGELOG.md
@@ -9,3 +9,11 @@
 
 - Pin the Rust toolchain to 1.96.0 for reproducible wasm builds. The package
   previously had no toolchain pin and built with whatever stable was current.
+
+## v0.1.1
+
+- Emit reserve-based token balances.
+
+## v0.1.0
+
+- Add the LunarBase protocol integration.

--- a/protocols/substreams/crates/substreams-helper/CHANGELOG.md
+++ b/protocols/substreams/crates/substreams-helper/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.0.2
+
+- Initial release.

--- a/protocols/substreams/crates/tycho-substreams/CHANGELOG.md
+++ b/protocols/substreams/crates/tycho-substreams/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## v0.8.1
+
+- Account for token balance changes when determining whether a contract change is empty (#1056).
+
+## v0.8.0
+
+- Initial release.

--- a/protocols/substreams/ethereum-ambient/CHANGELOG.md
+++ b/protocols/substreams/ethereum-ambient/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.6.1
+
+- Initial release.

--- a/protocols/substreams/ethereum-balancer-v2/CHANGELOG.md
+++ b/protocols/substreams/ethereum-balancer-v2/CHANGELOG.md
@@ -6,6 +6,10 @@
   Adds an event listener for `SwapFeePercentageChanged` so `fee` correctly tracks
   admin changes made after pool creation.
 
+## v0.4.4
+
+- Update the package version for the release.
+
 ## v0.4.3
 
 - Update `tycho-substreams` from `0.8.0` to `0.8.1`. Contract changes carrying only
@@ -17,3 +21,7 @@
   emits native balance changes in the block storage output consumed by the DCI.
   Earlier builds never emitted them, so native balances of DCI-tracked contracts
   stayed frozen at their initial snapshot.
+
+## v0.4.1
+
+- Initial release.

--- a/protocols/substreams/ethereum-balancer-v3/CHANGELOG.md
+++ b/protocols/substreams/ethereum-balancer-v3/CHANGELOG.md
@@ -20,3 +20,7 @@
   of DCI-tracked contracts stayed frozen at their initial snapshot.
 - Picks up the `previous_value` field and its multi-write fix for storage slot
   changes (tycho-substreams 0.5.0/0.5.1).
+
+## v0.4.0
+
+- Initial release.

--- a/protocols/substreams/ethereum-bopamm/CHANGELOG.md
+++ b/protocols/substreams/ethereum-bopamm/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## v0.1.1
+
+- Update the package version after a failed deployment.
+
+## v0.1.0
+
+- Add the BopAMM VM integration.

--- a/protocols/substreams/ethereum-cowamm/CHANGELOG.md
+++ b/protocols/substreams/ethereum-cowamm/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.3
+
+- Add the CowAMM Substreams package.

--- a/protocols/substreams/ethereum-curve/CHANGELOG.md
+++ b/protocols/substreams/ethereum-curve/CHANGELOG.md
@@ -15,3 +15,15 @@
   of DCI-tracked contracts stayed frozen at their initial snapshot.
 - Picks up the `previous_value` fix for storage slots written multiple times in one
   transaction, and drops intra-transaction no-op slot changes (tycho-substreams 0.5.1).
+
+## v0.3.7
+
+- Bump the Curve Substreams package version.
+
+## v0.3.6
+
+- Add the Curve Substreams integration.
+
+## v0.3.4
+
+- Initial release.

--- a/protocols/substreams/ethereum-ekubo-v2/CHANGELOG.md
+++ b/protocols/substreams/ethereum-ekubo-v2/CHANGELOG.md
@@ -4,3 +4,7 @@
 
 - Pin the Rust toolchain to 1.96.0 for reproducible wasm builds. The package
   previously had no toolchain pin and built with whatever stable was current.
+
+## v0.2.0
+
+- Initial release.

--- a/protocols/substreams/ethereum-ekubo-v3/CHANGELOG.md
+++ b/protocols/substreams/ethereum-ekubo-v3/CHANGELOG.md
@@ -4,3 +4,8 @@
 
 - Pin the Rust toolchain to 1.96.0 for reproducible wasm builds. The package
   previously had no toolchain pin and built with whatever stable was current.
+
+## v0.1.0
+
+- Add Ekubo V3 support.
+- Use the crates.io Ekubo SDK and resolve Substreams CI issues.

--- a/protocols/substreams/ethereum-erc4626/CHANGELOG.md
+++ b/protocols/substreams/ethereum-erc4626/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+- Initial release.

--- a/protocols/substreams/ethereum-fermiswap/CHANGELOG.md
+++ b/protocols/substreams/ethereum-fermiswap/CHANGELOG.md
@@ -40,3 +40,11 @@ staleness overwrite patches a dead registry slot.
   package relies on the token balance retention fix (#1056) included in `0.8.1`:
   the trader vault contract change often carries only token balance updates,
   which `0.8.0` dropped as empty.
+
+## v0.1.1
+
+- Isolate self-contained token proxies in the shared database.
+
+## v0.1.0
+
+- Add FermiSwap pair indexing with protobuf-backed stores.

--- a/protocols/substreams/ethereum-fluid/CHANGELOG.md
+++ b/protocols/substreams/ethereum-fluid/CHANGELOG.md
@@ -13,3 +13,7 @@
   stayed frozen at their initial snapshot.
 - Align `Cargo.toml` version (`0.2.0`) with the manifest version (`v0.3.0`); both are
   now `0.3.1`.
+
+## v0.2.0
+
+- Add the Ethereum Fluid indexer.

--- a/protocols/substreams/ethereum-lido/CHANGELOG.md
+++ b/protocols/substreams/ethereum-lido/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+- Initial release.

--- a/protocols/substreams/ethereum-liquidityparty/CHANGELOG.md
+++ b/protocols/substreams/ethereum-liquidityparty/CHANGELOG.md
@@ -4,3 +4,11 @@
 
 - Pin the Rust toolchain to 1.96.0 for reproducible wasm builds. The package
   previously had no toolchain pin and built with whatever stable was current.
+
+## v0.1.1
+
+- Bump the LiquidityParty Substreams package version.
+
+## v0.1.0
+
+- Add the LiquidityParty adapter.

--- a/protocols/substreams/ethereum-maverick-v2/CHANGELOG.md
+++ b/protocols/substreams/ethereum-maverick-v2/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.1
+
+- Initial release.

--- a/protocols/substreams/ethereum-pancakeswap-v3/CHANGELOG.md
+++ b/protocols/substreams/ethereum-pancakeswap-v3/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.2
+
+- Initial release.

--- a/protocols/substreams/ethereum-rocketpool/CHANGELOG.md
+++ b/protocols/substreams/ethereum-rocketpool/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## v0.2.1
+
+- Bump the Rocket Pool Substreams package version.
+
+## v0.2.0
+
+- Use verified initial state and run handlers on the creation block.
+
+## v0.1.0
+
+- Add the Ethereum Rocket Pool integration with protocol components and balance management.

--- a/protocols/substreams/ethereum-sfrax/CHANGELOG.md
+++ b/protocols/substreams/ethereum-sfrax/CHANGELOG.md
@@ -6,3 +6,7 @@
   workspace's version-4 `Cargo.lock`, so release builds from the package
   directory failed. The 1.75 pin was never honored in CI anyway — releases
   built from the workspace root with current stable.
+
+## v0.1.2
+
+- Initial release.

--- a/protocols/substreams/ethereum-sfraxeth/CHANGELOG.md
+++ b/protocols/substreams/ethereum-sfraxeth/CHANGELOG.md
@@ -6,3 +6,7 @@
   workspace's version-4 `Cargo.lock`, so release builds from the package
   directory failed. The 1.75 pin was never honored in CI anyway — releases
   built from the workspace root with current stable.
+
+## v0.1.1
+
+- Initial release.

--- a/protocols/substreams/ethereum-template-factory/CHANGELOG.md
+++ b/protocols/substreams/ethereum-template-factory/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+- Initial release.

--- a/protocols/substreams/ethereum-template-singleton/CHANGELOG.md
+++ b/protocols/substreams/ethereum-template-singleton/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+- Initial release.

--- a/protocols/substreams/ethereum-uniswap-v2/CHANGELOG.md
+++ b/protocols/substreams/ethereum-uniswap-v2/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## v0.3.2
 
 - Add the Robinhood Chain Uniswap V2 manifest.
+
+## v0.3.1
+
+- Initial release.

--- a/protocols/substreams/ethereum-uniswap-v3-logs-only/CHANGELOG.md
+++ b/protocols/substreams/ethereum-uniswap-v3-logs-only/CHANGELOG.md
@@ -4,3 +4,7 @@
 
 - Add the Robinhood Chain Uniswap V3 logs-only manifest.
 - Remove a redundant reference in a store-key format argument.
+
+## v0.1.2
+
+- Initial release.

--- a/protocols/substreams/ethereum-uniswap-v3/CHANGELOG.md
+++ b/protocols/substreams/ethereum-uniswap-v3/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.3.1
+
+- Initial release.

--- a/protocols/substreams/ethereum-uniswap-v4/no-hooks/CHANGELOG.md
+++ b/protocols/substreams/ethereum-uniswap-v4/no-hooks/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## v0.4.2
 
 - Add the Robinhood Chain Uniswap V4 no-hooks manifest.
+
+## v0.4.1
+
+- Initial release.

--- a/protocols/substreams/ethereum-uniswap-v4/shared/CHANGELOG.md
+++ b/protocols/substreams/ethereum-uniswap-v4/shared/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## v0.5.2
 
 - Remove redundant references in format arguments to retain compatibility with current Clippy.
+
+## v0.5.1
+
+- Initial release.

--- a/protocols/substreams/ethereum-uniswap-v4/with-hooks/CHANGELOG.md
+++ b/protocols/substreams/ethereum-uniswap-v4/with-hooks/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.7.0
+
+- Initial release.

--- a/protocols/substreams/polygon-ramses-v3/CHANGELOG.md
+++ b/protocols/substreams/polygon-ramses-v3/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+- Add Ramses V3 indexing for Polygon.

--- a/protocols/substreams/unichain-velodrome/CHANGELOG.md
+++ b/protocols/substreams/unichain-velodrome/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.3.1
+
+- Add the Velodrome Substreams integration.


### PR DESCRIPTION
## Summary
- Add concise release-history changelogs for all 33 Substreams Cargo packages.
- Document 71 versions reconstructed from Git history.
- Preserve existing entries and add missing package coverage, including helpers and templates.

## Validation
- Verified every qualifying package has one `CHANGELOG.md`.
- Verified every historical Cargo version has exactly one matching `## vX.Y.Z` heading.
- `git diff --check`
- Confirmed only `CHANGELOG.md` files changed.

Rust tests were not run because this is documentation-only.