### PR TITLE
fix: publish spkg under the manifest name, not the source dir

### DIFF
--- a/protocols/substreams/publish.sh
+++ b/protocols/substreams/publish.sh
@@ -60,12 +60,20 @@ if [[ ! -f "$yaml_file" ]]; then
     exit 1
 fi
 
-# Determine the version prefix based on the YAML file name
+# Determine the artifact name based on the YAML file name. The manifest name identifies the
+# chain and fork being published, which the source directory does not: packing
+# robinhood-uniswap-v4-no-hooks.yaml from ethereum-uniswap-v4/no-hooks must not publish under
+# "ethereum". Fall back to the Cargo package name, which flattens nested package paths, so no
+# "/" ever leaks into the S3 key.
 if [ "$yaml_name" = "substreams" ]; then
-    version_prefix="$package"
+    version_prefix="$cargo_package_name"
 else
     version_prefix="${yaml_name}"
 fi
+
+REPOSITORY=${REPOSITORY:-"s3://repo.propellerheads-propellerheads/substreams"}
+repository_path="$REPOSITORY/$version_prefix/$version_prefix-$version.spkg"
+output_file="./target/spkg/$version_prefix-$version.spkg"
 
 set -e  # Exit the script if any command fails
 
@@ -73,6 +81,7 @@ echo ""
 echo "Substreams package: $package"
 echo "YAML config: $yaml_file"
 echo "Version: $version"
+echo "Destination: $repository_path"
 echo ""
 
 # Ask for confirmation before proceeding
@@ -92,10 +101,6 @@ cargo build --target wasm32-unknown-unknown --release -p "$cargo_package_name"
 mkdir -p ./target/spkg/
 
 # Pack and upload the substreams package
-REPOSITORY=${REPOSITORY:-"s3://repo.propellerheads-propellerheads/substreams"}
-repository_path="$REPOSITORY/$package/$version_prefix-$version.spkg"
-output_file="./target/spkg/$version_prefix-$version.spkg"
-
 substreams pack "$yaml_file" -o "$output_file"
 
 # Check if the file already exists in S3 before uploading


### PR DESCRIPTION
## Problem

`publish.sh` builds the S3 key from the package *directory*:

```
repository_path="$REPOSITORY/$package/$version_prefix-$version.spkg"
```

Running `./publish.sh ethereum-uniswap-v4/no-hooks robinhood-uniswap-v4-no-hooks` uploaded to:

```
substreams/ethereum-uniswap-v4/no-hooks/robinhood-uniswap-v4-no-hooks-v0.4.2.spkg
```

Two things wrong with that key: the chain is `ethereum` for a Robinhood package, and the nested package path leaves a `/` in a registry that is otherwise flat. The object had to be moved by hand to `substreams/robinhood-uniswap-v4-no-hooks/robinhood-uniswap-v4-no-hooks-v0.4.2.spkg`.

## Change

Key the object by the manifest name, which is what identifies the chain and fork:

```
repository_path="$REPOSITORY/$version_prefix/$version_prefix-$version.spkg"
```

For `substreams.yaml` manifests, `version_prefix` now falls back to the Cargo package name instead of the package path. For flat packages the two are identical (`ethereum-balancer-v2`), so those keys are unchanged; for nested packages it flattens `ethereum-uniswap-v4/no-hooks` to `ethereum-uniswap-v4-no-hooks`, so no `/` can reach the key by either branch.

The destination is now printed before the confirmation prompt, so a wrong key is visible before the upload rather than after.

## Resulting keys

| invocation | before | after |
|---|---|---|
| `ethereum-uniswap-v4/no-hooks robinhood-uniswap-v4-no-hooks` | `ethereum-uniswap-v4/no-hooks/robinhood-…` | `robinhood-uniswap-v4-no-hooks/robinhood-…` |
| `ethereum-balancer-v2 substreams` | `ethereum-balancer-v2/ethereum-balancer-v2-…` | unchanged |
| `ethereum-uniswap-v2 arbitrum-uniswap-v2` | `ethereum-uniswap-v2/arbitrum-uniswap-v2-…` | `arbitrum-uniswap-v2/arbitrum-uniswap-v2-…` |

The third row is a deliberate consequence of the same rule: a fork manifest packed from a shared package directory now lands under its own name. Existing objects are untouched — only future publishes use the new key, and the `spkg:` entries in `extractors.yaml` that point at old keys keep resolving.

## Not in this PR

`release.sh` (the `release-substreams-package` CI job) has the same `$REPOSITORY/$package/…` construction and is unchanged here, so tagged releases still publish under the package directory while manual publishes no longer do. Aligning it changes where CI uploads every package, which is a registry-layout decision worth making explicitly — happy to follow up if we want them consistent. `protocols/substreams/Readme.md:21` documents the `release.sh` layout and stays accurate for that path.

## Testing

`shellcheck` clean. Dry-ran all three invocations above against the real manifests, answering `n` at the prompt, and confirmed the printed destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)