### PR TITLE
chore(deps): trim tokio features and unify TLS on rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3929,21 +3929,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4564,22 +4549,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.7.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -5598,23 +5567,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5829,48 +5781,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -6963,23 +6877,21 @@ dependencies = [
  "http-body-util",
  "hyper 1.7.0",
  "hyper-rustls 0.27.7",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls 0.23.31",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.2",
  "tokio-util",
  "tower 0.5.2",
@@ -8747,16 +8659,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-postgres"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8855,9 +8757,10 @@ checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls 0.24.1",
  "tungstenite 0.20.1",
 ]
 
@@ -8869,9 +8772,11 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
+ "rustls 0.23.31",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls 0.26.2",
  "tungstenite 0.28.0",
 ]
 
@@ -9320,8 +9225,8 @@ dependencies = [
  "http 0.2.12",
  "httparse",
  "log",
- "native-tls",
  "rand 0.8.5",
+ "rustls 0.21.12",
  "sha1",
  "thiserror 1.0.69",
  "url",
@@ -9339,8 +9244,9 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
- "native-tls",
  "rand 0.9.2",
+ "rustls 0.23.31",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.16",
  "utf-8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,13 +50,13 @@ typetag = "0.2.21"
 uuid = { version = "1.4.1", features = ["serde", "macro-diagnostics"] }
 
 # --- Async & concurrency ---
-tokio = { version = "1.47.1", features = ["full"] }
+tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "sync", "time", "net", "io-util", "signal"] }
 futures = "0.3.31"
 futures03 = { package = "futures", version = "0.3.31", features = ["compat"] }
 async-trait = "0.1.88"
 async-stream = "0.3.6"
 # Pinned at 0.20 for tycho-client; simulation's rfq feature uses 0.28 directly (separate semver)
-tokio-tungstenite = { version = "0.20.0", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.20.0", features = ["rustls-tls-native-roots"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 
 # --- Logging & tracing ---
@@ -91,7 +91,7 @@ unicode-segmentation = "1.12.0"
 clap = "4.5.48"
 reqwest = { version = "0.12", default-features = false, features = [
     "json",
-    "native-tls",
+    "rustls-tls-native-roots",
 ] }
 
 # --- Storage ---

--- a/crates/tycho-client/Cargo.toml
+++ b/crates/tycho-client/Cargo.toml
@@ -34,7 +34,14 @@ hex.workspace = true
 tracing-appender.workspace = true
 lru.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
-reqwest = { version = "0.12.7", features = ["json", "zstd"] }
+reqwest = { version = "0.12.7", default-features = false, features = [
+    "json",
+    "zstd",
+    "charset",
+    "http2",
+    "system-proxy",
+    "rustls-tls-native-roots",
+] }
 tracing-subscriber = { version = "0.3.17", default-features = false, features = [
     "env-filter",
     "fmt",

--- a/crates/tycho-ethereum/Cargo.toml
+++ b/crates/tycho-ethereum/Cargo.toml
@@ -28,7 +28,7 @@ serde_with = "3.16.1"
 
 # Required dependencies
 alloy = { workspace = true, default-features = false, features = [
-    "reqwest-default-tls",
+    "reqwest-rustls-tls",
     "rpc-client",
     "json-rpc",
     "sol-types",

--- a/crates/tycho-execution/Cargo.toml
+++ b/crates/tycho-execution/Cargo.toml
@@ -31,7 +31,7 @@ dotenvy    = "0.15.7"
 hex        = { workspace = true }
 num-bigint = { workspace = true }
 once_cell  = "1.20.2"
-reqwest    = { version = "0.12", features = ["json", "blocking"], optional = true }
+reqwest    = { version = "0.12", default-features = false, features = ["json", "blocking", "charset", "http2", "system-proxy", "rustls-tls-native-roots"], optional = true }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 thiserror  = { workspace = true }

--- a/crates/tycho-simulation/Cargo.toml
+++ b/crates/tycho-simulation/Cargo.toml
@@ -84,10 +84,10 @@ hex-literal = { workspace = true }
 http = { version = "1.0", optional = true }
 prost = { version = "0.13", optional = true }
 reqwest = { version = "0.12.22", default-features = false, features = [
-    "native-tls",
+    "rustls-tls-native-roots",
 ], optional = true }
 tokio-tungstenite = { version = "0.28.0", features = [
-    "native-tls",
+    "rustls-tls-native-roots",
 ], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Follow-up to the feature audit discussed on #1258:

- **tokio**: replace `features = ["full"]` with the seven features the workspace actually uses (`rt-multi-thread, macros, sync, time, net, io-util, signal`); `process`, `fs`, and `io-std` had no usages.
- **TLS**: the workspace compiled three TLS stacks — rustls (alloy, AWS SDK) plus native-tls (reqwest, tokio-tungstenite, and `tycho-ethereum`'s alloy transport, which contradicted `tycho-execution`'s rustls choice). Every native-tls selection now uses `rustls-tls-native-roots`, which keeps the OS trust store.

Removes 8 crates from the lockfile: `native-tls`, `hyper-tls`, `tokio-native-tls`, `openssl`, `openssl-sys`, `openssl-macros`, `foreign-types`, `foreign-types-shared` — Linux builds stop compiling OpenSSL entirely.

reqwest declarations that previously used default features keep `charset`, `http2`, and `system-proxy` explicitly, so only the TLS backend changes.

## Validation

- `cargo check --workspace --all-targets`: clean
- Live HTTPS verification: `tycho-ethereum`'s ignored RPC tests (`test_get_block_number`, `test_get_balance`, `test_get_code`, 7 cases) pass against a real archive node on the rustls stack

## Audit notes

Remaining feature surface is already tight: alloy is `default-features = false` with explicit per-crate feature lists, and reqwest/chrono/tracing-subscriber were trimmed previously. The AWS SDK pins its own rustls 0.21 internally, out of our control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)