### PR TITLE
chore: cover ramses_v3 in the polygon integration test

### DIFF
--- a/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
+++ b/crates/tycho-integration-test/src/stream_processor/protocol_stream_processor.rs
@@ -236,6 +236,7 @@ impl ProtocolStreamProcessor {
                     "uniswap_v3".to_string(),
                     "uniswap_v4".to_string(),
                     "quickswap_v2".to_string(),
+                    "ramses_v3".to_string(),
                 ]
             }
             Chain::Arbitrum => {

--- a/protocols/substreams/rustfmt.toml
+++ b/protocols/substreams/rustfmt.toml
@@ -30,4 +30,5 @@ ignore = [
     "ethereum-erc4626/src/abi",
     "ethereum-rocketpool/src/abi",
     "unichain-velodrome/src/abi",
+    "polygon-ramses-v3/src/abi",
 ]


### PR DESCRIPTION
Ramses V3 (Polygon) was added in #1208 but is not part of the Polygon default protocol list, so `tycho-integration-test` skips it unless `--protocols ramses_v3` is passed explicitly.

- Adds `ramses_v3` to `get_default_protocols_for_chain` for `Chain::Polygon`.
- Adds `polygon-ramses-v3/src/abi` to the `ignore` list in `protocols/substreams/rustfmt.toml`, matching every other protocol's generated ABI.

Note: Polygon's default TVL threshold is 2,000,000 POL (Medium tier). Ramses pools below that are filtered out of the stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)