### PR TITLE
fix(execution): only add mid-route wrap swaps for dangling balances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9609,6 +9609,7 @@ dependencies = [
  "dotenvy",
  "hex",
  "num-bigint",
+ "num-traits",
  "once_cell",
  "reqwest 0.12.23",
  "rstest 0.24.0",

--- a/crates/tycho-execution/Cargo.toml
+++ b/crates/tycho-execution/Cargo.toml
@@ -30,6 +30,7 @@ clap       = { workspace = true, features = ["derive"] }
 dotenvy    = "0.15.7"
 hex        = { workspace = true }
 num-bigint = { workspace = true }
+num-traits = { workspace = true }
 once_cell  = "1.20.2"
 reqwest    = { version = "0.12", features = ["json", "blocking"], optional = true }
 serde      = { workspace = true }

--- a/crates/tycho-execution/src/encoding/evm/tycho_encoders.rs
+++ b/crates/tycho-execution/src/encoding/evm/tycho_encoders.rs
@@ -103,6 +103,9 @@ impl TychoRouterEncoder {
     /// `available_tokens` tracks the tokens that still hold a balance at each point of the
     /// route. A 0%-split swap takes its input token's whole remainder, so it also removes
     /// that token again.
+    ///
+    /// `validate_native_wrap_gaps` has already rejected the solutions where a needed conversion
+    /// amount is ambiguous, so an unservable gap here simply inserts nothing.
     fn add_native_wrap_swaps(&self, solution: &Solution, chain: &Chain) -> Solution {
         let swaps = solution.swaps();
         let mut new_swaps: Vec<Swap> = Vec::with_capacity(swaps.len());
@@ -154,8 +157,8 @@ impl TychoRouterEncoder {
     ///
     /// The wrap swap takes the counterpart's whole remaining balance unless a later swap still
     /// consumes the counterpart, in which case it takes only the share `wrap_share` derives.
-    /// Without a derivable share the counterpart is left alone, because wrapping all of it would
-    /// starve that later swap.
+    /// Without a derivable share nothing is inserted; `validate_native_wrap_gaps` rejects those
+    /// solutions before they reach here.
     fn missing_wrap_swap(
         &self,
         consumed_token: &Bytes,
@@ -192,6 +195,61 @@ impl TychoRouterEncoder {
         Some(wrap_swap.with_split(share))
     }
 
+    /// Raises an `EncodingError` if a swap consumes a native or wrapped token that no swap
+    /// provides and the amount to convert from its counterpart does not follow from the solution.
+    ///
+    /// The amount is ambiguous when the counterpart's balance is the solution's payout, or when a
+    /// later swap also consumes the counterpart and `wrap_share` cannot derive a share. Either way
+    /// the solver has to emit an explicit `native_wrapper` swap carrying the split it wants.
+    ///
+    /// A token that neither the solution nor its counterpart can supply is left to the strategy
+    /// validators, which report it as an unconnected token.
+    fn validate_native_wrap_gaps(&self, solution: &Solution) -> Result<(), EncodingError> {
+        let swaps = solution.swaps();
+        let native = self.chain.native_token().address;
+        let wrapped = self
+            .chain
+            .wrapped_native_token()
+            .address;
+
+        for (i, swap) in swaps.iter().enumerate() {
+            let consumed_token = &swap.token_in().address;
+            let counterpart = if *consumed_token == native {
+                &wrapped
+            } else if *consumed_token == wrapped {
+                &native
+            } else {
+                continue;
+            };
+            if is_supplied(consumed_token, solution) || !is_supplied(counterpart, solution) {
+                continue;
+            }
+            if *counterpart == *solution.token_out() {
+                return Err(EncodingError::InvalidInput(format!(
+                    "A swap consumes {consumed_token} which no swap provides, and its counterpart \
+                     {counterpart} is the solution's output token. Converting that balance would \
+                     spend the payout. Add an explicit native_wrapper swap with the split to \
+                     convert."
+                )));
+            }
+            let remaining_swaps = &swaps[i..];
+            let counterpart_consumed_later = remaining_swaps
+                .iter()
+                .any(|swap| swap.token_in().address == *counterpart);
+            if counterpart_consumed_later &&
+                wrap_share(consumed_token, counterpart, swaps, remaining_swaps).is_none()
+            {
+                return Err(EncodingError::InvalidInput(format!(
+                    "A swap consumes {consumed_token} which no swap provides, and a later swap \
+                     also consumes its counterpart {counterpart}. The amount to convert does not \
+                     follow from the solution. Add an explicit native_wrapper swap with the split \
+                     to convert, or set estimated_amount_in on the swaps that consume both tokens."
+                )));
+            }
+        }
+        Ok(())
+    }
+
     /// Returns the swap that wraps or unwraps `token_in` into `token_out`, or `None`
     /// if the two tokens are not the chain's native/wrapped-native pair.
     fn wrap_swap_between(
@@ -215,6 +273,16 @@ impl TychoRouterEncoder {
             None
         }
     }
+}
+
+/// Returns whether `token` holds a balance at some point of the route, either because the
+/// solution starts from it or because a swap produces it.
+fn is_supplied(token: &Bytes, solution: &Solution) -> bool {
+    token == solution.token_in() ||
+        solution
+            .swaps()
+            .iter()
+            .any(|swap| swap.token_out().address == *token)
 }
 
 /// Returns the fraction of `counterpart`'s balance that must be wrapped to supply
@@ -292,7 +360,11 @@ impl TychoEncoder for TychoRouterEncoder {
     ///   `expectedAmountOut`).
     /// * The token cannot appear more than once in the solution unless it is the first and last
     ///   token (i.e. a true cyclical swap).
+    /// * Where a swap consumes a native or wrapped token that no swap provides, the amount to
+    ///   convert from its counterpart follows from the solution. `validate_native_wrap_gaps` lists
+    ///   what makes that amount ambiguous.
     fn validate_solution(&self, solution: &Solution) -> Result<(), EncodingError> {
+        self.validate_native_wrap_gaps(solution)?;
         if solution.swaps().is_empty() {
             return Err(EncodingError::FatalError("No swaps found in solution".to_string()));
         }
@@ -828,6 +900,71 @@ mod tests {
             assert!(encoded_solution
                 .function_signature()
                 .contains("splitSwap"));
+        }
+
+        /// The same shape as `test_add_native_wrap_swaps_partial_share`, but no swap carries an
+        /// estimated amount, so the share to convert does not follow from the solution.
+        #[rstest]
+        #[case::wrapped_branch_first(eth(), weth())]
+        #[case::native_branch_first(weth(), eth())]
+        fn test_validate_fails_undetermined_wrap_share(
+            #[case] input_token: Bytes,
+            #[case] counterpart_token: Bytes,
+        ) {
+            let encoder = get_tycho_router_encoder();
+            let solution = Solution::new(
+                Bytes::from_str("0xcd09f75E2BF2A4d11F3AB23f1389FcC1621c0cc2").unwrap(),
+                Bytes::default(),
+                input_token.clone(),
+                usdc(),
+                BigUint::from(1000u64),
+                BigUint::from_str("990_000000").unwrap(),
+                BigUint::from_str("970_000000").unwrap(),
+                vec![
+                    univ2_swap(&counterpart_token, &usdc(), 0.0),
+                    univ2_swap(&input_token, &usdc(), 0.0),
+                ],
+            );
+
+            let result = encoder.validate_solution(&solution);
+
+            let Err(EncodingError::InvalidInput(message)) = result else {
+                panic!("expected an InvalidInput error, got {result:?}");
+            };
+            assert!(message.contains("does not follow from the solution"), "{message}");
+        }
+
+        /// A cyclical solution whose mid-route branch needs the counterpart of the output token.
+        /// That balance is the payout, so converting it would deliver less than quoted.
+        //
+        //        ┌──[50%]── USDC ──┐
+        // WETH ──┤                 ├── WETH
+        //        └── (ETH) ── DAI ─┘
+        #[test]
+        fn test_validate_fails_wrap_would_spend_payout() {
+            let encoder = get_tycho_router_encoder();
+            let solution = Solution::new(
+                Bytes::from_str("0xcd09f75E2BF2A4d11F3AB23f1389FcC1621c0cc2").unwrap(),
+                Bytes::default(),
+                weth(),
+                weth(),
+                BigUint::from_str("1000_000000000000000000").unwrap(),
+                BigUint::from_str("1010_000000000000000000").unwrap(),
+                BigUint::from_str("1005_000000000000000000").unwrap(),
+                vec![
+                    univ2_swap(&weth(), &usdc(), 0.5),
+                    univ2_swap(&eth(), &dai(), 0.0),
+                    univ2_swap(&usdc(), &weth(), 0.0),
+                    univ2_swap(&dai(), &weth(), 0.0),
+                ],
+            );
+
+            let result = encoder.validate_solution(&solution);
+
+            let Err(EncodingError::InvalidInput(message)) = result else {
+                panic!("expected an InvalidInput error, got {result:?}");
+            };
+            assert!(message.contains("output token"), "{message}");
         }
 
         /// The solution's input token feeds one branch directly and its counterpart feeds

--- a/crates/tycho-execution/src/encoding/evm/tycho_encoders.rs
+++ b/crates/tycho-execution/src/encoding/evm/tycho_encoders.rs
@@ -632,11 +632,7 @@ mod tests {
                 default_token(token_out.clone()),
                 BigUint::ZERO,
             );
-            if split > 0.0 {
-                swap.with_split(split)
-            } else {
-                swap
-            }
+            swap.with_split(split)
         }
 
         /// A split solution with parallel ETH and WETH branches and no dangling balance:

--- a/crates/tycho-execution/src/encoding/evm/tycho_encoders.rs
+++ b/crates/tycho-execution/src/encoding/evm/tycho_encoders.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use num_bigint::BigUint;
+use num_traits::ToPrimitive;
 use tycho_common::{
     models::{protocol::ProtocolComponent, Chain},
     Bytes,
@@ -93,12 +94,11 @@ impl TychoRouterEncoder {
     /// swaps that produce its input token, and for each token the 0%-split swap that takes the
     /// remainder comes last. Reordering the swaps invalidates the inserted wrap swaps.
     ///
-    /// An inserted wrap swap carries a 0% split, meaning "consume the entire remaining
-    /// balance of the input token". A wrap swap is therefore inserted directly before the
-    /// first swap that consumes a token which neither the solution's input nor an earlier
-    /// swap provides. That position is after every swap that takes a fraction of the wrap
-    /// swap's input token, which the split ordering rules require. `missing_wrap_swap` lists
-    /// the conditions for an insertion.
+    /// A wrap swap is inserted directly before the first swap that consumes a token which
+    /// neither the solution's input nor an earlier swap provides. That position is after every
+    /// swap that takes a fraction of the wrap swap's input token, which the split ordering rules
+    /// require. `missing_wrap_swap` lists the conditions for an insertion, and decides whether
+    /// the wrap swap takes the whole remaining balance or only a share of it.
     ///
     /// `available_tokens` tracks the tokens that still hold a balance at each point of the
     /// route. A 0%-split swap takes its input token's whole remainder, so it also removes
@@ -113,10 +113,12 @@ impl TychoRouterEncoder {
                 &swap.token_in().address,
                 &available_tokens,
                 &swaps[i..],
-                solution.token_out(),
+                solution,
                 chain,
             ) {
-                available_tokens.remove(&wrap_swap.token_in().address);
+                if wrap_swap.split() == 0.0 {
+                    available_tokens.remove(&wrap_swap.token_in().address);
+                }
                 available_tokens.insert(wrap_swap.token_out().address.clone());
                 new_swaps.push(wrap_swap);
             }
@@ -142,23 +144,24 @@ impl TychoRouterEncoder {
     /// Returns the wrap swap that must run before a swap that consumes `consumed_token`,
     /// or `None` if no wrap swap is needed or possible.
     ///
-    /// `remaining_swaps` are the solution's swaps from the consuming swap onwards, and
-    /// `output_token` is the solution's output token.
+    /// `remaining_swaps` are the solution's swaps from the consuming swap onwards.
     ///
-    /// A wrap swap is needed when `consumed_token` is not available yet and the remaining
-    /// balance of its native/wrapped counterpart is dangling, meaning all of:
+    /// A wrap swap is needed when `consumed_token` is not available yet and the balance of its
+    /// native/wrapped counterpart can supply it, meaning both of:
     /// * the counterpart still holds a balance;
-    /// * no swap from this position onwards consumes the counterpart — an inserted wrap swap takes
-    ///   the counterpart's whole remaining balance, so any later consumer would be starved,
-    ///   including one that takes only a fraction;
     /// * the counterpart is not the solution's output token — that balance is the payout, and
     ///   wrapping it would re-route it through later swaps and deliver less than quoted.
+    ///
+    /// The wrap swap takes the counterpart's whole remaining balance unless a later swap still
+    /// consumes the counterpart, in which case it takes only the share `wrap_share` derives.
+    /// Without a derivable share the counterpart is left alone, because wrapping all of it would
+    /// starve that later swap.
     fn missing_wrap_swap(
         &self,
         consumed_token: &Bytes,
         available_tokens: &HashSet<Bytes>,
         remaining_swaps: &[Swap],
-        output_token: &Bytes,
+        solution: &Solution,
         chain: &Chain,
     ) -> Option<Swap> {
         if available_tokens.contains(consumed_token) {
@@ -174,16 +177,19 @@ impl TychoRouterEncoder {
             return None;
         };
 
+        if !available_tokens.contains(&counterpart) || counterpart == *solution.token_out() {
+            return None;
+        }
+        let wrap_swap = self.wrap_swap_between(&counterpart, consumed_token, chain)?;
+
         let counterpart_consumed_later = remaining_swaps
             .iter()
             .any(|swap| swap.token_in().address == counterpart);
-        if !available_tokens.contains(&counterpart) ||
-            counterpart_consumed_later ||
-            counterpart == *output_token
-        {
-            return None;
+        if !counterpart_consumed_later {
+            return Some(wrap_swap);
         }
-        self.wrap_swap_between(&counterpart, consumed_token, chain)
+        let share = wrap_share(consumed_token, &counterpart, solution.swaps(), remaining_swaps)?;
+        Some(wrap_swap.with_split(share))
     }
 
     /// Returns the swap that wraps or unwraps `token_in` into `token_out`, or `None`
@@ -208,6 +214,60 @@ impl TychoRouterEncoder {
         } else {
             None
         }
+    }
+}
+
+/// Returns the fraction of `counterpart`'s balance that must be wrapped to supply
+/// `consumed_token`, or `None` if the solution does not determine it.
+///
+/// Wrapping is 1:1, so the share follows from the solver's `estimated_amount_in` values:
+/// the amount the `consumed_token` swaps need, over that amount plus the amount the swap that
+/// takes the counterpart's remainder needs.
+///
+/// This only covers the shape where the share is unambiguous:
+/// * no swap produces `consumed_token`, so every swap consuming it must be supplied by wrapping;
+/// * exactly one swap from this position onwards consumes `counterpart`, and it takes the
+///   remainder. With several the existing splits could be relative to the balance either before or
+///   after wrapping, and picking the wrong reading would misroute funds;
+/// * every swap involved carries an `estimated_amount_in`.
+fn wrap_share(
+    consumed_token: &Bytes,
+    counterpart: &Bytes,
+    swaps: &[Swap],
+    remaining_swaps: &[Swap],
+) -> Option<f64> {
+    if swaps
+        .iter()
+        .any(|swap| swap.token_out().address == *consumed_token)
+    {
+        return None;
+    }
+
+    let mut wrapped_amount = BigUint::ZERO;
+    for swap in swaps
+        .iter()
+        .filter(|swap| swap.token_in().address == *consumed_token)
+    {
+        wrapped_amount += swap.estimated_amount_in().clone()?;
+    }
+
+    let mut counterpart_consumers = remaining_swaps
+        .iter()
+        .filter(|swap| swap.token_in().address == *counterpart);
+    let remainder_swap = counterpart_consumers.next()?;
+    if counterpart_consumers.next().is_some() || remainder_swap.split() != 0.0 {
+        return None;
+    }
+    let counterpart_amount = remainder_swap
+        .estimated_amount_in()
+        .clone()?;
+
+    let total = &wrapped_amount + &counterpart_amount;
+    let share = wrapped_amount.to_f64()? / total.to_f64()?;
+    if share > 0.0 && share < 1.0 {
+        Some(share)
+    } else {
+        None
     }
 }
 
@@ -804,6 +864,61 @@ mod tests {
 
             let solution = encoder.add_native_wrap_swaps(&solution, &encoder.chain);
             assert_eq!(solution.swaps(), input_swaps.as_slice());
+        }
+
+        /// Builds a uniswap_v2 swap carrying the amount the solver routed through it.
+        fn univ2_swap_with_amount(token_in: &Bytes, token_out: &Bytes, amount_in: u64) -> Swap {
+            univ2_swap(token_in, token_out, 0.0).with_estimated_amount_in(BigUint::from(amount_in))
+        }
+
+        /// The solution's input token feeds one branch and its counterpart the other. The
+        /// solver's estimated amounts say how much to convert, so the encoder inserts a wrap
+        /// swap carrying that share instead of taking the whole balance.
+        #[rstest]
+        //       ┌──[wrap 60%]── WETH ──┐
+        // ETH ──┤                      ├── USDC
+        //       └──[rem]───────────────┘
+        #[case::wrap_share(eth(), weth())]
+        //        ┌──[unwrap 60%]── ETH ──┐
+        // WETH ──┤                       ├── USDC
+        //        └──[rem]────────────────┘
+        #[case::unwrap_share(weth(), eth())]
+        fn test_add_native_wrap_swaps_partial_share(
+            #[case] input_token: Bytes,
+            #[case] counterpart_token: Bytes,
+        ) {
+            let encoder = get_tycho_router_encoder();
+            let input_swaps = vec![
+                univ2_swap_with_amount(&counterpart_token, &usdc(), 600),
+                univ2_swap_with_amount(&input_token, &usdc(), 400),
+            ];
+            let solution = Solution::new(
+                Bytes::from_str("0xcd09f75E2BF2A4d11F3AB23f1389FcC1621c0cc2").unwrap(),
+                Bytes::default(),
+                input_token.clone(),
+                usdc(),
+                BigUint::from(1000u64),
+                BigUint::from_str("990_000000").unwrap(),
+                BigUint::from_str("970_000000").unwrap(),
+                input_swaps.clone(),
+            );
+
+            let wrapped_solution = encoder.add_native_wrap_swaps(&solution, &encoder.chain);
+
+            let swaps = wrapped_solution.swaps();
+            assert_eq!(swaps.len(), 3);
+            assert_eq!(swaps[0].component().protocol_system, "native_wrapper");
+            assert_eq!(swaps[0].token_in().address, input_token);
+            assert_eq!(swaps[0].token_out().address, counterpart_token);
+            assert!((swaps[0].split() - 0.6).abs() < 1e-12);
+            assert_eq!(swaps[1..], input_swaps[..]);
+
+            let encoded_solution = encoder
+                .encode_solution(&solution)
+                .unwrap();
+            assert!(encoded_solution
+                .function_signature()
+                .contains("splitSwap"));
         }
 
         /// The counterpart's whole balance is already taken by an earlier 0%-split swap, so

--- a/crates/tycho-execution/src/encoding/evm/tycho_encoders.rs
+++ b/crates/tycho-execution/src/encoding/evm/tycho_encoders.rs
@@ -89,57 +89,99 @@ impl TychoRouterEncoder {
     /// its wrapped counterpart but doesn't include the corresponding
     /// wrapping or unwrapping swap.
     ///
-    /// A bridge swap carries a 0% split, meaning "consume the entire remaining balance of
-    /// its input token", so one is only inserted when that balance is genuinely dangling.
-    /// If any swap in the solution consumes the token itself, the apparent gap between two
-    /// adjacent swaps is a split solution's parallel-branch boundary rather than a
-    /// sequential discontinuity: a bridge there would starve that swap and violate the
-    /// one-remainder-per-token split ordering. A mid-route bridge is also skipped when its
-    /// input is the solution's output token — that balance is the payout, and wrapping it
-    /// would re-route it through later swaps.
+    /// An inserted wrap swap carries a 0% split, meaning "consume the entire remaining
+    /// balance of the input token". Mid-route, a wrap swap is therefore inserted directly
+    /// before the first swap that consumes a token which no earlier swap produces. This
+    /// position is after every swap that takes a fraction of the wrap swap's input token,
+    /// which the split ordering rules require. `missing_wrap_swap` lists the conditions
+    /// for an insertion.
     fn add_native_wrap_swaps(&self, solution: &Solution, chain: &Chain) -> Solution {
         let swaps = solution.swaps();
         let mut new_swaps: Vec<Swap> = Vec::with_capacity(swaps.len());
+        let mut available_tokens = HashSet::from([solution.token_in().clone()]);
 
         // Check if we need to add a wrapping swap at the beginning of the solution
-        if let Some(s) =
-            self._wrapping_bridge(solution.token_in(), &swaps[0].token_in().address, chain)
+        if let Some(wrap_swap) =
+            self.wrap_swap_between(solution.token_in(), &swaps[0].token_in().address, chain)
         {
-            new_swaps.push(s);
+            available_tokens.insert(wrap_swap.token_out().address.clone());
+            new_swaps.push(wrap_swap);
         }
 
-        // Iterate through the swaps and add them to the new solution, adding wrapping/unwrapping
-        // swaps in between if needed
-        for i in 0..swaps.len() {
-            new_swaps.push(swaps[i].clone());
-            if i + 1 < swaps.len() {
-                let token_out = &swaps[i].token_out().address;
-                let token_in = &swaps[i + 1].token_in().address;
-                if let Some(s) = self._wrapping_bridge(token_out, token_in, chain) {
-                    let bridge_input = &s.token_in().address;
-                    let is_consumed = swaps
-                        .iter()
-                        .any(|swap| &swap.token_in().address == bridge_input);
-                    if !is_consumed && bridge_input != solution.token_out() {
-                        new_swaps.push(s);
-                    }
-                }
+        for swap in swaps {
+            if let Some(wrap_swap) =
+                self.missing_wrap_swap(&swap.token_in().address, &available_tokens, solution, chain)
+            {
+                available_tokens.insert(wrap_swap.token_out().address.clone());
+                new_swaps.push(wrap_swap);
             }
+            available_tokens.insert(swap.token_out().address.clone());
+            new_swaps.push(swap.clone());
         }
 
         // Check if we need to add an unwrapping swap at the end of the solution
         if let Some(last_swap) = swaps.last() {
-            if let Some(s) =
-                self._wrapping_bridge(&last_swap.token_out().address, solution.token_out(), chain)
+            if let Some(unwrap_swap) =
+                self.wrap_swap_between(&last_swap.token_out().address, solution.token_out(), chain)
             {
-                new_swaps.push(s);
+                new_swaps.push(unwrap_swap);
             }
         }
 
         solution.clone().with_swaps(new_swaps)
     }
 
-    fn _wrapping_bridge(&self, token_a: &Bytes, token_b: &Bytes, chain: &Chain) -> Option<Swap> {
+    /// Returns the wrap swap that must run before a swap that consumes `consumed_token`,
+    /// or `None` if no wrap swap is needed or possible.
+    ///
+    /// A wrap swap is needed when `consumed_token` is not available yet and the remaining
+    /// balance of its native/wrapped counterpart is dangling, meaning all of:
+    /// * the counterpart is available;
+    /// * no swap takes the counterpart's remainder with a 0% split — a swap with a non-zero split
+    ///   takes only a fraction, so the remainder still needs wrapping or unwrapping;
+    /// * the counterpart is not the solution's output token — that balance is the payout, and
+    ///   wrapping it would re-route it through later swaps.
+    fn missing_wrap_swap(
+        &self,
+        consumed_token: &Bytes,
+        available_tokens: &HashSet<Bytes>,
+        solution: &Solution,
+        chain: &Chain,
+    ) -> Option<Swap> {
+        if available_tokens.contains(consumed_token) {
+            return None;
+        }
+        let native = chain.native_token().address;
+        let wrapped = chain.wrapped_native_token().address;
+        let counterpart = if *consumed_token == native {
+            wrapped
+        } else if *consumed_token == wrapped {
+            native
+        } else {
+            return None;
+        };
+
+        let remainder_taken = solution
+            .swaps()
+            .iter()
+            .any(|swap| swap.token_in().address == counterpart && swap.split() == 0.0);
+        if !available_tokens.contains(&counterpart) ||
+            remainder_taken ||
+            counterpart == *solution.token_out()
+        {
+            return None;
+        }
+        self.wrap_swap_between(&counterpart, consumed_token, chain)
+    }
+
+    /// Returns the swap that wraps or unwraps `token_in` into `token_out`, or `None`
+    /// if the two tokens are not the chain's native/wrapped-native pair.
+    fn wrap_swap_between(
+        &self,
+        token_in: &Bytes,
+        token_out: &Bytes,
+        chain: &Chain,
+    ) -> Option<Swap> {
         let native = chain.native_token();
         let wrapped_native = chain.wrapped_native_token();
         let wrap_component = ProtocolComponent {
@@ -147,9 +189,9 @@ impl TychoRouterEncoder {
             ..Default::default()
         };
 
-        if token_a == &wrapped_native.address && token_b == &native.address {
+        if token_in == &wrapped_native.address && token_out == &native.address {
             Some(Swap::new(wrap_component, wrapped_native, native, BigUint::from(14_000u64)))
-        } else if token_a == &native.address && token_b == &wrapped_native.address {
+        } else if token_in == &native.address && token_out == &wrapped_native.address {
             Some(Swap::new(wrap_component, native, wrapped_native, BigUint::from(7_000u64)))
         } else {
             None
@@ -585,11 +627,10 @@ mod tests {
             }
         }
 
-        /// A split solution containing a WETH/ETH-touching adjacency whose native balance is
-        /// not dangling: no wrap swap may be inserted. In `split_branch_boundary` the DAI→ETH
-        /// swap's output is consumed by the parallel ETH→USDC branch, not by the neighbouring
-        /// WETH→USDC swap. In `native_payout` the ETH produced by the DAI→ETH swap is the
-        /// solution's output, so nothing consumes it.
+        /// A split solution with parallel ETH and WETH branches and no dangling balance:
+        /// no wrap swap may be inserted. In `split_branch_boundary` the DAI→ETH swap's
+        /// output is fully consumed by the ETH→USDC branch. In `native_payout` the ETH
+        /// produced by the DAI→ETH swap is the solution's output, so nothing consumes it.
         #[rstest]
         //       ┌──[70%]── WETH ──┐
         // DAI ──┤                 ├── USDC   (ETH is consumed by its own branch)
@@ -615,7 +656,7 @@ mod tests {
             ],
             eth()
         )]
-        fn test_no_wrap_swap_for_non_dangling_balance(
+        fn test_add_native_wrap_swaps_non_dangling_balance(
             #[case] input_swaps: Vec<Swap>,
             #[case] token_out: Bytes,
         ) {
@@ -627,11 +668,65 @@ mod tests {
                 token_out,
                 BigUint::from_str("1000_000000000000000000").unwrap(),
                 BigUint::from_str("990_000000").unwrap(),
+                BigUint::from_str("970_000000").unwrap(),
                 input_swaps.clone(),
             );
 
             let solution = encoder.add_native_wrap_swaps(&solution, &encoder.chain);
             assert_eq!(solution.swaps(), input_swaps.as_slice());
+        }
+
+        /// A split solution where one branch takes a fraction of the ETH (or WETH)
+        /// balance and the other branch consumes the counterpart token: the remainder
+        /// dangles, so a wrap (or unwrap) swap must be inserted after the fractional
+        /// consumer, and the solution must still encode as a split swap.
+        #[rstest]
+        //                ┌──[30%]───────────┐
+        // DAI ─── ETH ───┤                  ├── USDC
+        //                └──[rem]── WETH ───┘
+        #[case::wrap_remainder(eth(), weth())]
+        //                ┌──[30%]───────────┐
+        // DAI ─── WETH ──┤                  ├── USDC
+        //                └──[rem]── ETH ────┘
+        #[case::unwrap_remainder(weth(), eth())]
+        fn test_add_native_wrap_swaps_dangling_remainder(
+            #[case] remainder_token: Bytes,
+            #[case] counterpart_token: Bytes,
+        ) {
+            let encoder = get_tycho_router_encoder();
+            let input_swaps = vec![
+                univ2_swap(&dai(), &remainder_token, 0.0),
+                univ2_swap(&remainder_token, &usdc(), 0.3),
+                univ2_swap(&counterpart_token, &usdc(), 0.0),
+            ];
+            let solution = Solution::new(
+                Bytes::from_str("0xcd09f75E2BF2A4d11F3AB23f1389FcC1621c0cc2").unwrap(),
+                Bytes::default(),
+                dai(),
+                usdc(),
+                BigUint::from_str("1000_000000000000000000").unwrap(),
+                BigUint::from_str("990_000000").unwrap(),
+                BigUint::from_str("970_000000").unwrap(),
+                input_swaps.clone(),
+            );
+
+            let wrapped_solution = encoder.add_native_wrap_swaps(&solution, &encoder.chain);
+
+            let swaps = wrapped_solution.swaps();
+            assert_eq!(swaps.len(), 4);
+            assert_eq!(swaps[..2], input_swaps[..2]);
+            assert_eq!(swaps[2].component().protocol_system, "native_wrapper");
+            assert_eq!(swaps[2].token_in().address, remainder_token);
+            assert_eq!(swaps[2].token_out().address, counterpart_token);
+            assert_eq!(swaps[2].split(), 0.0);
+            assert_eq!(swaps[3], input_swaps[2]);
+
+            let encoded_solution = encoder
+                .encode_solution(&solution)
+                .unwrap();
+            assert!(encoded_solution
+                .function_signature()
+                .contains("splitSwap"));
         }
 
         /// End-to-end regression: the split solution below must encode as a split swap
@@ -650,6 +745,7 @@ mod tests {
                 usdc(),
                 BigUint::from_str("1000_000000000000000000").unwrap(),
                 BigUint::from_str("990_000000").unwrap(),
+                BigUint::from_str("970_000000").unwrap(),
                 vec![
                     univ2_swap(&dai(), &weth(), 0.7),
                     univ2_swap(&dai(), &eth(), 0.0),

--- a/crates/tycho-execution/src/encoding/evm/tycho_encoders.rs
+++ b/crates/tycho-execution/src/encoding/evm/tycho_encoders.rs
@@ -88,6 +88,15 @@ impl TychoRouterEncoder {
     /// original solution contains a swap between a chain's native token and
     /// its wrapped counterpart but doesn't include the corresponding
     /// wrapping or unwrapping swap.
+    ///
+    /// A bridge swap carries a 0% split, meaning "consume the entire remaining balance of
+    /// its input token", so one is only inserted when that balance is genuinely dangling.
+    /// If any swap in the solution consumes the token itself, the apparent gap between two
+    /// adjacent swaps is a split solution's parallel-branch boundary rather than a
+    /// sequential discontinuity: a bridge there would starve that swap and violate the
+    /// one-remainder-per-token split ordering. A mid-route bridge is also skipped when its
+    /// input is the solution's output token — that balance is the payout, and wrapping it
+    /// would re-route it through later swaps.
     fn add_native_wrap_swaps(&self, solution: &Solution, chain: &Chain) -> Solution {
         let swaps = solution.swaps();
         let mut new_swaps: Vec<Swap> = Vec::with_capacity(swaps.len());
@@ -107,7 +116,13 @@ impl TychoRouterEncoder {
                 let token_out = &swaps[i].token_out().address;
                 let token_in = &swaps[i + 1].token_in().address;
                 if let Some(s) = self._wrapping_bridge(token_out, token_in, chain) {
-                    new_swaps.push(s);
+                    let bridge_input = &s.token_in().address;
+                    let is_consumed = swaps
+                        .iter()
+                        .any(|swap| &swap.token_in().address == bridge_input);
+                    if !is_consumed && bridge_input != solution.token_out() {
+                        new_swaps.push(s);
+                    }
                 }
             }
         }
@@ -314,6 +329,7 @@ mod tests {
     use std::{collections::HashMap, fs, str::FromStr};
 
     use num_bigint::{BigInt, BigUint};
+    use rstest::rstest;
     use tycho_common::models::{protocol::ProtocolComponent, Chain};
 
     use super::*;
@@ -548,6 +564,106 @@ mod tests {
             assert_eq!(last_swap.token_in().address, eth());
             assert_eq!(last_swap.token_out().address, weth());
             assert_eq!(last_swap.component().protocol_system, "native_wrapper");
+        }
+
+        /// Builds a uniswap_v2 swap between two ERC-20 tokens with an optional split.
+        fn univ2_swap(token_in: &Bytes, token_out: &Bytes, split: f64) -> Swap {
+            let swap = Swap::new(
+                ProtocolComponent {
+                    id: "0xA478c2975Ab1Ea89e8196811F51A7B7Ade33eB11".to_string(),
+                    protocol_system: "uniswap_v2".to_string(),
+                    ..Default::default()
+                },
+                default_token(token_in.clone()),
+                default_token(token_out.clone()),
+                BigUint::ZERO,
+            );
+            if split > 0.0 {
+                swap.with_split(split)
+            } else {
+                swap
+            }
+        }
+
+        /// A split solution containing a WETH/ETH-touching adjacency whose native balance is
+        /// not dangling: no wrap swap may be inserted. In `split_branch_boundary` the DAI→ETH
+        /// swap's output is consumed by the parallel ETH→USDC branch, not by the neighbouring
+        /// WETH→USDC swap. In `native_payout` the ETH produced by the DAI→ETH swap is the
+        /// solution's output, so nothing consumes it.
+        #[rstest]
+        //       ┌──[70%]── WETH ──┐
+        // DAI ──┤                 ├── USDC   (ETH is consumed by its own branch)
+        //       └──[rem]── ETH ───┘
+        #[case::split_branch_boundary(
+            vec![
+                univ2_swap(&dai(), &weth(), 0.7),
+                univ2_swap(&dai(), &eth(), 0.0),
+                univ2_swap(&weth(), &usdc(), 0.0),
+                univ2_swap(&eth(), &usdc(), 0.0),
+            ],
+            usdc()
+        )]
+        //       ┌──[60%]── WETH ── USDC ──┐
+        // DAI ──┤                         ├── ETH   (both branches deliver the payout)
+        //       └──[rem]──────────────────┘
+        #[case::native_payout(
+            vec![
+                univ2_swap(&dai(), &weth(), 0.6),
+                univ2_swap(&dai(), &eth(), 0.0),
+                univ2_swap(&weth(), &usdc(), 0.0),
+                univ2_swap(&usdc(), &eth(), 0.0),
+            ],
+            eth()
+        )]
+        fn test_no_wrap_swap_for_non_dangling_balance(
+            #[case] input_swaps: Vec<Swap>,
+            #[case] token_out: Bytes,
+        ) {
+            let encoder = get_tycho_router_encoder();
+            let solution = Solution::new(
+                Bytes::from_str("0xcd09f75E2BF2A4d11F3AB23f1389FcC1621c0cc2").unwrap(),
+                Bytes::default(),
+                dai(),
+                token_out,
+                BigUint::from_str("1000_000000000000000000").unwrap(),
+                BigUint::from_str("990_000000").unwrap(),
+                input_swaps.clone(),
+            );
+
+            let solution = encoder.add_native_wrap_swaps(&solution, &encoder.chain);
+            assert_eq!(solution.swaps(), input_swaps.as_slice());
+        }
+
+        /// End-to-end regression: the split solution below must encode as a split swap
+        /// instead of failing validation on an injected 0%-split wrap.
+        //
+        //       ┌──[70%]── WETH ──┐
+        // DAI ──┤                 ├── USDC
+        //       └──[rem]── ETH ───┘
+        #[test]
+        fn test_encode_split_solution_with_native_and_wrapped_branches() {
+            let encoder = get_tycho_router_encoder();
+            let solution = Solution::new(
+                Bytes::from_str("0xcd09f75E2BF2A4d11F3AB23f1389FcC1621c0cc2").unwrap(),
+                Bytes::default(),
+                dai(),
+                usdc(),
+                BigUint::from_str("1000_000000000000000000").unwrap(),
+                BigUint::from_str("990_000000").unwrap(),
+                vec![
+                    univ2_swap(&dai(), &weth(), 0.7),
+                    univ2_swap(&dai(), &eth(), 0.0),
+                    univ2_swap(&weth(), &usdc(), 0.0),
+                    univ2_swap(&eth(), &usdc(), 0.0),
+                ],
+            );
+
+            let encoded_solution = encoder
+                .encode_solution(&solution)
+                .unwrap();
+            assert!(encoded_solution
+                .function_signature()
+                .contains("splitSwap"));
         }
 
         #[test]

--- a/crates/tycho-execution/src/encoding/evm/tycho_encoders.rs
+++ b/crates/tycho-execution/src/encoding/evm/tycho_encoders.rs
@@ -89,31 +89,39 @@ impl TychoRouterEncoder {
     /// its wrapped counterpart but doesn't include the corresponding
     /// wrapping or unwrapping swap.
     ///
+    /// This assumes the swaps are already in a valid execution order: a swap comes after the
+    /// swaps that produce its input token, and for each token the 0%-split swap that takes the
+    /// remainder comes last. Reordering the swaps invalidates the inserted wrap swaps.
+    ///
     /// An inserted wrap swap carries a 0% split, meaning "consume the entire remaining
-    /// balance of the input token". Mid-route, a wrap swap is therefore inserted directly
-    /// before the first swap that consumes a token which no earlier swap produces. This
-    /// position is after every swap that takes a fraction of the wrap swap's input token,
-    /// which the split ordering rules require. `missing_wrap_swap` lists the conditions
-    /// for an insertion.
+    /// balance of the input token". A wrap swap is therefore inserted directly before the
+    /// first swap that consumes a token which neither the solution's input nor an earlier
+    /// swap provides. That position is after every swap that takes a fraction of the wrap
+    /// swap's input token, which the split ordering rules require. `missing_wrap_swap` lists
+    /// the conditions for an insertion.
+    ///
+    /// `available_tokens` tracks the tokens that still hold a balance at each point of the
+    /// route. A 0%-split swap takes its input token's whole remainder, so it also removes
+    /// that token again.
     fn add_native_wrap_swaps(&self, solution: &Solution, chain: &Chain) -> Solution {
         let swaps = solution.swaps();
         let mut new_swaps: Vec<Swap> = Vec::with_capacity(swaps.len());
         let mut available_tokens = HashSet::from([solution.token_in().clone()]);
 
-        // Check if we need to add a wrapping swap at the beginning of the solution
-        if let Some(wrap_swap) =
-            self.wrap_swap_between(solution.token_in(), &swaps[0].token_in().address, chain)
-        {
-            available_tokens.insert(wrap_swap.token_out().address.clone());
-            new_swaps.push(wrap_swap);
-        }
-
-        for swap in swaps {
-            if let Some(wrap_swap) =
-                self.missing_wrap_swap(&swap.token_in().address, &available_tokens, solution, chain)
-            {
+        for (i, swap) in swaps.iter().enumerate() {
+            if let Some(wrap_swap) = self.missing_wrap_swap(
+                &swap.token_in().address,
+                &available_tokens,
+                &swaps[i..],
+                solution.token_out(),
+                chain,
+            ) {
+                available_tokens.remove(&wrap_swap.token_in().address);
                 available_tokens.insert(wrap_swap.token_out().address.clone());
                 new_swaps.push(wrap_swap);
+            }
+            if swap.split() == 0.0 {
+                available_tokens.remove(&swap.token_in().address);
             }
             available_tokens.insert(swap.token_out().address.clone());
             new_swaps.push(swap.clone());
@@ -134,18 +142,23 @@ impl TychoRouterEncoder {
     /// Returns the wrap swap that must run before a swap that consumes `consumed_token`,
     /// or `None` if no wrap swap is needed or possible.
     ///
+    /// `remaining_swaps` are the solution's swaps from the consuming swap onwards, and
+    /// `output_token` is the solution's output token.
+    ///
     /// A wrap swap is needed when `consumed_token` is not available yet and the remaining
     /// balance of its native/wrapped counterpart is dangling, meaning all of:
-    /// * the counterpart is available;
-    /// * no swap takes the counterpart's remainder with a 0% split — a swap with a non-zero split
-    ///   takes only a fraction, so the remainder still needs wrapping or unwrapping;
+    /// * the counterpart still holds a balance;
+    /// * no swap from this position onwards consumes the counterpart — an inserted wrap swap takes
+    ///   the counterpart's whole remaining balance, so any later consumer would be starved,
+    ///   including one that takes only a fraction;
     /// * the counterpart is not the solution's output token — that balance is the payout, and
-    ///   wrapping it would re-route it through later swaps.
+    ///   wrapping it would re-route it through later swaps and deliver less than quoted.
     fn missing_wrap_swap(
         &self,
         consumed_token: &Bytes,
         available_tokens: &HashSet<Bytes>,
-        solution: &Solution,
+        remaining_swaps: &[Swap],
+        output_token: &Bytes,
         chain: &Chain,
     ) -> Option<Swap> {
         if available_tokens.contains(consumed_token) {
@@ -161,13 +174,12 @@ impl TychoRouterEncoder {
             return None;
         };
 
-        let remainder_taken = solution
-            .swaps()
+        let counterpart_consumed_later = remaining_swaps
             .iter()
-            .any(|swap| swap.token_in().address == counterpart && swap.split() == 0.0);
+            .any(|swap| swap.token_in().address == counterpart);
         if !available_tokens.contains(&counterpart) ||
-            remainder_taken ||
-            counterpart == *solution.token_out()
+            counterpart_consumed_later ||
+            counterpart == *output_token
         {
             return None;
         }
@@ -760,6 +772,102 @@ mod tests {
             assert!(encoded_solution
                 .function_signature()
                 .contains("splitSwap"));
+        }
+
+        /// The solution's input token feeds one branch directly and its counterpart feeds
+        /// another. Wrapping the whole input balance to serve the counterpart branch would
+        /// starve the branch that consumes the input token, so no wrap swap may be inserted.
+        #[rstest]
+        //       ┌── WETH ──┐
+        // ETH ──┤          ├── USDC
+        //       └── ETH ───┘
+        #[case::wrapped_branch_first(eth(), weth())]
+        //        ┌── ETH ───┐
+        // WETH ──┤          ├── USDC
+        //        └── WETH ──┘
+        #[case::native_branch_first(weth(), eth())]
+        fn test_add_native_wrap_swaps_input_consumed_by_later_branch(
+            #[case] input_token: Bytes,
+            #[case] counterpart_token: Bytes,
+        ) {
+            let encoder = get_tycho_router_encoder();
+            let input_swaps = vec![
+                univ2_swap(&counterpart_token, &usdc(), 0.0),
+                univ2_swap(&input_token, &usdc(), 0.0),
+            ];
+            let solution = Solution::new(
+                Bytes::from_str("0xcd09f75E2BF2A4d11F3AB23f1389FcC1621c0cc2").unwrap(),
+                Bytes::default(),
+                input_token,
+                usdc(),
+                BigUint::from_str("1000_000000000000000000").unwrap(),
+                BigUint::from_str("990_000000").unwrap(),
+                BigUint::from_str("970_000000").unwrap(),
+                input_swaps.clone(),
+            );
+
+            let solution = encoder.add_native_wrap_swaps(&solution, &encoder.chain);
+            assert_eq!(solution.swaps(), input_swaps.as_slice());
+        }
+
+        /// The counterpart's whole balance is already taken by an earlier 0%-split swap, so
+        /// there is nothing left to wrap and no wrap swap may be inserted.
+        //
+        // ETH ── USDC ──┐
+        //               ├── (WETH has no source) ── DAI ── USDC
+        #[test]
+        fn test_add_native_wrap_swaps_counterpart_already_drained() {
+            let encoder = get_tycho_router_encoder();
+            let input_swaps = vec![
+                univ2_swap(&eth(), &usdc(), 0.0),
+                univ2_swap(&weth(), &dai(), 0.0),
+                univ2_swap(&dai(), &usdc(), 0.0),
+            ];
+            let solution = Solution::new(
+                Bytes::from_str("0xcd09f75E2BF2A4d11F3AB23f1389FcC1621c0cc2").unwrap(),
+                Bytes::default(),
+                eth(),
+                usdc(),
+                BigUint::from_str("1000_000000000000000000").unwrap(),
+                BigUint::from_str("990_000000").unwrap(),
+                BigUint::from_str("970_000000").unwrap(),
+                input_swaps.clone(),
+            );
+
+            let solution = encoder.add_native_wrap_swaps(&solution, &encoder.chain);
+            assert_eq!(solution.swaps(), input_swaps.as_slice());
+        }
+
+        /// A cyclical solution whose mid-route branch consumes the native counterpart of the
+        /// output token. The encoder leaves the output token's balance alone: it cannot tell
+        /// the payout apart from feedstock for that branch, and wrapping the payout would
+        /// deliver less than quoted. A solver that wants the branch must emit the unwrap swap.
+        //
+        //        ┌──[50%]── USDC ──┐
+        // WETH ──┤                 ├── WETH
+        //        └── (ETH) ── DAI ─┘
+        #[test]
+        fn test_add_native_wrap_swaps_skips_cyclical_output_token() {
+            let encoder = get_tycho_router_encoder();
+            let input_swaps = vec![
+                univ2_swap(&weth(), &usdc(), 0.5),
+                univ2_swap(&eth(), &dai(), 0.0),
+                univ2_swap(&usdc(), &weth(), 0.0),
+                univ2_swap(&dai(), &weth(), 0.0),
+            ];
+            let solution = Solution::new(
+                Bytes::from_str("0xcd09f75E2BF2A4d11F3AB23f1389FcC1621c0cc2").unwrap(),
+                Bytes::default(),
+                weth(),
+                weth(),
+                BigUint::from_str("1000_000000000000000000").unwrap(),
+                BigUint::from_str("1010_000000000000000000").unwrap(),
+                BigUint::from_str("1005_000000000000000000").unwrap(),
+                input_swaps.clone(),
+            );
+
+            let wrapped_solution = encoder.add_native_wrap_swaps(&solution, &encoder.chain);
+            assert_eq!(wrapped_solution.swaps(), input_swaps.as_slice());
         }
 
         #[test]

--- a/docs/for-solvers/execution/encoding/README.md
+++ b/docs/for-solvers/execution/encoding/README.md
@@ -298,6 +298,8 @@ that surplus beyond your quote reaches the receiver. Amounts between `minAmountO
 
 The encoder automatically bridges ETH↔WETH gaps anywhere in the swap path — at the start, end, or between swaps — using a dedicated WETH executor. Set `token_in` and `token_out` to the tokens the user actually holds and expects to receive, and the encoder inserts wrap/unwrap steps as needed. This works with protocols like Uniswap V4 that accept native ETH directly, with no extra configuration required.
 
+A split that sends part of the route through native ETH and part through WETH also works: the encoder reads the `estimated_amount_in` of each branch to decide how much to convert, and gives the inserted wrap swap the matching split. It only does this where the amount follows from the solution. If several swaps each take a percentage of the same balance, adding a wrap in front of them changes what those percentages are measured against, and the solution does not say whether you already allowed for that — the encoder rejects it rather than guess. The same applies when the balance to convert is the solution's output token, since converting it would spend the user's payout. In both cases, add an explicit swap on the `native_wrapper` protocol carrying the split you want.
+
 #### Client Fee Signature <a href="#client-fee-signature" id="client-fee-signature"></a>
 
 Only required when charging a fee or allowing a client contribution. The `clientFeeReceiver` must sign


### PR DESCRIPTION
[Task](https://propeller-heads.atlassian.net/browse/ENG-6255)

## Problem
`add_native_wrap_swaps` finds ETH/WETH gaps with list adjacency, so in a split solution that contains both a WETH branch and a native-ETH branch it injects a 0%-split wrap swap between two parallel branches, and split validation then rejects the solution with "The 0% split for token ... must be the last swap". 
Not mentioned in the ticket: If the bridged token is the solution output, validation passes, the injected swap re-routes the user's payout through more pools, and the user receives less than the quote.

## Fix

The encoder now adds a mid-route bridge swap only if the balance is dangling: the bridged token has no consumer in the solution and is not the solution output. Bridge swaps at the start and at the end of a solution do not change, and sequential solutions do not change.

## Details

Adjacency means "chained" only in a sequential solution. In a flattened split solution, adjacent swaps can belong to different branches.

  The fix repairs two failure types.

  ### Type 1 — quote lost (validation error)

 A split route has both WETH and native ETH as intermediates. Observed in production (ENG-6255).

  **1a — WETH branch larger → error names ETH (0x0000…)**

  ```
  The solver emits:                    Today:                               After the fix:

  #1 USDT → WETH (0.7)         ★ ETH→WETH (0.0) is injected         ETH has a consumer (#4)
  #2 USDT → ETH  (0.0)           between #2 and #3                  → no injection
  #3 WETH → USDC (0.0)         → "The 0% split for token            → the solution encodes ✓
  #4 ETH  → USDC (0.0)           0x0000… must be the last swap"
  ```

  **1b — ETH branch larger → error names WETH (0xc02aaa…)**

  ```
  The solver emits (valid):    Today:                               After the fix:

  #1 USDT → ETH  (0.7)         ★ WETH→ETH (0.0) is injected         WETH has a consumer (#4)
  #2 USDT → WETH (0.0)           between #2 and #3                  → no injection
  #3 ETH  → USDC (0.0)         → "The 0% split for token            → the solution encodes ✓
  #4 WETH → USDC (0.0)           0xc02aaa… must be the last swap"
  ```

  The position of the fork does not matter. The same fix applies when the fork sits deeper (USDT→DAI→{WETH|ETH}→USDC).

  ### Type 2 — silent misroute (wrong execution, no error)

 The solution output is ETH or WETH, and the counterpart is an intermediate. This type does not appear in error logs. It shows as unexplained slippage.

  **2 -- buy ETH, large branch through WETH**

  ```
  The solver emits (valid):            Today:                            After the fix:

  #1 USDT → WETH (0.6)                 ★ ETH→WETH (0.0) is injected      ETH is the solution output
  #2 USDT → ETH  (0.0)  ← payout         between #2 and #3               → no injection
  #3 WETH → USDC (0.0)                 → validation passes               → the payout stays ETH
  #4 USDC → ETH  (0.0)  ← payout       → the 40% ETH payout is wrapped   → delivers as quoted ✓
                                         and re-traded through #3, #4
                                       → the user receives less than
                                         the quote
  ```


