### PR TITLE
fix(simulation): stop CLMM swaps panicking on an empty tick list

### DIFF
--- a/crates/tycho-simulation/src/evm/protocol/aerodrome_slipstreams/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/aerodrome_slipstreams/decoder.rs
@@ -165,15 +165,21 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for AerodromeSlipstreamsS
             })
             .collect();
 
-        let mut ticks = match ticks {
-            Ok(ticks) if !ticks.is_empty() => ticks
-                .into_iter()
-                .filter(|t| t.net_liquidity != 0)
-                .collect::<Vec<_>>(),
-            _ => return Err(InvalidSnapshotError::MissingAttribute("tick_liquidities".to_string())),
-        };
+        // An empty tick list decodes to a state that quotes no liquidity; rejecting it would
+        // leave no state for later deltas to repopulate.
+        let mut ticks: Vec<_> = ticks?
+            .into_iter()
+            .filter(|tick| tick.net_liquidity != 0)
+            .collect();
 
         ticks.sort_by_key(|tick| tick.index);
+
+        if liquidity != 0 && ticks.is_empty() {
+            tracing::warn!(
+                pool_id = %snapshot.component.id,
+                "snapshot carries nonzero liquidity but no initialized ticks"
+            );
+        }
 
         let observations: Vec<Observation> = snapshot
             .state
@@ -307,6 +313,70 @@ mod tests {
         .expect("pools without a supported marker should remain decodable");
 
         assert_eq!(decoded, expected_state(DynamicFeeConfig::default()));
+    }
+
+    #[tokio::test]
+    async fn no_tick_attributes_decode_to_an_empty_tick_list() {
+        let mut snapshot = snapshot(None);
+        snapshot
+            .state
+            .attributes
+            .retain(|key, _| !key.starts_with("ticks/"));
+
+        let decoded = try_decode_snapshot_with_defaults::<AerodromeSlipstreamsState>(snapshot)
+            .await
+            .expect("a snapshot without tick attributes is a decodable, empty pool");
+
+        let expected = AerodromeSlipstreamsState::new(
+            "test-pool".to_string(),
+            0,
+            100,
+            get_sqrt_ratio_at_tick(0).expect("tick zero should have a sqrt price"),
+            0,
+            1,
+            100,
+            1,
+            0,
+            vec![],
+            vec![Observation { initialized: true, index: 0, ..Default::default() }],
+            DynamicFeeConfig::default(),
+        )
+        .expect("an empty tick list is a valid pool state");
+        assert_eq!(decoded, expected);
+    }
+
+    #[tokio::test]
+    async fn all_zero_ticks_decode_to_an_empty_tick_list() {
+        let mut snapshot = snapshot(None);
+        snapshot
+            .state
+            .attributes
+            .insert("ticks/-1".to_string(), Bytes::from(0_i128.to_be_bytes()));
+        snapshot
+            .state
+            .attributes
+            .insert("ticks/1".to_string(), Bytes::from(0_i128.to_be_bytes()));
+
+        let decoded = try_decode_snapshot_with_defaults::<AerodromeSlipstreamsState>(snapshot)
+            .await
+            .expect("an all-zero tick set is a decodable, empty pool");
+
+        let expected = AerodromeSlipstreamsState::new(
+            "test-pool".to_string(),
+            0,
+            100,
+            get_sqrt_ratio_at_tick(0).expect("tick zero should have a sqrt price"),
+            0,
+            1,
+            100,
+            1,
+            0,
+            vec![],
+            vec![Observation { initialized: true, index: 0, ..Default::default() }],
+            DynamicFeeConfig::default(),
+        )
+        .expect("an empty tick list is a valid pool state");
+        assert_eq!(decoded, expected);
     }
 
     #[rstest]

--- a/crates/tycho-simulation/src/evm/protocol/aerodrome_slipstreams/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/aerodrome_slipstreams/state.rs
@@ -202,7 +202,14 @@ impl AerodromeSlipstreamsState {
                             )),
                         ));
                     }
-                    _ => return Err(SimulationError::FatalError("Unknown error".to_string())),
+                    TickListErrorKind::Empty => {
+                        return Err(SimulationError::RecoverableError("No liquidity".to_string()))
+                    }
+                    TickListErrorKind::NotFound |
+                    TickListErrorKind::BelowSmallest |
+                    TickListErrorKind::AtOrAboveLargest => {
+                        return Err(SimulationError::FatalError("Unknown error".to_string()))
+                    }
                 },
             };
 
@@ -653,6 +660,62 @@ mod tests {
             },
         },
     };
+
+    #[test]
+    fn test_empty_tick_list_with_liquidity_errors_instead_of_panicking() {
+        let sqrt_price = get_sqrt_ratio_at_tick(0).expect("Failed to calculate sqrt price");
+        let pool = AerodromeSlipstreamsState::new(
+            "test-pool".to_string(),
+            1_000_000,
+            100_000_000_000_000_000_000u128,
+            sqrt_price,
+            0,
+            1,
+            3000,
+            1,
+            0,
+            vec![],
+            vec![Observation::default()],
+            DynamicFeeConfig::new(3000, 10_000, 1, false, 0),
+        )
+        .expect("an empty tick list is a valid pool state");
+        let amount =
+            I256::checked_from_sign_and_abs(Sign::Positive, U256::from(100_000_000_000_000_000u64))
+                .unwrap();
+
+        let result = pool.swap(true, amount, None);
+
+        assert!(
+            matches!(result, Err(SimulationError::RecoverableError(_))),
+            "expected a recoverable no-liquidity error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_get_limits_on_empty_tick_list_returns_zero() {
+        let sqrt_price = get_sqrt_ratio_at_tick(0).expect("Failed to calculate sqrt price");
+        let pool = AerodromeSlipstreamsState::new(
+            "test-pool".to_string(),
+            1_000_000,
+            100_000_000_000_000_000_000u128,
+            sqrt_price,
+            0,
+            1,
+            3000,
+            1,
+            0,
+            vec![],
+            vec![Observation::default()],
+            DynamicFeeConfig::new(3000, 10_000, 1, false, 0),
+        )
+        .expect("an empty tick list is a valid pool state");
+
+        let limits = pool
+            .get_limits(Bytes::from([0_u8; 20]), Bytes::from([1_u8; 20]))
+            .expect("limits of a pool without ticks are computable");
+
+        assert_eq!(limits, (BigUint::zero(), BigUint::zero()));
+    }
 
     fn create_basic_test_pool() -> AerodromeSlipstreamsState {
         let sqrt_price = get_sqrt_ratio_at_tick(0).expect("Failed to calculate sqrt price");

--- a/crates/tycho-simulation/src/evm/protocol/ramses_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/ramses_v3/state.rs
@@ -166,7 +166,14 @@ impl RamsesV3State {
                             )),
                         ));
                     }
-                    _ => return Err(SimulationError::FatalError("Unknown error".to_string())),
+                    TickListErrorKind::Empty => {
+                        return Err(SimulationError::RecoverableError("No liquidity".to_string()))
+                    }
+                    TickListErrorKind::NotFound |
+                    TickListErrorKind::BelowSmallest |
+                    TickListErrorKind::AtOrAboveLargest => {
+                        return Err(SimulationError::FatalError("Unknown error".to_string()))
+                    }
                 },
             };
 
@@ -606,6 +613,44 @@ mod tests {
             .unwrap();
 
         assert_eq!(res.amount, BigUint::from_str("64352395915550406461").unwrap());
+    }
+
+    #[test]
+    fn test_empty_tick_list_with_liquidity_errors_instead_of_panicking() {
+        let wbtc = Token::new(
+            &Bytes::from_str("0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599").unwrap(),
+            "WBTC",
+            8,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        );
+        let weth = Token::new(
+            &Bytes::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap(),
+            "WETH",
+            18,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        );
+        let pool = RamsesV3State::new(
+            377952820878029838,
+            U256::from_str("28437325270877025820973479874632004").unwrap(),
+            500,
+            10,
+            255830,
+            vec![],
+        )
+        .expect("an empty tick list is a valid pool state");
+
+        let result = pool.get_amount_out(500000000.to_biguint().unwrap(), &wbtc, &weth);
+
+        assert!(
+            matches!(result, Err(SimulationError::RecoverableError(_))),
+            "expected a recoverable no-liquidity error, got {result:?}"
+        );
     }
 
     #[test]

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/decoder.rs
@@ -116,15 +116,21 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for UniswapV3State {
             })
             .collect();
 
-        let mut ticks = match ticks {
-            Ok(ticks) if !ticks.is_empty() => ticks
-                .into_iter()
-                .filter(|t| t.net_liquidity != 0)
-                .collect::<Vec<_>>(),
-            _ => return Err(InvalidSnapshotError::MissingAttribute("tick_liquidities".to_string())),
-        };
+        // An empty tick list decodes to a state that quotes no liquidity; rejecting it would
+        // leave no state for later deltas to repopulate.
+        let mut ticks: Vec<_> = ticks?
+            .into_iter()
+            .filter(|tick| tick.net_liquidity != 0)
+            .collect();
 
         ticks.sort_by_key(|tick| tick.index);
+
+        if liquidity != 0 && ticks.is_empty() {
+            tracing::warn!(
+                pool_id = %snapshot.component.id,
+                "snapshot carries nonzero liquidity but no initialized ticks"
+            );
+        }
 
         UniswapV3State::new(liquidity, sqrt_price, fee, tick, ticks)
             .map_err(|err| InvalidSnapshotError::ValueError(err.to_string()))
@@ -207,20 +213,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_usv3_try_from_all_zero_ticks_decodes_to_empty_list() {
+        let mut attributes = usv3_attributes();
+        attributes.insert(
+            "ticks/60/net_liquidity".to_string(),
+            Bytes::from(0_i128.to_be_bytes().to_vec()),
+        );
+        let snapshot = ComponentWithState {
+            state: ProtocolComponentState {
+                component_id: "State1".to_owned(),
+                attributes,
+                balances: HashMap::new(),
+            },
+            component: usv3_component(),
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        };
+
+        let decoded = try_decode_snapshot_with_defaults::<UniswapV3State>(snapshot)
+            .await
+            .expect("an all-zero tick set is a decodable, empty pool");
+
+        let expected =
+            UniswapV3State::new(100, U256::from(200), FeeAmount::Medium, 300, vec![]).unwrap();
+        assert_eq!(decoded, expected);
+    }
+
+    #[tokio::test]
+    async fn test_usv3_try_from_no_tick_attributes_decodes_to_empty_list() {
+        let mut attributes = usv3_attributes();
+        attributes.retain(|key, _| !key.starts_with("ticks/"));
+        let snapshot = ComponentWithState {
+            state: ProtocolComponentState {
+                component_id: "State1".to_owned(),
+                attributes,
+                balances: HashMap::new(),
+            },
+            component: usv3_component(),
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        };
+
+        let decoded = try_decode_snapshot_with_defaults::<UniswapV3State>(snapshot)
+            .await
+            .expect("a snapshot without tick attributes is a decodable, empty pool");
+
+        let expected =
+            UniswapV3State::new(100, U256::from(200), FeeAmount::Medium, 300, vec![]).unwrap();
+        assert_eq!(decoded, expected);
+    }
+
+    #[tokio::test]
     #[rstest]
     #[case::missing_liquidity("liquidity")]
     #[case::missing_sqrt_price("sqrt_price")]
     #[case::missing_tick("tick")]
-    #[case::missing_tick_liquidity("tick_liquidities")]
     #[case::missing_fee("fee")]
     async fn test_usv3_try_from_invalid(#[case] missing_attribute: String) {
         // remove missing attribute
         let mut attributes = usv3_attributes();
         attributes.remove(&missing_attribute);
-
-        if missing_attribute == "tick_liquidities" {
-            attributes.remove("ticks/60/net_liquidity");
-        }
 
         if missing_attribute == "sqrt_price" {
             attributes.remove("sqrt_price_x96");

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
@@ -776,6 +776,43 @@ mod tests {
         assert_eq!(limits, (BigUint::zero(), BigUint::zero()));
     }
 
+    // A created-but-uninitialized pool decodes now that empty tick lists are kept, and its zero
+    // sqrt price is not a price: reporting one would be zero in one direction, infinite in the
+    // other.
+    #[test]
+    fn test_spot_price_on_an_uninitialized_pool_errors() {
+        let pool = UniswapV3State::new(0, U256::ZERO, FeeAmount::Medium, 0, vec![])
+            .expect("an uninitialized pool is a valid state");
+        let wbtc = Token::new(
+            &Bytes::from_str("0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599").unwrap(),
+            "WBTC",
+            8,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        );
+        let weth = Token::new(
+            &Bytes::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap(),
+            "WETH",
+            18,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        );
+
+        for (base, quote) in [(&wbtc, &weth), (&weth, &wbtc)] {
+            let price = pool.spot_price(base, quote);
+            assert!(
+                matches!(price, Err(SimulationError::RecoverableError(_))),
+                "{} -> {}: expected an uninitialized-pool error, got {price:?}",
+                base.symbol,
+                quote.symbol
+            );
+        }
+    }
+
     #[test]
     fn test_get_amount_out() {
         let wbtc = Token::new(

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
@@ -162,7 +162,14 @@ impl UniswapV3State {
                             )),
                         ));
                     }
-                    _ => return Err(SimulationError::FatalError("Unknown error".to_string())),
+                    TickListErrorKind::Empty => {
+                        return Err(SimulationError::RecoverableError("No liquidity".to_string()))
+                    }
+                    TickListErrorKind::NotFound |
+                    TickListErrorKind::BelowSmallest |
+                    TickListErrorKind::AtOrAboveLargest => {
+                        return Err(SimulationError::FatalError("Unknown error".to_string()))
+                    }
                 },
             };
 
@@ -504,7 +511,8 @@ impl ProtocolSim for UniswapV3State {
     /// until the target price is reached.
     fn query_pool_swap(&self, params: &QueryPoolSwapParams) -> Result<PoolSwap, SimulationError> {
         if self.liquidity == 0 {
-            return Err(SimulationError::FatalError("No liquidity".to_string()));
+            // Recoverable: the pool stays in the state map for later deltas to populate.
+            return Err(SimulationError::RecoverableError("No liquidity".to_string()));
         }
 
         match params.swap_constraint() {
@@ -633,6 +641,139 @@ mod tests {
         symbol: &'static str,
         sell: BigUint,
         exp: BigUint,
+    }
+
+    #[test]
+    fn test_empty_tick_list_with_liquidity_errors_instead_of_panicking() {
+        let wbtc = Token::new(
+            &Bytes::from_str("0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599").unwrap(),
+            "WBTC",
+            8,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        );
+        let weth = Token::new(
+            &Bytes::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap(),
+            "WETH",
+            18,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        );
+        let pool = UniswapV3State::new(
+            377952820878029838,
+            U256::from_str("28437325270877025820973479874632004").unwrap(),
+            FeeAmount::Low,
+            255830,
+            vec![],
+        )
+        .unwrap();
+
+        let result = pool.get_amount_out(BigUint::from(1000u32), &wbtc, &weth);
+
+        assert!(
+            matches!(result, Err(SimulationError::RecoverableError(_))),
+            "expected a recoverable no-liquidity error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_empty_pool_recovers_after_delta_repopulates_ticks() {
+        let token_x = Token::new(
+            &Bytes::from_str("0x6b175474e89094c44da98b954eedeac495271d0f").unwrap(),
+            "X",
+            18,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        );
+        let token_y = Token::new(
+            &Bytes::from_str("0xf1ca9cb74685755965c7458528a36934df52a3ef").unwrap(),
+            "Y",
+            18,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        );
+        let mut pool = UniswapV3State::new(
+            8330443394424070888454257,
+            U256::from_str("188562464004052255423565206602").unwrap(),
+            FeeAmount::Medium,
+            17342,
+            vec![],
+        )
+        .expect("an empty tick list is a valid pool state");
+        let sell_amount = BigUint::from_str("11_000_000000000000000000").unwrap();
+
+        let before = pool.get_amount_out(sell_amount.clone(), &token_x, &token_y);
+
+        assert!(
+            matches!(before, Err(SimulationError::RecoverableError(_))),
+            "expected a recoverable no-liquidity error, got {before:?}"
+        );
+
+        let attributes: HashMap<String, Bytes> = [
+            (
+                "liquidity".to_string(),
+                Bytes::from(
+                    8330443394424070888454257_u128
+                        .to_be_bytes()
+                        .to_vec(),
+                ),
+            ),
+            (
+                "sqrt_price_x96".to_string(),
+                Bytes::from(
+                    188562464004052255423565206602_u128
+                        .to_be_bytes()
+                        .to_vec(),
+                ),
+            ),
+            ("tick".to_string(), Bytes::from(17342_i32.to_be_bytes().to_vec())),
+            ("ticks/0/net_liquidity".to_string(), Bytes::from(10000_i128.to_be_bytes().to_vec())),
+            (
+                "ticks/46080/net_liquidity".to_string(),
+                Bytes::from((-10000_i128).to_be_bytes().to_vec()),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let delta = ProtocolStateDelta {
+            component_id: "State1".to_owned(),
+            updated_attributes: attributes,
+            deleted_attributes: HashSet::new(),
+        };
+        pool.delta_transition(delta, &HashMap::new(), &Balances::default())
+            .expect("a delta carrying ticks applies to a pool that has none");
+
+        let after = pool
+            .get_amount_out(sell_amount, &token_x, &token_y)
+            .expect("a repopulated pool quotes again");
+
+        assert!(after.amount > BigUint::zero(), "expected a non-zero quote, got {}", after.amount);
+    }
+
+    #[test]
+    fn test_get_limits_on_empty_tick_list_returns_zero() {
+        let pool = UniswapV3State::new(
+            1000000,
+            U256::from_str("79228162514264337593543950336").unwrap(),
+            FeeAmount::Medium,
+            0,
+            vec![],
+        )
+        .expect("an empty tick list is a valid pool state");
+
+        let limits = pool
+            .get_limits(Bytes::from([0_u8; 20]), Bytes::from([1_u8; 20]))
+            .expect("limits of a pool without ticks are computable");
+
+        assert_eq!(limits, (BigUint::zero(), BigUint::zero()));
     }
 
     #[test]

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/decoder.rs
@@ -127,24 +127,22 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for UniswapV4State {
             .static_attributes
             .get("hooks");
 
-        let mut ticks = match ticks {
-            Ok(ticks) if !ticks.is_empty() => ticks
-                .into_iter()
-                .filter(|t| t.net_liquidity != 0)
-                .collect::<Vec<_>>(),
-            _ => {
-                // there might be pools where the liquidity is managed by the hook
-                if hook_address.is_some() {
-                    Vec::new()
-                } else {
-                    return Err(InvalidSnapshotError::MissingAttribute(
-                        "tick_liquidities".to_string(),
-                    ));
-                }
-            }
-        };
+        // An empty tick list (uninitialized pool, drained ticks, or hook-managed liquidity)
+        // decodes to a state that quotes no liquidity; rejecting it would leave no state for
+        // later deltas to repopulate.
+        let mut ticks: Vec<_> = ticks?
+            .into_iter()
+            .filter(|tick| tick.net_liquidity != 0)
+            .collect();
 
         ticks.sort_by_key(|tick| tick.index);
+
+        if liquidity != 0 && ticks.is_empty() {
+            tracing::warn!(
+                pool_id = %snapshot.component.id,
+                "snapshot carries nonzero liquidity but no initialized ticks"
+            );
+        }
 
         let mut state = UniswapV4State::new(liquidity, sqrt_price, fees, tick, tick_spacing, ticks)
             .map_err(|err| {
@@ -204,15 +202,31 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for UniswapV4State {
 mod tests {
     use std::str::FromStr;
 
+    use alloy::primitives::aliases::U24;
     use chrono::DateTime;
+    use num_bigint::BigUint;
     use rstest::rstest;
-    use tycho_common::models::{
-        protocol::{ProtocolComponent, ProtocolComponentState},
-        Chain, ChangeType,
+    use tycho_common::{
+        models::{
+            protocol::{ProtocolComponent, ProtocolComponentState},
+            Chain, ChangeType,
+        },
+        simulation::errors::SimulationError,
     };
 
     use super::*;
-    use crate::evm::protocol::test_utils::try_decode_snapshot_with_defaults;
+    use crate::evm::protocol::{
+        test_utils::try_decode_snapshot_with_defaults,
+        uniswap_v4::hooks::{
+            angstrom::hook_handler::{AngstromFees, AngstromHookHandler},
+            hook_handler_creator::initialize_hook_handlers,
+        },
+    };
+
+    // The Angstrom hook is the only hook whose handler is built without an EVM engine, so it is
+    // the one hooked pool a unit test can decode.
+    const ANGSTROM_HOOK_ADDRESS: [u8; 20] =
+        hex_literal::hex!("0000000aa232009084Bd71A5797d089AA4Edfad4");
 
     fn usv4_component() -> ProtocolComponent {
         let creation_time = DateTime::from_timestamp(1622526000, 0)
@@ -256,6 +270,37 @@ mod tests {
         ])
     }
 
+    fn usv4_hooked_component() -> ProtocolComponent {
+        let mut component = usv4_component();
+        component
+            .static_attributes
+            .insert("hooks".to_string(), Bytes::from(ANGSTROM_HOOK_ADDRESS));
+        component
+    }
+
+    fn usv4_hooked_attributes() -> HashMap<String, Bytes> {
+        let mut attributes = usv4_attributes();
+        attributes.extend([
+            ("balance_owner".to_string(), Bytes::from([0_u8; 20])),
+            ("angstrom_unlocked_fee".to_string(), Bytes::from([0_u8; 3])),
+            ("angstrom_protocol_unlocked_fee".to_string(), Bytes::from([0_u8; 3])),
+            ("angstrom_removed_pool".to_string(), Bytes::from([0_u8])),
+        ]);
+        attributes
+    }
+
+    fn token(last_byte: u8) -> Token {
+        let mut address = [0_u8; 20];
+        address[19] = last_byte;
+        Token::new(&Bytes::from(address), "TKN", 18, 0, &[Some(10_000)], Chain::Ethereum, 100)
+    }
+
+    fn limits(state: &UniswapV4State) -> (BigUint, BigUint) {
+        state
+            .get_limits(token(0).address, token(1).address)
+            .expect("limits of a pool without ticks are computable")
+    }
+
     #[tokio::test]
     async fn test_usv4_try_from() {
         let snapshot = ComponentWithState {
@@ -287,11 +332,132 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_usv4_try_from_all_zero_ticks_decodes_to_empty_list() {
+        let mut attributes = usv4_attributes();
+        attributes.insert(
+            "ticks/60/net_liquidity".to_string(),
+            Bytes::from(0_i128.to_be_bytes().to_vec()),
+        );
+        let snapshot = ComponentWithState {
+            state: ProtocolComponentState {
+                component_id: "State1".to_owned(),
+                attributes,
+                balances: HashMap::new(),
+            },
+            component: usv4_component(),
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        };
+
+        let decoded = try_decode_snapshot_with_defaults::<UniswapV4State>(snapshot)
+            .await
+            .expect("an all-zero tick set is a decodable, empty pool");
+
+        // `PartialEq for UniswapV4State` compares hook handlers only, so the limits witness
+        // the empty tick list instead.
+        assert_eq!(limits(&decoded), (BigUint::from(0u32), BigUint::from(0u32)));
+    }
+
+    #[tokio::test]
+    async fn test_usv4_try_from_no_tick_attributes_decodes_to_empty_list() {
+        let mut attributes = usv4_attributes();
+        attributes.retain(|key, _| !key.starts_with("ticks/"));
+        let snapshot = ComponentWithState {
+            state: ProtocolComponentState {
+                component_id: "State1".to_owned(),
+                attributes,
+                balances: HashMap::new(),
+            },
+            component: usv4_component(),
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        };
+
+        let decoded = try_decode_snapshot_with_defaults::<UniswapV4State>(snapshot)
+            .await
+            .expect("a snapshot without tick attributes is a decodable, empty pool");
+
+        assert_eq!(limits(&decoded), (BigUint::from(0u32), BigUint::from(0u32)));
+        let quote = decoded.get_amount_out(BigUint::from(1000u32), &token(0), &token(1));
+        assert!(
+            matches!(quote, Err(SimulationError::RecoverableError(_))),
+            "expected a recoverable no-liquidity error, got {quote:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_usv4_try_from_hooked_pool_no_tick_attributes_decodes_to_empty_list() {
+        initialize_hook_handlers().expect("hook handlers should register");
+        let mut attributes = usv4_hooked_attributes();
+        attributes.retain(|key, _| !key.starts_with("ticks/"));
+        let snapshot = ComponentWithState {
+            state: ProtocolComponentState {
+                component_id: "State1".to_owned(),
+                attributes,
+                balances: HashMap::new(),
+            },
+            component: usv4_hooked_component(),
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        };
+
+        let decoded = try_decode_snapshot_with_defaults::<UniswapV4State>(snapshot)
+            .await
+            .expect("a hooked snapshot without tick attributes is a decodable, empty pool");
+
+        let mut expected = UniswapV4State::new(
+            100,
+            U256::from(79228162514264337593543950336_u128),
+            UniswapV4Fees::new(0, 0, 500),
+            300,
+            60,
+            vec![],
+        )
+        .unwrap();
+        expected.set_hook_handler(Box::new(AngstromHookHandler::new(
+            Address::from(ANGSTROM_HOOK_ADDRESS),
+            Address::ZERO,
+            AngstromFees { unlock: U24::ZERO, protocol_unlock: U24::ZERO },
+            false,
+        )));
+        assert_eq!(decoded, expected);
+        assert_eq!(limits(&decoded), (BigUint::from(0u32), BigUint::from(0u32)));
+    }
+
+    #[tokio::test]
+    async fn test_usv4_try_from_hooked_pool_rejects_malformed_tick_index() {
+        initialize_hook_handlers().expect("hook handlers should register");
+        let mut attributes = usv4_hooked_attributes();
+        attributes.insert(
+            "ticks/not-a-number/net_liquidity".to_string(),
+            Bytes::from(400_i128.to_be_bytes().to_vec()),
+        );
+        let snapshot = ComponentWithState {
+            state: ProtocolComponentState {
+                component_id: "State1".to_owned(),
+                attributes,
+                balances: HashMap::new(),
+            },
+            component: usv4_hooked_component(),
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        };
+
+        let error = try_decode_snapshot_with_defaults::<UniswapV4State>(snapshot)
+            .await
+            .expect_err("an unparseable tick index must not decode");
+
+        assert!(
+            matches!(&error, InvalidSnapshotError::ValueError(msg) if msg.contains("invalid digit")),
+            "expected the tick index parse failure to surface, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
     #[rstest]
     #[case::missing_liquidity("liquidity")]
     #[case::missing_sqrt_price("sqrt_price")]
     #[case::missing_tick("tick")]
-    #[case::missing_tick_liquidity("tick_liquidities")]
     #[case::missing_fee("key_lp_fee")]
     #[case::missing_fee("protocol_fees/one2zero")]
     #[case::missing_fee("protocol_fees/zero2one")]
@@ -300,10 +466,6 @@ mod tests {
         let mut component = usv4_component();
         let mut attributes = usv4_attributes();
         attributes.remove(&missing_attribute);
-
-        if missing_attribute == "tick_liquidities" {
-            attributes.remove("ticks/60/net_liquidity");
-        }
 
         if missing_attribute == "sqrt_price" {
             attributes.remove("sqrt_price_x96");

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
@@ -246,7 +246,14 @@ impl UniswapV4State {
                             )),
                         ));
                     }
-                    _ => return Err(SimulationError::FatalError("Unknown error".to_string())),
+                    TickListErrorKind::Empty => {
+                        return Err(SimulationError::RecoverableError("No liquidity".to_string()))
+                    }
+                    TickListErrorKind::NotFound |
+                    TickListErrorKind::BelowSmallest |
+                    TickListErrorKind::AtOrAboveLargest => {
+                        return Err(SimulationError::FatalError("Unknown error".to_string()))
+                    }
                 },
             };
 
@@ -915,7 +922,8 @@ impl ProtocolSim for UniswapV4State {
     /// determine available liquidity at a given price without executing an actual swap.
     fn query_pool_swap(&self, params: &QueryPoolSwapParams) -> Result<PoolSwap, SimulationError> {
         if self.liquidity == 0 {
-            return Err(SimulationError::FatalError("No liquidity".to_string()));
+            // Recoverable: the pool stays in the state map for later deltas to populate.
+            return Err(SimulationError::RecoverableError("No liquidity".to_string()));
         }
 
         // Calculate total fee (protocol + LP fee) for V4
@@ -937,7 +945,7 @@ impl ProtocolSim for UniswapV4State {
                 max_amount_in: _,
             } => {
                 if self.liquidity == 0 {
-                    return Err(SimulationError::FatalError("No liquidity".to_string()));
+                    return Err(SimulationError::RecoverableError("No liquidity".to_string()));
                 }
 
                 let (amount_in, amount_out, swap_result) = clmm_swap_to_price(
@@ -1969,6 +1977,32 @@ mod tests {
         let result = fees.calculate_swap_fees_pips(true, None);
         // 500 + 0 - (500 * 0 / 1_000_000) = 500
         assert_eq!(result, 500);
+    }
+
+    #[test]
+    fn test_empty_tick_list_with_liquidity_errors_instead_of_panicking() {
+        let sqrt_price = get_sqrt_price_q96(U256::from(20_000_000u64), U256::from(10_000_000u64))
+            .expect("Failed to calculate sqrt price");
+        let tick = get_tick_at_sqrt_ratio(sqrt_price).expect("Failed to calculate tick");
+        let pool = UniswapV4State::new(
+            100_000_000_000_000_000_000u128,
+            sqrt_price,
+            UniswapV4Fees { zero_for_one: 0, one_for_zero: 0, lp_fee: 3000 },
+            tick,
+            60,
+            vec![],
+        )
+        .expect("an empty tick list is a valid pool state");
+        let amount =
+            I256::checked_from_sign_and_abs(Sign::Positive, U256::from(100_000_000_000_000_000u64))
+                .unwrap();
+
+        let result = pool.swap(true, amount, None, None);
+
+        assert!(
+            matches!(result, Err(SimulationError::RecoverableError(_))),
+            "expected a recoverable no-liquidity error, got {result:?}"
+        );
     }
 
     // Helper to create a basic test pool for swap_to_price tests

--- a/crates/tycho-simulation/src/evm/protocol/utils/uniswap/sqrt_price_math.rs
+++ b/crates/tycho-simulation/src/evm/protocol/utils/uniswap/sqrt_price_math.rs
@@ -193,6 +193,13 @@ pub(crate) fn sqrt_price_q96_to_f64(
             "sqrt_price_q96_to_f64: x value {x} exceeds U160 max"
         )));
     }
+    // A pool that was created but never initialized carries a zero sqrt price. Returning a price
+    // here would be zero in one token direction and infinite in the other.
+    if x.is_zero() {
+        return Err(SimulationError::RecoverableError(
+            "sqrt_price_q96_to_f64: pool is not initialized".to_string(),
+        ));
+    }
     let token_correction = 10f64.powi(token_0_decimals as i32 - token_1_decimals as i32);
 
     let price = u256_to_f64(x)? / 2.0f64.powi(96);
@@ -439,6 +446,17 @@ mod tests {
         let res = sqrt_price_q96_to_f64(sqrt_price, t0d, t1d).expect("convert sqrt price");
 
         assert_ulps_eq!(res, exp, epsilon = f64::EPSILON);
+    }
+
+    // An uninitialized pool would otherwise price at zero one way and infinity the other.
+    #[test]
+    fn test_q96_to_f64_rejects_an_uninitialized_pool() {
+        let result = sqrt_price_q96_to_f64(U256::ZERO, 18, 6);
+
+        assert!(
+            matches!(result, Err(SimulationError::RecoverableError(ref msg)) if msg.contains("not initialized")),
+            "expected an uninitialized-pool error, got: {result:?}"
+        );
     }
 
     #[test]

--- a/crates/tycho-simulation/src/evm/protocol/utils/uniswap/tick_list.rs
+++ b/crates/tycho-simulation/src/evm/protocol/utils/uniswap/tick_list.rs
@@ -39,6 +39,7 @@ pub(crate) enum TickListErrorKind {
     BelowSmallest,
     AtOrAboveLargest,
     TicksExeeded,
+    Empty,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -136,8 +137,10 @@ impl TickList {
                 }
             }
             Err(insert_idx) => {
-                self.ticks
-                    .insert(insert_idx, TickInfo::new(tick, liquidity)?);
+                if liquidity != 0 {
+                    self.ticks
+                        .insert(insert_idx, TickInfo::new(tick, liquidity)?);
+                }
             }
         }
         Ok(())
@@ -191,6 +194,9 @@ impl TickList {
     }
 
     fn next_initialized_tick(&self, index: i32, lte: bool) -> Result<&TickInfo, TickListError> {
+        if self.ticks.is_empty() {
+            return Err(TickListError { kind: TickListErrorKind::Empty });
+        }
         if lte {
             if self.is_below_smallest(index) {
                 return Err(TickListError { kind: TickListErrorKind::BelowSmallest });
@@ -229,6 +235,9 @@ impl TickList {
         tick: i32,
         lte: bool,
     ) -> Result<(i32, bool), TickListError> {
+        if self.ticks.is_empty() {
+            return Err(TickListError { kind: TickListErrorKind::Empty });
+        }
         let spacing = self.tick_spacing as i32;
         let compressed = div_floor(tick, spacing);
 
@@ -677,5 +686,51 @@ mod tests {
 
         assert!(tick_list.get_tick(-10).is_err());
         assert!(tick_list.get_tick(10).is_err());
+    }
+
+    #[test]
+    fn test_set_tick_liquidity_zero_on_absent_tick_leaves_list_unchanged() {
+        let mut tick_list =
+            TickList::from(10, vec![create_tick_info(10, 10), create_tick_info(20, -5)]).unwrap();
+        let unchanged = tick_list.clone();
+
+        tick_list
+            .set_tick_liquidity(30, 0)
+            .unwrap();
+
+        assert_eq!(tick_list, unchanged);
+    }
+
+    #[test]
+    fn test_set_tick_liquidity_zero_removes_existing_tick() {
+        let mut tick_list =
+            TickList::from(10, vec![create_tick_info(10, 10), create_tick_info(20, -5)]).unwrap();
+
+        tick_list
+            .set_tick_liquidity(20, 0)
+            .unwrap();
+
+        assert_eq!(tick_list.ticks, vec![create_tick_info(10, 10)]);
+    }
+
+    #[test]
+    fn test_empty_tick_list_reports_empty_instead_of_panicking() {
+        let tick_list = TickList::from(10, vec![]).unwrap();
+
+        for lte in [true, false] {
+            let within_word = tick_list.next_initialized_tick_within_one_word(0, lte);
+            assert_eq!(
+                within_word.unwrap_err().kind,
+                TickListErrorKind::Empty,
+                "next_initialized_tick_within_one_word(lte={lte})"
+            );
+
+            let next = tick_list.next_initialized_tick(0, lte);
+            assert_eq!(
+                next.unwrap_err().kind,
+                TickListErrorKind::Empty,
+                "next_initialized_tick(lte={lte})"
+            );
+        }
     }
 }

--- a/crates/tycho-simulation/src/evm/protocol/velodrome_slipstreams/decoder.rs
+++ b/crates/tycho-simulation/src/evm/protocol/velodrome_slipstreams/decoder.rs
@@ -115,15 +115,21 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for VelodromeSlipstreamsS
             })
             .collect();
 
-        let mut ticks = match ticks {
-            Ok(ticks) if !ticks.is_empty() => ticks
-                .into_iter()
-                .filter(|t| t.net_liquidity != 0)
-                .collect::<Vec<_>>(),
-            _ => return Err(InvalidSnapshotError::MissingAttribute("tick_liquidities".to_string())),
-        };
+        // An empty tick list decodes to a state that quotes no liquidity; rejecting it would
+        // leave no state for later deltas to repopulate.
+        let mut ticks: Vec<_> = ticks?
+            .into_iter()
+            .filter(|tick| tick.net_liquidity != 0)
+            .collect();
 
         ticks.sort_by_key(|tick| tick.index);
+
+        if liquidity != 0 && ticks.is_empty() {
+            tracing::warn!(
+                pool_id = %snapshot.component.id,
+                "snapshot carries nonzero liquidity but no initialized ticks"
+            );
+        }
 
         VelodromeSlipstreamsState::new(
             liquidity,
@@ -135,5 +141,157 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for VelodromeSlipstreamsS
             ticks,
         )
         .map_err(|err| InvalidSnapshotError::ValueError(err.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use chrono::DateTime;
+    use rstest::rstest;
+    use tycho_common::models::{
+        protocol::{ProtocolComponent, ProtocolComponentState},
+        Chain, ChangeType,
+    };
+
+    use super::*;
+    use crate::evm::protocol::test_utils::try_decode_snapshot_with_defaults;
+
+    fn velodrome_component() -> ProtocolComponent {
+        let creation_time = DateTime::from_timestamp(1622526000, 0)
+            .unwrap()
+            .naive_utc();
+
+        let static_attributes = HashMap::from([
+            ("tick_spacing".to_string(), Bytes::from(1_i32.to_be_bytes().to_vec())),
+            ("default_fee".to_string(), Bytes::from(3000_u32.to_be_bytes().to_vec())),
+        ]);
+
+        ProtocolComponent {
+            id: "State1".to_string(),
+            protocol_system: "system1".to_string(),
+            protocol_type_name: "typename1".to_string(),
+            chain: Chain::Ethereum,
+            tokens: Vec::new(),
+            contract_addresses: Vec::new(),
+            static_attributes,
+            change: ChangeType::Creation,
+            creation_tx: Bytes::from_str("0x0000").unwrap(),
+            created_at: creation_time,
+        }
+    }
+
+    fn velodrome_attributes() -> HashMap<String, Bytes> {
+        HashMap::from([
+            ("liquidity".to_string(), Bytes::from(100_u128.to_be_bytes().to_vec())),
+            ("sqrt_price_x96".to_string(), Bytes::from(200_u64.to_be_bytes().to_vec())),
+            ("custom_fee".to_string(), Bytes::from(500_u32.to_be_bytes().to_vec())),
+            ("tick".to_string(), Bytes::from(0_i32.to_be_bytes().to_vec())),
+            ("ticks/60".to_string(), Bytes::from(400_i128.to_be_bytes().to_vec())),
+        ])
+    }
+
+    fn snapshot(
+        attributes: HashMap<String, Bytes>,
+        component: ProtocolComponent,
+    ) -> ComponentWithState {
+        ComponentWithState {
+            state: ProtocolComponentState {
+                component_id: "State1".to_owned(),
+                attributes,
+                balances: HashMap::new(),
+            },
+            component,
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_velodrome_try_from() {
+        let decoded = try_decode_snapshot_with_defaults::<VelodromeSlipstreamsState>(snapshot(
+            velodrome_attributes(),
+            velodrome_component(),
+        ))
+        .await
+        .expect("a complete snapshot should decode");
+
+        let expected = VelodromeSlipstreamsState::new(
+            100,
+            U256::from(200),
+            3000,
+            500,
+            1,
+            0,
+            vec![TickInfo::new(60, 400).unwrap()],
+        )
+        .unwrap();
+        assert_eq!(decoded, expected);
+    }
+
+    #[rstest]
+    #[case::missing_liquidity("liquidity")]
+    #[case::missing_sqrt_price("sqrt_price")]
+    #[case::missing_custom_fee("custom_fee")]
+    #[case::missing_tick("tick")]
+    #[case::missing_tick_spacing("tick_spacing")]
+    #[case::missing_default_fee("default_fee")]
+    #[tokio::test]
+    async fn test_velodrome_try_from_invalid(#[case] missing_attribute: String) {
+        let mut attributes = velodrome_attributes();
+        let mut component = velodrome_component();
+
+        // The sqrt price is reported under a shorter name than the attribute holding it.
+        let attribute_key =
+            if missing_attribute == "sqrt_price" { "sqrt_price_x96" } else { &missing_attribute };
+        attributes.remove(attribute_key);
+        component
+            .static_attributes
+            .remove(&missing_attribute);
+
+        let result = try_decode_snapshot_with_defaults::<VelodromeSlipstreamsState>(snapshot(
+            attributes, component,
+        ))
+        .await;
+
+        assert!(matches!(
+            result.expect_err("a snapshot missing a required attribute must not decode"),
+            InvalidSnapshotError::MissingAttribute(attr) if attr == missing_attribute
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_velodrome_try_from_no_tick_attributes_decodes_to_empty_list() {
+        let mut attributes = velodrome_attributes();
+        attributes.retain(|key, _| !key.starts_with("ticks/"));
+
+        let decoded = try_decode_snapshot_with_defaults::<VelodromeSlipstreamsState>(snapshot(
+            attributes,
+            velodrome_component(),
+        ))
+        .await
+        .expect("a snapshot without tick attributes is a decodable, empty pool");
+
+        let expected =
+            VelodromeSlipstreamsState::new(100, U256::from(200), 3000, 500, 1, 0, vec![]).unwrap();
+        assert_eq!(decoded, expected);
+    }
+
+    #[tokio::test]
+    async fn test_velodrome_try_from_all_zero_ticks_decodes_to_empty_list() {
+        let mut attributes = velodrome_attributes();
+        attributes.insert("ticks/60".to_string(), Bytes::from(0_i128.to_be_bytes().to_vec()));
+
+        let decoded = try_decode_snapshot_with_defaults::<VelodromeSlipstreamsState>(snapshot(
+            attributes,
+            velodrome_component(),
+        ))
+        .await
+        .expect("an all-zero tick set is a decodable, empty pool");
+
+        let expected =
+            VelodromeSlipstreamsState::new(100, U256::from(200), 3000, 500, 1, 0, vec![]).unwrap();
+        assert_eq!(decoded, expected);
     }
 }

--- a/crates/tycho-simulation/src/evm/protocol/velodrome_slipstreams/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/velodrome_slipstreams/state.rs
@@ -149,7 +149,14 @@ impl VelodromeSlipstreamsState {
                             )),
                         ));
                     }
-                    _ => return Err(SimulationError::FatalError("Unknown error".to_string())),
+                    TickListErrorKind::Empty => {
+                        return Err(SimulationError::RecoverableError("No liquidity".to_string()))
+                    }
+                    TickListErrorKind::NotFound |
+                    TickListErrorKind::BelowSmallest |
+                    TickListErrorKind::AtOrAboveLargest => {
+                        return Err(SimulationError::FatalError("Unknown error".to_string()))
+                    }
                 },
             };
 
@@ -498,6 +505,52 @@ mod tests {
             MIN_TICK,
         },
     };
+
+    #[test]
+    fn test_empty_tick_list_with_liquidity_errors_instead_of_panicking() {
+        let sqrt_price = get_sqrt_ratio_at_tick(0).expect("Failed to calculate sqrt price");
+        let pool = VelodromeSlipstreamsState::new(
+            100_000_000_000_000_000_000u128,
+            sqrt_price,
+            3000,
+            0,
+            1,
+            0,
+            vec![],
+        )
+        .expect("an empty tick list is a valid pool state");
+        let amount =
+            I256::checked_from_sign_and_abs(Sign::Positive, U256::from(100_000_000_000_000_000u64))
+                .unwrap();
+
+        let result = pool.swap(true, amount, None);
+
+        assert!(
+            matches!(result, Err(SimulationError::RecoverableError(_))),
+            "expected a recoverable no-liquidity error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_get_limits_on_empty_tick_list_returns_zero() {
+        let sqrt_price = get_sqrt_ratio_at_tick(0).expect("Failed to calculate sqrt price");
+        let pool = VelodromeSlipstreamsState::new(
+            100_000_000_000_000_000_000u128,
+            sqrt_price,
+            3000,
+            0,
+            1,
+            0,
+            vec![],
+        )
+        .expect("an empty tick list is a valid pool state");
+
+        let limits = pool
+            .get_limits(Bytes::from([0_u8; 20]), Bytes::from([1_u8; 20]))
+            .expect("limits of a pool without ticks are computable");
+
+        assert_eq!(limits, (BigUint::zero(), BigUint::zero()));
+    }
 
     fn create_basic_test_pool() -> VelodromeSlipstreamsState {
         let sqrt_price = get_sqrt_ratio_at_tick(0).expect("Failed to calculate sqrt price");


### PR DESCRIPTION
## Problem

`TickList`'s bounds helpers index `ticks[0]` and `ticks[len - 1]` directly, so a pool holding no
ticks panicked with an index-out-of-bounds instead of reporting an error. `uniswap_v3`,
`uniswap_v4`, `velodrome_slipstreams` and `aerodrome_slipstreams` all reach those helpers after
guarding only `liquidity == 0`, and liquidity is updated independently of the ticks: a delta drops
a tick entry once its net liquidity reaches zero without touching the pool's liquidity attribute,
and a snapshot whose ticks all carry zero net liquidity decoded to an empty list because emptiness
was checked before those ticks were filtered out. The panic was therefore already reachable in
production.

## Changes

- `next_initialized_tick` and `next_initialized_tick_within_one_word` reject an empty list with a
  new `TickListErrorKind::Empty`, which every fork maps to `RecoverableError("No liquidity")` —
  the same answer they already give for zero liquidity, and the one `ramses_v3` already returns
  from its `has_initialized_ticks` guards.
- The match arms are now exhaustive over `TickListErrorKind`: adding a variant becomes a compile
  error instead of being silently swallowed as `FatalError("Unknown error")`.
- `set_tick_liquidity` skips inserting a zero-net tick for an absent index, mirroring its removal
  branch, so deltas can no longer re-create the inconsistent shape the guards protect against.
- `query_pool_swap`'s zero-liquidity guard on `uniswap_v3` and `uniswap_v4` returns
  `RecoverableError` instead of `FatalError`: an uninitialised pool stays in the state map so
  later deltas can populate it, instead of being blacklisted permanently by consumers.
- Decoders keep an empty tick list rather than rejecting the snapshot, matching `ramses_v3`. An
  empty pool is unquotable until its ticks arrive; a lifecycle test pins that such a pool quotes
  again once a delta supplies ticks. A snapshot carrying nonzero liquidity but no initialized
  ticks — impossible on-chain — is logged at decode as an upstream data-quality signal.
- Tick parse failures surface as their own `ValueError` instead of being reported as a missing
  `tick_liquidities` attribute. For `uniswap_v4` hook pools a malformed tick attribute previously
  decoded to an empty list silently and now rejects the snapshot, pinned by a hooked-pool decoder
  test.
- The `velodrome_slipstreams` decoder had no tests; it gains a module covering its required
  attributes alongside the empty-snapshot assertion.

## Testing

Rebased onto 0.349.0 main. 150 targeted tests across the five protocols plus `tick_list`, clippy
(`-D warnings`) and fmt green; the 5 uniswap_v4 hook tests that need a node RPC were not run
locally and are untouched by this change. A 5-agent local review produced 14 findings, all
addressed; the new tests were verified to fail against the unfixed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
