### PR TITLE
fix(tycho-client): partial-aware BlockHistory linkage for flashblock reverts

### DIFF
--- a/crates/tycho-client/src/feed/block_history.rs
+++ b/crates/tycho-client/src/feed/block_history.rs
@@ -257,6 +257,11 @@ impl BlockHistory {
                     // if this is not a revert it means this block is delayed.
                     BlockPosition::Delayed
                 }
+            } else if block.revert && self.partial_at_height(block.number) {
+                // A revert to a block retained only as a mid-block partial: the revert carries
+                // the sealed hash, which an ephemeral partial hash can never match. Same height
+                // means same canonical block, so this is the expected forward update.
+                BlockPosition::NextExpected
             } else if block.is_partial() && !block.revert {
                 // A non-revert partial block at or below the tip whose hash is not in history is a
                 // superseded/delayed partial. Partials share a block number but carry ephemeral
@@ -291,6 +296,12 @@ impl BlockHistory {
         self.history
             .iter()
             .any(|b| &b.hash == h)
+    }
+
+    fn partial_at_height(&self, number: u64) -> bool {
+        self.history
+            .iter()
+            .any(|b| b.number == number && b.is_partial())
     }
 
     pub fn latest(&self) -> Option<&BlockHeader> {
@@ -709,6 +720,31 @@ mod test {
                 .determine_block_position(&incoming)
                 .unwrap(),
             expected
+        );
+    }
+
+    #[test]
+    fn test_revert_to_block_retained_as_partial_is_next_expected() {
+        // History retains block 9 only as a mid-block partial (ephemeral hash). A revert to
+        // sealed 9 cannot be found by hash but is the same canonical block by height.
+        let mut blocks = generate_blocks(2, 7, None); // full blocks 7, 8
+        blocks.push(partial_block(9, 2, int_hash(8)));
+        blocks.push(partial_block(10, 0, int_hash(9)));
+        let history = BlockHistory::new(blocks, 15).unwrap();
+
+        let revert = BlockHeader {
+            number: 9,
+            hash: int_hash(9),
+            parent_hash: int_hash(8),
+            revert: true,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            history
+                .determine_block_position(&revert)
+                .expect("must classify, not error"),
+            BlockPosition::NextExpected
         );
     }
 

--- a/crates/tycho-client/src/feed/block_history.rs
+++ b/crates/tycho-client/src/feed/block_history.rs
@@ -96,9 +96,18 @@ impl BlockHistory {
                     .iter()
                     .find(|b| b.hash == current_hash)
                     .or_else(|| {
-                        candidates
+                        let fallback = candidates
                             .iter()
-                            .find(|b| b.is_partial())
+                            .find(|b| b.is_partial());
+                        if let Some(b) = fallback {
+                            debug!(
+                                number = b.number,
+                                hash = ?b.hash,
+                                expected_parent = ?current_hash,
+                                "HistoryStitchHeightFallback"
+                            );
+                        }
+                        fallback
                     });
 
                 let Some(chosen) = chosen else { break };
@@ -149,21 +158,26 @@ impl BlockHistory {
                             .back()
                             .ok_or(BlockHistoryError::RevertPositionNotFound)?;
 
-                        if head.hash == block.parent_hash ||
-                            (!hash_findable &&
-                                head.is_partial() &&
-                                head.number + 1 == block.number)
-                        {
+                        if head.hash == block.parent_hash {
                             break;
-                        } else {
-                            let reverted_block = self
-                                .history
-                                .pop_back()
-                                .ok_or(BlockHistoryError::RevertPositionNotFound)?;
-                            // record reverted blocks in cache
-                            self.reverts
-                                .push(reverted_block.hash.clone(), reverted_block);
                         }
+                        if !hash_findable && head.is_partial() && head.number + 1 == block.number {
+                            debug!(
+                                revert_number = block.number,
+                                revert_parent = ?block.parent_hash,
+                                fork_number = head.number,
+                                fork_hash = ?head.hash,
+                                "RevertForkPointHeightFallback"
+                            );
+                            break;
+                        }
+                        let reverted_block = self
+                            .history
+                            .pop_back()
+                            .ok_or(BlockHistoryError::RevertPositionNotFound)?;
+                        // record reverted blocks in cache
+                        self.reverts
+                            .push(reverted_block.hash.clone(), reverted_block);
                     }
                 }
                 // This mirrors the drain loop's two exit conditions above, so it can never fail
@@ -302,6 +316,11 @@ impl BlockHistory {
                 // A revert to a block retained only as a mid-block partial: the revert carries
                 // the sealed hash, which an ephemeral partial hash can never match. Same height
                 // means same canonical block, so this is the expected forward update.
+                debug!(
+                    number = block.number,
+                    hash = ?block.hash,
+                    "RevertClassifiedByPartialHeight"
+                );
                 BlockPosition::NextExpected
             } else if block.is_partial() && !block.revert {
                 // A non-revert partial block at or below the tip whose hash is not in history is a

--- a/crates/tycho-client/src/feed/block_history.rs
+++ b/crates/tycho-client/src/feed/block_history.rs
@@ -64,27 +64,48 @@ impl BlockHistory {
             let mut current_hash = latest.parent_hash.clone();
             let mut current_number = latest.number;
 
-            // Find connected blocks in sequence
-            for block in history.iter().skip(1) {
-                // Skip duplicates or same-height forks. The input may contain overlapping blocks
-                // (e.g. when merging retained history with current stream headers on reinit).
+            // Find connected blocks in sequence, one height at a time.
+            let mut i = 1;
+            while i < history.len() {
+                let block = &history[i];
+                // Skip duplicates or same-height forks already consumed at a taller height. The
+                // input may contain overlapping blocks (e.g. when merging retained history with
+                // current stream headers on reinit).
                 if block.number >= current_number {
+                    i += 1;
                     continue;
                 }
                 // If we find a gap in block numbers, stop building the chain
                 if block.number != current_number - 1 {
                     break;
                 }
-                // Hash connection (preceding block is parent of current block). A partial at
-                // the parent height also connects: flashblock partials carry ephemeral hashes
-                // (only the last partial holds the sealed hash), so a child linking to the
-                // sealed hash can never hash-match a retained mid-block partial. Same height
-                // means same canonical block.
-                if block.hash == current_hash || block.is_partial() {
-                    connected_chain.push(block.clone());
-                    current_hash = block.parent_hash.clone();
-                    current_number = block.number;
-                }
+
+                // Consider every candidate at this height together, not just the first one
+                // encountered. A real hash match always wins: flashblock partials carry ephemeral
+                // hashes (only the last partial of a block holds the sealed hash), so a
+                // hash-matching full block must never be displaced by a same-height partial from
+                // a losing fork. Only fall back to a partial when no candidate at this height
+                // hash-matches — same height still means same canonical block.
+                let height = block.number;
+                let same_height_end = i + history[i..]
+                    .iter()
+                    .take_while(|b| b.number == height)
+                    .count();
+                let candidates = &history[i..same_height_end];
+                let chosen = candidates
+                    .iter()
+                    .find(|b| b.hash == current_hash)
+                    .or_else(|| {
+                        candidates
+                            .iter()
+                            .find(|b| b.is_partial())
+                    });
+
+                let Some(chosen) = chosen else { break };
+                connected_chain.push(chosen.clone());
+                current_hash = chosen.parent_hash.clone();
+                current_number = chosen.number;
+                i = same_height_end;
             }
         }
 
@@ -116,10 +137,10 @@ impl BlockHistory {
                     // down to it over stopping early at a same-height partial. Height is only a
                     // fallback for when the fork point is retained solely under an ephemeral
                     // mid-block partial hash, so it genuinely cannot be found by hash — that is
-                    // the crash case this fallback exists for. Gating on unfindability also
-                    // avoids misreading a real hash mismatch against a stale sibling partial (a
-                    // losing branch retained at the same height by BlockHistory::new's
-                    // height-based stitching) as a match.
+                    // the crash case this fallback exists for. The gate is defensive: it makes a
+                    // real hash match win whenever the fork point is findable at all. BlockHistory
+                    // keeps at most one entry per height, so there is no stale same-height sibling
+                    // for it to guard against in practice.
                     let hash_findable = self.hash_in_history(&block.parent_hash);
                     // keep removing the head until the new block fits
                     loop {
@@ -145,8 +166,11 @@ impl BlockHistory {
                         }
                     }
                 }
-                // Final sanity check against things going awfully wrong. Same rationale as the
-                // drain above: height is only accepted once a real hash match is ruled out.
+                // This mirrors the drain loop's two exit conditions above, so it can never fail
+                // today — `push` never returns having stopped anywhere else. It is a
+                // belt-and-braces check against future changes to that loop, not a live guard
+                // against a stale same-height sibling: BlockHistory retains at most one entry per
+                // height, so that state cannot arise.
                 if let Some(latest) = self.latest() {
                     let connects = latest.hash == block.parent_hash ||
                         (!self.hash_in_history(&block.parent_hash) &&
@@ -476,6 +500,46 @@ mod test {
             .map(|b| b.number)
             .collect();
         assert_eq!(retained, vec![7, 8, 9, 10], "ancestry must survive the ephemeral-hash break");
+    }
+
+    #[test]
+    fn test_new_prefers_hash_match_over_partial_at_same_height() {
+        // Regression: among several candidates at the same height, the connected-chain stitch
+        // used to accept the first one that either hash-matched or was a partial. Since stream
+        // headers are appended after retained history and the list is reversed, a same-height
+        // partial from a Delayed synchronizer's losing fork was examined before — and beat —
+        // the canonical hash-matching block, dropping the canonical block and all its ancestors.
+        let mut retained = generate_blocks(2, 323, None); // full 323, full 324
+        retained.push(partial_block(325, 2, int_hash(324))); // mid-block partial, ephemeral hash
+
+        // Stream headers merged in on reinit: the tip advanced via a partial parented on the
+        // sealed hash of 325, and a Delayed synchronizer still holds a losing-fork partial at
+        // 324's height. Appended after retained history, it is examined first once reversed —
+        // exactly the ordering that made the old first-match code pick it over canonical 324.
+        let mut input = retained;
+        input.push(partial_block(326, 0, int_hash(325)));
+        input.push(partial_block(324, 1, random_hash()));
+
+        let history = BlockHistory::new(input, 15).expect("failed to create history");
+
+        let retained: Vec<u64> = history
+            .blocks()
+            .map(|b| b.number)
+            .collect();
+        assert_eq!(
+            retained,
+            vec![323, 324, 325, 326],
+            "canonical 324 and its ancestor 323 must survive"
+        );
+        assert_eq!(
+            history
+                .blocks()
+                .find(|b| b.number == 324)
+                .unwrap()
+                .hash,
+            int_hash(324),
+            "the canonical full block must win, not the losing-fork partial"
+        );
     }
 
     #[test]

--- a/crates/tycho-client/src/feed/block_history.rs
+++ b/crates/tycho-client/src/feed/block_history.rs
@@ -119,7 +119,13 @@ impl BlockHistory {
                             .back()
                             .ok_or(BlockHistoryError::RevertPositionNotFound)?;
 
-                        if head.hash == block.parent_hash {
+                        // The fork point may be retained as a mid-block partial whose ephemeral
+                        // hash the revert's sealed parent hash can never match. Same height
+                        // means same canonical block, so a partial directly below the
+                        // reverted-to block is the fork point.
+                        if head.hash == block.parent_hash ||
+                            (head.is_partial() && head.number + 1 == block.number)
+                        {
                             break;
                         } else {
                             let reverted_block = self
@@ -132,12 +138,14 @@ impl BlockHistory {
                         }
                     }
                 }
-                // Final sanity check against things going awfully wrong.
-                if let Some(true) = self
-                    .latest()
-                    .map(|b| b.hash != block.parent_hash)
-                {
-                    return Err(BlockHistoryError::DetachedBlock);
+                // Final sanity check against things going awfully wrong. A partial fork point
+                // cannot hash-match (ephemeral hash), so it is accepted by height.
+                if let Some(latest) = self.latest() {
+                    let connects = latest.hash == block.parent_hash ||
+                        (latest.is_partial() && latest.number + 1 == block.number);
+                    if !connects {
+                        return Err(BlockHistoryError::DetachedBlock);
+                    }
                 }
                 // Push new block to history, marking it as latest.
                 debug!(
@@ -894,5 +902,36 @@ mod test {
         assert!(history
             .reverts
             .contains(&partial_1.hash));
+    }
+
+    #[test]
+    fn test_revert_drain_stops_at_partial_fork_point() {
+        // The fork point (block 9) is retained as a mid-block partial. A revert to block 10
+        // must drain down to it and re-push the reverted-to block, not exhaust the history.
+        let mut blocks = generate_blocks(2, 7, None); // full blocks 7, 8
+        blocks.push(partial_block(9, 2, int_hash(8)));
+        blocks.push(partial_block(10, 0, int_hash(9)));
+        let mut history = BlockHistory::new(blocks, 15).unwrap();
+
+        let revert = BlockHeader {
+            number: 10,
+            hash: int_hash(10),
+            parent_hash: int_hash(9),
+            revert: true,
+            ..Default::default()
+        };
+
+        history
+            .push(revert)
+            .expect("revert with a partial fork point must resolve");
+
+        let retained: Vec<u64> = history
+            .blocks()
+            .map(|b| b.number)
+            .collect();
+        assert_eq!(retained, vec![7, 8, 9, 10]);
+        let latest = history.latest().unwrap();
+        assert!(latest.revert);
+        assert!(!latest.is_partial());
     }
 }

--- a/crates/tycho-client/src/feed/block_history.rs
+++ b/crates/tycho-client/src/feed/block_history.rs
@@ -75,8 +75,12 @@ impl BlockHistory {
                 if block.number != current_number - 1 {
                     break;
                 }
-                // Check hash connection (preceeding block is parent of current block)
-                if block.hash == current_hash {
+                // Hash connection (preceding block is parent of current block). A partial at
+                // the parent height also connects: flashblock partials carry ephemeral hashes
+                // (only the last partial holds the sealed hash), so a child linking to the
+                // sealed hash can never hash-match a retained mid-block partial. Same height
+                // means same canonical block.
+                if block.hash == current_hash || block.is_partial() {
                     connected_chain.push(block.clone());
                     current_hash = block.parent_hash.clone();
                     current_number = block.number;
@@ -426,6 +430,24 @@ mod test {
         assert_eq!(history.history.len(), 4);
         assert_eq!(history.oldest().unwrap().number, 5);
         assert_eq!(history.latest().unwrap().number, 8);
+    }
+
+    #[test]
+    fn test_new_stitches_partial_parent_by_height() {
+        // Reinit merges retained history with stream headers. The child of a mid-block partial
+        // links to the sealed block hash, which the partial's ephemeral hash can never match —
+        // the chain must connect by height instead of dropping all ancestry.
+        let mut blocks = generate_blocks(2, 7, None); // full blocks 7, 8
+        blocks.push(partial_block(9, 2, int_hash(8))); // mid-block partial, ephemeral hash
+        blocks.push(partial_block(10, 0, int_hash(9))); // child linking to the sealed hash of 9
+
+        let history = BlockHistory::new(blocks, 15).expect("failed to create history");
+
+        let retained: Vec<u64> = history
+            .blocks()
+            .map(|b| b.number)
+            .collect();
+        assert_eq!(retained, vec![7, 8, 9, 10], "ancestry must survive the ephemeral-hash break");
     }
 
     #[test]

--- a/crates/tycho-client/src/feed/block_history.rs
+++ b/crates/tycho-client/src/feed/block_history.rs
@@ -112,6 +112,15 @@ impl BlockHistory {
                 // block (via parent hash) -> we are dealing with a
                 // revert.
                 if block.revert {
+                    // A real hash match anywhere in history is always preferred: prefer walking
+                    // down to it over stopping early at a same-height partial. Height is only a
+                    // fallback for when the fork point is retained solely under an ephemeral
+                    // mid-block partial hash, so it genuinely cannot be found by hash — that is
+                    // the crash case this fallback exists for. Gating on unfindability also
+                    // avoids misreading a real hash mismatch against a stale sibling partial (a
+                    // losing branch retained at the same height by BlockHistory::new's
+                    // height-based stitching) as a match.
+                    let hash_findable = self.hash_in_history(&block.parent_hash);
                     // keep removing the head until the new block fits
                     loop {
                         let head = self
@@ -119,12 +128,10 @@ impl BlockHistory {
                             .back()
                             .ok_or(BlockHistoryError::RevertPositionNotFound)?;
 
-                        // The fork point may be retained as a mid-block partial whose ephemeral
-                        // hash the revert's sealed parent hash can never match. Same height
-                        // means same canonical block, so a partial directly below the
-                        // reverted-to block is the fork point.
                         if head.hash == block.parent_hash ||
-                            (head.is_partial() && head.number + 1 == block.number)
+                            (!hash_findable &&
+                                head.is_partial() &&
+                                head.number + 1 == block.number)
                         {
                             break;
                         } else {
@@ -138,11 +145,13 @@ impl BlockHistory {
                         }
                     }
                 }
-                // Final sanity check against things going awfully wrong. A partial fork point
-                // cannot hash-match (ephemeral hash), so it is accepted by height.
+                // Final sanity check against things going awfully wrong. Same rationale as the
+                // drain above: height is only accepted once a real hash match is ruled out.
                 if let Some(latest) = self.latest() {
                     let connects = latest.hash == block.parent_hash ||
-                        (latest.is_partial() && latest.number + 1 == block.number);
+                        (!self.hash_in_history(&block.parent_hash) &&
+                            latest.is_partial() &&
+                            latest.number + 1 == block.number);
                     if !connects {
                         return Err(BlockHistoryError::DetachedBlock);
                     }

--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -1601,11 +1601,11 @@ mod tests {
         )
         .expect("reinit failed");
 
-        let oldest = new_history.oldest().unwrap();
-        assert!(
-            oldest.number <= 324,
-            "reinit rooted the history at the advanced partial, ancestry lost: oldest = {oldest}"
-        );
+        let retained: Vec<u64> = new_history
+            .blocks()
+            .map(|b| b.number)
+            .collect();
+        assert_eq!(retained, vec![323, 324, 325, 326]);
     }
 
     /// Full prod sequence behind the Base outages: partial-advanced reinit, the stream proceeds

--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -1654,6 +1654,18 @@ mod tests {
         new_history
             .push(revert)
             .expect("1-block revert after partial-advanced reinit must resolve");
+
+        // The drain must stop exactly at the retained partial fork point (325), not overshoot
+        // it or stop early at some other same-height block.
+        let retained: Vec<u64> = new_history
+            .blocks()
+            .map(|b| b.number)
+            .collect();
+        assert_eq!(retained, vec![323, 324, 325, 326]);
+        let latest = new_history.latest().unwrap();
+        assert_eq!(latest.number, 326);
+        assert!(latest.revert);
+        assert!(!latest.is_partial());
     }
 
     #[test(tokio::test)]

--- a/crates/tycho-client/src/feed/mod.rs
+++ b/crates/tycho-client/src/feed/mod.rs
@@ -1292,6 +1292,35 @@ mod tests {
         }
     }
 
+    /// Builds a partial block header with an ephemeral hash derived from number + partial index.
+    /// Flashblocks only carry the correct block hash on the last partial (`is_last_partial`), so
+    /// mid-block partials have hashes that no later header can link to.
+    fn partial_header(number: u64, partial_idx: u32, parent: u64) -> BlockHeader {
+        BlockHeader {
+            number,
+            hash: Bytes::from(
+                [number.to_be_bytes().as_slice(), partial_idx.to_be_bytes().as_slice()].concat(),
+            ),
+            parent_hash: Bytes::from(parent.to_be_bytes()),
+            revert: false,
+            timestamp: 1000,
+            partial_block_index: Some(partial_idx),
+        }
+    }
+
+    /// Builds the last partial of a block: still a partial, but carrying the sealed block hash
+    /// (same 8-byte scheme as `full_header`).
+    fn sealed_partial_header(number: u64, partial_idx: u32, parent: u64) -> BlockHeader {
+        BlockHeader {
+            number,
+            hash: Bytes::from(number.to_be_bytes()),
+            parent_hash: Bytes::from(parent.to_be_bytes()),
+            revert: false,
+            timestamp: 1000,
+            partial_block_index: Some(partial_idx),
+        }
+    }
+
     /// Builds a `SynchronizerStream` pinned to a given state, for exercising state-transition
     /// logic without a live synchronizer. The receiver is never polled by these tests.
     fn stream_in_state(name: &str, state: SynchronizerState) -> SynchronizerStream {
@@ -1531,6 +1560,100 @@ mod tests {
             vec![400],
             "detached advanced block must not be stitched to old history"
         );
+    }
+
+    /// Companion regression test for the same crash with a *partial* advanced block — the
+    /// variant actually running on Base (the only chain with `--partial-blocks`).
+    ///
+    /// The retained tip is a mid-block partial whose ephemeral hash differs from the sealed
+    /// block hash (flashblocks only carry the correct hash on the last partial). The advanced
+    /// partial of the next block links to the sealed hash, so the hash-based stitch in
+    /// `BlockHistory::new` cannot connect it to anything retained and the rebuilt history is
+    /// rooted at the advanced partial alone — every fork point below it is lost.
+    #[test]
+    fn test_reinit_preserves_history_for_partial_advanced_block() {
+        // Old history: sealed 323 -> sealed 324 -> mid-block partial of 325 (ephemeral hash).
+        let old_blocks = vec![
+            full_header(323, 323, 322),
+            full_header(324, 324, 323),
+            partial_header(325, 2, 324),
+        ];
+        let mut old_history = BlockHistory::new(old_blocks, BLOCK_HISTORY_SIZE).unwrap();
+
+        // A stream races ahead by one partial: first partial of 326, parented on the sealed
+        // hash of 325, which the history never saw. This is what classifies it Advanced.
+        let advanced = partial_header(326, 0, 325);
+        assert_eq!(
+            old_history
+                .determine_block_position(&advanced)
+                .unwrap(),
+            BlockPosition::Advanced
+        );
+
+        let mut streams = vec![
+            stream_in_state("aerodrome", SynchronizerState::Advanced(advanced)),
+            stream_in_state("uniswap_v3", SynchronizerState::Delayed(partial_header(325, 2, 324))),
+        ];
+
+        let new_history = BlockSynchronizer::<MockStateSync>::reinit_block_history(
+            &mut streams,
+            &mut old_history,
+        )
+        .expect("reinit failed");
+
+        let oldest = new_history.oldest().unwrap();
+        assert!(
+            oldest.number <= 324,
+            "reinit rooted the history at the advanced partial, ancestry lost: oldest = {oldest}"
+        );
+    }
+
+    /// Full prod sequence behind the Base outages: partial-advanced reinit, the stream proceeds
+    /// for one more block, then a shallow (1-block) revert arrives. The revert must resolve;
+    /// in prod it drained the whole history and killed the feed with "Reverting block's insert
+    /// position not found! History exceeded".
+    #[test]
+    fn test_revert_below_tip_resolves_after_partial_advanced_reinit() {
+        let old_blocks = vec![
+            full_header(323, 323, 322),
+            full_header(324, 324, 323),
+            partial_header(325, 2, 324),
+        ];
+        let mut old_history = BlockHistory::new(old_blocks, BLOCK_HISTORY_SIZE).unwrap();
+
+        let mut streams = vec![
+            stream_in_state("aerodrome", SynchronizerState::Advanced(partial_header(326, 0, 325))),
+            stream_in_state("uniswap_v3", SynchronizerState::Delayed(partial_header(325, 2, 324))),
+        ];
+
+        let mut new_history = BlockSynchronizer::<MockStateSync>::reinit_block_history(
+            &mut streams,
+            &mut old_history,
+        )
+        .expect("reinit failed");
+
+        // The stream proceeds normally: the last partial seals 326 with the correct hash, then
+        // the first partial of 327 arrives on top of it.
+        new_history
+            .push(sealed_partial_header(326, 5, 325))
+            .expect("sealed partial push failed");
+        new_history
+            .push(partial_header(327, 0, 326))
+            .expect("next partial push failed");
+
+        // The chain reorgs one block: revert to sealed 326. Its fork point is block 325, which
+        // the client saw (as a partial) and which the reinit must have retained.
+        let revert = BlockHeader {
+            number: 326,
+            hash: Bytes::from(326u64.to_be_bytes()),
+            parent_hash: Bytes::from(325u64.to_be_bytes()),
+            revert: true,
+            timestamp: 1000,
+            partial_block_index: None,
+        };
+        new_history
+            .push(revert)
+            .expect("1-block revert after partial-advanced reinit must resolve");
     }
 
     #[test(tokio::test)]


### PR DESCRIPTION
Flashblock partials carry ephemeral hashes. Only the last partial of a block carries the sealed
block hash (`sf.substreams.rpc.v2.BlockScopedData`). `BlockHistory` linked blocks by hash only.
When history retained a mid-block partial, three things broke: the connected-chain build in
`BlockHistory::new` could not stitch across it, so a reinit after an `Advanced` partial rooted the
new history at that partial and dropped all ancestry; `determine_block_position` could not find a
revert's fork point; and the revert drain in `push` emptied the deque looking for it. The error
propagates out of `BlockSynchronizer::handle_next_message`, which tears down the feed for every
extractor at once. That is the Base outage, about 20 times a day.

A partial at height H is now the same canonical block as any header at height H. Hash matching
still wins wherever a hash match exists: the stitch searches all candidates at a height for a hash
match before it accepts a partial, and the drain takes the height fallback only when the fork point
is not findable by hash. Full blocks still need a hash match, so a genuine gap or a detached
restart still roots the history at the advanced block.

Supersedes f1d7cee3d, which preserved the retained history across reinit but left it unconnectable.
Its regression test used a full block, so the partial path stayed untested.

Not verified against prod traffic. Six tests cover it, including two that replay the logged prod
sequence end to end: partial advanced block, reinit, then a shallow revert.

Base is the only chain running `--partial-blocks` today. Any chain that enables flashblocks
inherits the bug, so this needs a release before the next one does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)