### PR TITLE
feat: add HTTP/1 RPC mode to Tycho client

### DIFF
--- a/crates/tycho-client/src/rpc.rs
+++ b/crates/tycho-client/src/rpc.rs
@@ -1278,7 +1278,21 @@ pub struct HttpRPCClient {
 }
 
 impl HttpRPCClient {
+    /// Creates a client that uses HTTP/2 prior knowledge.
     pub fn new(base_uri: &str, options: HttpRPCClientOptions) -> Result<Self, RPCError> {
+        Self::new_with_http_version(base_uri, options, false)
+    }
+
+    /// Creates a client that uses HTTP/1 instead of HTTP/2 prior knowledge.
+    pub fn new_http1_only(base_uri: &str, options: HttpRPCClientOptions) -> Result<Self, RPCError> {
+        Self::new_with_http_version(base_uri, options, true)
+    }
+
+    fn new_with_http_version(
+        base_uri: &str,
+        options: HttpRPCClientOptions,
+        http1_only: bool,
+    ) -> Result<Self, RPCError> {
         let uri = base_uri
             .parse::<Url>()
             .map_err(|e| RPCError::UrlParsing(base_uri.to_string(), e.to_string()))?;
@@ -1314,9 +1328,12 @@ impl HttpRPCClient {
             headers.insert(header::HeaderName::from_static(CLIENT_METADATA_HEADER), value);
         }
 
-        let mut client_builder = ClientBuilder::new()
-            .default_headers(headers)
-            .http2_prior_knowledge();
+        let client_builder = ClientBuilder::new().default_headers(headers);
+        let mut client_builder = if http1_only {
+            client_builder.http1_only()
+        } else {
+            client_builder.http2_prior_knowledge()
+        };
 
         // When compression is disabled, turn off all automatic compression
         if !options.compression {
@@ -1991,6 +2008,10 @@ mod tests {
 
     use mockito::Server;
     use rstest::rstest;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
     use tycho_common::models::blockchain::AddressStorageLocation;
 
     use super::*;
@@ -2054,6 +2075,84 @@ mod tests {
             }
         }
         "#;
+
+    async fn start_http1_only_server() -> (String, tokio::task::JoinHandle<[u8; 24]>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind HTTP/1.1 test server");
+        let address = listener
+            .local_addr()
+            .expect("get HTTP/1.1 test server address");
+        let handle = tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("accept test connection");
+            let mut prefix = [0_u8; 24];
+            stream
+                .read_exact(&mut prefix)
+                .await
+                .expect("read request prefix");
+
+            if prefix.starts_with(b"POST ") {
+                let body =
+                    r#"{"protocol_systems":[],"pagination":{"page":0,"page_size":20,"total":0}}"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .await
+                    .expect("write HTTP/1.1 response");
+            }
+
+            prefix
+        });
+
+        (format!("http://{address}"), handle)
+    }
+
+    #[tokio::test]
+    async fn test_default_cleartext_client_rejects_http1_only_server() {
+        let (url, request) = start_http1_only_server().await;
+        let client = HttpRPCClient::new(&url, HttpRPCClientOptions::default())
+            .expect("create default client")
+            .with_test_backoff_policy();
+
+        let result = client
+            .get_protocol_systems(ProtocolSystemsParams::new(Chain::Ethereum))
+            .await;
+
+        assert!(result.is_err(), "default cleartext client must retain h2c prior knowledge");
+        assert_eq!(
+            request
+                .await
+                .expect("HTTP/1.1 test server task"),
+            *b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_http1_only_client_works_with_http1_only_server() {
+        let (url, request) = start_http1_only_server().await;
+        let client = HttpRPCClient::new_http1_only(&url, HttpRPCClientOptions::default())
+            .expect("create HTTP/1-only client");
+
+        let result = client
+            .get_protocol_systems(ProtocolSystemsParams::new(Chain::Ethereum))
+            .await;
+
+        assert!(result.is_ok(), "HTTP/1-only client must support an HTTP/1.1-only service");
+        assert!(
+            request
+                .await
+                .expect("HTTP/1.1 test server task")
+                .starts_with(b"POST "),
+            "HTTP/1-only client must send an HTTP/1.1 request"
+        );
+    }
 
     #[rstest]
     #[case::string_input(vec![

--- a/crates/tycho-client/src/stream.rs
+++ b/crates/tycho-client/src/stream.rs
@@ -23,7 +23,7 @@ use crate::{
         component_tracker::ComponentFilter, synchronizer::ProtocolStateSynchronizer, BlockHeader,
         BlockSynchronizer, BlockSynchronizerError, FeedMessage,
     },
-    rpc::{HttpRPCClientOptions, ProtocolSystemsParams, RPCClient},
+    rpc::{HttpRPCClientOptions, ProtocolSystemsParams, RPCClient, RPCError},
     HttpRPCClient, WsDeltasClient,
 };
 
@@ -86,6 +86,7 @@ pub struct TychoStreamBuilder {
     no_tls: bool,
     include_tvl: bool,
     compression: bool,
+    http1_only: bool,
     partial_blocks: bool,
     max_messages: Option<usize>,
     client_metadata: HashMap<String, String>,
@@ -118,6 +119,7 @@ impl TychoStreamBuilder {
             no_tls: true,
             include_tvl: false,
             compression: true,
+            http1_only: false,
             partial_blocks: false,
             max_messages: None,
             client_metadata: HashMap::new(),
@@ -258,6 +260,14 @@ impl TychoStreamBuilder {
         self
     }
 
+    /// Configures HTTP RPC requests to use HTTP/1 only instead of the default HTTP/2 mode.
+    ///
+    /// This setting does not affect the WebSocket connection.
+    pub fn http1_only(mut self, http1_only: bool) -> Self {
+        self.http1_only = http1_only;
+        self
+    }
+
     /// Enables the client to receive partial block updates (flashblocks).
     pub fn enable_partial_blocks(mut self) -> Self {
         self.partial_blocks = true;
@@ -288,6 +298,23 @@ impl TychoStreamBuilder {
     pub fn blocklisted_ids(mut self, ids: impl IntoIterator<Item = String>) -> Self {
         self.blocklisted_ids.extend(ids);
         self
+    }
+
+    fn rpc_client(
+        &self,
+        rpc_url: &str,
+        auth_key: Option<String>,
+        metadata_header: Option<String>,
+    ) -> Result<HttpRPCClient, RPCError> {
+        let options = HttpRPCClientOptions::new()
+            .with_auth_key(auth_key)
+            .with_compression(self.compression)
+            .with_client_metadata_header(metadata_header);
+        if self.http1_only {
+            HttpRPCClient::new_http1_only(rpc_url, options)
+        } else {
+            HttpRPCClient::new(rpc_url, options)
+        }
     }
 
     /// Builds and starts the Tycho client, connecting to the Tycho server and
@@ -347,14 +374,9 @@ impl TychoStreamBuilder {
         }
         .map_err(|e| StreamError::SetUpError(e.to_string()))?
         .with_client_metadata_header(metadata_header.clone());
-        let rpc_client = HttpRPCClient::new(
-            &tycho_rpc_url,
-            HttpRPCClientOptions::new()
-                .with_auth_key(auth_key)
-                .with_compression(self.compression)
-                .with_client_metadata_header(metadata_header),
-        )
-        .map_err(|e| StreamError::SetUpError(e.to_string()))?;
+        let rpc_client = self
+            .rpc_client(&tycho_rpc_url, auth_key, metadata_header)
+            .map_err(|e| StreamError::SetUpError(e.to_string()))?;
         let ws_jh = ws_client
             .connect()
             .await
@@ -533,7 +555,46 @@ impl ProtocolSystemsInfo {
 
 #[cfg(test)]
 mod tests {
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
+
     use super::*;
+
+    async fn start_http1_only_server() -> (String, tokio::task::JoinHandle<[u8; 24]>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind HTTP/1.1 test server");
+        let address = listener
+            .local_addr()
+            .expect("get HTTP/1.1 test server address");
+        let handle = tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("accept test connection");
+            let mut prefix = [0_u8; 24];
+            stream
+                .read_exact(&mut prefix)
+                .await
+                .expect("read request prefix");
+            let body =
+                r#"{"protocol_systems":[],"pagination":{"page":0,"page_size":20,"total":0}}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("write HTTP/1.1 response");
+            prefix
+        });
+
+        (format!("http://{address}"), handle)
+    }
 
     #[test]
     fn test_validate_chain_config_errors_on_broken_file() {
@@ -597,6 +658,29 @@ mod tests {
         let builder = TychoStreamBuilder::new("localhost:4242", Chain::Ethereum);
         assert!(builder.compression, "Compression should be enabled by default.");
         assert!(!builder.partial_blocks, "partial_blocks should be disabled by default.");
+        assert!(!builder.http1_only, "HTTP/1-only RPC should be disabled by default.");
+    }
+
+    #[tokio::test]
+    async fn test_stream_builder_enables_http1_only_rpc() {
+        let (url, request) = start_http1_only_server().await;
+        let builder = TychoStreamBuilder::new("localhost:4242", Chain::Ethereum).http1_only(true);
+        let client = builder
+            .rpc_client(&url, None, None)
+            .expect("create HTTP/1-only stream RPC client");
+
+        let result = client
+            .get_protocol_systems(ProtocolSystemsParams::new(Chain::Ethereum))
+            .await;
+
+        assert!(result.is_ok(), "stream builder must propagate HTTP/1-only to RPC snapshots");
+        assert!(
+            request
+                .await
+                .expect("HTTP/1.1 test server task")
+                .starts_with(b"POST "),
+            "stream RPC client must send an HTTP/1.1 request"
+        );
     }
 
     #[tokio::test]

--- a/crates/tycho-simulation/src/evm/stream.rs
+++ b/crates/tycho-simulation/src/evm/stream.rs
@@ -494,6 +494,16 @@ impl ProtocolStreamBuilder {
         self
     }
 
+    /// Configures HTTP RPC requests to use HTTP/1 only instead of the default HTTP/2 mode.
+    ///
+    /// This setting does not affect the WebSocket connection.
+    pub fn http1_only(mut self, http1_only: bool) -> Self {
+        self.stream_builder = self
+            .stream_builder
+            .http1_only(http1_only);
+        self
+    }
+
     /// Enables partial block updates (flashblocks).
     pub fn enable_partial_blocks(mut self) -> Self {
         self.stream_builder = self
@@ -914,13 +924,78 @@ fn inject_native_wrapper(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, time::Duration};
 
     use futures::{stream, StreamExt};
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+        sync::oneshot,
+    };
     use tycho_common::models::Chain;
 
     use super::*;
-    use crate::protocol::models::Update;
+    use crate::{evm::protocol::uniswap_v2::state::UniswapV2State, protocol::models::Update};
+
+    async fn start_http1_stream_server() -> (String, oneshot::Receiver<[u8; 24]>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind stream test server");
+        let address = listener
+            .local_addr()
+            .expect("get stream test server address");
+        let (request_tx, request_rx) = oneshot::channel();
+
+        tokio::spawn(async move {
+            let mut request_tx = Some(request_tx);
+            while let Ok((mut stream, _)) = listener.accept().await {
+                let mut method = [0_u8; 4];
+                while stream
+                    .peek(&mut method)
+                    .await
+                    .expect("peek stream request") <
+                    method.len()
+                {
+                    tokio::task::yield_now().await;
+                }
+
+                if &method == b"GET " {
+                    tokio::spawn(async move {
+                        let _connection = tokio_tungstenite::accept_async(stream)
+                            .await
+                            .expect("accept WebSocket connection");
+                        futures::future::pending::<()>().await;
+                    });
+                    continue;
+                }
+
+                let mut prefix = [0_u8; 24];
+                stream
+                    .read_exact(&mut prefix)
+                    .await
+                    .expect("read RPC request prefix");
+                let body =
+                    r#"{"protocol_systems":[],"pagination":{"page":0,"page_size":20,"total":0}}"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .await
+                    .expect("write RPC response");
+                request_tx
+                    .take()
+                    .expect("receive only one RPC request")
+                    .send(prefix)
+                    .expect("send RPC request prefix");
+                break;
+            }
+        });
+
+        (address.to_string(), request_rx)
+    }
 
     fn empty_update(block: u64) -> Update {
         Update::new(block, HashMap::new(), HashMap::new())
@@ -980,6 +1055,26 @@ mod tests {
         let (_builder, controller) = builder.with_step_controller();
         // The controller was successfully returned — verifying the public API is callable.
         drop(controller);
+    }
+
+    #[tokio::test]
+    async fn test_protocol_stream_builder_forwards_http1_only_rpc() {
+        let (address, request) = start_http1_stream_server().await;
+        let builder = ProtocolStreamBuilder::new(&address, Chain::Ethereum)
+            .http1_only(true)
+            .exchange::<UniswapV2State>("uniswap_v2", ComponentFilter::Ids(Vec::new()), None);
+        let build = builder.build();
+        tokio::pin!(build);
+
+        let prefix = tokio::select! {
+            request = request => request.expect("receive RPC request prefix"),
+            _ = &mut build => panic!("stream build ended before RPC request"),
+            _ = tokio::time::sleep(Duration::from_secs(2)) => {
+                panic!("timed out waiting for stream RPC request")
+            }
+        };
+
+        assert!(prefix.starts_with(b"POST "), "protocol stream RPC must use HTTP/1.1");
     }
 
     /// Connects to a live Tycho instance, verifies that the stream blocks until


### PR DESCRIPTION
## Summary
- Add an explicit HTTP/1-only constructor for Tycho RPC clients.
- Propagate the opt-in through `TychoStreamBuilder` and `ProtocolStreamBuilder`.
- Preserve the existing h2c/HTTP/2-prior-knowledge default and unchanged WebSocket handling.

## Why
Fynd configured with `--disable-tls` must use the in-cluster nginx auth proxy on port 80. That proxy accepts HTTP/1.1, while Tycho RPC clients currently send an h2c prior-knowledge preface. Fynd derives RPC and WebSocket URLs from the same host and port, so a separate h2c-only proxy listener would break the ordinary HTTP/1.1 WebSocket upgrade. This opt-in keeps both paths compatible with the existing proxy.

## Validation
- `cargo test -p tycho-client --lib` — 148 passed, 1 ignored
- `cargo test -p tycho-simulation --lib evm::stream::tests` — 3 passed, 1 ignored
- `cargo clippy -p tycho-client -p tycho-simulation --all-targets --all-features -- -D warnings` — passed
- `cargo +nightly fmt --all -- --check` — passed
- Interactive Claude Code review — APPROVE; focused tests repeated 70 times with 0 failures

## Compatibility
`HttpRPCClientOptions` is unchanged. New APIs are additive; the default remains h2c.