### PR TITLE
feat: Point ekubo_v3 at the redeployed executor

### DIFF
--- a/crates/tycho-execution/config/executor_addresses.json
+++ b/crates/tycho-execution/config/executor_addresses.json
@@ -16,7 +16,7 @@
     "fluid_v1": "0xAB081CBB3c88219A030928Ece277feAd99cAB742",
     "rocketpool": "0xDa551e2AA856101ea172F0F6eFE25bF27DfdF9e0",
     "erc4626": "0xeE2452ce461EA71e15F06aF8055FFAAd4B7B90ae",
-    "ekubo_v3": "0xc77A1a9B8ebecc6bFB386720E0A37Bc900860f5b",
+    "ekubo_v3": "0xD58B803DBE049903f3C1aDaacc2D82e9e514647C",
     "native_wrapper": "0x8FD892DD5F8E153fe15cc3A7567E18ed6f7b1E0A",
     "rfq:liquorice": "0x81c7febeed3fd67a5fdcf892d43489091caeb186",
     "vm:fermiswap": "0xe2c352232127AfC9803e7eD79F129E458B20925e",


### PR DESCRIPTION
The executor at `0xc77A1a9B…` cannot parse a SignedExclusiveSwap hop. It reads the signature tail as another hop, derives a token address from those bytes, and the router reverts on the `balanceOf` call to that address. The redeployed executor walks the tail by its embedded `sigLen`.

New address: `0xD58B803DBE049903f3C1aDaacc2D82e9e514647C`, deployed on Ethereum mainnet.

The router still needs `setExecutors([0xD58B803D…])` before exclusive Ekubo routes execute. That call waits on the timelock, which passes Monday.

Split out of #1262 so that PR does not wait on the timelock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)