### PR TITLE
chore(ekubo-v3): sync package version to 0.2.1

### DIFF
--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-ekubo-v3"
-version = "0.1.2"
+version = "0.2.1"
 dependencies = [
  "alloy-primitives",
  "anyhow",

--- a/protocols/substreams/ethereum-ekubo-v3/CHANGELOG.md
+++ b/protocols/substreams/ethereum-ekubo-v3/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.2.1
+
+- Align the `Cargo.toml` package version with the `substreams.yaml` manifest
+  version, which has been `v0.2.1` since the CI fix. No behavior change.
+
 ## v0.1.3
 
 - Replace the `SIGNED_EXCLUSIVE_SWAP_ADDRESS` placeholder with the deployed

--- a/protocols/substreams/ethereum-ekubo-v3/Cargo.toml
+++ b/protocols/substreams/ethereum-ekubo-v3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-ekubo-v3"
-version = "0.1.3"
+version = "0.2.1"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
`protocols/substreams/ethereum-ekubo-v3/Cargo.toml` was at `0.1.3` while `substreams.yaml` has shipped `v0.2.1` since the substreams CI fix (2a25b64ed). `protocols/substreams/Cargo.lock` was staler still at `0.1.2`.

This sets all three to `0.2.1`, matching the version deployed via helm, and adds a CHANGELOG entry. No code changes.

Note: `ethereum-ekubo-v2` has the same kind of drift in the opposite direction (Cargo.toml `0.2.1`, substreams.yaml `v0.2.0`) — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)