### PR TITLE
fix(rfq): surface why the Bebop WebSocket closes

### DIFF
--- a/crates/tycho-simulation/src/rfq/protocols/bebop/client.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/bebop/client.rs
@@ -418,8 +418,11 @@ impl RFQClient for BebopClient {
                                 }
                             }
                         }
-                        Ok(Message::Close(_)) => {
-                            info!("WebSocket connection closed by server");
+                        Ok(Message::Close(frame)) => {
+                            match frame {
+                                Some(frame) => warn!("WebSocket closed by server: {frame}"),
+                                None => warn!("WebSocket closed by server without a close frame"),
+                            }
                             break;
                         }
                         Err(e) => {

--- a/crates/tycho-simulation/src/rfq/protocols/bebop/client.rs
+++ b/crates/tycho-simulation/src/rfq/protocols/bebop/client.rs
@@ -280,8 +280,8 @@ impl RFQClient for BebopClient {
 
         Box::pin(async_stream::stream! {
             let mut current_components: HashMap<String, ComponentWithState> = HashMap::new();
-            let mut reconnect_attempts = 0;
-            const MAX_RECONNECT_ATTEMPTS: u32 = 10;
+            let mut consecutive_failures = 0;
+            const MAX_CONSECUTIVE_FAILURES: u32 = 10;
 
             loop {
                 let request = Request::builder()
@@ -300,19 +300,18 @@ impl RFQClient for BebopClient {
                 let (ws_stream, _) = match connect_async_with_config(request, None, false).await {
                     Ok(connection) => {
                         info!("Successfully connected to Bebop WebSocket");
-                        reconnect_attempts = 0; // Reset counter on successful connection
                         connection
                     },
                     Err(e) => {
-                        reconnect_attempts += 1;
-                        error!("Failed to connect to Bebop WebSocket (attempt {}): {}", reconnect_attempts, e);
+                        consecutive_failures += 1;
+                        error!("Failed to connect to Bebop WebSocket (consecutive failure {}): {}", consecutive_failures, e);
 
-                        if reconnect_attempts >= MAX_RECONNECT_ATTEMPTS {
-                            yield Err(RFQError::ConnectionError(format!("Failed to connect after {MAX_RECONNECT_ATTEMPTS} attempts: {e}")));
+                        if consecutive_failures >= MAX_CONSECUTIVE_FAILURES {
+                            yield Err(RFQError::ConnectionError(format!("Failed to connect after {MAX_CONSECUTIVE_FAILURES} consecutive failures: {e}")));
                             return;
                         }
 
-                        let backoff_duration = Duration::from_secs(2_u64.pow(reconnect_attempts.min(5)));
+                        let backoff_duration = Duration::from_secs(2_u64.pow(consecutive_failures.min(5)));
                         info!("Retrying connection in {} seconds...", backoff_duration.as_secs());
                         sleep(backoff_duration).await;
                         continue;
@@ -327,6 +326,10 @@ impl RFQClient for BebopClient {
                         Ok(Message::Binary(data)) => {
                             match BebopPricingUpdate::decode(&data[..]) {
                                 Ok(protobuf_update) => {
+                                    // A completed handshake says nothing about whether the
+                                    // connection works, so only pricing data clears the counter.
+                                    consecutive_failures = 0;
+
                                     let mut new_components = HashMap::new();
 
                                     // Process all pairs directly from protobuf
@@ -433,15 +436,16 @@ impl RFQClient for BebopClient {
                     }
                 }
 
-                // If we're here, the message loop exited - always attempt to reconnect
-                reconnect_attempts += 1;
-                if reconnect_attempts >= MAX_RECONNECT_ATTEMPTS {
-                    yield Err(RFQError::ConnectionError(format!("Connection failed after {MAX_RECONNECT_ATTEMPTS} attempts")));
+                // If we're here, the message loop exited - always attempt to reconnect.
+                // Pricing data resets this, so it only grows while the feed stays unusable.
+                consecutive_failures += 1;
+                if consecutive_failures >= MAX_CONSECUTIVE_FAILURES {
+                    yield Err(RFQError::ConnectionError(format!("No pricing data received after {MAX_CONSECUTIVE_FAILURES} consecutive failures")));
                     return;
                 }
 
-                let backoff_duration = Duration::from_secs(2_u64.pow(reconnect_attempts.min(5)));
-                info!("Reconnecting in {} seconds (attempt {})...", backoff_duration.as_secs(), reconnect_attempts);
+                let backoff_duration = Duration::from_secs(2_u64.pow(consecutive_failures.min(5)));
+                info!("Reconnecting in {} seconds (consecutive failure {})...", backoff_duration.as_secs(), consecutive_failures);
                 sleep(backoff_duration).await;
                 // Continue to the next iteration of the main loop
             }


### PR DESCRIPTION
## Close reason

The Bebop client logged `WebSocket connection closed by server` and discarded the close frame, hiding the reason the server gave. It now logs the frame, at `warn` level since a server-initiated close stops the price feed:

```
WebSocket closed by server: Superseded by newer standard protobuf pricing connection. (1000)
```

That reason is what Bebop sends when a second connection authenticates with the same API key — it permits only one pricing connection per key and closes the older one. Two consumers sharing a key therefore flap indefinitely, since both reconnect. Without the reason in the log that is indistinguishable from a transient network drop, which is why the reconnect loop reported against Fynd could not be diagnosed from its logs.

## Retry counter

The retry counter was reset on a completed handshake, which says nothing about whether the connection works. A connection that Bebop accepts and then closes reset it every cycle, so backoff stayed at 2s forever, the log reported `attempt 1` on every reconnect, and the cap was unreachable. It is now reset on the first decoded pricing message and renamed to `consecutive_failures`, since it counts both failed handshakes and connections that delivered nothing.

## Verification

Reproduced and checked against the live Bebop feed on Ethereum. Every connection using our shared test key is superseded within 0–2.2s, and backoff now escalates (2s, 4s, 8s) instead of staying at 2s.

Note this does not make a flapping feed terminate with an error: a cycle that delivers one message before being superseded resets the counter, so the cap only trips for connections that deliver nothing at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)