### PR TITLE
feat: add /v1/version endpoint to tycho-indexer

### DIFF
--- a/crates/tycho-common/src/dto.rs
+++ b/crates/tycho-common/src/dto.rs
@@ -1654,6 +1654,11 @@ pub enum Health {
     NotReady(String),
 }
 
+#[derive(Debug, Serialize, Deserialize, ToSchema, PartialEq, Eq, Clone)]
+pub struct AppVersion {
+    pub version: String,
+}
+
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, ToSchema, Eq, Hash, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ProtocolSystemsRequestBody {

--- a/crates/tycho-indexer/src/services/api_docs.rs
+++ b/crates/tycho-indexer/src/services/api_docs.rs
@@ -1,13 +1,13 @@
 use tycho_common::dto::{
-    AccountOverrides, AccountUpdate, BlockParam, Chain, ChangeType, ComponentTvlRequestBody,
-    ComponentTvlRequestResponse, ContractId, EntryPoint, EntryPointWithTracingParams, Health,
-    PaginationParams, PaginationResponse, ProtocolComponent, ProtocolComponentRequestResponse,
-    ProtocolComponentsRequestBody, ProtocolId, ProtocolStateDelta, ProtocolStateRequestBody,
-    ProtocolStateRequestResponse, ProtocolSystemsRequestBody, ProtocolSystemsRequestResponse,
-    RPCTracerParams, ResponseAccount, ResponseProtocolState, ResponseToken, StateRequestBody,
-    StateRequestResponse, StorageOverride, TokensRequestBody, TokensRequestResponse,
-    TracedEntryPointRequestBody, TracedEntryPointRequestResponse, TracingParams, TracingResult,
-    VersionParam,
+    AccountOverrides, AccountUpdate, AppVersion, BlockParam, Chain, ChangeType,
+    ComponentTvlRequestBody, ComponentTvlRequestResponse, ContractId, EntryPoint,
+    EntryPointWithTracingParams, Health, PaginationParams, PaginationResponse, ProtocolComponent,
+    ProtocolComponentRequestResponse, ProtocolComponentsRequestBody, ProtocolId,
+    ProtocolStateDelta, ProtocolStateRequestBody, ProtocolStateRequestResponse,
+    ProtocolSystemsRequestBody, ProtocolSystemsRequestResponse, RPCTracerParams, ResponseAccount,
+    ResponseProtocolState, ResponseToken, StateRequestBody, StateRequestResponse, StorageOverride,
+    TokensRequestBody, TokensRequestResponse, TracedEntryPointRequestBody,
+    TracedEntryPointRequestResponse, TracingParams, TracingResult, VersionParam,
 };
 use utoipa::{
     openapi::security::{ApiKey, ApiKeyValue, SecurityScheme},
@@ -36,6 +36,7 @@ impl Modify for SecurityAddon {
     info(title = "Tycho-Indexer RPC",),
     paths(
         rpc::health,
+        rpc::version,
         rpc::protocol_systems,
         rpc::tokens,
         rpc::protocol_components,
@@ -70,6 +71,7 @@ impl Modify for SecurityAddon {
         schemas(ChangeType),
         schemas(ProtocolStateDelta),
         schemas(Health),
+        schemas(AppVersion),
         schemas(ProtocolSystemsRequestBody),
         schemas(ProtocolSystemsRequestResponse),
         schemas(ComponentTvlRequestBody),

--- a/crates/tycho-indexer/src/services/mod.rs
+++ b/crates/tycho-indexer/src/services/mod.rs
@@ -256,6 +256,10 @@ where
                         .route(web::get().to(rpc::health)),
                 )
                 .service(
+                    web::resource(format!("/{}/version", self.prefix))
+                        .route(web::get().to(rpc::version)),
+                )
+                .service(
                     web::resource(format!("/{}/protocol_systems", self.prefix))
                         .route(web::post().to(rpc::protocol_systems::<G, EVMEntrypointService>)),
                 )

--- a/crates/tycho-indexer/src/services/rpc.rs
+++ b/crates/tycho-indexer/src/services/rpc.rs
@@ -1508,6 +1508,23 @@ pub async fn health() -> Result<HttpResponse, RpcError> {
     Ok(HttpResponse::Ok().json(dto::Health::Ready))
 }
 
+/// Version endpoint
+///
+/// This endpoint returns the application version.
+#[utoipa::path(
+    get,
+    path = "/v1/version",
+    responses(
+        (status = 200, description = "OK", body=AppVersion),
+    ),
+    security(
+         ("apiKey" = [])
+    )
+)]
+pub async fn version() -> Result<HttpResponse, RpcError> {
+    Ok(HttpResponse::Ok().json(dto::AppVersion { version: env!("CARGO_PKG_VERSION").to_string() }))
+}
+
 #[cfg(test)]
 // mockall::mock! parses method signatures as tokens and does not apply lifetime
 // elision, so the mocked trait methods need explicit lifetime parameters.
@@ -3416,5 +3433,20 @@ plans:
         } else {
             assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
         }
+    }
+
+    #[actix_web::test]
+    async fn test_version() {
+        let app = test::init_service(App::new().route("/v1/version", web::get().to(version))).await;
+
+        let req = test::TestRequest::get()
+            .uri("/v1/version")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+
+        let body: dto::AppVersion = test::read_body_json(resp).await;
+        assert_eq!(body.version, env!("CARGO_PKG_VERSION"));
     }
 }


### PR DESCRIPTION
- Add AppVersion DTO with OpenAPI schema support
- Add GET /v1/version handler returning CARGO_PKG_VERSION
- Register route and OpenAPI path/schema
- Add focused endpoint unit test