### PR TITLE
feat(sushiswap-v2): add Base and Arbitrum manifests

### DIFF
--- a/protocols/substreams/Cargo.lock
+++ b/protocols/substreams/Cargo.lock
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-uniswap-v2"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "ethabi 18.0.0",

--- a/protocols/substreams/ethereum-uniswap-v2/CHANGELOG.md
+++ b/protocols/substreams/ethereum-uniswap-v2/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.3
+
+- Add the Base and Arbitrum SushiSwap V2 manifests.
+
 ## v0.3.2
 
 - Add the Robinhood Chain Uniswap V2 manifest.

--- a/protocols/substreams/ethereum-uniswap-v2/Cargo.toml
+++ b/protocols/substreams/ethereum-uniswap-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-uniswap-v2"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 
 [lib]

--- a/protocols/substreams/ethereum-uniswap-v2/arbitrum-sushiswap-v2.yaml
+++ b/protocols/substreams/ethereum-uniswap-v2/arbitrum-sushiswap-v2.yaml
@@ -1,0 +1,49 @@
+specVersion: v0.1.0
+package:
+  name: "arbitrum_sushiswap_v2"
+  version: v0.3.3
+  url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v2"
+
+protobuf:
+  files:
+    - tycho/evm/v1/common.proto
+    - uniswap.proto
+  importPaths:
+    - ./proto/v1
+    - ../../../proto/
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v2.wasm
+
+modules:
+  - name: map_pools_created
+    kind: map
+    initialBlock: 70
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+  - name: store_pools
+    kind: store
+    initialBlock: 70
+    updatePolicy: set_if_not_exists
+    valueType: proto:tycho.evm.uniswap.v2.Pool
+    inputs:
+      - map: map_pools_created
+
+  - name: map_pool_events
+    kind: map
+    initialBlock: 70
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - map: map_pools_created
+      - store: store_pools
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+params:
+  map_pools_created: factory_address=c35DADB65012eC5796536bD9864eD8773aBc74C4&protocol_type_name=sushiswap_v2_pool

--- a/protocols/substreams/ethereum-uniswap-v2/base-sushiswap-v2.yaml
+++ b/protocols/substreams/ethereum-uniswap-v2/base-sushiswap-v2.yaml
@@ -1,0 +1,49 @@
+specVersion: v0.1.0
+package:
+  name: "base_sushiswap_v2"
+  version: v0.3.3
+  url: "https://github.com/propeller-heads/tycho-protocol-sdk/tree/main/substreams/ethereum-uniswap-v2"
+
+protobuf:
+  files:
+    - tycho/evm/v1/common.proto
+    - uniswap.proto
+  importPaths:
+    - ./proto/v1
+    - ../../../proto/
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ../target/wasm32-unknown-unknown/release/ethereum_uniswap_v2.wasm
+
+modules:
+  - name: map_pools_created
+    kind: map
+    initialBlock: 2631214
+    inputs:
+      - params: string
+      - source: sf.ethereum.type.v2.Block
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+  - name: store_pools
+    kind: store
+    initialBlock: 2631214
+    updatePolicy: set_if_not_exists
+    valueType: proto:tycho.evm.uniswap.v2.Pool
+    inputs:
+      - map: map_pools_created
+
+  - name: map_pool_events
+    kind: map
+    initialBlock: 2631214
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - map: map_pools_created
+      - store: store_pools
+    output:
+      type: proto:tycho.evm.v1.BlockChanges
+
+params:
+  map_pools_created: factory_address=71524B4f93c58fcbF659783284E38825f0622859&protocol_type_name=sushiswap_v2_pool


### PR DESCRIPTION
Adds two Substreams manifests to the `ethereum-uniswap-v2` package for SushiSwap V2 on Base and Arbitrum. No Rust changes — both reuse `ethereum_uniswap_v2.wasm`, since the map modules take the factory address and protocol type name as params and SushiSwap V2 pairs on both chains are standard 0.3% UniswapV2 pairs (verified on-chain: the pairs have no `swapFee()`, matching the hardcoded 30 bps `fee` attribute).

| Manifest | Factory | initialBlock |
|---|---|---|
| `base-sushiswap-v2.yaml` | `0x71524B4f93c58fcbF659783284E38825f0622859` | 2631214 |
| `arbitrum-sushiswap-v2.yaml` | `0xc35DADB65012eC5796536bD9864eD8773aBc74C4` | 70 |

Both use `protocol_type_name=sushiswap_v2_pool`, matching `ethereum-sushiswap-v2.yaml`.

`initialBlock` is the factory deployment block on each chain. On Arbitrum that is block 70 (2021-05-30, pre-Nitro); the first `PairCreated` is at 228460 and over a thousand pairs — including WETH/USDC.e — were created before the Nitro migration, so the start block cannot be moved up to the fork point. Backfill from block 70 requires the Substreams provider to serve Arbitrum One from genesis, including logs for classic-era blocks.

Package version bumped to 0.3.3 with a changelog entry, per `protocols/substreams/CLAUDE.md`.

Publishing is manual — `release.sh` only auto-selects `ethereum*` manifests in this package:

```
cd protocols/substreams
./publish.sh ethereum-uniswap-v2 base-sushiswap-v2
./publish.sh ethereum-uniswap-v2 arbitrum-sushiswap-v2
```

Not included, needed before these run in production: `sushiswap_v2` entries under `base` and `arbitrum` in `crates/tycho-execution/config/executor_addresses.json` (same executor address as `uniswap_v2` on each chain), and the extractor config for both chains.

## Testing

- `cargo +nightly fmt`, `cargo +nightly clippy -- -D warnings`, `cargo build --target wasm32-unknown-unknown`, `cargo test` for `ethereum-uniswap-v2` — all pass
- `substreams pack` succeeds for both manifests; `substreams info` confirms params and initial blocks, and the pack warnings match the existing `ethereum-sushiswap-v2.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)