### PR TITLE
fix(curve): refuse to decode a pool while its A/gamma ramp is active

### DIFF
--- a/crates/tycho-simulation/src/evm/protocol/curve/vm.rs
+++ b/crates/tycho-simulation/src/evm/protocol/curve/vm.rs
@@ -37,6 +37,7 @@ sol! {
         function fee() external view returns (uint256);
         function initial_A() external view returns (uint256);
         function future_A() external view returns (uint256);
+        function future_A_gamma_time() external view returns (uint256);
         function offpeg_fee_multiplier() external view returns (uint256);
         function gamma() external view returns (uint256);
         function D() external view returns (uint256);
@@ -175,6 +176,7 @@ where
     <D as DatabaseRef>::Error: Debug,
     <D as EngineDatabaseInterface>::Error: Debug,
 {
+    ensure_no_active_a_gamma_ramp(engine, pool)?;
     let balances = read_balances(engine, pool, 2)?;
     let price_scale = call(engine, pool, ICurve::price_scaleCall {})?;
     let precisions = call_opt(engine, pool, ICurveTwo::precisionsCall {}).map(|p| p.to_vec());
@@ -212,6 +214,7 @@ where
     <D as DatabaseRef>::Error: Debug,
     <D as EngineDatabaseInterface>::Error: Debug,
 {
+    ensure_no_active_a_gamma_ramp(engine, pool)?;
     let balances = read_balances(engine, pool, 3)?;
     let ps0 = call(engine, pool, ICurveTri::price_scaleCall { i: U256::from(0) })?;
     let ps1 = call(engine, pool, ICurveTri::price_scaleCall { i: U256::from(1) })?;
@@ -230,6 +233,45 @@ where
         precisions,
         ..Default::default()
     })
+}
+
+/// Refuse to read a CryptoSwap pool while its A/gamma ramp is active.
+///
+/// While `future_A_gamma_time > block.timestamp` the pool contract stops using its stored `D`:
+/// `get_dy`/`exchange` recompute the invariant from live balances via `newton_D` on every call.
+/// `A()` and `gamma()` are computed getters that interpolate to the read block, but `D()` is a
+/// plain storage getter, so reading all three uniformly pairs a stale invariant with ramped
+/// coefficients — a state no real pool has, which misquotes without bound. Recomputing `D` in
+/// Rust (a `newton_D` next to `core::tricrypto_ng::newton_y_3`) is the eventual fix; until then
+/// decoding fails for the duration of the ramp. Pools without the getter predate A/gamma ramping
+/// and are read as before.
+fn ensure_no_active_a_gamma_ramp<D: EngineDatabaseInterface + Clone + Debug>(
+    engine: &SimulationEngine<D>,
+    pool: &AlloyAddress,
+) -> Result<(), SimulationError>
+where
+    <D as DatabaseRef>::Error: Debug,
+    <D as EngineDatabaseInterface>::Error: Debug,
+{
+    let Some(future_a_gamma_time) = call_opt(engine, pool, ICurve::future_A_gamma_timeCall {})
+    else {
+        return Ok(());
+    };
+    let block = engine
+        .state
+        .get_current_block()
+        .ok_or_else(|| {
+            // Unreachable in practice: the getter call above only succeeds when the engine has a
+            // current block to simulate against.
+            SimulationError::FatalError("curve: current block not set in engine".to_string())
+        })?;
+    if future_a_gamma_time > U256::from(block.timestamp) {
+        return Err(SimulationError::RecoverableError(format!(
+            "curve pool {pool} is ramping A/gamma until timestamp {future_a_gamma_time}: its \
+             stored D is not used by the contract during the ramp, so quotes would be wrong"
+        )));
+    }
+    Ok(())
 }
 
 /// Read the amplification coefficient, preferring `initial_A` when the pool is not ramping
@@ -596,6 +638,7 @@ mod test {
 
     sol! {
         function get_dy_stable(int128 i, int128 j, uint256 dx) external view returns (uint256);
+        function get_dy(uint256 i, uint256 j, uint256 dx) external view returns (uint256);
         function coins(uint256 i) external view returns (address);
         function decimals() external view returns (uint8);
     }
@@ -805,6 +848,46 @@ mod test {
             .unwrap();
         assert!(correct_out > U256::from(10).pow(U256::from(17)), "correct ~0.6 ETH");
         assert!(wrong_out > correct_out * U256::from(100u64), "wrong decimals corrupt the quote");
+    }
+
+    /// While a CryptoSwap pool's A/gamma ramp is active the contract ignores its stored `D`
+    /// (it recomputes the invariant from balances on every call), so decoding must refuse the
+    /// pool; once the ramp is over the same pool must decode and match on-chain `get_dy`.
+    #[test]
+    #[ignore = "Requires RPC_URL to be set in environment variables or .env file"]
+    fn differential_tricrypto_active_a_gamma_ramp_is_refused() {
+        // TricryptoUSDT (USDT/WBTC/WETH), `future_A_gamma_time` = 1_786_178_519.
+        let pool = AlloyAddress::from_str("0xf5f5b97624542d72a9e06f04804bf81baa15e2b4").unwrap();
+        let decode_at = |number: u64, timestamp: u64| {
+            let header = BlockHeader { number, timestamp, ..Default::default() };
+            let mut db = SimulationDB::new(get_client(None).unwrap(), get_runtime().unwrap(), None);
+            db.set_block(Some(header));
+            let engine = SimulationEngine::new(db, false);
+            let decimals = read_decimals(&engine, &pool, 3);
+            (decode_from_vm(&engine, &pool, CurveVariant::TriCryptoNG, &decimals), engine)
+        };
+
+        // Mid-ramp block (ts 1_786_171_667 < ramp end): decoding must fail naming the ramp.
+        let (ramping, _) = decode_at(25_708_548, 1_786_171_667);
+        let error = ramping.expect_err("decode must fail while the A/gamma ramp is active");
+        assert!(
+            error
+                .to_string()
+                .contains("ramping A/gamma"),
+            "unexpected error: {error}"
+        );
+
+        // Post-ramp block (ts 1_786_309_559 > ramp end): decode succeeds and matches `get_dy`.
+        let (decoded, engine) = decode_at(25_720_000, 1_786_309_559);
+        let decoded = decoded.expect("decode must succeed once the ramp is over");
+        let dx = U256::from(1_982_505u64); // 1.982505 USDT
+        let ours = decoded
+            .get_amount_out(0, 1, dx)
+            .expect("get_amount_out returned None");
+        let onchain: U256 =
+            call(&engine, &pool, get_dyCall { i: U256::ZERO, j: U256::from(1), dx })
+                .expect("on-chain get_dy failed");
+        assert_eq!(ours, onchain, "curve quote diverged from on-chain get_dy");
     }
 
     #[test]


### PR DESCRIPTION
# fix(curve): refuse to decode a pool while its A/gamma ramp is active

## Mechanism

Curve CryptoSwap pools store their invariant `D`, but stop using it while an
`A`/`gamma` ramp is in progress. Every quote path in the Vyper contract does:

```vyper
if self.future_A_gamma_time > block.timestamp:
    D = MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)   # recomputed each call
else:
    D = self.D                                          # stored
```

The trap is an asymmetry in Curve's own contract API, not in how
`tycho-simulation` calls it:

- `A()` and `gamma()` are **computed** getters — the contract interpolates them
  from `block.timestamp` on every read, so reading them during a ramp returns
  the correct current value automatically.
- `D()` is a **plain storage** getter — it returns the raw stored variable with
  no recomputation, and during a ramp the pool itself has stopped using that
  value.

`decode_from_vm` reads all three the same uniform way and gets two right and
one wrong, purely because two of the getters self-correct on read and the third
does not. During a ramp the decoded state therefore pairs a stale invariant
with correctly ramped coefficients — a combination no real pool has — and the
vendored math has no `newton_D` to recompute it. Nothing about the call site
looks wrong; the ramp concept is even handled elsewhere in the crate
(`read_ramped_amp` in `vm.rs`, which covers the StableSwap `A` ramp — it does
not apply to the CryptoSwap path, where the bug lives).

## 30-second proof (two `eth_call`s, no Rust)

Pool `0xf5f5b97624542d72a9e06f04804bf81baa15e2b4` (TricryptoUSDT, mainnet,
`future_A_gamma_time = 1786178519`). Override the pool's stored `D` (storage
slot 14, e.g. double it) in the `eth_call` state overrides and call
`get_dy(0, 1, dx)`:

- block 25708548 (timestamp 1786171667, ramp active): the result is
  byte-identical to the un-overridden call — stored `D` is never read.
- block 25720000 (timestamp 1786309559, ramp finished): the same override makes
  the call revert.

## What this PR does

Fail closed. At decode time, `read_twocrypto`/`read_tricrypto` (the two paths
that read `D()`) now call `future_A_gamma_time()` and compare it with the
engine's current block timestamp (the same `BlockHeader` the decoder already
stores in the engine DB before decoding, and the one every getter simulation
runs under). While the ramp is active, decoding returns a
`SimulationError::RecoverableError` naming the pool and the ramp end timestamp
instead of building a state. Once the ramp ends, the next rebuild decodes as
before.

Pools that do not expose `future_A_gamma_time()` (variants that predate
A/gamma ramping) are read via `call_opt` and treated as not ramping, so
existing pools decode exactly as before.

## Symptoms observed

Ramps are rare but real; we hit one in production during the ramp window above.
Two distinct symptoms, depending on how the state was obtained:

- Reconstructed from raw on-chain storage at the ramp block, decoding produced a
  state whose quotes error (solver failure) — this branch is reproduced
  deterministically by the test below.
- Against Tycho's indexed state in production, the same pool over-quoted by
  8.5x–83x instead of erroring. We could not stage this branch deterministically
  from outside the indexer, so the over-quoting path is supported by field data
  (below) rather than a reproduction. The one-sidedness is structural: a `D`
  below what balances imply over-quotes without bound, while a `D` above makes
  the solver revert, so a caller that drops errors keeps only the flattering
  half.

Both symptoms have the same root cause and both are removed by failing closed.

## Complete fix (proposed, not in this PR)

Port `newton_D` to Rust, next to the solver that is already there. The follow-up
would mirror the Vyper branch: while `future_A_gamma_time > block.timestamp`,
compute `D` from balances with the ramped `A`/`gamma` instead of reading `D()`.

`math/core/tricrypto_ng.rs` already contains `isqrt`, `cbrt`, `snekmate_log_2`,
`newton_y_3`, `get_y_3_ng` and `crypto_fee` in Rust, with convergence tests in
the same file. `newton_y_3` is `newton_D`'s mirror image — given `D`, solve for
a balance; `newton_D` is given balances, solve for `D` — so the crate has
already done this class of work once, wei-exact, and has a sibling solver to
model the port on. Scope: one `newton_D` per math family (3-coin and 2-coin),
the ramp detection this PR already adds, and tests — roughly 150–250 lines.

The real difficulty is not the line count: `newton_D` must converge to the same
integer as the Vyper original, so the stopping condition and rounding have to
be transcribed exactly (Curve uses a `diff <= max(1, D / 1e14)`-style bound). A
subtly different tolerance yields a few-wei discrepancy that is hard to
localise, so the cost is differential verification across many pools and
blocks.

Alternative considered: call the pool's `MATH()` contract through the engine
(`vm.rs` already reads `MATH()` and loads its code). Rejected as the primary
route because `TwoCryptoV1`/`TriCryptoV1` have no external MATH contract at all
(see `adapter/variant.rs`), and the MATH generations that do exist (v0.1.0,
v2.0.0/v2.1.0) differ in behaviour — a Rust port sidesteps both problems.

This PR stops the wrong answers; the follow-up restores the ability to quote
ramping pools.

## Field evidence

From a mainnet searcher replaying its own Curve swaps against on-chain `get_dy`
at their own blocks: 841 swaps across 6 of 25 indexed Curve pools gave 606
exact matches, 235 over-quotes, and 0 under-quotes. The zero under-quotes match
the structural one-sidedness described above.

## Testing

- `differential_tricrypto_active_a_gamma_ramp_is_refused` (in `vm.rs`, RPC-
  gated like the neighbouring differential tests): decoding TricryptoUSDT at
  the mid-ramp block fails with the ramp error; decoding at a post-ramp block
  succeeds and matches on-chain `get_dy` wei-for-wei. Note: `RPC_URL` must be
  an **archive** node — both pinned blocks are historical, so a standard node
  fails with a state-not-available error rather than a skip.
- An external reproduction crate pinning `tycho-simulation =0.355.1` from
  crates.io, repointed at this branch via a path dependency, shows the ramp
  block now failing with the named error while its control block (ramp
  finished) still matches `get_dy` exactly.
- `cargo +nightly fmt --all --check` and `cargo clippy -p tycho-simulation
  --all-targets --all-features -- -D warnings` pass locally. The
  `cargo nextest run -p tycho-simulation --all-features` result follows as a
  PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TK9rdcSpGXeGcXN7yDhhwj
