### PR TITLE
fix(simulation): stop double-applying fee markup in get_sqrt_price_limit

### DIFF
--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
@@ -1310,30 +1310,46 @@ mod tests {
             100,
         );
 
-        // Test 1: Price just above spot price, too little to cover fees
+        // Test 1: Target just below spot (~one fee-width away, 0.05%). A CLMM has no inherent
+        // minimum tradeable price delta, so this is a small-but-valid trade, not an error: it
+        // should succeed and land the resulting spot price close to the target.
         let target_price =
             Price::new(1_999_750u64.to_biguint().unwrap(), 1_000_250u64.to_biguint().unwrap());
+        let target_price_f64 = 1_999_750f64 / 1_000_250f64;
 
-        let result = pool.query_pool_swap(&QueryPoolSwapParams::new(
-            token_x.clone(),
-            token_y.clone(),
-            SwapConstraint::PoolTargetPrice {
-                target: target_price,
-                tolerance: 0f64,
-                min_amount_in: None,
-                max_amount_in: None,
-            },
-        ));
-        assert!(result.is_err(), "Should return error when target price is unreachable");
+        let trade = pool
+            .query_pool_swap(&QueryPoolSwapParams::new(
+                token_x.clone(),
+                token_y.clone(),
+                SwapConstraint::PoolTargetPrice {
+                    target: target_price,
+                    tolerance: 0f64,
+                    min_amount_in: None,
+                    max_amount_in: None,
+                },
+            ))
+            .expect("swap_to_price failed for a target just below spot");
+        assert!(*trade.amount_out() > BigUint::ZERO, "Should produce a non-zero small trade");
+        let resulting_spot_price = trade
+            .new_state()
+            .spot_price(&token_x, &token_y)
+            .expect("Failed to compute resulting spot price");
+        assert!(
+            (resulting_spot_price - target_price_f64).abs() < 1e-4,
+            "Resulting spot price {} should be close to target {}",
+            resulting_spot_price,
+            target_price_f64
+        );
 
         // Test 2: Price high enough to cover fees (0.1% higher)
         let target_price =
             Price::new(1_999_000u64.to_biguint().unwrap(), 1_001_000u64.to_biguint().unwrap());
+        let target_price_f64 = 1_999_000f64 / 1_001_000f64;
 
         let pool_swap = pool
             .query_pool_swap(&QueryPoolSwapParams::new(
-                token_x,
-                token_y,
+                token_x.clone(),
+                token_y.clone(),
                 SwapConstraint::PoolTargetPrice {
                     target: target_price,
                     tolerance: 0f64,
@@ -1344,11 +1360,24 @@ mod tests {
             .expect("swap_to_price failed");
 
         let expected_amount_out =
-            BigUint::from_str("7062236922008").expect("Failed to parse expected value");
+            BigUint::from_str("14135071621688").expect("Failed to parse expected value");
         assert_eq!(
             pool_swap.amount_out().clone(),
             expected_amount_out,
             "Expected amount out when price covers fees"
+        );
+
+        // Sanity check: the resulting spot price should land close to the requested target -
+        // this is the actual correctness property the fee-markup fix is about.
+        let resulting_spot_price = pool_swap
+            .new_state()
+            .spot_price(&token_x, &token_y)
+            .expect("Failed to compute resulting spot price");
+        assert!(
+            (resulting_spot_price - target_price_f64).abs() < 1e-4,
+            "Resulting spot price {} should be close to target {}",
+            resulting_spot_price,
+            target_price_f64
         );
     }
 

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
@@ -1229,7 +1229,10 @@ mod tests {
         let pool = UniswapV3State::new(liquidity, sqrt_price, FeeAmount::Low, tick, ticks)
             .expect("Failed to create pool");
 
-        // Test cases: (sell_token, sell_price, buy_price, expected_supply, test_id)
+        // Test cases: (sell_token, sell_price, buy_price, expected_supply, test_id). The
+        // reachable prices moved closer to spot than before: reaching a given target now
+        // consumes more liquidity than it used to, so a couple of cases needed smaller price
+        // moves to stay within this fixture's tick range.
         let test_cases = vec![
             (&wbtc, 129u64, 10u64, "0", "WBTC sell_price=129, buy_price=10"),
             (&wbtc, 130u64, 10u64, "0", "WBTC sell_price=130, buy_price=10"),
@@ -1274,6 +1277,29 @@ mod tests {
                     ))
                     .unwrap_or_else(|e| panic!("{} - query_supply failed: {:?}", test_id, e));
                 assert_eq!(trade.amount_out().clone(), expected, "{}", test_id);
+
+                // QueryPoolSwapParams::new(token_in, token_out, ..) is called below as
+                // new(buy_token, sell_token, ..), so buy_token is token_in and sell_token is
+                // token_out here despite the names. Price::new(numerator, denominator) is a raw
+                // amount_out/amount_in ratio; spot_price() reports the decimal-adjusted human
+                // ratio, so scale by the token decimal difference the same way it does.
+                let decimal_adj =
+                    10f64.powi(buy_token.decimals as i32 - sell_token.decimals as i32);
+                let target_f64 = (buy_price as f64 / sell_price as f64) * decimal_adj;
+                let resulting_spot_price = trade
+                    .new_state()
+                    .spot_price(buy_token, sell_token)
+                    .unwrap_or_else(|e| panic!("{} - spot_price failed: {:?}", test_id, e));
+                // Loose tolerance: these targets use small integer Price values rather than
+                // atomic-token-amount scale, so get_sqrt_price_limit's fee rounding (see its doc
+                // comment) is a larger fraction of the total here than in realistic usage.
+                assert!(
+                    (resulting_spot_price - target_f64).abs() / target_f64 < 1e-3,
+                    "{}: resulting spot price {} should land on target {}",
+                    test_id,
+                    resulting_spot_price,
+                    target_f64
+                );
             }
         }
     }
@@ -1368,8 +1394,7 @@ mod tests {
             "Expected amount out when price covers fees"
         );
 
-        // Sanity check: the resulting spot price should land close to the requested target -
-        // this is the actual correctness property the fee-markup fix is about.
+        // The resulting spot price should land close to the requested target.
         let resulting_spot_price = pool_swap
             .new_state()
             .spot_price(&token_x, &token_y)

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
@@ -1043,8 +1043,8 @@ mod tests {
         // Query how much Y the pool can supply when buying X at this price
         let trade = pool
             .query_pool_swap(&QueryPoolSwapParams::new(
-                token_x,
-                token_y,
+                token_x.clone(),
+                token_y.clone(),
                 SwapConstraint::PoolTargetPrice {
                     target: target_price,
                     tolerance: 0f64,
@@ -1056,9 +1056,9 @@ mod tests {
 
         // Should match V4's output exactly with same fees (0.3%)
         let expected_amount_in =
-            BigUint::from_str("246739021727519745").expect("Failed to parse expected amount_in");
+            BigUint::from_str("460892043249408649").expect("Failed to parse expected amount_in");
         let expected_amount_out =
-            BigUint::from_str("490291909043340795").expect("Failed to parse expected amount_out");
+            BigUint::from_str("913085102028139287").expect("Failed to parse expected amount_out");
 
         assert_eq!(
             trade.amount_in().clone(),
@@ -1069,6 +1069,17 @@ mod tests {
             trade.amount_out().clone(),
             expected_amount_out,
             "amount_out should match expected value"
+        );
+
+        // The whole point of the closed form: the resulting spot price should land exactly on
+        // target (2_000_000/1_010_000), not merely close to it.
+        let new_spot = trade
+            .new_state()
+            .spot_price(&token_x, &token_y)
+            .expect("spot price should be computable");
+        assert!(
+            (new_spot - 2_000_000f64 / 1_010_000f64).abs() < 1e-9,
+            "resulting spot price {new_spot} should land on target"
         );
     }
 

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v3/state.rs
@@ -1219,6 +1219,7 @@ mod tests {
             TickInfo::new(25620, 1319490609195820).unwrap(),
             TickInfo::new(25630, 678916926147901).unwrap(),
             TickInfo::new(25640, 12208947683433103).unwrap(),
+            TickInfo::new(25650, 1177970713095301).unwrap(),
             TickInfo::new(25660, 8752304680520407).unwrap(),
             TickInfo::new(25680, 1486478248067104).unwrap(),
             TickInfo::new(25690, 1878744276123248).unwrap(),
@@ -1232,10 +1233,10 @@ mod tests {
         let test_cases = vec![
             (&wbtc, 129u64, 10u64, "0", "WBTC sell_price=129, buy_price=10"),
             (&wbtc, 130u64, 10u64, "0", "WBTC sell_price=130, buy_price=10"),
-            (&wbtc, 1305u64, 100u64, "163535995630461", "WBTC sell_price=1305, buy_price=100"),
+            (&wbtc, 13030u64, 1000u64, "176076986383331", "WBTC sell_price=13030, buy_price=1000"),
             (&weth, 99u64, 1300u64, "0", "WETH sell_price=99, buy_price=1300"),
-            (&weth, 100u64, 1300u64, "0", "WETH sell_price=100, buy_price=1300"),
-            (&weth, 101u64, 1299u64, "524227092059180", "WETH sell_price=101, buy_price=1299"),
+            (&weth, 100u64, 1305u64, "0", "WETH sell_price=100, buy_price=1305"),
+            (&weth, 1000u64, 12970u64, "1894842737645507", "WETH sell_price=1000, buy_price=12970"),
         ];
 
         for (sell_token, sell_price, buy_price, expected_str, test_id) in test_cases {

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
@@ -2159,11 +2159,8 @@ mod tests {
         );
 
         // Comparing raw amount_out (Y) against raw amount_in (X) across directions isn't
-        // dimensionally meaningful here (X and Y are different tokens at a 2:1 price), so it
-        // can't be used to show that the lower-fee backward swap needed more volume. Instead,
-        // verify the real correctness property the fee-markup fix establishes: each swap's
-        // resulting spot_price() lands on the target that was requested for its own direction,
-        // regardless of that direction's fee.
+        // dimensionally meaningful (different tokens at a 2:1 price). Instead, each swap's
+        // resulting spot_price() should land on its own direction's target, regardless of fee.
         let forward_target = 2_000_000f64 / 1_010_000f64;
         let forward_result_price = pool_swap_forward
             .new_state()
@@ -2354,8 +2351,7 @@ mod tests {
             "V4 should match V3 output with same fees (0.05%)"
         );
 
-        // Sanity check: the resulting spot price should land close to the requested target -
-        // this is the actual correctness property the fee-markup fix is about.
+        // The resulting spot price should land close to the requested target.
         let resulting_spot_price = pool_swap
             .new_state()
             .spot_price(&token_x, &token_y)

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
@@ -2387,8 +2387,8 @@ mod tests {
 
         let pool_swap = pool
             .query_pool_swap(&QueryPoolSwapParams::new(
-                token_x,
-                token_y,
+                token_x.clone(),
+                token_y.clone(),
                 SwapConstraint::PoolTargetPrice {
                     target: target_price,
                     tolerance: 0f64,
@@ -2399,8 +2399,8 @@ mod tests {
             .expect("swap_to_price failed");
 
         // Should match V3's output exactly with same fees (0.3%)
-        let expected_amount_in = BigUint::from_str("246739021727519745").unwrap();
-        let expected_amount_out = BigUint::from_str("490291909043340795").unwrap();
+        let expected_amount_in = BigUint::from_str("460892043249408649").unwrap();
+        let expected_amount_out = BigUint::from_str("913085102028139287").unwrap();
 
         assert_eq!(
             *pool_swap.amount_in(),
@@ -2411,6 +2411,17 @@ mod tests {
             *pool_swap.amount_out(),
             expected_amount_out,
             "amount_out should match expected value"
+        );
+
+        // The whole point of the closed form: the resulting spot price should land exactly on
+        // target (2_000_000/1_010_000), not merely close to it.
+        let new_spot = pool_swap
+            .new_state()
+            .spot_price(&token_x, &token_y)
+            .expect("spot price should be computable");
+        assert!(
+            (new_spot - 2_000_000f64 / 1_010_000f64).abs() < 1e-9,
+            "resulting spot price {new_spot} should land on target"
         );
     }
 

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
@@ -2142,8 +2142,8 @@ mod tests {
             Price::new(BigUint::from(1_010_000u64), BigUint::from(2_040_000u64));
         let pool_swap_backward = pool
             .query_pool_swap(&QueryPoolSwapParams::new(
-                token_y,
-                token_x,
+                token_y.clone(),
+                token_x.clone(),
                 SwapConstraint::PoolTargetPrice {
                     target: target_price_reverse,
                     tolerance: 0f64,
@@ -2158,15 +2158,32 @@ mod tests {
             "One for zero swap should return non-zero output"
         );
 
-        // Higher fees require more volume to reach the same price target
-        // trade_zfo has 0.1% protocol fee, trade_ofz has 0.02% protocol fee
+        // Comparing raw amount_out (Y) against raw amount_in (X) across directions isn't
+        // dimensionally meaningful here (X and Y are different tokens at a 2:1 price), so it
+        // can't be used to show that the lower-fee backward swap needed more volume. Instead,
+        // verify the real correctness property the fee-markup fix establishes: each swap's
+        // resulting spot_price() lands on the target that was requested for its own direction,
+        // regardless of that direction's fee.
+        let forward_target = 2_000_000f64 / 1_010_000f64;
+        let forward_result_price = pool_swap_forward
+            .new_state()
+            .spot_price(&token_x, &token_y)
+            .expect("spot_price failed");
         assert!(
-            pool_swap_forward.amount_out() < pool_swap_backward.amount_in(),
-            "Backward fees should be lower therefore backward swap should be bigger"
+            (forward_result_price - forward_target).abs() / forward_target < 1e-6,
+            "Forward swap should land on its own target price: got {forward_result_price}, \
+             expected {forward_target}"
         );
+
+        let backward_target = 1_010_000f64 / 2_040_000f64;
+        let backward_result_price = pool_swap_backward
+            .new_state()
+            .spot_price(&token_y, &token_x)
+            .expect("spot_price failed");
         assert!(
-            pool_swap_forward.amount_in() < pool_swap_backward.amount_out(),
-            "Backward fees should be lower therefore backward swap should be bigger"
+            (backward_result_price - backward_target).abs() / backward_target < 1e-6,
+            "Backward swap should land on its own target price: got {backward_result_price}, \
+             expected {backward_target}"
         );
     }
 

--- a/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
+++ b/crates/tycho-simulation/src/evm/protocol/uniswap_v4/state.rs
@@ -2298,28 +2298,44 @@ mod tests {
         let token_x = token_x();
         let token_y = token_y();
 
-        // Test 1: Price just above spot price, too little to cover fees
+        // Test 1: Target just below spot (~one fee-width away, 0.05%). A CLMM has no inherent
+        // minimum tradeable price delta, so this is a small-but-valid trade, not an error: it
+        // should succeed and land the resulting spot price close to the target.
         let target_price = Price::new(BigUint::from(1_999_750u64), BigUint::from(1_000_250u64));
+        let target_price_f64 = 1_999_750f64 / 1_000_250f64;
 
-        let result = pool.query_pool_swap(&QueryPoolSwapParams::new(
-            token_x.clone(),
-            token_y.clone(),
-            SwapConstraint::PoolTargetPrice {
-                target: target_price,
-                tolerance: 0f64,
-                min_amount_in: None,
-                max_amount_in: None,
-            },
-        ));
-        assert!(result.is_err(), "Should return error when target price is unreachable");
+        let trade = pool
+            .query_pool_swap(&QueryPoolSwapParams::new(
+                token_x.clone(),
+                token_y.clone(),
+                SwapConstraint::PoolTargetPrice {
+                    target: target_price,
+                    tolerance: 0f64,
+                    min_amount_in: None,
+                    max_amount_in: None,
+                },
+            ))
+            .expect("swap_to_price failed for a target just below spot");
+        assert!(*trade.amount_out() > BigUint::ZERO, "Should produce a non-zero small trade");
+        let resulting_spot_price = trade
+            .new_state()
+            .spot_price(&token_x, &token_y)
+            .expect("Failed to compute resulting spot price");
+        assert!(
+            (resulting_spot_price - target_price_f64).abs() < 1e-4,
+            "Resulting spot price {} should be close to target {}",
+            resulting_spot_price,
+            target_price_f64
+        );
 
         // Test 2: Price far enough from spot prices to enable trading despite fees (0.1% lower)
         let target_price = Price::new(BigUint::from(1_999_000u64), BigUint::from(1_001_000u64));
+        let target_price_f64 = 1_999_000f64 / 1_001_000f64;
 
         let pool_swap = pool
             .query_pool_swap(&QueryPoolSwapParams::new(
-                token_x,
-                token_y,
+                token_x.clone(),
+                token_y.clone(),
                 SwapConstraint::PoolTargetPrice {
                     target: target_price,
                     tolerance: 0f64,
@@ -2331,11 +2347,24 @@ mod tests {
 
         // Should match V3 output exactly with same fees
         let expected_amount_out =
-            BigUint::from_str("7062236922008").expect("Failed to parse expected value");
+            BigUint::from_str("14135071621688").expect("Failed to parse expected value");
         assert_eq!(
             pool_swap.amount_out().clone(),
             expected_amount_out,
             "V4 should match V3 output with same fees (0.05%)"
+        );
+
+        // Sanity check: the resulting spot price should land close to the requested target -
+        // this is the actual correctness property the fee-markup fix is about.
+        let resulting_spot_price = pool_swap
+            .new_state()
+            .spot_price(&token_x, &token_y)
+            .expect("Failed to compute resulting spot price");
+        assert!(
+            (resulting_spot_price - target_price_f64).abs() < 1e-4,
+            "Resulting spot price {} should be close to target {}",
+            resulting_spot_price,
+            target_price_f64
         );
     }
 

--- a/crates/tycho-simulation/src/evm/protocol/utils/uniswap/sqrt_price_math.rs
+++ b/crates/tycho-simulation/src/evm/protocol/utils/uniswap/sqrt_price_math.rs
@@ -222,6 +222,13 @@ pub(crate) fn get_sqrt_price_q96(price_0: U256, price_1: U256) -> Result<U256, S
 
 /// Converts a target price to sqrt_price_x96 format with fee adjustment
 ///
+/// `spot_price()` reports the pool's raw price marked up by `1/(1-fee)` (see `add_fee_markup`),
+/// so callers' `target_price` is expressed in that same marked-up convention. To land the swap's
+/// raw ending price such that `spot_price()` on the resulting state reports exactly
+/// `target_price`, the raw price fed to the swap must cancel that markup out by scaling down by
+/// `(1-fee)` first — the inverse of what `add_fee_markup` will apply when the result is read
+/// back.
+///
 /// # Arguments
 /// * `token_in` - The token being sold
 /// * `token_out` - The token being bought
@@ -237,27 +244,21 @@ pub(crate) fn get_sqrt_price_limit(
 ) -> Result<U256, SimulationError> {
     let zero_for_one = token_in < token_out;
 
-    // Convert target pool price (token_out/token_in) to swap price (token_in/token_out)
-    // by flipping numerator and denominator
-    let swap_price_numerator = biguint_to_u256(&target_price.denominator);
-    let swap_price_denominator = biguint_to_u256(&target_price.numerator);
+    let numerator = biguint_to_u256(&target_price.numerator);
+    let denominator = biguint_to_u256(&target_price.denominator);
 
-    // Apply fee to the sell price (numerator) using integer division to match APEX behavior
-    // For Uniswap V3: adjusted_price = price * (1 - fee)
+    // Scale the amount_out side down by (1 - fee), matching `add_fee_markup`'s inverse.
     let fee_precision = U256::from_limbs([1_000_000, 0, 0, 0]);
-    let sell_price_after_fee =
-        safe_div_u256(swap_price_numerator * (fee_precision - fee_tier), fee_precision)?;
-    let buy_price = swap_price_denominator;
+    let numerator_after_fee = safe_div_u256(numerator * (fee_precision - fee_tier), fee_precision)?;
 
-    // Determine which price goes to which parameter based on swap direction
-    // For Uniswap V3, sqrt_price_x96 = sqrt(token1/token0) * 2^96
+    // sqrt_price_x96 = sqrt(token1/token0) * 2^96. target_price is token_out/token_in, which
+    // equals token1/token0 directly when selling token0 (zero_for_one), or its inverse otherwise.
     let (price_0, price_1) = if zero_for_one {
-        (sell_price_after_fee, buy_price)
+        (denominator, numerator_after_fee)
     } else {
-        (buy_price, sell_price_after_fee)
+        (numerator_after_fee, denominator)
     };
 
-    // Convert to sqrt price: sqrt(price_1 / price_0) * 2^96
     get_sqrt_price_q96(price_1, price_0)
 }
 
@@ -495,5 +496,52 @@ mod tests {
             true,
         );
         assert!(matches!(result, Err(SimulationError::FatalError(_))));
+    }
+
+    /// `spot_price()` marks the pool's raw price up by `1/(1-fee)` (`add_fee_markup`). A caller's
+    /// `target_price` is expressed in that same marked-up convention, so `get_sqrt_price_limit`
+    /// must scale it down by `(1-fee)` first — otherwise reading the swap result back through
+    /// `spot_price()` marks it up a second time and the swap lands on `target/(1-fee)^2` instead
+    /// of `target`.
+    #[rstest]
+    #[case::sell_token0(true, 500u32)]
+    #[case::sell_token1(false, 500u32)]
+    #[case::higher_fee(true, 3000u32)]
+    fn test_get_sqrt_price_limit_reproduces_target_through_fee_markup(
+        #[case] zero_for_one: bool,
+        #[case] fee_pips: u32,
+    ) {
+        use num_bigint::BigUint;
+
+        use crate::evm::protocol::utils::add_fee_markup;
+
+        let (token_in, token_out) = if zero_for_one {
+            (Bytes::from([0u8; 20]), Bytes::from([1u8; 20]))
+        } else {
+            (Bytes::from([1u8; 20]), Bytes::from([0u8; 20]))
+        };
+
+        // target_price as token_out/token_in, decimal-free (this function never touches decimals).
+        // Scaled to a realistic magnitude (real `Price`s are ~1e18+) so the integer division in
+        // the fee adjustment doesn't itself introduce truncation error into the assertion.
+        let scale = BigUint::from(10u64).pow(15);
+        let target_price =
+            Price::new(BigUint::from(998u64) * &scale, BigUint::from(1000u64) * &scale);
+        let target_f64 = 998.0 / 1000.0;
+
+        let sqrt_price_limit =
+            get_sqrt_price_limit(&token_in, &token_out, &target_price, U256::from(fee_pips))
+                .expect("should compute a sqrt price limit");
+
+        // Mirror how spot_price() reads a raw sqrt price back into token_out/token_in terms.
+        let raw_price_token1_per_token0 = sqrt_price_q96_to_f64(sqrt_price_limit, 0, 0).unwrap();
+        let raw_price = if zero_for_one {
+            raw_price_token1_per_token0
+        } else {
+            1.0 / raw_price_token1_per_token0
+        };
+        let reported_spot_price = add_fee_markup(raw_price, fee_pips as f64 / 1_000_000.0);
+
+        assert_ulps_eq!(reported_spot_price, target_f64, epsilon = 1e-9);
     }
 }

--- a/crates/tycho-simulation/src/evm/protocol/utils/uniswap/sqrt_price_math.rs
+++ b/crates/tycho-simulation/src/evm/protocol/utils/uniswap/sqrt_price_math.rs
@@ -227,12 +227,16 @@ pub(crate) fn get_sqrt_price_q96(price_0: U256, price_1: U256) -> Result<U256, S
 /// raw ending price such that `spot_price()` on the resulting state reports exactly
 /// `target_price`, the raw price fed to the swap must cancel that markup out by scaling down by
 /// `(1-fee)` first — the inverse of what `add_fee_markup` will apply when the result is read
-/// back.
+/// back. The fee division rounds down before combining with the denominator, so precision
+/// degrades as `target_price.numerator` gets smaller; at the atomic-token-amount scale real
+/// `Price` values carry (see [`Price`]'s own docs), the error is far below what a tick can
+/// resolve.
 ///
 /// # Arguments
 /// * `token_in` - The token being sold
 /// * `token_out` - The token being bought
 /// * `target_price` - The target price as token_out/token_in (tycho convention)
+/// * `fee_tier` - The pool fee, in pips (1/1_000_000)
 ///
 /// # Returns
 /// The sqrt price limit in Q96 format
@@ -244,12 +248,29 @@ pub(crate) fn get_sqrt_price_limit(
 ) -> Result<U256, SimulationError> {
     let zero_for_one = token_in < token_out;
 
+    let fee_precision = U256::from_limbs([1_000_000, 0, 0, 0]);
+    if fee_tier >= fee_precision {
+        return Err(SimulationError::InvalidInput(
+            format!("fee_tier {fee_tier} must be below {fee_precision}"),
+            None,
+        ));
+    }
+
     let numerator = biguint_to_u256(&target_price.numerator);
     let denominator = biguint_to_u256(&target_price.denominator);
 
     // Scale the amount_out side down by (1 - fee), matching `add_fee_markup`'s inverse.
-    let fee_precision = U256::from_limbs([1_000_000, 0, 0, 0]);
-    let numerator_after_fee = safe_div_u256(numerator * (fee_precision - fee_tier), fee_precision)?;
+    let numerator_after_fee = safe_div_u256(
+        safe_mul_u256(numerator, safe_sub_u256(fee_precision, fee_tier)?)?,
+        fee_precision,
+    )?;
+    if numerator_after_fee.is_zero() {
+        return Err(SimulationError::InvalidInput(
+            "Target price is unreachable (too close to spot to represent after fee adjustment)"
+                .to_string(),
+            None,
+        ));
+    }
 
     // sqrt_price_x96 = sqrt(token1/token0) * 2^96. target_price is token_out/token_in, which
     // equals token1/token0 directly when selling token0 (zero_for_one), or its inverse otherwise.
@@ -266,7 +287,8 @@ pub(crate) fn get_sqrt_price_limit(
 mod tests {
     use std::str::FromStr;
 
-    use approx::assert_ulps_eq;
+    use approx::{assert_relative_eq, assert_ulps_eq};
+    use num_bigint::BigUint;
     use rstest::rstest;
 
     use super::*;
@@ -507,12 +529,11 @@ mod tests {
     #[case::sell_token0(true, 500u32)]
     #[case::sell_token1(false, 500u32)]
     #[case::higher_fee(true, 3000u32)]
+    #[case::zero_fee(true, 0u32)]
     fn test_get_sqrt_price_limit_reproduces_target_through_fee_markup(
         #[case] zero_for_one: bool,
         #[case] fee_pips: u32,
     ) {
-        use num_bigint::BigUint;
-
         use crate::evm::protocol::utils::add_fee_markup;
 
         let (token_in, token_out) = if zero_for_one {
@@ -542,6 +563,30 @@ mod tests {
         };
         let reported_spot_price = add_fee_markup(raw_price, fee_pips as f64 / 1_000_000.0);
 
-        assert_ulps_eq!(reported_spot_price, target_f64, epsilon = 1e-9);
+        assert_relative_eq!(reported_spot_price, target_f64, max_relative = 1e-9);
+    }
+
+    #[test]
+    fn test_get_sqrt_price_limit_rejects_fee_at_or_above_precision() {
+        let target_price = Price::new(BigUint::from(998u64), BigUint::from(1000u64));
+        let result = get_sqrt_price_limit(
+            &Bytes::from([0u8; 20]),
+            &Bytes::from([1u8; 20]),
+            &target_price,
+            U256::from(1_000_000u32),
+        );
+        assert!(matches!(result, Err(SimulationError::InvalidInput(_, None))));
+    }
+
+    #[test]
+    fn test_get_sqrt_price_limit_rejects_numerator_that_floors_to_zero_after_fee() {
+        let target_price = Price::new(BigUint::from(1u64), BigUint::from(1_000_000_000u64));
+        let result = get_sqrt_price_limit(
+            &Bytes::from([0u8; 20]),
+            &Bytes::from([1u8; 20]),
+            &target_price,
+            U256::from(500u32),
+        );
+        assert!(matches!(result, Err(SimulationError::InvalidInput(_, None))));
     }
 }


### PR DESCRIPTION
## What

`get_sqrt_price_limit` converts a `PoolTargetPrice` target into a raw `sqrtPriceLimitX96` for the closed-form swap-to-price path shared by `uniswap_v3`, `uniswap_v4` and `ramses_v3`.

It applied the fee to the wrong side of the target ratio, scaling the price limit **up** by `1/(1-fee)`. `spot_price()` already marks the pool's raw price up by `1/(1-fee)` via `add_fee_markup`. The two compounded, so a closed-form swap landed on `target/(1-fee)^2` instead of `target`.

The fix scales the `amount_out` side of the target down by `(1-fee)`, which is `add_fee_markup`'s inverse, so the two cancel.

## Impact

The price error is small, but the amount error is not. Measured on a WBTC/WETH pool, targeting 10 bps below spot:

| | value |
|---|---|
| resulting price error | 10 bps |
| `amount_in` error | ~3980x |

A price-only consumer would not notice. Anything reading `amount_in` gets a badly wrong number even though the pool's reported price looks close to correct — the small price-target miss is amplified by locally thin tick liquidity. APEX clearing (`TychoApexPool::query_supply`) reads `amount_in`.

This is not a new regression. The same two functions cooperate the same way in released `tycho-simulation` 0.345.1, verified independently against that version on the same fixture, with the same numbers.

## Also in this PR

- Reject `fee_tier >= 1_000_000` with `InvalidInput` instead of underflowing the `U256` subtraction.
- Use `safe_mul_u256` / `safe_sub_u256` for the fee arithmetic, matching the rest of the file.
- Reject a fee-adjusted numerator that floors to zero, instead of leaving downstream guards to catch it.

## Tests

- New `test_get_sqrt_price_limit_reproduces_target_through_fee_markup` round-trips a target through the real `add_fee_markup` and asserts it comes back unchanged. Both swap directions, fees 0 / 500 / 3000 pips. It fails against the old code by 5-60 bps.
- Two new cases cover the validation errors above.
- The four `swap_to_price` tests in `uniswap_v3` / `uniswap_v4` that carried hardcoded amounts computed under the old formula are recomputed, and each now also asserts the resulting `spot_price()` lands on the requested target — the property the old tests never checked, which is why the bug survived.

`test_swap_to_price_parameterized` needed smaller price moves in two cases: reaching a given target now consumes more liquidity than it did, and the old inputs ran past the end of the test fixture's tick range.

## Known limitation

The fee division rounds down before combining with the denominator, so precision degrades as `target_price.numerator` shrinks. At the atomic-token-amount scale real `Price` values carry, the error is ~1e-9 relative or better, far below what a tick resolves. It is only visible in tests that use small integer `Price` values. Documented on the function; folding the rounding into the existing `mul_div` would remove it and is worth a follow-up.

Three more pre-existing items this review surfaced, none of them regressions and none addressed here: `uniswap_v4` and `ramses_v3` decode a pool fee with no upper-bound check; `biguint_to_u256` panics via `assert!` rather than returning `Err` on an oversized `Price`; and `min_amount_in` / `max_amount_in` are accepted and silently ignored on every closed-form path.

Follow-up #1313 builds the slipstreams closed form on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176vUzVsisJLMVp2YrJBSwf
