### PR TITLE
fix(deps): resolve RUSTSEC-2026-0258 (h2 unbounded empty DATA frames)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,10 +3,14 @@
 # RUSTSEC-2025-0055: tracing-subscriber ^0.2 log poisoning via ANSI escapes
 # Dep chain: tycho-simulation <- revm <- ark-bn254 <- ark-r1cs-std <- ark-relations <- tracing-subscriber ^0.2
 # We need ark to update their dependencies to fix this.
+# RUSTSEC-2026-0258: h2 unbounded empty DATA frames (low severity DoS)
+# Only patched in h2 >= 0.4.16 (which we use). The 0.3.x line has no fix and is pulled in by
+# actix-http 3.x, hyper 0.14 (tonic 0.9-0.11) and aws-smithy-http-client; nothing to bump.
 ignore = [
     "RUSTSEC-2026-0049",
     "RUSTSEC-2026-0098",
     "RUSTSEC-2026-0099",
     "RUSTSEC-2026-0104",
     "RUSTSEC-2025-0055",
+    "RUSTSEC-2026-0258",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,7 +2139,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.12",
+ "h2 0.4.16",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
@@ -4304,9 +4304,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4568,7 +4568,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
+ "h2 0.4.16",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -7067,7 +7067,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
+ "h2 0.4.16",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -7113,7 +7113,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
+ "h2 0.4.16",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -9188,7 +9188,7 @@ dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.12",
+ "h2 0.4.16",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",


### PR DESCRIPTION
## What

The Security Audit workflow started failing on `main` after [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258) (h2 unbounded empty DATA frames, published 2026-08-17) flagged both h2 copies in the tree — `0.3.27` and `0.4.12`.

- `Cargo.lock`: bump h2 `0.4.12` → `0.4.16`, the patched release.
- `.cargo/audit.toml`: add `RUSTSEC-2026-0258` to the `ignore` list, with rationale.

## Why the ignore

The advisory is `patched = [">= 0.4.16"]` — there is no fix on the 0.3 line, and that copy is pulled in by:

- `actix-http` 3.x (still `h2 = "0.3.27"` as of 3.13.3)
- `hyper` 0.14, via `tonic` 0.9–0.11
- `aws-smithy-http-client`

Nothing there is bumpable today. Since cargo-audit's `ignore` is advisory-ID-scoped it also covers the 0.4 finding, so the lockfile pin to 0.4.16 is what actually protects that line — noted in the config comment.

## Verification

- `cargo audit --json | jq .vulnerabilities.count` → `0` (exactly what the CI step gates on)
- `cargo check --workspace --locked` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)