### PR TITLE
chore(substreams): stop polygon-ramses-v3 ABI regeneration from dirtying every worktree

### DIFF
--- a/protocols/substreams/polygon-ramses-v3/src/abi/factory.rs
+++ b/protocols/substreams/polygon-ramses-v3/src/abi/factory.rs
@@ -18,9 +18,38 @@ pub mod events {
     }
     impl PoolCreated {
         const TOPIC_ID: [u8; 32] = [
-            120u8, 60u8, 202u8, 28u8, 4u8, 18u8, 221u8, 13u8, 105u8, 94u8, 120u8, 69u8, 104u8,
-            201u8, 109u8, 162u8, 233u8, 194u8, 47u8, 249u8, 137u8, 53u8, 122u8, 46u8, 139u8, 29u8,
-            155u8, 43u8, 78u8, 107u8, 113u8, 24u8,
+            120u8,
+            60u8,
+            202u8,
+            28u8,
+            4u8,
+            18u8,
+            221u8,
+            13u8,
+            105u8,
+            94u8,
+            120u8,
+            69u8,
+            104u8,
+            201u8,
+            109u8,
+            162u8,
+            233u8,
+            194u8,
+            47u8,
+            249u8,
+            137u8,
+            53u8,
+            122u8,
+            46u8,
+            139u8,
+            29u8,
+            155u8,
+            43u8,
+            78u8,
+            107u8,
+            113u8,
+            24u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 4usize {
@@ -29,22 +58,23 @@ pub mod events {
             if log.data.len() != 64usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[ethabi::ParamType::Int(24usize), ethabi::ParamType::Address],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[ethabi::ParamType::Int(24usize), ethabi::ParamType::Address],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
-                token0: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                token0: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
                     .map_err(|e| {
                         format!(
                             "unable to decode param 'token0' from topic of type 'address': {:?}",
@@ -57,7 +87,10 @@ pub mod events {
                     .expect(INTERNAL_ERR)
                     .as_bytes()
                     .to_vec(),
-                token1: ethabi::decode(&[ethabi::ParamType::Address], log.topics[2usize].as_ref())
+                token1: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[2usize].as_ref(),
+                    )
                     .map_err(|e| {
                         format!(
                             "unable to decode param 'token1' from topic of type 'address': {:?}",
@@ -73,17 +106,20 @@ pub mod events {
                 fee: {
                     let mut v = [0 as u8; 32];
                     ethabi::decode(
-                        &[ethabi::ParamType::Uint(24usize)],
-                        log.topics[3usize].as_ref(),
-                    )
-                    .map_err(|e| {
-                        format!("unable to decode param 'fee' from topic of type 'uint24': {:?}", e)
-                    })?
-                    .pop()
-                    .expect(INTERNAL_ERR)
-                    .into_uint()
-                    .expect(INTERNAL_ERR)
-                    .to_big_endian(v.as_mut_slice());
+                            &[ethabi::ParamType::Uint(24usize)],
+                            log.topics[3usize].as_ref(),
+                        )
+                        .map_err(|e| {
+                            format!(
+                                "unable to decode param 'fee' from topic of type 'uint24': {:?}",
+                                e
+                            )
+                        })?
+                        .pop()
+                        .expect(INTERNAL_ERR)
+                        .into_uint()
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
                     substreams::scalar::BigInt::from_unsigned_bytes_be(&v)
                 },
                 tick_spacing: {

--- a/protocols/substreams/polygon-ramses-v3/src/abi/pool.rs
+++ b/protocols/substreams/polygon-ramses-v3/src/abi/pool.rs
@@ -19,9 +19,38 @@ pub mod events {
     }
     impl Burn {
         const TOPIC_ID: [u8; 32] = [
-            12u8, 57u8, 108u8, 217u8, 137u8, 163u8, 159u8, 68u8, 89u8, 181u8, 250u8, 26u8, 237u8,
-            106u8, 154u8, 141u8, 205u8, 188u8, 69u8, 144u8, 138u8, 207u8, 214u8, 126u8, 2u8, 140u8,
-            213u8, 104u8, 218u8, 152u8, 152u8, 44u8,
+            12u8,
+            57u8,
+            108u8,
+            217u8,
+            137u8,
+            163u8,
+            159u8,
+            68u8,
+            89u8,
+            181u8,
+            250u8,
+            26u8,
+            237u8,
+            106u8,
+            154u8,
+            141u8,
+            205u8,
+            188u8,
+            69u8,
+            144u8,
+            138u8,
+            207u8,
+            214u8,
+            126u8,
+            2u8,
+            140u8,
+            213u8,
+            104u8,
+            218u8,
+            152u8,
+            152u8,
+            44u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 4usize {
@@ -30,26 +59,27 @@ pub mod events {
             if log.data.len() != 96usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[
-                    ethabi::ParamType::Uint(128usize),
-                    ethabi::ParamType::Uint(256usize),
-                    ethabi::ParamType::Uint(256usize),
-                ],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[
+                        ethabi::ParamType::Uint(128usize),
+                        ethabi::ParamType::Uint(256usize),
+                        ethabi::ParamType::Uint(256usize),
+                    ],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
-                owner: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                owner: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
                     .map_err(|e| {
                         format!(
                             "unable to decode param 'owner' from topic of type 'address': {:?}",
@@ -121,9 +151,38 @@ pub mod events {
     }
     impl Collect {
         const TOPIC_ID: [u8; 32] = [
-            112u8, 147u8, 83u8, 56u8, 230u8, 151u8, 117u8, 69u8, 106u8, 133u8, 221u8, 239u8, 34u8,
-            108u8, 57u8, 95u8, 182u8, 104u8, 182u8, 63u8, 160u8, 17u8, 95u8, 95u8, 32u8, 97u8,
-            11u8, 56u8, 142u8, 108u8, 169u8, 192u8,
+            112u8,
+            147u8,
+            83u8,
+            56u8,
+            230u8,
+            151u8,
+            117u8,
+            69u8,
+            106u8,
+            133u8,
+            221u8,
+            239u8,
+            34u8,
+            108u8,
+            57u8,
+            95u8,
+            182u8,
+            104u8,
+            182u8,
+            63u8,
+            160u8,
+            17u8,
+            95u8,
+            95u8,
+            32u8,
+            97u8,
+            11u8,
+            56u8,
+            142u8,
+            108u8,
+            169u8,
+            192u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 4usize {
@@ -132,26 +191,27 @@ pub mod events {
             if log.data.len() != 96usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[
-                    ethabi::ParamType::Address,
-                    ethabi::ParamType::Uint(128usize),
-                    ethabi::ParamType::Uint(128usize),
-                ],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[
+                        ethabi::ParamType::Address,
+                        ethabi::ParamType::Uint(128usize),
+                        ethabi::ParamType::Uint(128usize),
+                    ],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
-                owner: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                owner: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
                     .map_err(|e| {
                         format!(
                             "unable to decode param 'owner' from topic of type 'address': {:?}",
@@ -218,9 +278,38 @@ pub mod events {
     }
     impl CollectProtocol {
         const TOPIC_ID: [u8; 32] = [
-            89u8, 107u8, 87u8, 57u8, 6u8, 33u8, 141u8, 52u8, 17u8, 133u8, 11u8, 38u8, 166u8, 180u8,
-            55u8, 214u8, 196u8, 82u8, 47u8, 219u8, 67u8, 210u8, 210u8, 56u8, 98u8, 99u8, 248u8,
-            109u8, 80u8, 184u8, 177u8, 81u8,
+            89u8,
+            107u8,
+            87u8,
+            57u8,
+            6u8,
+            33u8,
+            141u8,
+            52u8,
+            17u8,
+            133u8,
+            11u8,
+            38u8,
+            166u8,
+            180u8,
+            55u8,
+            214u8,
+            196u8,
+            82u8,
+            47u8,
+            219u8,
+            67u8,
+            210u8,
+            210u8,
+            56u8,
+            98u8,
+            99u8,
+            248u8,
+            109u8,
+            80u8,
+            184u8,
+            177u8,
+            81u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 3usize {
@@ -229,22 +318,26 @@ pub mod events {
             if log.data.len() != 64usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[ethabi::ParamType::Uint(128usize), ethabi::ParamType::Uint(128usize)],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[
+                        ethabi::ParamType::Uint(128usize),
+                        ethabi::ParamType::Uint(128usize),
+                    ],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
-                sender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                sender: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
                     .map_err(|e| {
                         format!(
                             "unable to decode param 'sender' from topic of type 'address': {:?}",
@@ -258,21 +351,21 @@ pub mod events {
                     .as_bytes()
                     .to_vec(),
                 recipient: ethabi::decode(
-                    &[ethabi::ParamType::Address],
-                    log.topics[2usize].as_ref(),
-                )
-                .map_err(|e| {
-                    format!(
-                        "unable to decode param 'recipient' from topic of type 'address': {:?}",
-                        e
+                        &[ethabi::ParamType::Address],
+                        log.topics[2usize].as_ref(),
                     )
-                })?
-                .pop()
-                .expect(INTERNAL_ERR)
-                .into_address()
-                .expect(INTERNAL_ERR)
-                .as_bytes()
-                .to_vec(),
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'recipient' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
                 amount0: {
                     let mut v = [0 as u8; 32];
                     values
@@ -312,9 +405,38 @@ pub mod events {
     }
     impl FeeAdjustment {
         const TOPIC_ID: [u8; 32] = [
-            12u8, 186u8, 135u8, 24u8, 144u8, 85u8, 211u8, 181u8, 171u8, 5u8, 201u8, 111u8, 189u8,
-            100u8, 27u8, 199u8, 102u8, 87u8, 108u8, 158u8, 124u8, 240u8, 209u8, 149u8, 189u8,
-            251u8, 88u8, 160u8, 198u8, 166u8, 223u8, 36u8,
+            12u8,
+            186u8,
+            135u8,
+            24u8,
+            144u8,
+            85u8,
+            211u8,
+            181u8,
+            171u8,
+            5u8,
+            201u8,
+            111u8,
+            189u8,
+            100u8,
+            27u8,
+            199u8,
+            102u8,
+            87u8,
+            108u8,
+            158u8,
+            124u8,
+            240u8,
+            209u8,
+            149u8,
+            189u8,
+            251u8,
+            88u8,
+            160u8,
+            198u8,
+            166u8,
+            223u8,
+            36u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 1usize {
@@ -323,19 +445,20 @@ pub mod events {
             if log.data.len() != 64usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[ethabi::ParamType::Uint(24usize), ethabi::ParamType::Uint(24usize)],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[
+                        ethabi::ParamType::Uint(24usize),
+                        ethabi::ParamType::Uint(24usize),
+                    ],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
                 old_fee: {
@@ -381,9 +504,38 @@ pub mod events {
     }
     impl Flash {
         const TOPIC_ID: [u8; 32] = [
-            189u8, 189u8, 183u8, 29u8, 120u8, 96u8, 55u8, 107u8, 165u8, 43u8, 37u8, 165u8, 2u8,
-            139u8, 238u8, 162u8, 53u8, 129u8, 54u8, 74u8, 64u8, 82u8, 47u8, 107u8, 207u8, 184u8,
-            107u8, 177u8, 242u8, 220u8, 166u8, 51u8,
+            189u8,
+            189u8,
+            183u8,
+            29u8,
+            120u8,
+            96u8,
+            55u8,
+            107u8,
+            165u8,
+            43u8,
+            37u8,
+            165u8,
+            2u8,
+            139u8,
+            238u8,
+            162u8,
+            53u8,
+            129u8,
+            54u8,
+            74u8,
+            64u8,
+            82u8,
+            47u8,
+            107u8,
+            207u8,
+            184u8,
+            107u8,
+            177u8,
+            242u8,
+            220u8,
+            166u8,
+            51u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 3usize {
@@ -392,27 +544,28 @@ pub mod events {
             if log.data.len() != 128usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[
-                    ethabi::ParamType::Uint(256usize),
-                    ethabi::ParamType::Uint(256usize),
-                    ethabi::ParamType::Uint(256usize),
-                    ethabi::ParamType::Uint(256usize),
-                ],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[
+                        ethabi::ParamType::Uint(256usize),
+                        ethabi::ParamType::Uint(256usize),
+                        ethabi::ParamType::Uint(256usize),
+                        ethabi::ParamType::Uint(256usize),
+                    ],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
-                sender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                sender: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
                     .map_err(|e| {
                         format!(
                             "unable to decode param 'sender' from topic of type 'address': {:?}",
@@ -426,21 +579,21 @@ pub mod events {
                     .as_bytes()
                     .to_vec(),
                 recipient: ethabi::decode(
-                    &[ethabi::ParamType::Address],
-                    log.topics[2usize].as_ref(),
-                )
-                .map_err(|e| {
-                    format!(
-                        "unable to decode param 'recipient' from topic of type 'address': {:?}",
-                        e
+                        &[ethabi::ParamType::Address],
+                        log.topics[2usize].as_ref(),
                     )
-                })?
-                .pop()
-                .expect(INTERNAL_ERR)
-                .into_address()
-                .expect(INTERNAL_ERR)
-                .as_bytes()
-                .to_vec(),
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'recipient' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
                 amount0: {
                     let mut v = [0 as u8; 32];
                     values
@@ -500,9 +653,38 @@ pub mod events {
     }
     impl Initialize {
         const TOPIC_ID: [u8; 32] = [
-            152u8, 99u8, 96u8, 54u8, 203u8, 102u8, 169u8, 193u8, 154u8, 55u8, 67u8, 94u8, 252u8,
-            30u8, 144u8, 20u8, 33u8, 144u8, 33u8, 78u8, 138u8, 190u8, 184u8, 33u8, 189u8, 186u8,
-            63u8, 41u8, 144u8, 221u8, 76u8, 149u8,
+            152u8,
+            99u8,
+            96u8,
+            54u8,
+            203u8,
+            102u8,
+            169u8,
+            193u8,
+            154u8,
+            55u8,
+            67u8,
+            94u8,
+            252u8,
+            30u8,
+            144u8,
+            20u8,
+            33u8,
+            144u8,
+            33u8,
+            78u8,
+            138u8,
+            190u8,
+            184u8,
+            33u8,
+            189u8,
+            186u8,
+            63u8,
+            41u8,
+            144u8,
+            221u8,
+            76u8,
+            149u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 1usize {
@@ -511,19 +693,20 @@ pub mod events {
             if log.data.len() != 64usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[ethabi::ParamType::Uint(160usize), ethabi::ParamType::Int(24usize)],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[
+                        ethabi::ParamType::Uint(160usize),
+                        ethabi::ParamType::Int(24usize),
+                    ],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
                 sqrt_price_x96: {
@@ -571,9 +754,38 @@ pub mod events {
     }
     impl Mint {
         const TOPIC_ID: [u8; 32] = [
-            215u8, 130u8, 24u8, 192u8, 211u8, 4u8, 232u8, 137u8, 60u8, 179u8, 32u8, 10u8, 190u8,
-            57u8, 75u8, 188u8, 141u8, 91u8, 120u8, 4u8, 217u8, 197u8, 31u8, 35u8, 109u8, 249u8,
-            253u8, 207u8, 72u8, 29u8, 2u8, 211u8,
+            215u8,
+            130u8,
+            24u8,
+            192u8,
+            211u8,
+            4u8,
+            232u8,
+            137u8,
+            60u8,
+            179u8,
+            32u8,
+            10u8,
+            190u8,
+            57u8,
+            75u8,
+            188u8,
+            141u8,
+            91u8,
+            120u8,
+            4u8,
+            217u8,
+            197u8,
+            31u8,
+            35u8,
+            109u8,
+            249u8,
+            253u8,
+            207u8,
+            72u8,
+            29u8,
+            2u8,
+            211u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 4usize {
@@ -582,28 +794,29 @@ pub mod events {
             if log.data.len() != 160usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[
-                    ethabi::ParamType::Address,
-                    ethabi::ParamType::Uint(256usize),
-                    ethabi::ParamType::Uint(128usize),
-                    ethabi::ParamType::Uint(256usize),
-                    ethabi::ParamType::Uint(256usize),
-                ],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[
+                        ethabi::ParamType::Address,
+                        ethabi::ParamType::Uint(256usize),
+                        ethabi::ParamType::Uint(128usize),
+                        ethabi::ParamType::Uint(256usize),
+                        ethabi::ParamType::Uint(256usize),
+                    ],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
-                owner: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                owner: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
                     .map_err(|e| {
                         format!(
                             "unable to decode param 'owner' from topic of type 'address': {:?}",
@@ -693,9 +906,38 @@ pub mod events {
     }
     impl Swap {
         const TOPIC_ID: [u8; 32] = [
-            196u8, 32u8, 121u8, 249u8, 74u8, 99u8, 80u8, 215u8, 230u8, 35u8, 95u8, 41u8, 23u8,
-            73u8, 36u8, 249u8, 40u8, 204u8, 42u8, 200u8, 24u8, 235u8, 100u8, 254u8, 216u8, 0u8,
-            78u8, 17u8, 95u8, 188u8, 202u8, 103u8,
+            196u8,
+            32u8,
+            121u8,
+            249u8,
+            74u8,
+            99u8,
+            80u8,
+            215u8,
+            230u8,
+            35u8,
+            95u8,
+            41u8,
+            23u8,
+            73u8,
+            36u8,
+            249u8,
+            40u8,
+            204u8,
+            42u8,
+            200u8,
+            24u8,
+            235u8,
+            100u8,
+            254u8,
+            216u8,
+            0u8,
+            78u8,
+            17u8,
+            95u8,
+            188u8,
+            202u8,
+            103u8,
         ];
         pub fn match_log(log: &substreams_ethereum::pb::eth::v2::Log) -> bool {
             if log.topics.len() != 3usize {
@@ -704,28 +946,29 @@ pub mod events {
             if log.data.len() != 160usize {
                 return false;
             }
-            return log
-                .topics
-                .get(0)
-                .expect("bounds already checked")
-                .as_ref() ==
-                Self::TOPIC_ID;
+            return log.topics.get(0).expect("bounds already checked").as_ref()
+                == Self::TOPIC_ID;
         }
-        pub fn decode(log: &substreams_ethereum::pb::eth::v2::Log) -> Result<Self, String> {
+        pub fn decode(
+            log: &substreams_ethereum::pb::eth::v2::Log,
+        ) -> Result<Self, String> {
             let mut values = ethabi::decode(
-                &[
-                    ethabi::ParamType::Int(256usize),
-                    ethabi::ParamType::Int(256usize),
-                    ethabi::ParamType::Uint(160usize),
-                    ethabi::ParamType::Uint(128usize),
-                    ethabi::ParamType::Int(24usize),
-                ],
-                log.data.as_ref(),
-            )
-            .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
+                    &[
+                        ethabi::ParamType::Int(256usize),
+                        ethabi::ParamType::Int(256usize),
+                        ethabi::ParamType::Uint(160usize),
+                        ethabi::ParamType::Uint(128usize),
+                        ethabi::ParamType::Int(24usize),
+                    ],
+                    log.data.as_ref(),
+                )
+                .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
             values.reverse();
             Ok(Self {
-                sender: ethabi::decode(&[ethabi::ParamType::Address], log.topics[1usize].as_ref())
+                sender: ethabi::decode(
+                        &[ethabi::ParamType::Address],
+                        log.topics[1usize].as_ref(),
+                    )
                     .map_err(|e| {
                         format!(
                             "unable to decode param 'sender' from topic of type 'address': {:?}",
@@ -739,21 +982,21 @@ pub mod events {
                     .as_bytes()
                     .to_vec(),
                 recipient: ethabi::decode(
-                    &[ethabi::ParamType::Address],
-                    log.topics[2usize].as_ref(),
-                )
-                .map_err(|e| {
-                    format!(
-                        "unable to decode param 'recipient' from topic of type 'address': {:?}",
-                        e
+                        &[ethabi::ParamType::Address],
+                        log.topics[2usize].as_ref(),
                     )
-                })?
-                .pop()
-                .expect(INTERNAL_ERR)
-                .into_address()
-                .expect(INTERNAL_ERR)
-                .as_bytes()
-                .to_vec(),
+                    .map_err(|e| {
+                        format!(
+                            "unable to decode param 'recipient' from topic of type 'address': {:?}",
+                            e
+                        )
+                    })?
+                    .pop()
+                    .expect(INTERNAL_ERR)
+                    .into_address()
+                    .expect(INTERNAL_ERR)
+                    .as_bytes()
+                    .to_vec(),
                 amount0: {
                     let mut v = [0 as u8; 32];
                     values


### PR DESCRIPTION
## Problem

`protocols/substreams/polygon-ramses-v3/src/abi/{factory,pool}.rs` show up as modified in
essentially every worktree, permanently. Reproduce on `main`:

```console
$ git checkout -- protocols/substreams/polygon-ramses-v3/src/abi
$ cargo check -p polygon-ramses-v3
$ git status --short
 M protocols/substreams/polygon-ramses-v3/src/abi/factory.rs
 M protocols/substreams/polygon-ramses-v3/src/abi/pool.rs
```

It is not a formatting command — it's `build.rs`, which runs
`substreams_ethereum::Abigen(...).write_to_file("src/abi/…")` on every `cargo check`/`build`/`test`
of the package.

## Why only this package

The committed ABI came from #1208 as *nightly-rustfmt-formatted* Abigen output (packed byte
arrays). Until #1264 that was self-healing: the build wrote raw Abigen output, and the next
`cargo +nightly fmt` silently re-compacted it back to the committed shape.

#1264 (`9e0fe4924`) then added `polygon-ramses-v3/src/abi` to the `ignore` list in
`protocols/substreams/rustfmt.toml` — a reasonable response to the diffs, but it removed the
repair step, so the raw regenerated output now stays as a permanent diff. The other ignored
`*/src/abi` dirs don't drift because their committed content already equals raw Abigen output.

## Fix

Commit exactly what Abigen emits, so regeneration is a byte-for-byte no-op — bringing ramses in
line with every other ignored ABI dir. No behavioural change: pure formatting of generated code
that the build overwrites anyway.

## Verification

- `cargo check -p polygon-ramses-v3` and `cargo build -p polygon-ramses-v3
  --target wasm32-unknown-unknown` both leave the working tree clean.
- `cargo +nightly fmt --all --check` in `protocols/substreams`: 0 diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
