### PR TITLE
chore(substreams): glob-ignore src/abi in rustfmt instead of listing packages

### DIFF
--- a/protocols/substreams/rustfmt.toml
+++ b/protocols/substreams/rustfmt.toml
@@ -9,26 +9,8 @@ trailing_semicolon = false
 use_field_init_shorthand = true
 chain_width = 40
 ignore = [
-    "crates/tycho-substreams/src/pb",
+    # Abigen output. build.rs regenerates src/abi on every cargo check/build.
+    "*/src/abi",
+    "ethereum-uniswap-v4/*/src/abi",
     "crates/tycho-substreams/src/abi",
-    "ethereum-balancer-v2/src/abi",
-    "ethereum-sfraxeth/src/abi",
-    "ethereum-sfrax/src/abi",
-    "ethereum-curve/src/abi",
-    "ethereum-ring-swap-v2/src/abi",
-    "ethereum-uniswap-v2/src/abi",
-    "ethereum-uniswap-v3/src/abi",
-    "ethereum-uniswap-v3-logs-only/src/abi",
-    "ethereum-pancakeswap-v3/src/abi",
-    "ethereum-uniswap-v4/shared/src/abi",
-    "ethereum-maverick-v2/src/abi",
-    "ethereum-balancer-v3/src/abi",
-    "ethereum-liquidityparty/src/abi",
-    "base-aerodrome-v1/src/abi",
-    "base-aerodrome-slipstreams/src/abi",
-    "base-lunarbase/src/abi",
-    "ethereum-erc4626/src/abi",
-    "ethereum-rocketpool/src/abi",
-    "unichain-velodrome/src/abi",
-    "polygon-ramses-v3/src/abi",
 ]


### PR DESCRIPTION
## Problem

`protocols/substreams/rustfmt.toml` ignored `src/abi` with 21 hand-maintained per-package entries.
That list is what makes drift like #1333 possible:

- a new package's `src/abi` is formatted by rustfmt, while `build.rs` keeps writing raw Abigen
  output on every `cargo check`/`build` — so the files show as modified in every worktree;
- the list only grows once someone notices, and by then the committed content is fmt-shaped, so
  adding the entry *freezes* the mismatch instead of healing it (exactly what happened to
  `polygon-ramses-v3` in #1264 → #1333).

## Fix

Replace the 21 entries with a glob, so a new package is covered on its first build rather than
after someone notices a dirty tree:

```toml
ignore = [
    # Abigen output. build.rs regenerates src/abi on every cargo check/build.
    "*/src/abi",
    "ethereum-uniswap-v4/*/src/abi",
    "crates/tycho-substreams/src/abi",
]
```

- rustfmt's `ignore` is gitignore syntax, so `*` does not cross `/`: `*/src/abi` alone leaves
  `ethereum-uniswap-v4/{shared,with-hooks}/src/abi` formatted, hence the second pattern.
- `crates/tycho-substreams/src/abi` stays explicit — it is the shared library, not a substreams
  package.
- `src/pb` is dropped from the list entirely, including the pre-existing
  `crates/tycho-substreams/src/pb` entry: nothing regenerates `src/pb` during a build, and raw
  `substreams protogen` output is already rustfmt-clean under this config (checked by removing the
  entry and re-running `--check`), so it was inert.

No `.rs` file changes — the currently-committed ABI content is untouched.

## Verification

From `protocols/substreams`:

- `cargo +nightly fmt --all -- --check`: 0 diffs.
- `cargo +nightly fmt --package <p> -- --check` for every workspace member (the CI shape): all pass.
- Glob coverage checked positively, not just by absence: misformatted probe functions planted in
  `ethereum-curve/src/abi`, `ethereum-uniswap-v4/{shared,with-hooks}/src/abi` and
  `crates/tycho-substreams/src/abi` are all ignored, while a deliberately non-matching control
  pattern surfaces all of them.

Note this is independent of #1333, which fixes the committed ramses ABI *content*; this PR fixes the
policy that let it drift. Neither touches the other's files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)