### PR TITLE
fix(testing): load live-phase tokens through the harness's own loader

### DIFF
--- a/protocols/testing/src/test_runner.rs
+++ b/protocols/testing/src/test_runner.rs
@@ -335,19 +335,19 @@ impl TestRunner {
         info!("Starting live testing for protocol {}", &config.protocol_system);
 
         let chain = self.chain;
-        // Load tokens for the stream
-        let all_tokens = tycho_simulation::utils::load_all_tokens(
-            &self.tycho_host(),
-            true,
-            Some("dummy"),
-            true,
-            chain,
-            None,
-            None,
-        )
-        .await
-        .into_diagnostic()
-        .wrap_err("Failed to load tokens from Tycho RPC")?;
+        // Load tokens without quality or last-traded filters: the local harness
+        // never runs the token analyzer, so substreams-discovered tokens keep
+        // their insertion quality and production-style filters would drop them
+        // all — silently excluding every component from the stream as
+        // undecodable ("unknown token").
+        let tycho_client = TychoClient::new(&self.tycho_http_url(), Some("dummy".to_string()))
+            .into_diagnostic()
+            .wrap_err("Failed to create Tycho client for token loading")?;
+        let all_tokens = tycho_client
+            .get_tokens(chain, None, None)
+            .await
+            .into_diagnostic()
+            .wrap_err("Failed to load tokens from Tycho RPC")?;
 
         let _ = tycho_simulation::evm::engine_db::SHARED_TYCHO_DB.clear();
 


### PR DESCRIPTION
## Problem

The protocol-testing harness's **full-mode live phase** loads tokens via `tycho_simulation::utils::load_all_tokens`, whose production defaults (quality ≥ 100, recently traded) assume a token-analyzer-populated DB. The local harness never runs the token analyzer (it needs trace RPC), so substreams-discovered tokens keep their insertion quality (10) and are all filtered out. Every component's state decode then fails with "unknown token", `skip_state_decode_failures(true)` drops them **silently**, and the stream tracks only the synthetic native_wrapper pair — logging "0 new pairs and 0 states" on every block while the chain is busy. Any protocol's full-mode live phase on a local DB is affected; range mode is not (its `tycho_client.get_tokens(chain, None, None)` sends no quality filter).

Found while live-testing the Sky integration (#1321): etherscan showed the PSM active in 53 of ~160 streamed blocks while the stream reported zero states. With this fix (validated via the equivalent DB workaround), the same run simulated and executed 12–18 sky swaps per active block, 0 failures.

## Fix

The live phase now loads tokens through the harness's own filter-free `TychoClient::get_tokens` — the same loader range mode uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
