### PR TITLE
feat(liquidityparty): add mainnet executor address

### DIFF
--- a/crates/tycho-execution/config/executor_addresses.json
+++ b/crates/tycho-execution/config/executor_addresses.json
@@ -20,6 +20,7 @@
     "native_wrapper": "0x8FD892DD5F8E153fe15cc3A7567E18ed6f7b1E0A",
     "rfq:liquorice": "0x81c7febeed3fd67a5fdcf892d43489091caeb186",
     "vm:fermiswap": "0xe2c352232127AfC9803e7eD79F129E458B20925e",
+    "vm:liquidityparty": "0x95cA663A10736A748981139F3071cdb21BAAC954",
     "vm:bopamm": "0x63A1ffF3A4b6e93D5687f7B340Ff51bA3a88901C",
     "rfq:metric": "0xD95D619fA709BA559D9CeE7645C5F71dbCf19f0F",
     "ring_swap_v2": "0x08BA9E85c8944098DEAacE0E164b7EC379A7e810",


### PR DESCRIPTION
Adds the deployed `LiquidityPartyExecutor` address for Ethereum to
`crates/tycho-execution/config/executor_addresses.json`:

```
"vm:liquidityparty": "0x95cA663A10736A748981139F3071cdb21BAAC954"
```

This was the last missing piece for `vm:liquidityparty`: the substreams
package, the VM adapter, the swap encoder and the `LiquidityPartyExecutor`
deployment entry are already in the repo, and `vm:liquidityparty` is already in
the Ethereum default protocol list of `tycho-integration-test`. Without an
executor address the encoder is never registered, so execution simulation could
not run.

Verification: the runtime bytecode at `0x95cA663A10736A748981139F3071cdb21BAAC954`
on mainnet is byte-for-byte identical to the repo's compiled
`LiquidityPartyExecutor` artifact (metadata included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)