### PR TITLE
fix: update Base tokens filter default and simulation exampled

### DIFF
--- a/crates/tycho-simulation/examples/price_printer/Readme.md
+++ b/crates/tycho-simulation/examples/price_printer/Readme.md
@@ -7,8 +7,11 @@ quotes from each pool.
 
 ```bash
 export RPC_URL=<your-node-rpc-url>
-cargo run --release --example price_printer -- --tvl-threshold 1000 --chain <ethereum | base | unichain>
+cargo run --release --example price_printer -- --tvl-threshold 1000 --chain <ethereum | base | unichain | arbitrum | bsc | polygon | robinhood>
 ```
+
+The TVL threshold is denominated in the chain's native token. Omit `--tvl-threshold` to use a
+chain-appropriate default targeting ~$200K USD equivalent.
 
 Both the token loader and the protocol stream default to TLS (`https`/`wss`). Pass `--no-tls`
 (or set `TYCHO_NO_TLS=true`) when pointing at a local dev instance served over plain HTTP

--- a/crates/tycho-simulation/examples/price_printer/main.rs
+++ b/crates/tycho-simulation/examples/price_printer/main.rs
@@ -104,7 +104,18 @@ fn register_exchanges(
                 .exchange::<UniswapV4State>("uniswap_v4", tvl_filter.clone(), None)
         }
         Chain::Polygon => {
-            builder = builder.exchange::<RamsesV3State>("ramses_v3", tvl_filter.clone(), None)
+            builder = builder
+                .exchange::<UniswapV2State>("uniswap_v2", tvl_filter.clone(), None)
+                .exchange::<UniswapV2State>("quickswap_v2", tvl_filter.clone(), None)
+                .exchange::<UniswapV3State>("uniswap_v3", tvl_filter.clone(), None)
+                .exchange::<UniswapV4State>("uniswap_v4", tvl_filter.clone(), None)
+                .exchange::<RamsesV3State>("ramses_v3", tvl_filter.clone(), None)
+        }
+        Chain::Robinhood => {
+            builder = builder
+                .exchange::<UniswapV2State>("uniswap_v2", tvl_filter.clone(), None)
+                .exchange::<UniswapV3State>("uniswap_v3", tvl_filter.clone(), None)
+                .exchange::<UniswapV4State>("uniswap_v4", tvl_filter.clone(), None)
         }
         _ => {}
     }

--- a/crates/tycho-simulation/examples/quickstart/Readme.md
+++ b/crates/tycho-simulation/examples/quickstart/Readme.md
@@ -14,7 +14,18 @@ cargo run --release --example quickstart
 ```
 
 By default, the example will trade 10 USDC -> WETH on Ethereum Mainnet. Setting the chain will by default trade 10
-USDC -> WETH on that chain.
+units of that chain's main stablecoin into its wrapped native token:
+
+| Chain | Default trade |
+|---|---|
+| `ethereum` | USDC -> WETH |
+| `base` | USDC -> WETH |
+| `unichain` | USDC -> WETH |
+| `arbitrum` | USDC -> WETH |
+| `bsc` | USDC -> WBNB |
+| `polygon` | USDC -> WPOL |
+| `robinhood` | USDG -> WETH |
+
 If you want a different trade or chain, you can do:
 
 ```bash

--- a/crates/tycho-simulation/examples/quickstart/main.rs
+++ b/crates/tycho-simulation/examples/quickstart/main.rs
@@ -90,29 +90,40 @@ struct Cli {
 
 impl Cli {
     fn with_defaults(mut self) -> Self {
-        // By default, we swap a small amount of USDC to WETH on whatever chain we choose
+        // By default, we swap a small amount of the chain's main stablecoin into its wrapped
+        // native token.
 
         if self.buy_token.is_none() {
-            self.buy_token = Some(match self.chain.to_string().as_str() {
-                "ethereum" => "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2".to_string(),
-                "base" => "0x4200000000000000000000000000000000000006".to_string(),
-                "unichain" => "0x4200000000000000000000000000000000000006".to_string(),
-                "arbitrum" => "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1".to_string(),
-                _ => panic!("Execution does not yet support chain {chain}", chain = self.chain),
-            });
+            self.buy_token = Some(
+                self.chain
+                    .wrapped_native_token()
+                    .address
+                    .to_string(),
+            );
         }
 
         if self.sell_token.is_none() {
-            self.sell_token = Some(match self.chain.to_string().as_str() {
-                "ethereum" => "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48".to_string(),
-                "base" => "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913".to_string(),
-                "unichain" => "0x078d782b760474a361dda0af3839290b0ef57ad6".to_string(),
-                "arbitrum" => "0xaf88d065e77c8cC2239327C5EDb3A432268e5831".to_string(),
-                _ => panic!("Execution does not yet support chain {chain}", chain = self.chain),
-            });
+            self.sell_token = Some(default_stablecoin(self.chain).to_string());
         }
 
         self
+    }
+}
+
+/// Returns the stablecoin used as the default sell token on the given chain.
+///
+/// This is USDC everywhere except Robinhood Chain, whose canonical stablecoin is USDG.
+/// Panics on chains without a default — pass `--sell-token` for those.
+fn default_stablecoin(chain: Chain) -> &'static str {
+    match chain {
+        Chain::Ethereum => "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        Chain::Base => "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        Chain::Unichain => "0x078d782b760474a361dda0af3839290b0ef57ad6",
+        Chain::Arbitrum => "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+        Chain::Bsc => "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d",
+        Chain::Polygon => "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+        Chain::Robinhood => "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168",
+        _ => panic!("No default sell token for chain {chain}. Please pass --sell-token."),
     }
 }
 
@@ -249,8 +260,18 @@ async fn main() {
                 .exchange::<UniswapV4State>("uniswap_v4", tvl_filter.clone(), None)
         }
         Chain::Polygon => {
-            protocol_stream =
-                protocol_stream.exchange::<RamsesV3State>("ramses_v3", tvl_filter.clone(), None)
+            protocol_stream = protocol_stream
+                .exchange::<UniswapV2State>("uniswap_v2", tvl_filter.clone(), None)
+                .exchange::<UniswapV2State>("quickswap_v2", tvl_filter.clone(), None)
+                .exchange::<UniswapV3State>("uniswap_v3", tvl_filter.clone(), None)
+                .exchange::<UniswapV4State>("uniswap_v4", tvl_filter.clone(), None)
+                .exchange::<RamsesV3State>("ramses_v3", tvl_filter.clone(), None)
+        }
+        Chain::Robinhood => {
+            protocol_stream = protocol_stream
+                .exchange::<UniswapV2State>("uniswap_v2", tvl_filter.clone(), None)
+                .exchange::<UniswapV3State>("uniswap_v3", tvl_filter.clone(), None)
+                .exchange::<UniswapV4State>("uniswap_v4", tvl_filter.clone(), None)
         }
         _ => {}
     }

--- a/crates/tycho-simulation/src/utils.rs
+++ b/crates/tycho-simulation/src/utils.rs
@@ -117,6 +117,8 @@ pub fn get_default_url(chain: &Chain) -> Option<String> {
         Chain::Unichain => Some("tycho-unichain-beta.propellerheads.xyz".to_string()),
         Chain::Bsc => Some("tycho-bsc-beta.propellerheads.xyz".to_string()),
         Chain::Arbitrum => Some("tycho-arbitrum-beta.propellerheads.xyz".to_string()),
+        Chain::Polygon => Some("tycho-polygon-beta.propellerheads.xyz".to_string()),
+        Chain::Robinhood => Some("tycho-robinhood-beta.propellerheads.xyz".to_string()),
         _ => None,
     }
 }

--- a/crates/tycho-simulation/src/utils.rs
+++ b/crates/tycho-simulation/src/utils.rs
@@ -83,7 +83,7 @@ pub async fn load_all_tokens(
         .map_err(|err| map_rpc_error(err, "Failed to create Tycho RPC client"))?;
 
     // Chain specific defaults for special case chains. Otherwise defaults to 14 days.
-    let default_min_days = HashMap::from([(Chain::Base, 1_u64), (Chain::Ethereum, 30_u64)]);
+    let default_min_days = HashMap::from([(Chain::Base, 7_u64), (Chain::Ethereum, 30_u64)]);
 
     #[allow(clippy::mutable_key_type)]
     let min_q = min_quality.or(Some(100));


### PR DESCRIPTION
Updated Base's 'n_days_since_last_traded' value from 1 -> 7 days. The number of tokens served for various 'last_traded' values is:
1 day: 7672
3 days: 31579
7 days: 39142
4 days: 55857

Ethereum loads 38k tokens currently so it's safe to use the 7 day filter here without overwhelming Fynd's graph.

Also updated our simulation examples with the new chains.