### PR TITLE
feat: sample integration-test blocks on fast chains

### DIFF
--- a/crates/tycho-integration-test/CLAUDE.md
+++ b/crates/tycho-integration-test/CLAUDE.md
@@ -28,12 +28,15 @@ cargo run -p tycho-integration-test -- \
 Key optional flags: `--no-tls`, `--disable-onchain`, `--disable-rfq`,
 `--disable-price-level-stream`, `--disable-execution`, `--protocols uniswap_v2,curve`,
 `--max-blocks 100`, `--parallel-simulations 5`, `--always-test-components <id,...>`,
-`--price-level-stream-block-interval 1`, `--price-level-stream-stale-threshold-secs 10`.
+`--price-level-stream-block-interval 1`, `--price-level-stream-stale-threshold-secs 10`,
+`--test-every-n-blocks 10`.
 
 ## Module Structure
 
 - **`main.rs`**: CLI (`Cli` struct), top-level orchestration loop — subscribes to Tycho,
-  dispatches blocks to stream processors, calls `poll_rpc_for_block` for on-chain comparison
+  dispatches blocks to stream processors, calls `poll_rpc_for_block` (every-block mode) or
+  `await_target_block` (`--test-every-n-blocks` > 1, fetches the sampled block by number) for
+  on-chain comparison
 - **`stream_processor/`**:
   - `protocol_stream_processor.rs`: Handles on-chain protocol updates — applies deltas to
     `ProtocolSim` instances, runs `get_amount_out` simulations, validates via RPC execution

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -927,6 +927,11 @@ async fn process_update(
 
             let update_block_number = update.update.block_number_or_timestamp;
 
+            if !is_sampled_block(update_block_number, cli.test_every_n_blocks) {
+                metrics::record_protocol_update_sampled_out();
+                return Ok(());
+            }
+
             // Flashblocks-capable endpoints expose sequencer pre-confirmed state under `pending`;
             // standard endpoints use `latest` (confirmed blocks only).
             let block_tag = if cli.partial_blocks && update.update.is_partial {
@@ -1886,7 +1891,7 @@ fn reached_max_blocks(max_blocks: u64, statistics: Option<&Arc<RwLock<TestStatis
 
 /// True when `block_number` is selected by the `--test-every-n-blocks` sampling interval.
 fn is_sampled_block(block_number: u64, interval: u64) -> bool {
-    block_number % interval == 0
+    block_number.is_multiple_of(interval)
 }
 
 /// Selector of the priority-update-registry's `StaleUpdate()` error, the freshness guard of the

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -932,50 +932,88 @@ async fn process_update(
                 return Ok(());
             }
 
-            // Flashblocks-capable endpoints expose sequencer pre-confirmed state under `pending`;
-            // standard endpoints use `latest` (confirmed blocks only).
-            let block_tag = if cli.partial_blocks && update.update.is_partial {
-                BlockNumberOrTag::Pending
-            } else {
-                BlockNumberOrTag::Latest
-            };
             let poll_interval = Duration::from_millis(cli.rpc_poll_interval_ms);
 
-            let poll_result = poll_rpc_for_block(
-                &rpc_tools,
-                update_block_number,
-                block_tag,
-                cli.rpc_poll_attempts,
-                poll_interval,
-            )
-            .await?;
+            let block = if cli.test_every_n_blocks > 1 {
+                // Sampled mode: on fast chains the head is expected to be past the update, so the
+                // target block is fetched by number instead of racing the head. clap rejects
+                // --partial-blocks in this mode, so the block is always full.
+                match await_target_block(
+                    &rpc_tools,
+                    update_block_number,
+                    cli.rpc_poll_attempts,
+                    poll_interval,
+                )
+                .await
+                {
+                    Ok(Some(b)) => {
+                        let latency_seconds =
+                            update.received_at.as_secs_f64() - b.header.timestamp as f64;
+                        metrics::record_block_processing_duration(latency_seconds, "full");
+                        Arc::new(b)
+                    }
+                    Ok(None) => {
+                        warn!("RPC did not serve sampled block {update_block_number}, skipping.");
+                        metrics::record_protocol_update_skipped();
+                        for protocol in update.update.sync_states.keys() {
+                            metrics::record_protocol_sync_state_skipped(protocol);
+                        }
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        metrics::record_protocol_update_skipped();
+                        for protocol in update.update.sync_states.keys() {
+                            metrics::record_protocol_sync_state_skipped(protocol);
+                        }
+                        return Err(e);
+                    }
+                }
+            } else {
+                // Flashblocks-capable endpoints expose sequencer pre-confirmed state under
+                // `pending`; standard endpoints use `latest` (confirmed blocks only).
+                let block_tag = if cli.partial_blocks && update.update.is_partial {
+                    BlockNumberOrTag::Pending
+                } else {
+                    BlockNumberOrTag::Latest
+                };
 
-            let block_type =
-                if block_tag == BlockNumberOrTag::Pending { "partial" } else { "full" };
-            let block = match poll_result {
-                BlockPollResult::Ready(b) => {
-                    let latency_seconds =
-                        update.received_at.as_secs_f64() - b.header.timestamp as f64;
-                    metrics::record_block_processing_duration(latency_seconds, block_type);
-                    Arc::new(*b)
-                }
-                BlockPollResult::Stale { target_block_timestamp } => {
-                    if let Some(ts) = target_block_timestamp {
-                        let latency_seconds = update.received_at.as_secs_f64() - ts as f64;
+                let poll_result = poll_rpc_for_block(
+                    &rpc_tools,
+                    update_block_number,
+                    block_tag,
+                    cli.rpc_poll_attempts,
+                    poll_interval,
+                )
+                .await?;
+
+                let block_type =
+                    if block_tag == BlockNumberOrTag::Pending { "partial" } else { "full" };
+                match poll_result {
+                    BlockPollResult::Ready(b) => {
+                        let latency_seconds =
+                            update.received_at.as_secs_f64() - b.header.timestamp as f64;
                         metrics::record_block_processing_duration(latency_seconds, block_type);
+                        Arc::new(*b)
                     }
-                    metrics::record_protocol_update_skipped();
-                    for protocol in update.update.sync_states.keys() {
-                        metrics::record_protocol_sync_state_skipped(protocol);
+                    BlockPollResult::Stale { target_block_timestamp } => {
+                        if let Some(ts) = target_block_timestamp {
+                            let latency_seconds = update.received_at.as_secs_f64() - ts as f64;
+                            metrics::record_block_processing_duration(latency_seconds, block_type);
+                        }
+                        metrics::record_protocol_update_skipped();
+                        for protocol in update.update.sync_states.keys() {
+                            metrics::record_protocol_sync_state_skipped(protocol);
+                        }
+                        return Ok(());
                     }
-                    return Ok(());
-                }
-                BlockPollResult::Timeout => {
-                    warn!(
-                    "RPC ({block_tag}) did not reach update block {update_block_number}, skipping."
-                );
-                    metrics::record_protocol_update_skipped();
-                    return Ok(());
+                    BlockPollResult::Timeout => {
+                        warn!(
+                            "RPC ({block_tag}) did not reach update block \
+                             {update_block_number}, skipping."
+                        );
+                        metrics::record_protocol_update_skipped();
+                        return Ok(());
+                    }
                 }
             };
             if update.is_first_update {

--- a/crates/tycho-integration-test/src/main.rs
+++ b/crates/tycho-integration-test/src/main.rs
@@ -182,6 +182,18 @@ struct Cli {
     #[arg(long, default_value_t = false)]
     partial_blocks: bool,
 
+    /// Run the protocol-stream test pipeline only on blocks whose number is a multiple of this
+    /// value. 1 tests every block (current behavior). Use a higher value on fast chains (e.g.
+    /// Robinhood) where the harness cannot keep up with the head. State from every block is
+    /// still ingested. Incompatible with --partial-blocks.
+    #[arg(
+        long,
+        default_value_t = 1,
+        value_parser = clap::value_parser!(u64).range(1..),
+        conflicts_with = "partial_blocks"
+    )]
+    test_every_n_blocks: u64,
+
     /// Seconds without a protocol update before marking all known protocols as stale in metrics.
     /// 0 disables the watchdog.
     #[arg(long, default_value_t = 30)]
@@ -1872,6 +1884,11 @@ fn reached_max_blocks(max_blocks: u64, statistics: Option<&Arc<RwLock<TestStatis
     stats.blocks_processed >= max_blocks
 }
 
+/// True when `block_number` is selected by the `--test-every-n-blocks` sampling interval.
+fn is_sampled_block(block_number: u64, interval: u64) -> bool {
+    block_number % interval == 0
+}
+
 /// Selector of the priority-update-registry's `StaleUpdate()` error, the freshness guard of the
 /// registry-priced pAMMs (FermiSwap, Kipseli, Bebop, TaurusFi).
 const STALE_UPDATE_SELECTOR: &str = "666a2814";
@@ -1949,9 +1966,10 @@ fn format_error_chain(e: &miette::Error) -> String {
 
 #[cfg(test)]
 mod tests {
+    use clap::Parser;
     use rstest::rstest;
 
-    use super::is_oracle_stale_revert;
+    use super::{is_oracle_stale_revert, is_sampled_block, Cli};
 
     #[rstest]
     #[case::stale_update_name("fermiswap", "execution reverted: StaleUpdate()")]
@@ -1977,5 +1995,34 @@ mod tests {
     #[case::feed_stalled_on_non_metric_pamm("fermiswap", "execution reverted: FeedStalled()")]
     fn other_reverts_stay_real_failures(#[case] pamm: &str, #[case] reason: &str) {
         assert!(!is_oracle_stale_revert(pamm, reason));
+    }
+
+    #[rstest]
+    #[case::interval_one_selects_every_block(1, 41513952, true)]
+    #[case::interval_one_selects_multiples_too(1, 41513950, true)]
+    #[case::multiple_of_interval(10, 41513950, true)]
+    #[case::not_a_multiple(10, 41513952, false)]
+    #[case::block_zero(10, 0, true)]
+    fn sampling_selects_multiples_of_interval(
+        #[case] interval: u64,
+        #[case] block: u64,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(is_sampled_block(block, interval), expected);
+    }
+
+    #[test]
+    fn test_every_n_blocks_conflicts_with_partial_blocks() {
+        let result = Cli::try_parse_from([
+            "tycho-integration-test",
+            "--tycho-url",
+            "localhost:4242",
+            "--rpc-url",
+            "http://localhost:8545",
+            "--partial-blocks",
+            "--test-every-n-blocks",
+            "10",
+        ]);
+        assert!(result.is_err());
     }
 }

--- a/crates/tycho-integration-test/src/metrics.rs
+++ b/crates/tycho-integration-test/src/metrics.rs
@@ -267,6 +267,14 @@ pub fn record_protocol_update_skipped() {
     counter!("tycho_integration_protocol_updates_skipped_total").increment(1);
 }
 
+/// Record a protocol update whose block was not selected by `--test-every-n-blocks` sampling.
+///
+/// Deliberately separate from `tycho_integration_protocol_updates_skipped_total`: skipped means
+/// the harness wanted to test the block but could not; sampled-out is a configured decision.
+pub fn record_protocol_update_sampled_out() {
+    counter!("tycho_integration_protocol_updates_sampled_out_total").increment(1);
+}
+
 /// Record the block delay of protocol updates
 pub fn record_protocol_update_block_delay(block_delay: u64) {
     histogram!("tycho_integration_protocol_update_block_delay_blocks").record(block_delay as f64);


### PR DESCRIPTION
## Problem

`[PROD-ROBINHOOD] Protocol sync state skipped` fired and resolved about 30 times between Aug 15 and Aug 20 in #tycho-alerts. The `robinhood-tycho-integration-test` logs repeat `Update block (N) is behind latest block (M), skipping to catch up.`

## Root cause

The fault is in `tycho-integration-test`, not in the Robinhood indexer. `process_update` merges each protocol update into the state cache, then calls `poll_rpc_for_block`, which proceeds only when the RPC `latest` block **equals** the update block. Robinhood is an Arbitrum Orbit chain with on-demand blocks, so updates arrive 3 to 7 blocks behind the head. The equality check almost always fails, the harness sets `tycho_integration_protocol_sync_state` to 7 ("skipped"), and the gauge latches until a test succeeds. The alert is `gauge == 7 for 10m`. Simulation volume was already at the floor: `--max-simulations 2 --max-simulations-stale 1`, and clap enforces a minimum of 1.

## Fix

A new `--test-every-n-blocks` flag runs the test pipeline only on blocks whose number is a multiple of N. The default of 1 keeps today's behavior on every chain.

- Every update still merges into the state cache. Stream states are full snapshots, so state stays complete.
- Sampled-out blocks return early and increment a new counter, `tycho_integration_protocol_updates_sampled_out_total`. They never touch the skipped gauge, so gauge 7 keeps its meaning: the harness wanted to test the block but could not.
- When N > 1, the target block is fetched by number with `await_target_block` instead of racing the head. The chain being ahead is expected in this mode. Gauge 7 is set only when the RPC cannot serve the block at all.
- The flag conflicts with `--partial-blocks`: pending blocks cannot be fetched by number.

## Notes for reviewers

`--max-blocks` counts tested blocks only. `record_protocol_update_block_delay` is not recorded in sampled mode; block lag stays visible through the `record_block_processing_duration` histogram, which is unbiased because selection is by block number, not latency.

## Follow-ups

Robinhood needs `--test-every-n-blocks 10` added to its container args in helm-configuration. That change must merge after this image is released, or the container fails on an unknown flag.
