### PR TITLE
fix(storage): postgres protocol type per component

### DIFF
--- a/crates/tycho-storage/src/postgres/protocol.rs
+++ b/crates/tycho-storage/src/postgres/protocol.rs
@@ -436,10 +436,7 @@ impl PostgresGateway {
         }
         .instrument(debug_span!("resolve_tx_ids"))
         .await?;
-        // Resolved per distinct type name, not once for the whole batch. A protocol may emit more
-        // than one component type — Pendle creates a market and its SY wrapper in the same
-        // transaction — and taking `new[0]`'s type for all of them silently stamps every component
-        // in the batch with whichever happened to be first.
+
         let mut pt_ids: HashMap<&str, i64> = HashMap::new();
         for pc in new {
             if pt_ids.contains_key(pc.protocol_type_name.as_str()) {

--- a/crates/tycho-storage/src/postgres/protocol.rs
+++ b/crates/tycho-storage/src/postgres/protocol.rs
@@ -436,15 +436,30 @@ impl PostgresGateway {
         }
         .instrument(debug_span!("resolve_tx_ids"))
         .await?;
-        let pt_id = orm::ProtocolType::id_by_name(&new[0].protocol_type_name, conn)
-            .await
-            .map_err(|err| {
-                storage_error_from_diesel(err, "ProtocolType", &new[0].protocol_type_name, None)
-            })?;
+        // Resolved per distinct type name, not once for the whole batch. A protocol may emit more
+        // than one component type — Pendle creates a market and its SY wrapper in the same
+        // transaction — and taking `new[0]`'s type for all of them silently stamps every component
+        // in the batch with whichever happened to be first.
+        let mut pt_ids: HashMap<&str, i64> = HashMap::new();
+        for pc in new {
+            if pt_ids.contains_key(pc.protocol_type_name.as_str()) {
+                continue;
+            }
+            let pt_id = orm::ProtocolType::id_by_name(&pc.protocol_type_name, conn)
+                .await
+                .map_err(|err| {
+                    storage_error_from_diesel(err, "ProtocolType", &pc.protocol_type_name, None)
+                })?;
+            pt_ids.insert(pc.protocol_type_name.as_str(), pt_id);
+        }
+
         for pc in new {
             let txh = tx_hash_id_mapping
                 .get::<TxHash>(&pc.creation_tx.clone())
                 .ok_or(StorageError::DecodeError("TxHash not found".to_string()))?;
+            let pt_id = *pt_ids
+                .get(pc.protocol_type_name.as_str())
+                .expect("every distinct type name was resolved above");
 
             let new_pc = orm::NewProtocolComponent::new(
                 &pc.id,
@@ -3536,6 +3551,67 @@ mod test {
             .await;
 
         assert!(contract.is_ok())
+    }
+
+    /// A batch carrying more than one component type must keep each component's own type.
+    ///
+    /// The type used to be resolved once from `new[0]`, so every component in a batch inherited
+    /// whichever type happened to be first. Protocols that create two kinds of component in one
+    /// transaction hit this — Pendle emits a market and its SY wrapper together — and the damage is
+    /// silent: the component is stored and served, just under the wrong type, so it decodes against
+    /// the wrong state and fails much later with a confusing missing-attribute error.
+    #[tokio::test]
+    async fn test_add_protocol_components_with_mixed_types() {
+        let mut conn = setup_db().await;
+        setup_data(&mut conn).await;
+        let gw = EVMGateway::from_connection(&mut conn).await;
+
+        let first_type = String::from("Test_Type_1");
+        let second_type = String::from("Test_Type_2");
+        let first_type_id =
+            db_fixtures::insert_protocol_type(&mut conn, &first_type, None, None, None).await;
+        let second_type_id =
+            db_fixtures::insert_protocol_type(&mut conn, &second_type, None, None, None).await;
+        assert_ne!(first_type_id, second_type_id);
+
+        let component = |id: &str, type_name: &str| {
+            ProtocolComponent::new(
+                id,
+                "ambient",
+                type_name,
+                Chain::Ethereum,
+                vec![Bytes::from(WETH)],
+                vec![Bytes::from(WETH)],
+                HashMap::new(),
+                ChangeType::Creation,
+                Bytes::from("0xbb7e16d797a9e2fbc537e30f91ed3d27a254dd9578aa4c3af3e5f0d3e8130945"),
+                Default::default(),
+            )
+        };
+
+        // Both orderings, because the bug took the type of whichever came first: with only one
+        // ordering the test would pass for the component that happens to lead the batch.
+        let batch =
+            [component("mixed_first", &first_type), component("mixed_second", &second_type)];
+        gw.add_protocol_components(&batch, &mut conn)
+            .await
+            .expect("adding components failed");
+
+        let first_stored = schema::protocol_component::table
+            .filter(schema::protocol_component::external_id.eq("mixed_first"))
+            .select(orm::ProtocolComponent::as_select())
+            .first::<orm::ProtocolComponent>(&mut conn)
+            .await
+            .expect("failed to read back the first component");
+        let second_stored = schema::protocol_component::table
+            .filter(schema::protocol_component::external_id.eq("mixed_second"))
+            .select(orm::ProtocolComponent::as_select())
+            .first::<orm::ProtocolComponent>(&mut conn)
+            .await
+            .expect("failed to read back the second component");
+
+        assert_eq!(first_stored.protocol_type_id, first_type_id);
+        assert_eq!(second_stored.protocol_type_id, second_type_id);
     }
 
     fn create_test_protocol_component(id: &str) -> ProtocolComponent {

--- a/protocols/testing/src/config.rs
+++ b/protocols/testing/src/config.rs
@@ -13,6 +13,8 @@ pub struct ProtocolComponentExpectation {
     #[serde(default)]
     pub static_attributes: HashMap<String, Bytes>,
     pub creation_tx: Bytes,
+    #[serde(default)]
+    pub protocol_type_name: Option<String>,
 }
 
 /// Represents a ProtocolComponent with test configuration
@@ -74,6 +76,22 @@ impl ProtocolComponentExpectation {
                 }
             }
         }
+        // Compare protocol_type_name, when the test declares one
+        if let Some(expected_type) = &self.protocol_type_name {
+            if expected_type != &other.protocol_type_name {
+                let diff = self.format_diff(
+                    "protocol_type_name",
+                    expected_type,
+                    &other.protocol_type_name,
+                    colorize_output,
+                );
+                diffs.push(format!(
+                    "Field 'protocol_type_name' mismatch for {}:\n{}",
+                    self.id, diff
+                ));
+            }
+        }
+
         // Compare creation_tx
         if self.creation_tx != other.creation_tx {
             let self_tx = format!("{}", self.creation_tx.clone());

--- a/protocols/testing/src/test_runner.rs
+++ b/protocols/testing/src/test_runner.rs
@@ -1144,6 +1144,24 @@ impl TestRunner {
             .map(|c| c.base.id.to_lowercase())
             .collect();
 
+        // The decoder is built with `skip_state_decode_failures(true)`, so a component whose state
+        // cannot be decoded is dropped with a warning rather than raising. The loop below iterates
+        // what survived, so without this check a dropped component is simply never simulated and
+        // the test still passes. Anything the test claims to simulate must have reached the
+        // decoder intact.
+        let undecoded: Vec<String> = expected_components
+            .iter()
+            .filter(|c| !c.skip_simulation)
+            .map(|c| c.base.id.to_lowercase())
+            .filter(|id| !update.states.contains_key(id))
+            .collect();
+        if !undecoded.is_empty() {
+            return Err(miette!(
+                "Components were indexed but produced no simulation state, so they were never \
+                 simulated: {undecoded:?}. Look for StateDecodingFailure warnings above."
+            ));
+        }
+
         let mut execution_data = HashMap::new();
 
         for (id, state) in update.states.iter() {


### PR DESCRIPTION
This is intended to be a preparation for Pendle integration (#1353) - current code assumes that a protocol spawns components of only one type - Pendle is going to have two.

Current implementation gives the same protocol type name to each of protocol's components. This makes some components fail to decode, and current implementation silently omits such components from asserting.