### PR TITLE
feat(execution): fetch 10 blocks of Angstrom attestations

### DIFF
--- a/crates/tycho-execution/CLAUDE.md
+++ b/crates/tycho-execution/CLAUDE.md
@@ -259,7 +259,7 @@ whitelisted on the PropAMMRouter may use the prefix.
 
 Angstrom's Uniswap V4 pools start every block locked. A swap against one carries a pool unlock attestation, signed by
 the current Angstrom leader, as its `hookData`. The attestation is scoped to a block number and says nothing about the
-swap, so one fetched window (covering `ANGSTROM_BLOCKS_IN_FUTURE` blocks, default 5) serves every swap, pool and route.
+swap, so one fetched window (covering `ANGSTROM_BLOCKS_IN_FUTURE` blocks, default 10) serves every swap, pool and route.
 
 `AttestationCache` therefore keeps the window in a process-wide cache instead of fetching it during encoding:
 

--- a/crates/tycho-execution/src/encoding/evm/constants.rs
+++ b/crates/tycho-execution/src/encoding/evm/constants.rs
@@ -46,7 +46,7 @@ pub static ROUTER_ETH_ADDRESS: LazyLock<Bytes> = LazyLock::new(|| {
 /// It is important to note that fetching more blocks will send more attestations to the
 /// Tycho Router, resulting in a higher gas usage. Fetching fewer blocks may result in attestations
 /// expiring if the transaction is not sent fast enough.
-pub const ANGSTROM_DEFAULT_BLOCKS_IN_FUTURE: u64 = 5;
+pub const ANGSTROM_DEFAULT_BLOCKS_IN_FUTURE: u64 = 10;
 
 /// The endpoint serving Angstrom pool unlock attestations.
 pub(crate) const ANGSTROM_DEFAULT_API_URL: &str =

--- a/docs/for-solvers/supported-protocols.md
+++ b/docs/for-solvers/supported-protocols.md
@@ -116,7 +116,7 @@ Angstrom locks its pools at the start of every block. A swap that trades against
 **Required configuration**:
 
 * Set the `ANGSTROM_API_KEY` environment variable (request one from the Angstrom team directly)
-* Set `ANGSTROM_BLOCKS_IN_FUTURE` environment variable (if you want to override the <a href="https://github.com/propeller-heads/tycho-indexer/blob/main/crates/tycho-execution/src/encoding/evm/constants.rs" target="_blank" rel="noopener noreferrer">default value</a> of 5 blocks). **Important trade-off**: The more blocks you fetch, the more calldata will be sent to the Tycho Router, making execution more gas expensive.
+* Set `ANGSTROM_BLOCKS_IN_FUTURE` environment variable (if you want to override the <a href="https://github.com/propeller-heads/tycho-indexer/blob/main/crates/tycho-execution/src/encoding/evm/constants.rs" target="_blank" rel="noopener noreferrer">default value</a> of 10 blocks). **Important trade-off**: The more blocks you fetch, the more calldata will be sent to the Tycho Router, making execution more gas expensive.
 
 If `ANGSTROM_API_KEY` is not set, `ProtocolStreamBuilder` excludes Angstrom pools from `uniswap_v4_hooks` by default (unless you pass your own filter function), since routes over these pools would fail at encoding without attestations.
 


### PR DESCRIPTION
## What changed

`ANGSTROM_DEFAULT_BLOCKS_IN_FUTURE` goes from 5 to 10. A fetched attestation window now covers the current block plus 10 future ones, so it holds 11 entries instead of 6.


🤖 Generated with [Claude Code](https://claude.com/claude-code)