### PR TITLE
fix(simulation): keep the Angstrom filter when a caller filter is set

### DIFF
--- a/crates/tycho-simulation/src/evm/decoder.rs
+++ b/crates/tycho-simulation/src/evm/decoder.rs
@@ -100,7 +100,7 @@ where
     skip_state_decode_failures: bool,
     min_token_quality: u32,
     registry: HashMap<String, Box<RegistryFn<H>>>,
-    inclusion_filters: HashMap<String, FilterFn>,
+    inclusion_filters: HashMap<String, Vec<FilterFn>>,
     /// Live override providers keyed by `protocol_system`. A pool of that protocol subscribes to
     /// its provider at creation time and reads fresh overrides on every simulation.
     override_providers: HashMap<String, Arc<dyn StateOverrideProvider>>,
@@ -265,9 +265,23 @@ where
     /// For example, you might use a filter to exclude pools that are not fully supported in the
     /// protocol, or to ignore pools with certain attributes that are irrelevant to your
     /// application.
+    ///
+    /// Filters accumulate: registering a second predicate for the same exchange keeps the first,
+    /// and a component is admitted only when every registered predicate accepts it.
     pub fn register_filter(&mut self, exchange: &str, predicate: FilterFn) {
         self.inclusion_filters
-            .insert(exchange.to_string(), predicate);
+            .entry(exchange.to_string())
+            .or_default()
+            .push(predicate);
+    }
+
+    /// Whether every filter registered for `exchange` accepts `snapshot`. An exchange with no
+    /// registered filter admits every component.
+    fn admits(&self, exchange: &str, snapshot: &ComponentWithState) -> bool {
+        let Some(predicates) = self.inclusion_filters.get(exchange) else { return true };
+        predicates
+            .iter()
+            .all(|predicate| predicate(snapshot))
     }
 
     /// Decodes a `FeedMessage` into a `BlockUpdate` containing the updated states of protocol
@@ -516,11 +530,7 @@ where
                     .clone()
                 {
                     // Skip any unsupported pools
-                    if self
-                        .inclusion_filters
-                        .get(protocol.as_str())
-                        .is_some_and(|predicate| !predicate(&snapshot))
-                    {
+                    if !self.admits(protocol.as_str(), &snapshot) {
                         continue;
                     }
 
@@ -1527,5 +1537,38 @@ mod tests {
             .expect("Get amount out failed");
 
         assert_eq!(amount_out.amount, BigUint::from_str("1216190190361759119").unwrap());
+    }
+
+    fn component_with_id(id: &str) -> ComponentWithState {
+        use tycho_common::models::protocol::{ProtocolComponent, ProtocolComponentState};
+
+        ComponentWithState {
+            state: ProtocolComponentState::new(id, HashMap::new(), HashMap::new()),
+            component: ProtocolComponent { id: id.to_string(), ..Default::default() },
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        }
+    }
+
+    fn rejects_a(component: &ComponentWithState) -> bool {
+        component.component.id != "a"
+    }
+
+    fn rejects_b(component: &ComponentWithState) -> bool {
+        component.component.id != "b"
+    }
+
+    #[test]
+    fn test_admits_requires_every_registered_filter() {
+        // Two filters on one exchange both apply: the second registration does not replace the
+        // first, and a component must pass both. An exchange without filters admits everything.
+        let mut decoder = TychoStreamDecoder::<BlockHeader>::new();
+        decoder.register_filter("x", rejects_a);
+        decoder.register_filter("x", rejects_b);
+
+        assert!(!decoder.admits("x", &component_with_id("a")));
+        assert!(!decoder.admits("x", &component_with_id("b")));
+        assert!(decoder.admits("x", &component_with_id("c")));
+        assert!(decoder.admits("y", &component_with_id("a")));
     }
 }

--- a/crates/tycho-simulation/src/evm/protocol/filters.rs
+++ b/crates/tycho-simulation/src/evm/protocol/filters.rs
@@ -63,7 +63,7 @@ pub fn uniswap_v4_angstrom_hook_pool_filter(component: &ComponentWithState) -> b
 /// authenticated with `ANGSTROM_API_KEY`. Without the key the swap fails at encoding time —
 /// after route selection — so consumers without the key should exclude these pools up front.
 /// [`ProtocolStreamBuilder`](crate::evm::stream::ProtocolStreamBuilder) applies this filter to
-/// `uniswap_v4_hooks` automatically when no filter function is provided and the key is unset.
+/// `uniswap_v4_hooks` whenever the key is unset, alongside any filter function the caller passes.
 pub fn uniswap_v4_non_angstrom_hook_pool_filter(component: &ComponentWithState) -> bool {
     !uniswap_v4_angstrom_hook_pool_filter(component)
 }

--- a/crates/tycho-simulation/src/evm/stream.rs
+++ b/crates/tycho-simulation/src/evm/stream.rs
@@ -144,12 +144,14 @@ use crate::{
 
 const EXCHANGES_REQUIRING_FILTER: [&str; 4] = ["vm:balancer_v2", "fluid_v1", "erc4626", "ekubo_v3"];
 
-/// The client-side filter applied to exchange `name` when the caller provides none.
+/// The client-side filter exchange `name` always gets, in addition to any filter the caller
+/// provides.
 ///
 /// `uniswap_v4_hooks`: without `ANGSTROM_API_KEY`, Angstrom swaps cannot be encoded (they carry
 /// per-block attestations from the Angstrom API), so Angstrom pools are excluded up front rather
-/// than failing every route that selects them at encoding time.
-fn default_filter_fn(name: &str) -> Option<fn(&ComponentWithState) -> bool> {
+/// than failing every route that selects them at encoding time. A caller's own hook filter does
+/// not replace this one: the encoder still has no key.
+fn mandatory_filter_fn(name: &str) -> Option<fn(&ComponentWithState) -> bool> {
     if name == "uniswap_v4_hooks" && std::env::var("ANGSTROM_API_KEY").is_err() {
         warn!(
             "ANGSTROM_API_KEY is not set: excluding Angstrom pools from '{name}'. \
@@ -325,7 +327,8 @@ impl ProtocolStreamBuilder {
         if let Some(predicate) = filter_fn {
             self.decoder
                 .register_filter(name, predicate);
-        } else if let Some(predicate) = default_filter_fn(name) {
+        }
+        if let Some(predicate) = mandatory_filter_fn(name) {
             self.decoder
                 .register_filter(name, predicate);
         }
@@ -385,7 +388,8 @@ impl ProtocolStreamBuilder {
         if let Some(predicate) = filter_fn {
             self.decoder
                 .register_filter(name, predicate);
-        } else if let Some(predicate) = default_filter_fn(name) {
+        }
+        if let Some(predicate) = mandatory_filter_fn(name) {
             self.decoder
                 .register_filter(name, predicate);
         }


### PR DESCRIPTION
`ProtocolStreamBuilder::exchange` and `exchange_with_decoder_context` applied the non-Angstrom hook filter to `uniswap_v4_hooks` only when the caller passed no `filter_fn`. A caller with its own hook filter (fynd's hook blocklist since fynd PR #469) let Angstrom pools into the graph, and every route that selected one failed at encode time with `ANGSTROM_API_KEY environment variable is required for Angstrom swaps`. In prod hindsight this made 5% of ethereum records unsolvable.

Now:
- `TychoStreamDecoder` keeps a `Vec<FilterFn>` per exchange. `register_filter` appends, and a component is admitted only when every registered filter accepts it (`admits`).
- The builder registers the caller's filter when given, and always registers the non-Angstrom filter for `uniswap_v4_hooks` when `ANGSTROM_API_KEY` is unset (`mandatory_filter_fn`, formerly `default_filter_fn`).

Public signatures are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)